### PR TITLE
fix(gda): preserve the captured output of every timed-out launch (#714)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -88,24 +88,25 @@ _Avoid_: consistency, coherence, sync
 
 **Headless launch**:
 The one-shot `godot --headless` spawn primitive that the Phase-1 channels share —
-the sentinel op-dispatch runner, the native-export runner, the `gda script run`
-user-script runner (ADR-0031), and the `gda scene preflight` runner, which
-dispatches an ordinary sentinel op but calls the primitive itself for its
-streaming capture (#664). Given the binary, an argv tail, an optional working
-directory, and a timeout, it builds `[binary, --headless, --log-file <gda-owned
-path>, *args]`, captures bytes with the timeout, and normalizes the outcome into a
-`Raw run` (the single home of the spawn / timeout / launch-failure / UTF-8-decode
-handling). Each channel contributes only its argv tail and the export-only cwd. It
-also owns the launch's `User-data placement` — resolved and preflighted here, once,
-so no channel plumbs it (#653). It offers two **capture strategies**, differing only
-in how the child is read: **buffered** (the sentinel-runner and export channels),
-which discards the child's output when the timeout expires and reports the wait
-instead; and **streaming** (`gda script run`, and `gda scene preflight` — which
-dispatches a sentinel op but calls the primitive itself precisely for this
-capture), which reads both pipes as they arrive, so the output survives a timeout,
-times the launch, and lets the channel end the run early through a caller-supplied
-watch. Both share one timeout / launch-failure mapping
-(#655).
+the sentinel op-dispatch runner, the native-export runner, the `gda resource
+import` engine pass, the `gda script run` user-script runner (ADR-0031), and the
+`gda scene preflight` runner, which dispatches an ordinary sentinel op but calls
+the primitive itself because it bifurcates on the launch's own outcome, a timeout
+being its verdict rather than a failure to classify (#664). Given the binary, an
+argv tail, an optional working directory, and a timeout, it builds `[binary,
+--headless, --log-file <gda-owned path>, *args]`, captures bytes with the timeout,
+and normalizes the outcome into a `Raw run` (the single home of the spawn /
+timeout / launch-failure / UTF-8-decode handling). Each channel contributes only
+its argv tail and the export-only cwd. It also owns the launch's `User-data
+placement` — resolved and preflighted here, once, so no channel plumbs it (#653).
+Every launch **streams**: both pipes are read as they arrive, so whatever the run
+produced before gda ended it survives, and the launch is timed. #655 introduced
+that beside a **buffered** strategy which discarded the child's output at the
+timeout and reported the wait instead, keeping the other channels on it while the
+mechanism was proven; #714 moved the last three across and deleted it, so there is
+ONE strategy and no channel can be left on the discard. What a channel may still
+choose is a `LaunchWatch` — POLICY, not strategy: a rule for ending a run EARLY
+that only that channel can state (`gda script run`'s `Completion marker`).
 _Avoid_: spawn helper, subprocess wrapper
 
 **User-data placement**:
@@ -126,18 +127,23 @@ _Avoid_: log redirect, user dir, sandbox
 
 **Raw run**:
 The normalized outcome a `Headless launch` returns — `{stdout, stderr, exit_code,
-launch_failure, elapsed_seconds}`, unparsed — before any classification.
-`launch_failure` is set only when the primitive synthesized the result (binary
-missing, timed out, the `User-data placement` was refused, or a watch ended the run)
-rather than the engine returning one, so the classifier keys environment failures on
-that typed reason, not on the overloaded exit code. Under the streaming capture
-strategy the streams hold **what the run had already produced** rather than a gda
-notice, and `elapsed_seconds` carries the wall clock; under the buffered strategy they
-are empty on a timeout and `elapsed_seconds` is `None` (#655). Those launch-backed
-channels all return the one `RunResult` shape. Normally internal, it is **promoted to
-a public result by `gda script run`** — the one operation whose success result *is* a
-Raw run (minus `launch_failure`, `elapsed_seconds`, and the streams' timeout
-semantics, all of which are lifted out into an `Error envelope`; since #665 the
+launch_failure, elapsed_seconds, timeout_bound}`, unparsed — before any
+classification. `launch_failure` is set only when the primitive synthesized the
+result (binary missing, timed out, the `User-data placement` was refused, or a
+watch ended the run) rather than the engine returning one, so the classifier keys
+environment failures on that typed reason, not on the overloaded exit code. The
+streams hold **what the run had already produced** rather than a gda notice, and
+`elapsed_seconds` carries the wall clock — on every channel (#655, #714).
+`timeout_bound` is the pair a timed-out run cannot state for itself: WHICH launch
+gave up (its channel label) and the ceiling it reached. It is set only on a
+`TIMEOUT` result and it rides the result because it is the only thing that crosses
+the runner seam — the shared `launch_timeout` classifier has the raw run and
+nothing else, so without it two of the three channels could not name their own
+ceiling (#714). Those launch-backed channels all return the one `RunResult` shape.
+Normally internal, it is **promoted to a public result by `gda script run`** — the
+one operation whose success result *is* a Raw run (minus `launch_failure`,
+`elapsed_seconds`, `timeout_bound`, and the streams' timeout semantics, all of
+which are lifted out into an `Error envelope`; since #665 the
 promoted `stdout` is additionally a BOUNDED projection — verbatim up to a cap,
 above it the leading cap bytes with the complete stream spilled to a file the
 result names), so its `exit_status` can be non-zero on success (ADR-0031).

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -233,7 +233,7 @@ operation, and parse codes the CLI assigns).
 | Code | Category | Source | Exit Code | Meaning |
 | --- | --- | --- | --- | --- |
 | `binary_not_found` | `environment` | `runner` | `127` | The Godot binary could not be launched. |
-| `launch_timeout` | `environment` | `runner` | `124` | Godot launched but did not return before the runner timeout. One command does not report it: `scene preflight` reports its own `timeout` status instead (#664). |
+| `launch_timeout` | `environment` | `runner` | `124` | Godot launched but did not return before the runner timeout; the envelope carries the run's captured partial output, the ceiling it reached and the elapsed wall clock. One command does not report it: `scene preflight` reports its own `timeout` status instead (#664). |
 | `user_data_unwritable` | `environment` | `runner` | `127` | The log or user-data placement for the launch could not be made usable, so the launch was refused. |
 | `unknown_command` | `usage` | `classifier` | `2` | gda has no such command; discover the surface with `gda schema` or `gda --help`. A recognized near miss also carries the supported invocation in the envelope's `hint`. |
 | `unknown_option` | `usage` | `classifier` | `2` | The command exists but has no such option; read its options with `--help` or its input contract with `--schema`. A recognized near miss also carries the supported invocation in the envelope's `hint`. |

--- a/docs/adr/0031-headless-script-run-passthrough-execution.md
+++ b/docs/adr/0031-headless-script-run-passthrough-execution.md
@@ -454,3 +454,20 @@ added incrementally under ADR-0025 if a concrete need appears.
 > status and full byte count) and the TMPDIR remediation; a post-create failure
 > releases the descriptor and unlinks the partial file before failing. `stderr`
 > and the failure envelopes' partial-output evidence keep their existing shapes.
+
+> **Outcome (2026-08-31, #714) — the buffered strategy is gone; every channel streams.**
+> The 2026-08-17 amendment above recorded the sentinel and export channels staying on the
+> buffered capture, with their published timeout envelopes byte-identical, and named moving
+> them as follow-up work. That follow-up landed. Three channels moved, not two — the
+> `resource import` engine pass calls the same primitive and classifies through the same
+> branch — which left the buffered strategy with no caller and it was deleted, so a future
+> channel cannot be silently left on the discard. The shared `launch_timeout` branch
+> (`classify_launch_or_crash`) now builds the envelope for all three: the captured partial
+> output under `--- captured stdout ---` / `--- captured stderr ---` (the script-run labels
+> above are untrue of an export or an import pass), tail-capped at the same 16 KiB per
+> stream, plus the elapsed wall clock and the ceiling that was reached. Those last two ride
+> the `Raw run` as `timeout_bound`, because the runner seam hands a classifier a raw run and
+> nothing else. `script run` and `scene preflight` are unchanged: each still classifies its
+> own timeout, since each carries something the shared branch cannot know (a termination
+> phase and the recognized script errors; a `timeout` STATUS that is the command's answer).
+> The `--- script stdout ---` labels, and every non-timeout envelope, keep their bytes.

--- a/docs/adr/0031-headless-script-run-passthrough-execution.md
+++ b/docs/adr/0031-headless-script-run-passthrough-execution.md
@@ -465,9 +465,10 @@ added incrementally under ADR-0025 if a concrete need appears.
 > (`classify_launch_or_crash`) now builds the envelope for all three: the captured partial
 > output under `--- captured stdout ---` / `--- captured stderr ---` (the script-run labels
 > above are untrue of an export or an import pass), tail-capped at the same 16 KiB per
-> stream, plus the elapsed wall clock and the ceiling that was reached. Those last two ride
-> the `Raw run` as `timeout_bound`, because the runner seam hands a classifier a raw run and
-> nothing else. `script run` and `scene preflight` are unchanged: each still classifies its
+> stream, plus the elapsed wall clock and the ceiling that was reached. Both ride the
+> `Raw run` — the wall clock in its existing `elapsed_seconds`, the channel label and
+> ceiling in the new `timeout_bound` — because the runner seam hands a classifier a raw
+> run and nothing else. `script run` and `scene preflight` are unchanged: each still classifies its
 > own timeout, since each carries something the shared branch cannot know (a termination
 > phase and the recognized script errors; a `timeout` STATUS that is the command's answer).
 > The `--- script stdout ---` labels, and every non-timeout envelope, keep their bytes.

--- a/src/gda/commands/scene.py
+++ b/src/gda/commands/scene.py
@@ -937,26 +937,6 @@ def render_scene_preflight(preflight: "ScenePreflightResult") -> str:
     return "\n".join(lines)
 
 
-class _CaptureOnlyWatch:
-    """``scene preflight``'s :class:`~gda.runner.LaunchWatch`: stream, never abort (#664).
-
-    Passing a watch is what switches the launch primitive from BUFFERED capture to
-    STREAMING (see :class:`gda.runner.LaunchWatch`), and streaming is what this
-    channel needs: a buffered timeout DISCARDS everything the child wrote, and for a
-    scene that never came up that discarded text is the entire evidence — the
-    verdict would say "timeout" and carry nothing.
-
-    It observes and never ends a run, which is deliberate rather than unfinished.
-    ``script run``'s watch can end one because its caller DECLARED what finishing
-    looks like (``--completion-marker``); nobody declares that for a booting scene,
-    and a scene that prints an error is very often still coming up. So the only
-    bound here is the caller's ``--timeout``, and what the watch buys is the capture.
-    """
-
-    def observe(self, *, stdout: str, stderr: str, elapsed: float) -> bool:
-        return False
-
-
 def run_scene_preflight_operation(
     params: ScenePreflightParams,
     *,
@@ -973,10 +953,10 @@ def run_scene_preflight_operation(
     It dispatches an ordinary ADR-0002 sentinel op — the entry script is gda's own
     ``operations.gd``, so the engine can and does report a structured verdict — but
     it calls :func:`gda.runner.launch` directly instead of going through the runner
-    seam, for ONE reason: the seam's buffered capture throws the child's output away
-    at a timeout, and a scene that never came up leaves nothing else behind. The argv
-    is still the shared :func:`gda.runner.sentinel_args` spelling, so the two
-    channels cannot drift on how an op is dispatched.
+    seam, for ONE reason: it bifurcates on the launch's OWN outcome, since a run gda
+    ended at the bound is this command's verdict rather than a failure to classify.
+    The argv is still the shared :func:`gda.runner.sentinel_args` spelling, so the
+    two channels cannot drift on how an op is dispatched.
 
     The outcome bifurcates by WHOSE failure it is, which is where this command
     departs from every other launch-backed channel:
@@ -1020,7 +1000,6 @@ def run_scene_preflight_operation(
         cwd=None,
         timeout=params.timeout,
         timeout_label="Godot scene preflight",
-        watch=_CaptureOnlyWatch(),
     )
     # Forward the engine's own stream, exactly as the sentinel channel does
     # (``HeadlessCommand.execute``): a preflight's stderr is where the booted scene's

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -1563,12 +1563,11 @@ def run_script_run_operation(
     # via --path, so no working directory is needed (unlike the export channel,
     # whose relative output path needs cwd=project).
     args = ["--path", str(project), "--script", script]
-    # Pass a watch, which is what switches the shared primitive from buffered
-    # capture to STREAMING capture (#655): whatever the run produced survives a
-    # timeout, the wall clock is measured, and — only when the caller declared a
-    # completion marker — a run whose script died can be ended in seconds instead
-    # of at the ceiling. The watch is inert without a marker, so the no-marker
-    # invocation gains the captured output and nothing else.
+    # Pass a watch, this channel's POLICY over the shared primitive (#655): only
+    # when the caller declared a completion marker can a run whose script died be
+    # ended in seconds instead of at the ceiling. The watch is inert without a
+    # marker; the captured output and the measured wall clock come from the launch
+    # itself, which every channel gets.
     raw = run_launch(
         binary,
         args,

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -95,9 +95,10 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         # wall-clock bound of its own and reports exceeding it as a `timeout`
         # STATUS on a successful result, so an agent that branches on this code
         # alone would never see that command's timeout.
-        "Godot launched but did not return before the runner timeout. One command "
-        "does not report it: `scene preflight` reports its own `timeout` status "
-        "instead.",
+        "Godot launched but did not return before the runner timeout; the envelope "
+        "carries the run's captured partial output, the ceiling it reached and "
+        "the elapsed wall clock. One command does not report it: `scene "
+        "preflight` reports its own `timeout` status instead.",
     ),
     ErrorCodeSpec(
         "user_data_unwritable",

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -19,7 +19,8 @@ engine. The decision tree, top to bottom (``code`` in parentheses; the four
 
 - launch NOT_FOUND → environment / binary_not_found  (runner could not launch it)
 - launch TIMEOUT   → environment / launch_timeout     (runner launched it but it
-  hung past the timeout)
+  hung past the timeout; the envelope carries the captured partial output, the
+  ceiling it reached and the elapsed wall clock, #714)
 - launch USER_DATA_UNWRITABLE → environment / user_data_unwritable (the engine log
   target gda owns could not be created, so the launch was refused, #653)
 - exit < 0  → operation   / engine_crashed         (engine killed by a signal)
@@ -57,7 +58,7 @@ from gda.models import (
     OperationErrorEnvelope,
 )
 from gda.parser import parse_result
-from gda.runner import LaunchFailure, RunResult
+from gda.runner import DEFAULT_TIMEOUT_LABEL, LaunchFailure, RunResult
 
 # The minimum supported Godot version (ADR-0003): the floor where the modern
 # features gda relies on exist. Resolved from the version gda info reports; the
@@ -244,16 +245,154 @@ def invalid_params_json_failure(detail: str) -> Failure:
     )
 
 
+# --- What a failure reports of the output a run had already produced. Shared by
+# the ``script run`` verdicts that own a script's output (#651, #655) and, since
+# #714, by the ``launch_timeout`` envelope every launch-backed channel reports.
+# ---------------------------------------------------------------------------
+
+# The section headers of a `script_failed` envelope's ``diagnostics`` (#651). The
+# layout is fixed and both sections are ALWAYS emitted — an empty stream yields an
+# empty section rather than a missing one — so a consumer can split on the headers
+# without first discovering which streams the script happened to write to.
+SCRIPT_OUTPUT_STDOUT_HEADER = "--- script stdout ---"
+SCRIPT_OUTPUT_STDERR_HEADER = "--- script stderr ---"
+
+# The same two sections for a failure whose subject is the LAUNCH rather than a
+# script (#714). A distinct pair, because "script" would be untrue of an export or
+# an import pass — and because the script-run headers are published envelope bytes
+# that AC3 keeps unchanged. The `captured` wording names what these sections are:
+# what gda had read when it stopped waiting, not a stream the run finished writing.
+CAPTURED_STDOUT_HEADER = "--- captured stdout ---"
+CAPTURED_STDERR_HEADER = "--- captured stderr ---"
+
+
+def _labelled_output(
+    stdout: str, stderr: str, *, stdout_header: str, stderr_header: str
+) -> str:
+    """Both of the child's streams as one labelled ``diagnostics`` string (#651).
+
+    ``GdaError.diagnostics`` is a free-form ``str`` (ADR-0004), and for a failure
+    that IS the script's own — ``script_failed`` — the script's own output is the
+    diagnostic. A GDScript test runner reports through ``print()``, i.e. stdout, so
+    carrying stderr alone would hand a ``--strict`` CI caller a failure with no
+    content. Both streams are labelled rather than concatenated so the caller can
+    still tell which is which. The headers are the caller's because the same layout
+    serves two subjects — a script's own output, and a launch's capture (#714).
+    """
+    parts = []
+    for header, stream in ((stdout_header, stdout), (stderr_header, stderr)):
+        # Keep each section's payload verbatim, only guaranteeing the newline that
+        # puts the next header on its own line.
+        body = stream if stream.endswith("\n") or not stream else stream + "\n"
+        parts.append(f"{header}\n{body}")
+    return "".join(parts)
+
+
+def _labelled_script_output(stdout: str, stderr: str) -> str:
+    """:func:`_labelled_output` under the ``script run`` headers (#651)."""
+    return _labelled_output(
+        stdout,
+        stderr,
+        stdout_header=SCRIPT_OUTPUT_STDOUT_HEADER,
+        stderr_header=SCRIPT_OUTPUT_STDERR_HEADER,
+    )
+
+
+# How much of each stream a failure carries into its ``diagnostics`` when it
+# reports what a run had already produced (#655). Such a run can have produced
+# arbitrarily much output — a test suite that looped for two minutes — and
+# ``diagnostics`` is serialized inline in the JSON result, so it is bounded. The cap
+# is FIXED rather than an option: one more knob to reason about buys nothing an
+# agent wants, and a stated constant is something a caller can rely on. The TAIL is
+# kept, not the head: the interesting part of a run that did not finish is where it
+# got to.
+#
+# The bound is in **UTF-8 bytes**, not characters, because bytes are what actually
+# costs: a character cap of the same number let non-ASCII output through at up to
+# 3-4x the intended size (16Ki CJK characters encode to ~48KiB), so a bound meant to
+# keep a result payload small silently did not. Bytes also make the stated figure
+# mean one thing to a reader measuring the JSON.
+CAPTURED_OUTPUT_TAIL_CAP_BYTES = 16 * 1024
+
+
+def _tail(stream: str) -> str:
+    """The last :data:`CAPTURED_OUTPUT_TAIL_CAP_BYTES` UTF-8 bytes of a stream.
+
+    Slicing bytes can land inside a multi-byte sequence, so the decode uses
+    ``errors="ignore"`` to drop a leading partial character rather than emit a
+    replacement character for it: the truncation is gda's own doing, and inventing a
+    ``U+FFFD`` would misreport the engine's output as malformed. Only that boundary
+    is affected — anything genuinely malformed was already replaced when the capture
+    was decoded, and survives here as the replacement character it became.
+    """
+    encoded = stream.encode("utf-8")
+    if len(encoded) <= CAPTURED_OUTPUT_TAIL_CAP_BYTES:
+        return stream
+    return encoded[-CAPTURED_OUTPUT_TAIL_CAP_BYTES:].decode("utf-8", errors="ignore")
+
+
+def launch_timeout_failure(raw: RunResult) -> Failure:
+    """The ``launch_timeout`` envelope for a run gda stopped waiting for (#714).
+
+    The ONE place a launch's timeout becomes an error envelope, and the
+    reason it is a function of the raw result alone: the sentinel, export and
+    import channels reach it through three different classifiers, and two of them
+    cannot see the ceiling their runner was given — the runner seam hands them a
+    :class:`~gda.runner.RunResult` and nothing else. So the primitive puts the
+    ceiling ON the result (:class:`~gda.runner.TimeoutBound`) and this builder reads
+    it, instead of every ``classify_run`` call site plumbing a timeout through.
+
+    What the envelope carries is the evidence the discard used to destroy: the
+    partial output both streams held when gda ended the run, tail-capped with the
+    cap stated, plus the elapsed wall clock beside the ceiling — which is what tells
+    a run that was merely slow from one that was stuck (GDA-DF-012/GDA-DF-032, the
+    dogfooding pair that #655 fixed for ``script run`` and this closes for the rest).
+
+    ``script run`` and ``scene preflight`` do NOT come here: each classifies its own
+    timeout, because each has something to add this cannot know — a termination
+    phase and the recognized script errors, or a ``timeout`` status that is the
+    command's ANSWER rather than a failure at all.
+
+    Both optional inputs degrade rather than crash. A hand-built ``RunResult`` at a
+    test seam carries neither bound nor clock, and reporting a timeout is a better
+    answer to that than an assertion that would kill the command.
+    """
+    bound = raw.timeout_bound
+    label = bound.label if bound is not None else DEFAULT_TIMEOUT_LABEL
+    ceiling = "" if bound is None else f" of {bound.seconds}s"
+    elapsed = (
+        "" if raw.elapsed_seconds is None else f" (elapsed {raw.elapsed_seconds:.2f}s)"
+    )
+    return make_failure(
+        "launch_timeout",
+        f"{label} launched but did not return before the timeout"
+        f"{ceiling}{elapsed}. The captured output is in diagnostics, truncated to "
+        f"the last {CAPTURED_OUTPUT_TAIL_CAP_BYTES} UTF-8 bytes (16 KiB) of each "
+        f"stream.",
+        _labelled_output(
+            _tail(raw.stdout),
+            _tail(raw.stderr),
+            stdout_header=CAPTURED_STDOUT_HEADER,
+            stderr_header=CAPTURED_STDERR_HEADER,
+        ),
+    )
+
+
 def classify_launch_or_crash(raw: RunResult, binary: Path | None) -> Failure | None:
-    """The env/crash classifier prefix shared by both headless channels (#185).
+    """The env/crash classifier prefix shared by the headless channels (#185).
 
     The single home of the launch-failure and signal-death mapping that the
-    sentinel channel (``classify_run``) and the native-export channel
-    (``classify_export_run``) both open with, so a missing binary, a hung run,
-    or a signal death is classified identically across both (ADR-0010 — reuse
-    the machinery rather than duplicate it). Returns the env/crash ``Failure``
-    for the three modes below, or ``None`` to let the caller's channel-specific
-    tail (sentinel parse+validate vs synthesize-from-exit-code) take over.
+    sentinel channel (``classify_run``), the native-export channel
+    (``classify_export_run``) and the ``resource import`` pass all open with, so a
+    missing binary, a hung run, or a signal death is classified identically across
+    every one of them (ADR-0010 — reuse the machinery rather than duplicate it).
+    Returns the env/crash ``Failure`` for the three modes below, or ``None`` to let
+    the caller's channel-specific tail (sentinel parse+validate vs
+    synthesize-from-exit-code) take over.
+
+    Being the single home is what makes the timeout evidence a property of every
+    channel rather than of whichever one was fixed last: the hung-run branch is
+    written ONCE, so all three report the same envelope (#714).
 
     Environment failures key on the runner's typed ``launch_failure`` reason,
     not the exit code, so an engine (or shell/AppImage wrapper) that *genuinely*
@@ -267,11 +406,7 @@ def classify_launch_or_crash(raw: RunResult, binary: Path | None) -> Failure | N
             raw.stderr,
         )
     if raw.launch_failure is LaunchFailure.TIMEOUT:
-        return make_failure(
-            "launch_timeout",
-            "Godot launched but did not return before the timeout",
-            raw.stderr,
-        )
+        return launch_timeout_failure(raw)
     if raw.launch_failure is LaunchFailure.USER_DATA_UNWRITABLE:
         # Refused before the spawn (issue #653): the engine builds its file logger
         # ahead of any project code and dies with signal 11 when it cannot open the
@@ -584,36 +719,6 @@ def script_did_not_run_failure(
     )
 
 
-# The section headers of a `script_failed` envelope's ``diagnostics`` (#651). The
-# layout is fixed and both sections are ALWAYS emitted — an empty stream yields an
-# empty section rather than a missing one — so a consumer can split on the headers
-# without first discovering which streams the script happened to write to.
-SCRIPT_OUTPUT_STDOUT_HEADER = "--- script stdout ---"
-SCRIPT_OUTPUT_STDERR_HEADER = "--- script stderr ---"
-
-
-def _labelled_script_output(stdout: str, stderr: str) -> str:
-    """Both of the child's streams as one labelled ``diagnostics`` string (#651).
-
-    ``GdaError.diagnostics`` is a free-form ``str`` (ADR-0004), and for a failure
-    that IS the script's own — ``script_failed`` — the script's own output is the
-    diagnostic. A GDScript test runner reports through ``print()``, i.e. stdout, so
-    carrying stderr alone would hand a ``--strict`` CI caller a failure with no
-    content. Both streams are labelled rather than concatenated so the caller can
-    still tell which is which.
-    """
-    parts = []
-    for header, stream in (
-        (SCRIPT_OUTPUT_STDOUT_HEADER, stdout),
-        (SCRIPT_OUTPUT_STDERR_HEADER, stderr),
-    ):
-        # Keep each section's payload verbatim, only guaranteeing the newline that
-        # puts the next header on its own line.
-        body = stream if stream.endswith("\n") or not stream else stream + "\n"
-        parts.append(f"{header}\n{body}")
-    return "".join(parts)
-
-
 def script_exit_status_failure(
     script: str, exit_status: int, stdout: str, stderr: str
 ) -> Failure:
@@ -639,38 +744,6 @@ def script_exit_status_failure(
         f"script run --strict: {script} exited with status {exit_status}",
         _labelled_script_output(stdout, stderr),
     )
-
-
-# How much of each stream a gda-ENDED ``script run`` carries into its
-# ``diagnostics`` (#655). A run gda cut short can have produced arbitrarily much
-# output — a test suite that looped for two minutes — and ``diagnostics`` is
-# serialized inline in the JSON result, so it is bounded. The cap is FIXED rather
-# than an option: one more knob to reason about buys nothing an agent wants, and a
-# stated constant is something a caller can rely on. The TAIL is kept, not the
-# head: the interesting part of a run that did not finish is where it got to.
-#
-# The bound is in **UTF-8 bytes**, not characters, because bytes are what actually
-# costs: a character cap of the same number let non-ASCII output through at up to
-# 3-4x the intended size (16Ki CJK characters encode to ~48KiB), so a bound meant to
-# keep a result payload small silently did not. Bytes also make the stated figure
-# mean one thing to a reader measuring the JSON.
-SCRIPT_OUTPUT_TAIL_CAP_BYTES = 16 * 1024
-
-
-def _tail(stream: str) -> str:
-    """The last :data:`SCRIPT_OUTPUT_TAIL_CAP_BYTES` UTF-8 bytes of a stream.
-
-    Slicing bytes can land inside a multi-byte sequence, so the decode uses
-    ``errors="ignore"`` to drop a leading partial character rather than emit a
-    replacement character for it: the truncation is gda's own doing, and inventing a
-    ``U+FFFD`` would misreport the engine's output as malformed. Only that boundary
-    is affected — anything genuinely malformed was already replaced when the capture
-    was decoded, and survives here as the replacement character it became.
-    """
-    encoded = stream.encode("utf-8")
-    if len(encoded) <= SCRIPT_OUTPUT_TAIL_CAP_BYTES:
-        return stream
-    return encoded[-SCRIPT_OUTPUT_TAIL_CAP_BYTES:].decode("utf-8", errors="ignore")
 
 
 def _ended_run_diagnostics(
@@ -734,7 +807,7 @@ def script_run_timeout_failure(
         f"script run: {script} did not return before the --timeout of {timeout}s "
         f"(elapsed {elapsed:.2f}s, termination phase '{phase}'). The captured "
         f"output is in diagnostics, truncated to the last "
-        f"{SCRIPT_OUTPUT_TAIL_CAP_BYTES} UTF-8 bytes (16 KiB) of each stream; raise "
+        f"{CAPTURED_OUTPUT_TAIL_CAP_BYTES} UTF-8 bytes (16 KiB) of each stream; raise "
         f"--timeout for a run that is merely slow, or declare "
         f"--completion-marker to end an aborted run early.",
         _ended_run_diagnostics("the timeout", script_errors, stdout, stderr),
@@ -793,7 +866,7 @@ def script_run_aborted_failure(
         f"should print progress during them, or run without a marker. "
         f"The --timeout of {timeout}s was not reached. The captured "
         f"output is in diagnostics, truncated to the last "
-        f"{SCRIPT_OUTPUT_TAIL_CAP_BYTES} UTF-8 bytes (16 KiB) of each stream; "
+        f"{CAPTURED_OUTPUT_TAIL_CAP_BYTES} UTF-8 bytes (16 KiB) of each stream; "
         f"termination phase '{phase}'.",
         _ended_run_diagnostics("the abort", script_errors, stdout, stderr),
     )

--- a/src/gda/export_runner.py
+++ b/src/gda/export_runner.py
@@ -93,10 +93,11 @@ class SubprocessExportRunner:
         if project is not None:
             args += ["--path", str(project)]
         args += [flag, preset, output_path]
-        # Pass the export-specific timeout label: on a timeout the primitive's
-        # stderr is carried into GdaError.diagnostics and serialized in
-        # `export run --json`, so it is part of the public error envelope and must
-        # stay byte-compatible with the pre-#185 "Godot export timed out" wording.
+        # Pass the export-specific timeout label: it rides a timed-out result as
+        # part of its `TimeoutBound` and names this channel in the public
+        # `launch_timeout` message that `export run --json` serializes (#714, which
+        # replaced the synthesized "Godot export timed out" stderr this label used
+        # to compose with the export's own captured output).
         return launch(
             self.binary,
             args,

--- a/src/gda/runner.py
+++ b/src/gda/runner.py
@@ -34,6 +34,13 @@ OPERATIONS_GD = Path(__file__).parent / "ops" / "operations.gd"
 # the CLI fails loudly instead of blocking forever.
 DEFAULT_TIMEOUT_SECONDS = 60.0
 
+# How a timeout NAMES the launch it ended. Each channel passes its own
+# (``"Godot export"``, ``"Godot import"``, …); the sentinel channel keeps the bare
+# engine name it has always reported. It rides the result as part of
+# :class:`TimeoutBound` and is rendered by the shared ``launch_timeout``
+# classifier, so a caller still learns WHICH launch gave up (#185, #714).
+DEFAULT_TIMEOUT_LABEL = "Godot"
+
 # The environment variable naming a per-invocation user-data root, the env half of
 # the `--user-data-root` option (issue #653). Same flag > env precedence shape as
 # ``GDA_GODOT`` / ``GDA_PROJECT``.
@@ -58,13 +65,32 @@ class LaunchFailure(enum.Enum):
     USER_DATA_UNWRITABLE = "user_data_unwritable"
     # gda ended the run EARLY, before the timeout, because the watching channel's
     # own :class:`LaunchWatch` asked it to (issue #655). Reachable only for a
-    # caller that passes a ``watch``, which today is ``gda script run`` alone —
-    # and that channel classifies this value itself, because only it knows what
-    # its watch condition means. ``classify_launch_or_crash`` therefore does NOT
-    # map it: a shared classifier has no honest generic code for "the caller's
+    # caller that passes a POLICY ``watch``, which today is ``gda script run``
+    # alone — and that channel classifies this value itself, because only it knows
+    # what its watch condition means. ``classify_launch_or_crash`` therefore does
+    # NOT map it: a shared classifier has no honest generic code for "the caller's
     # own declared condition fired". A future watching channel must classify it
     # too rather than fall through to that shared prefix.
     ABORTED = "aborted"
+
+
+@dataclass(frozen=True)
+class TimeoutBound:
+    """The bound a synthesized ``TIMEOUT`` result was ended at (issue #714).
+
+    Set by :func:`launch` and by nothing else, because the primitive is the only
+    place that knows both halves — and it is the only thing that CROSSES the runner
+    seam: ``GodotRunner.run`` hands a channel's classifier a
+    :class:`RunResult` and nothing more, so a shared classifier cannot otherwise
+    learn which launch gave up, or after how long. Carrying the pair here is what
+    lets ONE ``launch_timeout`` branch report "Godot export … before the timeout of
+    600.0s" without every ``classify_run`` call site plumbing it (#714).
+    """
+
+    #: How this launch is NAMED in the failure — see :data:`DEFAULT_TIMEOUT_LABEL`.
+    label: str
+    #: The ceiling, in seconds, that the launch reached.
+    seconds: float
 
 
 @dataclass
@@ -79,12 +105,16 @@ class RunResult:
     # engine returning one; ``None`` means the exit_code is the engine's own
     # (issue #15).
     launch_failure: "LaunchFailure | None" = None
-    # The launch's wall clock, measured only on the STREAMING capture path (issue
-    # #655) — ``None`` under the buffered capture, which does not time itself. It is the
-    # datum that tells a merely-slow run from a hung one: a timeout at 121s of a
-    # 120s ceiling is a suite that outgrew its budget, while one that produced its
-    # last output at 2s is stuck.
+    # The launch's wall clock, measured on every launch (issue #655; every channel
+    # since #714). It is the datum that tells a merely-slow run from a hung one: a
+    # timeout at 121s of a 120s ceiling is a suite that outgrew its budget, while
+    # one that produced its last output at 2s is stuck. ``None`` only on a result
+    # the primitive did not measure — a launch refused before the spawn, or a
+    # hand-built result at a test seam.
     elapsed_seconds: float | None = None
+    # The ceiling this run reached, set only on a synthesized ``TIMEOUT`` result
+    # (issue #714) — see :class:`TimeoutBound`.
+    timeout_bound: "TimeoutBound | None" = None
 
 
 # The per-invocation user-data root the CLI resolved, or ``None`` for the engine
@@ -414,19 +444,13 @@ def _user_data_unwritable_stderr(
 
 
 class LaunchWatch(Protocol):
-    """A channel's incremental view of one streaming launch (issue #655).
+    """A channel's incremental POLICY over one launch (issue #655).
 
-    Passing a watch to :func:`launch` switches the primitive from BUFFERED capture
-    (``subprocess.run``, which discards everything the child wrote when the
-    timeout expires) to STREAMING capture, which changes three things about the
-    launch and nothing else:
-
-    - the child's stdout/stderr are read as they arrive, so **whatever the run
-      produced before gda ended it survives** into the ``RunResult`` — the
-      dogfooding defect this seam exists for (GDA-DF-012/GDA-DF-032: a 120s
-      timeout whose diagnostics held only the timeout message);
-    - the launch is timed, so ``RunResult.elapsed_seconds`` is populated;
-    - the watch can **end the run early**, before the timeout.
+    Every launch streams — the child's stdout/stderr are read as they arrive, so
+    whatever a run produced before gda ended it survives into the ``RunResult``,
+    and the launch is timed (#714 moved the last three channels across; see
+    :func:`launch`). A watch adds the one thing streaming alone cannot decide:
+    **ending a run early**, before the timeout.
 
     The primitive owns the MECHANISM (spawn, read, decode, deadline, terminate)
     and the watch owns the POLICY (what the output means, and when a run is not
@@ -435,6 +459,7 @@ class LaunchWatch(Protocol):
     completion marker did not" is ``script run``'s domain knowledge, not the
     channel-agnostic primitive's — and ADR-0031 rejected gda imposing any
     contract on a user-authored entry script, so only a caller can declare one.
+    A channel with no such rule passes no watch and gets :class:`_CaptureOnly`.
 
     :meth:`observe` is polled on a fixed cadence for the whole run, **including
     polls where no output arrived** (both arguments empty), so a policy keyed on
@@ -460,11 +485,28 @@ class LaunchWatch(Protocol):
         ...
 
 
-# How often the streaming path polls the child and its watch. It bounds the extra
-# latency an early abort or a timeout can carry (a poll may sleep through the
-# moment the condition became true), so it is small — but not so small that a
-# 120s run spends its time waking up: 0.05s is ~2400 polls over the default
-# ``script run`` ceiling.
+class _CaptureOnly:
+    """The watch of a channel that has no early-abort rule (issue #714).
+
+    Streaming is the only capture strategy, so a channel no longer opts into it —
+    it opts into a POLICY, and most channels have none. Observing without ever
+    ending a run is the honest default: gda cannot tell from outside a process
+    whether a quiet engine is stuck or working, and only a caller who declared what
+    finishing looks like (``script run``'s ``--completion-marker``) can. So the
+    ONLY bound for these channels is the caller's timeout, and what they get from
+    the loop is the capture and the clock.
+    """
+
+    def observe(self, *, stdout: str, stderr: str, elapsed: float) -> bool:
+        return False
+
+
+# How often the launch loop polls its watch. It bounds the extra latency an early
+# abort or a timeout can carry (a poll may wait through the moment the condition
+# became true), so it is small — but not so small that a 120s run spends its time
+# waking up: 0.05s is ~2400 polls over the default ``script run`` ceiling. It does
+# NOT bound how quickly a finished run is noticed: the wait ends the instant the
+# child exits (see :func:`_spawn_streamed`).
 _POLL_INTERVAL_SECONDS = 0.05
 
 # One read syscall's ceiling on the streaming path. The pipe is read with
@@ -501,8 +543,8 @@ class _StreamCapture:
     and decoding each chunk independently would turn a legitimate non-ASCII
     character into two replacement characters. Feeding one decoder across every
     chunk — and flushing it once at the end — yields exactly what decoding the
-    whole buffer at once yields, so the streaming path's text is identical to the
-    buffered strategy's for the same bytes.
+    whole buffer at once yields, so the text is identical to a whole-buffer decode
+    of the same bytes.
     """
 
     def __init__(self, pipe: IO[bytes]) -> None:
@@ -558,28 +600,31 @@ def launch(
     *,
     cwd: Path | None,
     timeout: float,
-    timeout_label: str = "Godot",
+    timeout_label: str = DEFAULT_TIMEOUT_LABEL,
     watch: Optional[LaunchWatch] = None,
 ) -> RunResult:
     """Spawn one ``godot --headless`` process and normalize its raw outcome.
 
     The single home of the headless-launch primitive: it builds
     ``[binary, --headless, *args]``, runs it with a timeout capturing raw
-    *bytes*, and returns a normalized :class:`RunResult`. Both Phase-1 channels
-    — the sentinel op-dispatch runner and the native-export runner — build only
-    their channel-specific argv tail (and the export-only ``cwd``) and delegate
+    *bytes*, and returns a normalized :class:`RunResult`. Every Phase-1 channel
+    — the sentinel op-dispatch runner, the native-export runner, the
+    ``resource import`` pass, ``script run`` and ``scene preflight`` — builds only
+    its channel-specific argv tail (and the export-only ``cwd``) and delegates
     the spawn/timeout/``OSError``/decode handling here, so a launch-handling fix
-    lands in one place rather than two copies (issue #185, ADR-0010).
+    lands in one place rather than five copies (issue #185, ADR-0010).
 
-    The mapping, identical for both channels:
+    The mapping, identical for every channel:
 
-    - ``subprocess.TimeoutExpired`` → a synthesized ``EXIT_TIMEOUT`` result
-      flagged ``LaunchFailure.TIMEOUT``: launched, but did not return before the
-      timeout (a hung engine bounded so the CLI fails loudly, #15). The diagnostic
-      names ``timeout_label`` (default ``"Godot"``; the export channel passes
-      ``"Godot export"``) — this stderr is carried into ``GdaError.diagnostics``
-      and serialized in ``--json``, so the per-channel wording is part of the
-      public error envelope and stays byte-compatible across the refactor (#185);
+    - the timeout reached → a synthesized ``EXIT_TIMEOUT`` result flagged
+      ``LaunchFailure.TIMEOUT``: launched, but did not return before the
+      timeout (a hung engine bounded so the CLI fails loudly, #15). Both streams
+      hold **what the run had already produced**, verbatim, and no gda prose: the
+      classifier composes the diagnostics from that capture, so mixing gda's own
+      sentence into the child's stderr would corrupt the very evidence the
+      streaming capture exists to preserve. What the run cannot say for itself —
+      which launch this was, and the ceiling it reached — rides the result as
+      :class:`TimeoutBound`, beside the measured ``elapsed_seconds`` (#714);
     - ``OSError`` → a synthesized ``EXIT_NOT_FOUND`` result flagged
       ``LaunchFailure.NOT_FOUND``: the configured binary could not be launched —
       ``FileNotFoundError`` (missing), ``PermissionError`` (a directory like
@@ -587,9 +632,8 @@ def launch(
       file), and any other ``OSError`` from ``exec`` are the one environment
       failure of there being no engine to run (#33). The synthesized typed
       reason lets the classifier key environment on it, not on the overloaded
-      exit code (#15). ``OSError`` does not subsume ``TimeoutExpired`` (a
-      ``SubprocessError``), so the timeout path above is preserved. The OS
-      message is kept as advisory stderr to disambiguate which mode occurred;
+      exit code (#15). The OS message is kept as advisory stderr to disambiguate
+      which mode occurred;
     - otherwise → the engine's own ``returncode`` with ``launch_failure=None``,
       and stdout/stderr decoded as UTF-8 with ``errors="replace"`` (see below).
 
@@ -603,27 +647,20 @@ def launch(
     because it is an engine option and the sentinel channel's tail ends in the
     ``--`` user-args separator.
 
-    **Two capture strategies, one mapping (issue #655).** ``watch`` selects how the
-    child's output is captured, and nothing else:
+    **One capture strategy (issue #714).** Every launch STREAMS: both pipes are
+    read as they arrive and the run is timed. #655 introduced streaming beside a
+    buffered ``subprocess.run`` capture that discarded the child's output at the
+    timeout, keeping the sentinel and export channels on the buffered one so their
+    published timeout envelopes stayed byte-identical while the mechanism was
+    proven. #714 moved those channels — and the ``resource import`` pass, the third
+    that shared the discard — across, which left the buffered strategy with no
+    caller at all; a second capture path nothing selects is a trap for the next
+    channel, not an option, so it is gone.
 
-    - ``None`` (the default, and what the sentinel and export channels pass) —
-      BUFFERED capture via ``subprocess.run``. A timeout DISCARDS whatever the
-      child wrote and synthesizes the ``gda: <label> timed out after <n>s``
-      diagnostic in its place, exactly as before.
-    - a :class:`LaunchWatch` (``gda script run``) — STREAMING capture. A timeout
-      PRESERVES the captured stdout/stderr verbatim and carries no gda prose in
-      either stream, because the watching channel composes its own diagnostics
-      from the capture; ``elapsed_seconds`` is populated; and the watch may end
-      the run early as ``LaunchFailure.ABORTED``.
-
-    Keeping the buffered strategy is deliberate rather than transitional debt: the
-    other two channels' timeout results are a published part of their error
-    envelopes, and this change had to leave them byte-identical. Moving them onto
-    the preserving path is the named follow-up the issue records, and it is a
-    one-line switch here — not a second mechanism to write. What is NOT duplicated
-    is the failure mapping: both strategies return through the same
-    :func:`_timeout_result` / :func:`_not_found_result`, so the timeout and
-    launch-failure taxonomy still has exactly one home.
+    ``watch`` is therefore POLICY, not strategy: a channel that can recognize a run
+    not worth waiting out passes one and may end the launch early as
+    ``LaunchFailure.ABORTED`` (``gda script run``, ADR-0031); a channel with no
+    such rule passes nothing and gets :class:`_CaptureOnly`.
     """
     try:
         root = resolve_user_data_root()
@@ -648,22 +685,14 @@ def launch(
         with user_data_placement(root) as placement:
             # Only the preparation above can raise UserDataUnwritable: the spawn
             # itself maps every OSError to the NOT_FOUND result below.
-            if watch is None:
-                return _spawn(
-                    binary,
-                    args,
-                    cwd=cwd,
-                    timeout=timeout,
-                    timeout_label=timeout_label,
-                    placement=placement,
-                )
             return _spawn_streamed(
                 binary,
                 args,
                 cwd=cwd,
                 timeout=timeout,
+                timeout_label=timeout_label,
                 placement=placement,
-                watch=watch,
+                watch=watch if watch is not None else _CaptureOnly(),
             )
     except UserDataUnwritable as exc:
         return RunResult(
@@ -674,81 +703,12 @@ def launch(
         )
 
 
-def _spawn(
-    binary: Path,
-    args: list[str],
-    *,
-    cwd: Path | None,
-    timeout: float,
-    timeout_label: str,
-    placement: UserDataPlacement,
-) -> RunResult:
-    """Run one prepared launch with BUFFERED capture — see :func:`launch`.
-
-    Reads both streams in one ``subprocess.run`` call, which is why a timeout here
-    has nothing left to report: the call discards what it buffered when it raises.
-    """
-    cmd = [str(binary), "--headless", "--log-file", str(placement.log_file), *args]
-    try:
-        # Capture raw bytes (no ``text=True``): Godot's ``JSON.stringify`` emits
-        # UTF-8, but ``text=True`` would decode with the host locale, which
-        # mojibakes or raises ``UnicodeDecodeError`` on a non-UTF-8 locale (e.g.
-        # Windows cp1252/cp936) for a non-ASCII node name or echoed path. We
-        # decode UTF-8 explicitly below so user content round-trips regardless of
-        # locale (issue #33).
-        proc = subprocess.run(
-            cmd,
-            capture_output=True,
-            timeout=timeout,
-            # Pass the working directory as a string (not a Path): the export
-            # channel resolves a relative output path against this CWD, and the
-            # spawn shape stays byte-identical to the pre-#185 ``str(project)``.
-            cwd=str(cwd) if cwd is not None else None,
-            # ``None`` (the common case) inherits gda's own environment; a full
-            # child environment is built only when ``--user-data-root`` overrides
-            # the platform variable Godot resolves ``user://`` from (#653).
-            env=placement.env,
-        )
-    except subprocess.TimeoutExpired:
-        return _timeout_result(timeout, timeout_label)
-    except OSError as exc:
-        return _not_found_result(binary, exc)
-    return RunResult(
-        # Decode the engine's bytes as UTF-8 with a replacement policy: a
-        # well-behaved operation emits valid UTF-8, so ``replace`` only ever
-        # fires on genuinely malformed bytes — and the runner never crashes on
-        # engine output. A malformed result then surfaces as a structured
-        # ``contract_violation`` downstream rather than an escaping
-        # ``UnicodeDecodeError`` traceback (ADR-0002).
-        stdout=proc.stdout.decode("utf-8", errors="replace"),
-        stderr=proc.stderr.decode("utf-8", errors="replace"),
-        exit_code=proc.returncode,
-    )
-
-
-def _timeout_result(timeout: float, timeout_label: str) -> RunResult:
-    """The synthesized result of a run that outlived the BUFFERED capture's timeout.
-
-    The output is gone — ``subprocess.run`` discards it when the timeout expires —
-    so the diagnostic stands in for it. That wording is carried into
-    ``GdaError.diagnostics`` and serialized in ``--json``, which makes it part of
-    the public error envelope of the sentinel and export channels; it is kept
-    byte-for-byte, and shared here, so no channel can drift from it (#185, #655).
-    """
-    return RunResult(
-        stdout="",
-        stderr=f"gda: {timeout_label} timed out after {timeout}s\n",
-        exit_code=EXIT_TIMEOUT,
-        launch_failure=LaunchFailure.TIMEOUT,
-    )
-
-
 def _not_found_result(binary: Path, exc: OSError) -> RunResult:
     """The synthesized result of a binary that could not be launched at all.
 
-    Shared by both capture strategies: an ``OSError`` from ``exec`` is the one
-    environment failure of there being no engine to run, whichever way gda was
-    going to read its output (#33, #655).
+    An ``OSError`` from ``exec`` is the one environment failure of there being no
+    engine to run; it is reported before any capture exists, so it is the same
+    result for every channel (#33).
     """
     return RunResult(
         stdout="",
@@ -764,19 +724,19 @@ def _spawn_streamed(
     *,
     cwd: Path | None,
     timeout: float,
+    timeout_label: str,
     placement: UserDataPlacement,
     watch: LaunchWatch,
 ) -> RunResult:
-    """Run one prepared launch with STREAMING capture — see :func:`launch` (#655).
+    """Run one prepared launch, reading both pipes as they arrive (#655, #714).
 
-    The same argv, cwd and child environment as :func:`_spawn`; only the reading
-    differs. Both pipes are drained on their own threads while this loop owns the
-    deadline and the watch, so:
+    Both pipes are drained on their own threads while this loop owns the deadline
+    and the watch, so:
 
     - a timeout returns the output the child had ALREADY produced, verbatim,
       instead of discarding it. This is the whole point: a script error that
-      aborted a run before its ``quit()`` had already been printed, and a
-      buffered capture threw it away (GDA-DF-012);
+      aborted a run before its ``quit()`` had already been printed, and the
+      buffered capture this replaced threw it away (GDA-DF-012);
     - the watch can end the run before the deadline, reported as
       ``LaunchFailure.ABORTED``;
     - the wall clock is measured either way, so a slow-but-live run is
@@ -791,13 +751,23 @@ def _spawn_streamed(
     cmd = [str(binary), "--headless", "--log-file", str(placement.log_file), *args]
     started = time.monotonic()
     try:
-        # Bytes, not ``text=True``, for the same locale reason as ``_spawn`` (#33);
-        # the decode happens in ``_StreamCapture``, incrementally.
+        # Capture raw bytes (no ``text=True``): Godot's ``JSON.stringify`` emits
+        # UTF-8, but ``text=True`` would decode with the host locale, which
+        # mojibakes or raises ``UnicodeDecodeError`` on a non-UTF-8 locale (e.g.
+        # Windows cp1252/cp936) for a non-ASCII node name or echoed path. The decode
+        # happens in ``_StreamCapture``, incrementally and explicitly as UTF-8, so
+        # user content round-trips regardless of locale (issue #33).
         proc = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            # Pass the working directory as a string (not a Path): the export
+            # channel resolves a relative output path against this CWD, and the
+            # spawn shape stays byte-identical to the pre-#185 ``str(project)``.
             cwd=str(cwd) if cwd is not None else None,
+            # ``None`` (the common case) inherits gda's own environment; a full
+            # child environment is built only when ``--user-data-root`` overrides
+            # the platform variable Godot resolves ``user://`` from (#653).
             env=placement.env,
         )
     except OSError as exc:
@@ -841,7 +811,17 @@ def _spawn_streamed(
                 break
             if elapsed >= timeout:
                 break
-            time.sleep(_POLL_INTERVAL_SECONDS)
+            # WAIT on the child rather than sleeping through the interval: this loop
+            # now runs on every gda invocation (#714), and a plain sleep would charge
+            # each one up to a poll interval of latency after its engine had already
+            # exited. ``wait`` returns the instant the child does, and otherwise
+            # keeps exactly the cadence the watch is promised. It cannot deadlock on
+            # a full pipe — the documented hazard for ``wait`` with ``PIPE`` — because
+            # the reader threads are what drain those pipes, not this loop.
+            try:
+                proc.wait(timeout=_POLL_INTERVAL_SECONDS)
+            except subprocess.TimeoutExpired:
+                pass
         else:
             # The loop ended because the child exited on its own, so the wall clock
             # is that exit — not the stale value from the last poll.
@@ -855,14 +835,14 @@ def _spawn_streamed(
         # The WHOLE teardown lives here, so it runs on every exit from the loop
         # above — including one by exception. A streaming launch must never outlive
         # its gda process, and the guarantee cannot be left on the happy path: the
-        # runs this strategy exists for are exactly the ones that do NOT stop on
+        # runs this loop exists for are exactly the ones that do NOT stop on
         # their own, so an orphaned engine idles forever and repeated interruptions
-        # accumulate engines contending over ``user://``. The buffered strategy gets
-        # this free (``subprocess.run`` kills its child when an exception leaves its
-        # ``with`` block), so this path owes the same.
+        # accumulate engines contending over ``user://``. (``subprocess.run`` used to
+        # give this free by killing its child when an exception left its ``with``
+        # block; owning the process means owning that guarantee too.)
         #
         # ``BaseException`` matters, not just ``Exception``: a Ctrl-C out of the poll
-        # sleep is a ``KeyboardInterrupt``, and when gda runs in its own process
+        # wait is a ``KeyboardInterrupt``, and when gda runs in its own process
         # group the signal never reaches the engine at all. A ``finally`` covers
         # both, and covers whatever a caller's ``watch`` raised.
         #
@@ -902,14 +882,18 @@ def _spawn_streamed(
     if ended_by_gda:
         return RunResult(
             # The CAPTURE, kept verbatim — no gda prose in either stream. The
-            # watching channel composes the timeout diagnostics from this, so
+            # classifying channel composes the timeout diagnostics from this, so
             # mixing gda's own sentence into the child's stderr would corrupt the
-            # very evidence the streaming path exists to preserve.
+            # very evidence the streaming capture exists to preserve.
             stdout=stdout,
             stderr=stderr,
             exit_code=EXIT_TIMEOUT,
             launch_failure=LaunchFailure.TIMEOUT,
             elapsed_seconds=elapsed,
+            # What the capture cannot say for itself, and the only way a shared
+            # classifier can learn it: which launch this was, and the ceiling it
+            # reached (#714).
+            timeout_bound=TimeoutBound(timeout_label, timeout),
         )
     return RunResult(
         stdout=stdout,
@@ -977,10 +961,11 @@ def sentinel_args(
 
     Two channels build this tail (#664): :class:`SubprocessGodotRunner`, the
     default sentinel runner, and ``scene preflight``, which dispatches the same
-    kind of op but needs :func:`launch`'s STREAMING capture — so it calls the
-    primitive itself rather than going through the runner seam. Extracting the
-    spelling keeps that second channel from re-deriving it, and keeps a change to
-    it (a new separator, another engine flag) landing in one place.
+    kind of op but calls :func:`launch` itself — it bifurcates on the launch's own
+    outcome (a timeout is its VERDICT, not an error) rather than handing the result
+    to a classifier through the runner seam. Extracting the spelling keeps that
+    second channel from re-deriving it, and keeps a change to it (a new separator,
+    another engine flag) landing in one place.
     """
     args: list[str] = []
     if project is not None:

--- a/tests/support.py
+++ b/tests/support.py
@@ -13,7 +13,9 @@ between modules or imported test-module-to-test-module (issue #39).
 
 import json
 import re
+import subprocess
 import sys
+import tempfile
 
 from gda.runner import RunResult
 
@@ -980,3 +982,79 @@ def assert_windowed_ok(result):
         handle_no_display_code(gda_error_code(result.stdout))
     assert result.returncode == 0, result.stdout + result.stderr
     return result
+
+
+class RecordingSpawn:
+    """A ``subprocess.Popen`` double: records the spawn and replays a canned run.
+
+    Every headless launch STREAMS (#714), so the primitive reads the child's pipes
+    by file descriptor rather than taking a buffer back from ``subprocess.run``. A
+    double therefore has to have a PROCESS's shape — readable descriptors, a poll
+    that answers, a wait that returns — and it is one double rather than one per
+    suite because what the suites are actually after is the same in all of them:
+    the argv gda built, the ``cwd`` it spawned in, and the child environment it
+    passed. The canned streams are backed by temp FILES, not a pipe, so a payload
+    is not bounded by the OS pipe buffer the way a self-written pipe would be.
+
+    ``alive`` makes the child one that never returns: ``poll`` answers ``None``
+    and ``wait`` times out until ``terminate`` — a hung engine, for a test that
+    wants the launch's own bound to end the run without spending a real one.
+    """
+
+    def __init__(
+        self,
+        payload: str = "",
+        stderr: str = "",
+        returncode: int = 0,
+        *,
+        alive: bool = False,
+    ) -> None:
+        self.cmd: list[str] | None = None
+        self.kwargs: dict | None = None
+        self.spawns = 0
+        self._stdout = payload.encode()
+        self._stderr = stderr.encode()
+        self._returncode = returncode
+        self._alive = alive
+
+    def __call__(self, cmd, **kwargs):
+        self.cmd = cmd
+        self.kwargs = kwargs
+        self.spawns += 1
+        return _CannedProcess(
+            self._stdout, self._stderr, self._returncode, alive=self._alive
+        )
+
+
+class _CannedProcess:
+    """The child :class:`RecordingSpawn` hands back — see its docstring."""
+
+    def __init__(
+        self, stdout: bytes, stderr: bytes, returncode: int, *, alive: bool
+    ) -> None:
+        self.stdout = _readable(stdout)
+        self.stderr = _readable(stderr)
+        self.returncode = returncode
+        self._alive = alive
+
+    def poll(self):
+        return None if self._alive else self.returncode
+
+    def wait(self, timeout: float | None = None):
+        if self._alive:
+            raise subprocess.TimeoutExpired(cmd="fake-engine", timeout=timeout or 0.0)
+        return self.returncode
+
+    def terminate(self) -> None:
+        self._alive = False
+
+    def kill(self) -> None:
+        self._alive = False
+
+
+def _readable(data: bytes):
+    """A real readable file descriptor holding ``data``, then EOF."""
+    handle = tempfile.TemporaryFile(buffering=0)
+    handle.write(data)
+    handle.seek(0)
+    return handle

--- a/tests/test_classify_export_run.py
+++ b/tests/test_classify_export_run.py
@@ -20,7 +20,7 @@ from gda.commands.export import (
 )
 from gda.errors import Failure, export_path_unset_failure
 from gda.exit_codes import EXIT_OPERATION
-from gda.runner import LaunchFailure, RunResult
+from gda.runner import LaunchFailure, RunResult, TimeoutBound
 
 BINARY = Path("/x/Godot")
 
@@ -98,25 +98,30 @@ def test_other_nonzero_maps_to_generic_export_failed():
     assert "disk full" in outcome.error.diagnostics
 
 
-def test_export_timeout_envelope_keeps_byte_compatible_diagnostics():
-    # Regression for the #185 review: an export timeout maps to launch_timeout,
-    # and the runner-synthesized stderr is carried verbatim into the PUBLIC
-    # GdaError.diagnostics — the field serialized in `export run --json`. The
-    # refactor must keep that diagnostics string byte-compatible with the pre-#185
-    # "Godot export timed out" wording, so the error envelope is unchanged.
-    timeout_stderr = "gda: Godot export timed out after 600.0s\n"
+def test_export_timeout_envelope_carries_the_exports_own_captured_output():
+    # An export timeout maps to launch_timeout through the SHARED prefix, and since
+    # #714 the envelope carries the export's own partial output instead of the
+    # runner-synthesized "gda: Godot export timed out after 600.0s" that stood in
+    # for it. This channel keeps nothing of its own here: the pin is that it goes
+    # through the shared branch and that the export's evidence survives into the
+    # PUBLIC GdaError the `export run --json` failure serializes.
     outcome = _classify(
         RunResult(
-            stdout="",
-            stderr=timeout_stderr,
+            stdout="[  90% ] packing pck\n",
+            stderr="ERROR: the platform toolchain never answered\n",
             exit_code=124,
             launch_failure=LaunchFailure.TIMEOUT,
+            elapsed_seconds=600.4,
+            timeout_bound=TimeoutBound("Godot export", 600.0),
         )
     )
 
     assert isinstance(outcome, Failure)
     assert outcome.error.code == "launch_timeout"
-    assert outcome.error.diagnostics == timeout_stderr
+    assert outcome.error.message.startswith("Godot export launched but did not return")
+    assert "timeout of 600.0s" in outcome.error.message
+    assert "packing pck" in outcome.error.diagnostics
+    assert "the platform toolchain never answered" in outcome.error.diagnostics
 
 
 def test_export_path_unset_failure_builder():

--- a/tests/test_classify_launch_or_crash.py
+++ b/tests/test_classify_launch_or_crash.py
@@ -1,12 +1,17 @@
-"""classify_launch_or_crash — the env/crash classifier prefix (issue #185).
+"""classify_launch_or_crash — the env/crash classifier prefix (issues #185, #714).
 
-Both headless channels open classification with the same env/crash prefix: a
+Every headless channel opens classification with the same env/crash prefix: a
 synthesized ``NOT_FOUND`` launch failure → ``binary_not_found``, a synthesized
 ``TIMEOUT`` → ``launch_timeout``, and a signal death (``exit < 0``) →
 ``engine_crashed``; anything else returns ``None`` so the caller's
 channel-specific tail takes over. That mapping used to be written (and asserted)
 twice — once in ``classify_run``, once in ``classify_export_run``. It now lives in
 one shared function, tested here once; each channel's suite keeps only its tail.
+
+The ``TIMEOUT`` arm is where being ONE function pays: the sentinel, export and
+import channels reach it through three different classifiers, so the evidence a
+hung run reports — its captured output, the ceiling it reached and the wall clock
+it spent — is asserted here once and holds for all three (#714).
 
 Environment failures key on the runner's typed ``launch_failure`` reason, not the
 exit code, so an engine (or wrapper) that *genuinely* exits 124/127 falls through
@@ -17,10 +22,14 @@ fall-through is asserted here, the operation classification in each channel suit
 
 from pathlib import Path
 
-from gda.errors import Failure, classify_launch_or_crash
+from gda.errors import (
+    CAPTURED_OUTPUT_TAIL_CAP_BYTES,
+    Failure,
+    classify_launch_or_crash,
+)
 from gda.exit_codes import EXIT_NOT_FOUND, EXIT_OPERATION, EXIT_TIMEOUT
 from gda.models import ErrorCategory
-from gda.runner import LaunchFailure, RunResult
+from gda.runner import LaunchFailure, RunResult, TimeoutBound
 
 BINARY = Path("/x/Godot")
 
@@ -47,7 +56,7 @@ def test_synthesized_not_found_maps_to_binary_not_found():
 def test_synthesized_timeout_maps_to_launch_timeout_distinct_from_not_found():
     result = RunResult(
         stdout="",
-        stderr="gda: Godot timed out after 60.0s\n",
+        stderr="",
         exit_code=EXIT_TIMEOUT,
         launch_failure=LaunchFailure.TIMEOUT,
     )
@@ -58,6 +67,85 @@ def test_synthesized_timeout_maps_to_launch_timeout_distinct_from_not_found():
     assert failure.exit_code == EXIT_TIMEOUT
     assert failure.error.category == ErrorCategory.ENVIRONMENT
     assert failure.error.code == "launch_timeout"
+
+
+def test_a_timeout_carries_the_captured_output_the_ceiling_and_the_clock():
+    # THE #714 acceptance criterion, asserted on the ONE branch all three buffered
+    # channels open with. Before it, a hung sentinel op / export / import pass came
+    # back with nothing but "gda: <label> timed out after <n>s": the engine's own
+    # output was discarded by the buffered capture, and the envelope reported
+    # neither how long the run had actually taken nor how far it got.
+    result = RunResult(
+        stdout="[  50% ] exporting resources\n",
+        stderr="ERROR: the exporter wedged\n",
+        exit_code=EXIT_TIMEOUT,
+        launch_failure=LaunchFailure.TIMEOUT,
+        elapsed_seconds=601.25,
+        timeout_bound=TimeoutBound("Godot export", 600.0),
+    )
+
+    failure = classify_launch_or_crash(result, BINARY)
+
+    assert isinstance(failure, Failure)
+    assert failure.error.code == "launch_timeout"
+    # WHICH launch gave up, the ceiling it reached, and the wall clock it spent —
+    # the three numbers that tell a merely-slow run from a stuck one.
+    assert failure.error.message.startswith("Godot export launched but did not return")
+    assert "timeout of 600.0s" in failure.error.message
+    assert "elapsed 601.25s" in failure.error.message
+    # The cap is STATED, so a caller knows the diagnostics are a tail and not all.
+    assert f"{CAPTURED_OUTPUT_TAIL_CAP_BYTES} UTF-8 bytes (16 KiB)" in (
+        failure.error.message
+    )
+    # And both streams are carried under fixed labels, so one split reads either.
+    assert failure.error.diagnostics == (
+        "--- captured stdout ---\n[  50% ] exporting resources\n"
+        "--- captured stderr ---\nERROR: the exporter wedged\n"
+    )
+
+
+def test_a_timeout_tail_caps_each_captured_stream():
+    # `diagnostics` is serialized inline in the JSON result, so a run that looped for
+    # ten minutes must not put ten minutes of output in an error envelope. The TAIL
+    # is what is kept: where the run got to is the interesting end.
+    result = RunResult(
+        stdout="x" * (CAPTURED_OUTPUT_TAIL_CAP_BYTES * 2) + "LAST LINE\n",
+        stderr="y" * (CAPTURED_OUTPUT_TAIL_CAP_BYTES * 2),
+        exit_code=EXIT_TIMEOUT,
+        launch_failure=LaunchFailure.TIMEOUT,
+        elapsed_seconds=60.0,
+        timeout_bound=TimeoutBound("Godot", 60.0),
+    )
+
+    failure = classify_launch_or_crash(result, BINARY)
+
+    assert isinstance(failure, Failure)
+    diagnostics = failure.error.diagnostics
+    assert "LAST LINE" in diagnostics
+    assert diagnostics.count("x") == CAPTURED_OUTPUT_TAIL_CAP_BYTES - len("LAST LINE\n")
+    assert diagnostics.count("y") == CAPTURED_OUTPUT_TAIL_CAP_BYTES
+
+
+def test_an_unmeasured_timeout_still_reports_rather_than_crashing():
+    # A hand-built RunResult at a test seam carries neither bound nor clock. The
+    # builder degrades to the bare sentence instead of asserting on a boundary
+    # value, which would kill the command (and vanish under -O).
+    failure = classify_launch_or_crash(
+        RunResult(
+            stdout="",
+            stderr="",
+            exit_code=EXIT_TIMEOUT,
+            launch_failure=LaunchFailure.TIMEOUT,
+        ),
+        BINARY,
+    )
+
+    assert isinstance(failure, Failure)
+    assert failure.error.code == "launch_timeout"
+    assert failure.error.message.startswith(
+        "Godot launched but did not return before the timeout."
+    )
+    assert "elapsed" not in failure.error.message
 
 
 def test_signal_death_maps_to_engine_crashed_naming_the_signal():

--- a/tests/test_e2e_launch_timeout.py
+++ b/tests/test_e2e_launch_timeout.py
@@ -1,0 +1,225 @@
+"""S (e2e): a hung REAL engine leaves evidence on every launch channel (#714).
+
+The defect this closes is one a fake cannot show. The buffered capture discarded
+whatever the child had written when the timeout expired, so a sentinel op, an
+export or an import pass that wedged came back with nothing but ``gda: <label>
+timed out after <n>s`` — no engine output, no wall clock. Whether the engine
+really does write before it wedges, whether that output survives gda's own
+terminate-then-kill teardown, and whether the run is bounded at all are facts
+about a real Godot process; a canned ``RunResult`` would assert only the can.
+
+So each arm here wedges a REAL engine and asserts the same three things per
+channel: the run is ended at its own ceiling, the envelope names that ceiling and
+the wall clock, and the engine's own output is in the diagnostics.
+
+Two levers wedge it, one per engine path:
+
+- a blocking **autoload** ``_init`` wedges the GAME path (the sentinel channel),
+  after the engine has printed its banner and the entry script has run;
+- a blocking **editor plugin** ``_enter_tree`` wedges the EDITOR path, which both
+  ``--import`` and ``--export-<mode>`` boot. An autoload cannot do it there: the
+  editor does not instantiate autoloads.
+
+Neither can be interrupted politely — a GDScript loop never returns to the main
+loop, so the engine cannot honour the SIGTERM gda sends first — which makes these
+arms cover the kill path too, and is why each spends its ceiling plus gda's
+terminate grace.
+
+The sentinel and export channels are driven through their runner objects rather
+than through the CLI: neither exposes a timeout flag (60s and 600s, fixed), so a
+CLI arm would have to spend a real minute or ten. ``resource import`` does expose
+``--timeout``, so its arm is the full CLI round trip.
+"""
+
+import json
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+from gda.commands.export import ExportRunMode, classify_export_run
+from gda.errors import Failure, classify_run
+from gda.export_runner import SubprocessExportRunner
+from gda.models import EngineVersion
+from gda.runner import SubprocessGodotRunner
+from tests.support import GDA_CMD
+
+GODOT = resolve_godot_binary()
+
+# The ceiling every arm gives its wedged engine. Long enough for a real Godot to
+# boot and print, short enough that three arms plus gda's terminate grace stay
+# well inside a test run.
+CEILING_SECONDS = 4.0
+
+# A blocking autoload: it announces itself on BOTH streams and then never returns.
+# `printerr` matters — gda's stdout carries the ADR-0002 result object, so the
+# stderr line is the one a channel forwards, while the stdout line proves the
+# capture is not stderr-only.
+BLOCKING_AUTOLOAD_GD = """\
+extends Node
+
+
+func _init() -> void:
+	print("AUTOLOAD REACHED")
+	printerr("AUTOLOAD WEDGED")
+	while true:
+		OS.delay_msec(50)
+"""
+
+# A blocking editor plugin: the same wedge for the editor paths (`--import`,
+# `--export-<mode>`), which is where an autoload never runs.
+BLOCKING_PLUGIN_GD = """\
+@tool
+extends EditorPlugin
+
+
+func _enter_tree() -> void:
+	print("PLUGIN REACHED")
+	printerr("PLUGIN WEDGED")
+	while true:
+		OS.delay_msec(50)
+"""
+
+PLUGIN_CFG = """\
+[plugin]
+
+name="wedge"
+description="blocks editor startup so a launch has to be ended by gda"
+author="gda tests"
+version="1.0"
+script="plugin.gd"
+"""
+
+
+def _wedged_project(tmp_path: Path, *, autoload: bool, plugin: bool) -> Path:
+    """A project whose engine startup never finishes on the requested path(s)."""
+    sections = [
+        "config_version=5\n\n[application]\n\n",
+        'config/name="t714"\n\n',
+        # The e2e file-logging policy (#180): no launch here writes a shared
+        # user://logs/godot.log, so concurrent runs cannot contend over it.
+        "[debug]\n\nfile_logging/enable_file_logging=false\n"
+        "file_logging/enable_file_logging.pc=false\n\n",
+    ]
+    if autoload:
+        (tmp_path / "wedge.gd").write_text(BLOCKING_AUTOLOAD_GD, encoding="utf-8")
+        sections.append('[autoload]\n\nWedge="*res://wedge.gd"\n\n')
+    if plugin:
+        addon = tmp_path / "addons" / "wedge"
+        addon.mkdir(parents=True)
+        (addon / "plugin.gd").write_text(BLOCKING_PLUGIN_GD, encoding="utf-8")
+        (addon / "plugin.cfg").write_text(PLUGIN_CFG, encoding="utf-8")
+        sections.append(
+            "[editor_plugins]\n\n"
+            'enabled=PackedStringArray("res://addons/wedge/plugin.cfg")\n'
+        )
+    (tmp_path / "project.godot").write_text("".join(sections), encoding="utf-8")
+    return tmp_path
+
+
+def _assert_bounded(elapsed: float) -> None:
+    """The run was ended by gda's ceiling, not by the engine and not by luck."""
+    assert elapsed >= CEILING_SECONDS, f"the run ended early, at {elapsed:.1f}s"
+    # The ceiling plus gda's terminate-then-kill grace, generously. A wedged
+    # GDScript loop ignores the SIGTERM, so the grace is always spent in full.
+    assert elapsed < CEILING_SECONDS + 20, f"the run overran its bound: {elapsed:.1f}s"
+
+
+def _assert_timeout_envelope(
+    failure: Failure, label: str, *, expect: list[str]
+) -> None:
+    error = failure.error
+    assert error.code == "launch_timeout", error
+    assert error.category.value == "environment"
+    assert error.message.startswith(f"{label} launched but did not return")
+    assert f"timeout of {CEILING_SECONDS}s" in error.message
+    assert "elapsed 4." in error.message, error.message
+    assert "16384 UTF-8 bytes (16 KiB)" in error.message
+    for expected in expect:
+        assert expected in error.diagnostics, error.diagnostics
+
+
+@pytest.mark.e2e
+def test_a_wedged_sentinel_op_reports_what_the_engine_printed(tmp_path):
+    project = _wedged_project(tmp_path, autoload=True, plugin=False)
+    runner = SubprocessGodotRunner(GODOT, project=project, timeout=CEILING_SECONDS)
+
+    started = time.monotonic()
+    raw = runner.run("info", {})
+    elapsed = time.monotonic() - started
+
+    _assert_bounded(elapsed)
+    outcome = classify_run(raw, GODOT, EngineVersion)
+    assert isinstance(outcome, Failure)
+    _assert_timeout_envelope(
+        outcome,
+        "Godot",
+        # Both streams, and both from the engine itself: the banner it printed on
+        # its own, and the autoload's two lines from before it stopped returning.
+        expect=["Godot Engine v", "AUTOLOAD REACHED", "AUTOLOAD WEDGED"],
+    )
+
+
+@pytest.mark.e2e
+def test_a_wedged_export_reports_what_the_engine_printed(tmp_path):
+    project = _wedged_project(tmp_path, autoload=False, plugin=True)
+    runner = SubprocessExportRunner(GODOT, project=project, timeout=CEILING_SECONDS)
+
+    started = time.monotonic()
+    raw = runner.run("Linux/X11", "release", "build/game.x86_64")
+    elapsed = time.monotonic() - started
+
+    _assert_bounded(elapsed)
+    outcome = classify_export_run(
+        raw,
+        GODOT,
+        preset="Linux/X11",
+        platform="Linux/X11",
+        mode=ExportRunMode.RELEASE,
+        output_path="build/game.x86_64",
+        created_dirs=[],
+    )
+    assert isinstance(outcome, Failure)
+    _assert_timeout_envelope(
+        outcome, "Godot export", expect=["PLUGIN REACHED", "PLUGIN WEDGED"]
+    )
+
+
+@pytest.mark.e2e
+def test_a_wedged_import_pass_reports_what_the_engine_printed(tmp_path):
+    # The full CLI round trip, which this channel can afford: `resource import`
+    # exposes --timeout, so the ceiling is the test's to choose.
+    project = _wedged_project(tmp_path, autoload=False, plugin=True)
+    # An asset with no sidecar, so the pass is needed and really runs.
+    (project / "icon.png").write_bytes(b"\x89PNG not really an image")
+
+    started = time.monotonic()
+    run = subprocess.run(
+        [
+            *GDA_CMD,
+            "resource",
+            "import",
+            "res://icon.png",
+            "--timeout",
+            str(CEILING_SECONDS),
+            "--project",
+            str(project),
+            "--godot",
+            str(GODOT),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    elapsed = time.monotonic() - started
+
+    _assert_bounded(elapsed)
+    assert run.returncode == 124, run.stdout + run.stderr
+    error = json.loads(run.stdout)["error"]
+    assert error["code"] == "launch_timeout"
+    assert error["message"].startswith("Godot import launched but did not return")
+    assert f"timeout of {CEILING_SECONDS}s" in error["message"]
+    assert "elapsed 4." in error["message"]
+    assert "PLUGIN WEDGED" in error["diagnostics"]

--- a/tests/test_export_runner.py
+++ b/tests/test_export_runner.py
@@ -20,35 +20,15 @@ from pathlib import Path
 
 import gda.runner as runner_mod
 from gda.export_runner import SubprocessExportRunner
-
-
-class _RecordingRun:
-    """A ``subprocess.run`` double recording the call and returning a clean exit."""
-
-    def __init__(self) -> None:
-        self.cmd: list[str] | None = None
-        self.kwargs: dict | None = None
-
-    def __call__(self, cmd, **kwargs):
-        self.cmd = cmd
-        self.kwargs = kwargs
-
-        class _Proc:
-            # The primitive captures bytes (no text=True) and decodes UTF-8
-            # itself, so the double mirrors that real subprocess contract (#33).
-            stdout = b""
-            stderr = b""
-            returncode = 0
-
-        return _Proc()
+from tests.support import RecordingSpawn
 
 
 def test_export_runs_with_project_as_cwd(monkeypatch):
     # The configured export_path is relative and Godot resolves a relative output
     # path against its CWD, so the runner must spawn Godot with cwd = the project
     # for the artifact to land inside the project (the #121 acceptance behavior).
-    rec = _RecordingRun()
-    monkeypatch.setattr(runner_mod.subprocess, "run", rec)
+    rec = RecordingSpawn()
+    monkeypatch.setattr(runner_mod.subprocess, "Popen", rec)
     project = Path("/tmp/proj")
 
     runner = SubprocessExportRunner(Path("/x/Godot"), project=project)
@@ -74,8 +54,8 @@ def test_relative_project_is_absolutized_so_cwd_and_path_agree(monkeypatch):
     # empty export_failed. The runner must absolutize the project so --path and
     # cwd name the SAME absolute directory (reaching the resolution an absolute
     # --project reaches).
-    rec = _RecordingRun()
-    monkeypatch.setattr(runner_mod.subprocess, "run", rec)
+    rec = RecordingSpawn()
+    monkeypatch.setattr(runner_mod.subprocess, "Popen", rec)
     relative = Path("relproj")
     expected = str(relative.absolute())
 
@@ -103,8 +83,8 @@ def test_relative_and_absolute_project_reach_the_same_resolution(monkeypatch, tm
     abs_project.mkdir()
 
     def _spawn(project: Path) -> tuple[list[str], dict]:
-        rec = _RecordingRun()
-        monkeypatch.setattr(runner_mod.subprocess, "run", rec)
+        rec = RecordingSpawn()
+        monkeypatch.setattr(runner_mod.subprocess, "Popen", rec)
         SubprocessExportRunner(Path("/x/Godot"), project=project).run(
             "Linux/X11", "release", "build/game.x86_64"
         )
@@ -123,8 +103,8 @@ def test_relative_and_absolute_project_reach_the_same_resolution(monkeypatch, tm
 def test_export_without_project_passes_no_cwd(monkeypatch):
     # Projectless runs (no resolved project) spawn with the default cwd — there is
     # no project root to resolve a relative path against.
-    rec = _RecordingRun()
-    monkeypatch.setattr(runner_mod.subprocess, "run", rec)
+    rec = RecordingSpawn()
+    monkeypatch.setattr(runner_mod.subprocess, "Popen", rec)
 
     runner = SubprocessExportRunner(Path("/x/Godot"), project=None)
     runner.run("Linux/X11", "release", "/abs/out.x86_64")
@@ -152,25 +132,30 @@ def test_export_launch_failure_surfaces_through_the_typed_run_adapter(tmp_path):
     assert result.launch_failure is LaunchFailure.NOT_FOUND
 
 
-def test_export_timeout_keeps_the_export_worded_diagnostic(monkeypatch):
+def test_export_timeout_names_the_export_channel_and_its_ceiling(monkeypatch):
     # The export channel passes timeout_label="Godot export" to the shared
-    # primitive so its timeout stderr stays byte-compatible with the pre-#185
-    # wording. This stderr is what the classifier carries into the public
-    # GdaError.diagnostics, so the wording is part of `export run --json` (#185
-    # review). The shared launch handling itself is tested in test_launch.py.
-    import subprocess
-
+    # primitive. Since #714 that label no longer composes a synthesized stderr —
+    # the streams carry the export's own captured output — so it rides the result
+    # as its TimeoutBound, together with the ceiling. Both reach the public
+    # `launch_timeout` message of `export run --json` through the shared
+    # classifier, which is why this channel still declares a label at all. The
+    # shared launch handling itself is tested in test_launch.py.
     from gda.exit_codes import EXIT_TIMEOUT
     from gda.runner import LaunchFailure
 
-    def fake_run(*args, **kwargs):
-        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
+    monkeypatch.setattr(
+        runner_mod.subprocess,
+        "Popen",
+        RecordingSpawn(stderr="ERROR: export step wedged\n", alive=True),
+    )
 
-    monkeypatch.setattr(runner_mod.subprocess, "run", fake_run)
-
-    runner = SubprocessExportRunner(Path("/x/Godot"), timeout=600.0)
+    runner = SubprocessExportRunner(Path("/x/Godot"), timeout=0.05)
     result = runner.run("Linux/X11", "release", "out.x86_64")
 
     assert result.exit_code == EXIT_TIMEOUT
-    assert result.stderr == "gda: Godot export timed out after 600.0s\n"
     assert result.launch_failure is LaunchFailure.TIMEOUT
+    assert result.timeout_bound is not None
+    assert result.timeout_bound.label == "Godot export"
+    assert result.timeout_bound.seconds == 0.05
+    # And the export's own output survived the bound, in place of the discard.
+    assert result.stderr == "ERROR: export step wedged\n"

--- a/tests/test_info_errors.py
+++ b/tests/test_info_errors.py
@@ -13,7 +13,7 @@ import json
 from typer.testing import CliRunner
 
 from gda.cli import app
-from gda.runner import LaunchFailure, RunResult
+from gda.runner import LaunchFailure, RunResult, TimeoutBound
 from tests.support import inject_runner as _inject
 from tests.support import raw_sentinel, sentinel
 
@@ -42,16 +42,20 @@ def test_binary_not_found_maps_to_environment_error(monkeypatch):
 
 
 def test_launch_timeout_maps_to_environment_error_distinct_from_not_found(monkeypatch):
-    # A launched-but-hung engine is bounded by the runner's timeout: exit 124
-    # with a timeout diagnostic (#2). It is still an environment failure but
-    # must be distinguishable from binary-not-found.
+    # A launched-but-hung engine is bounded by the runner's timeout: exit 124 (#2).
+    # It is still an environment failure but must be distinguishable from
+    # binary-not-found. Since #714 the sentinel channel's own partial capture is
+    # what the run left behind, so that is what reaches both stderr (forwarded, as
+    # on any run) and the envelope's diagnostics.
     _inject(
         monkeypatch,
         RunResult(
             stdout="",
-            stderr="gda: Godot timed out after 60.0s\n",
+            stderr="Godot Engine v4.6.stable\n",
             exit_code=124,
             launch_failure=LaunchFailure.TIMEOUT,
+            elapsed_seconds=60.1,
+            timeout_bound=TimeoutBound("Godot", 60.0),
         ),
     )
 
@@ -62,7 +66,9 @@ def test_launch_timeout_maps_to_environment_error_distinct_from_not_found(monkey
     assert err["category"] == "environment"
     # Distinguishable from the binary-not-found case via a distinct code.
     assert err["code"] == "launch_timeout"
-    assert "timed out" in result.stderr
+    assert "did not return before the timeout of 60.0s" in err["message"]
+    assert "Godot Engine v4.6.stable" in err["diagnostics"]
+    assert "Godot Engine v4.6.stable" in result.stderr
 
 
 def test_operation_failure_maps_to_operation_error_distinct_from_environment(

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -1,13 +1,19 @@
 """The headless-launch primitive maps subprocess failures to a RunResult (#185).
 
 ``launch`` is the single home of the spawn / timeout / ``OSError`` / UTF-8-decode
-handling that both Phase-1 channels (the sentinel op runner and the native-export
-runner) delegate to. A hung or missing engine must not surface as a raw Python
-traceback; it is turned into a synthesized non-zero-exit :class:`RunResult` with a
-typed ``launch_failure`` and a diagnostic on stderr — the launch-handling contract
-that used to be written (and tested) twice, now exercised once here. The
-channel-specific argv tail / export-only cwd stay tested in each runner's own
-suite.
+handling that every Phase-1 channel (the sentinel op runner, the native-export
+runner, the ``resource import`` pass, ``script run`` and ``scene preflight``)
+delegates to. A hung or missing engine must not surface as a raw Python traceback;
+it is turned into a synthesized non-zero-exit :class:`RunResult` with a typed
+``launch_failure`` — the launch-handling contract that used to be written (and
+tested) twice, now exercised once here. The channel-specific argv tail /
+export-only cwd stay tested in each runner's own suite.
+
+Since #714 there is ONE capture strategy: every launch streams. These tests drive
+REAL child processes — a small stand-in script in place of the engine — rather
+than a fake ``Popen``, because what the capture is about is what real pipes and a
+real process lifetime do. (``tests.support.RecordingSpawn`` exists for the suites
+whose subject is the SPAWN SHAPE rather than the capture.)
 """
 
 import shlex
@@ -21,7 +27,7 @@ import pytest
 
 from gda import runner
 from gda.exit_codes import EXIT_NOT_FOUND, EXIT_TIMEOUT
-from gda.runner import LaunchFailure, launch
+from gda.runner import LaunchFailure, TimeoutBound, launch
 
 
 def test_missing_binary_maps_to_not_found_not_traceback():
@@ -62,174 +68,11 @@ def test_non_executable_file_binary_maps_to_not_found_not_traceback(tmp_path):
     assert result.launch_failure is LaunchFailure.NOT_FOUND
 
 
-def test_timeout_maps_to_synthesized_timeout_result(monkeypatch):
-    def fake_run(*args, **kwargs):
-        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-
-    result = launch(Path("/any/Godot"), ["--version"], cwd=None, timeout=0.01)
-
-    assert result.exit_code == EXIT_TIMEOUT
-    # Default label is "Godot": the sentinel channel keeps its exact pre-#185
-    # timeout diagnostic wording.
-    assert result.stderr == "gda: Godot timed out after 0.01s\n"
-    assert result.launch_failure is LaunchFailure.TIMEOUT
-
-
-def test_timeout_label_customizes_the_diagnostic(monkeypatch):
-    # The export channel passes a distinct label so its timeout diagnostic stays
-    # byte-compatible with the pre-#185 "Godot export timed out" wording — the
-    # stderr the classifier carries into the public GdaError.diagnostics (#185).
-    def fake_run(*args, **kwargs):
-        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-
-    result = launch(
-        Path("/any/Godot"),
-        ["--export-release", "Web", "out"],
-        cwd=None,
-        timeout=600.0,
-        timeout_label="Godot export",
-    )
-
-    assert result.exit_code == EXIT_TIMEOUT
-    assert result.stderr == "gda: Godot export timed out after 600.0s\n"
-    assert result.launch_failure is LaunchFailure.TIMEOUT
-
-
-def test_timeout_is_passed_through_to_subprocess(monkeypatch):
-    captured = {}
-
-    def fake_run(cmd, **kwargs):
-        captured["timeout"] = kwargs.get("timeout")
-
-        class _Proc:
-            # The primitive captures bytes (no text=True) and decodes UTF-8
-            # itself, so the double mirrors that real subprocess contract (#33).
-            stdout = b""
-            stderr = b""
-            returncode = 0
-
-        return _Proc()
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-
-    result = launch(Path("/any/Godot"), ["--version"], cwd=None, timeout=42.0)
-
-    assert captured["timeout"] == 42.0
-    # An engine that actually returned has no synthesized launch failure, so its
-    # exit code is classified as the engine's own result (#15).
-    assert result.launch_failure is None
-
-
-def test_builds_headless_argv_from_binary_and_tail(monkeypatch):
-    captured = {}
-
-    def fake_run(cmd, **kwargs):
-        captured["cmd"] = cmd
-
-        class _Proc:
-            stdout = b""
-            stderr = b""
-            returncode = 0
-
-        return _Proc()
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-
-    launch(Path("/x/Godot"), ["--path", "/p", "--version"], cwd=None, timeout=60.0)
-
-    # The primitive always prepends `[binary, --headless, --log-file <gda path>]`
-    # to the caller's tail: gda owns the engine log target on every launch (#653).
-    assert captured["cmd"][:3] == ["/x/Godot", "--headless", "--log-file"]
-    assert captured["cmd"][4:] == ["--path", "/p", "--version"]
-
-
-def test_engine_output_is_decoded_as_utf8_regardless_of_host_locale(monkeypatch):
-    # Godot's JSON.stringify emits raw UTF-8, but subprocess(text=True) would
-    # decode with the host locale. On a non-UTF-8 locale a non-ASCII node name
-    # mojibakes or raises UnicodeDecodeError. The primitive must capture bytes and
-    # decode UTF-8 explicitly so user content round-trips (#33). We prove this by
-    # returning raw UTF-8 *bytes* from subprocess (the bytes mode the fix uses).
-    payload = '<<<GDA:RESULT>>>{"name":"日本語"}<<<GDA:END>>>'
-    stdout_bytes = payload.encode("utf-8")
-    stderr_bytes = "警告: ノード名\n".encode("utf-8")
-
-    def fake_run(cmd, **kwargs):
-        # The fix drops text=True and captures bytes; assert that contract here
-        # so the test fails loudly if decoding silently reverts to locale text.
-        assert kwargs.get("text") in (None, False)
-
-        class _Proc:
-            stdout = stdout_bytes
-            stderr = stderr_bytes
-            returncode = 0
-
-        return _Proc()
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-
-    result = launch(Path("/any/Godot"), ["--version"], cwd=None, timeout=60.0)
-
-    assert "日本語" in result.stdout
-    assert "警告: ノード名" in result.stderr
-
-
-def test_cwd_is_passed_through_to_subprocess_as_a_string(monkeypatch, tmp_path):
-    # The export channel relies on cwd to resolve a relative output path; the
-    # primitive must forward it (as a string, the historical spawn shape).
-    captured = {}
-
-    def fake_run(cmd, **kwargs):
-        captured["cwd"] = kwargs.get("cwd")
-
-        class _Proc:
-            stdout = b""
-            stderr = b""
-            returncode = 0
-
-        return _Proc()
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-
-    launch(Path("/x/Godot"), ["--version"], cwd=tmp_path, timeout=60.0)
-
-    assert captured["cwd"] == str(tmp_path)
-
-
-def test_cwd_none_passes_no_working_directory(monkeypatch):
-    captured = {}
-
-    def fake_run(cmd, **kwargs):
-        captured["cwd"] = kwargs.get("cwd")
-
-        class _Proc:
-            stdout = b""
-            stderr = b""
-            returncode = 0
-
-        return _Proc()
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-
-    launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
-
-    assert captured["cwd"] is None
-
-
-# --- The STREAMING capture path (#655). Selected by passing a ``watch``; without one
-# the BUFFERED behaviour asserted above is unchanged, which the
-# ``test_the_buffered_path_still_*`` guard below pins for the sentinel and export
-# channels that rely on it.
-#
-# These drive a REAL child process — a small shebang script standing in for the
-# engine — rather than a fake ``Popen``. The whole point of the streaming path is
-# what real pipes and a real process lifetime do (a buffered capture threw away the
-# output that a real Godot had already written), so faking the spawn would only
-# assert the fake. The stand-in ignores the ``--headless --log-file <path>`` head
-# that ``launch`` injects, exactly as it ignores every other argv tail.
+# The stand-in engines every test below drives. A REAL child process, not a fake
+# ``Popen``: what the capture is about is what real pipes and a real process
+# lifetime do, so faking the spawn would only assert the fake. Both ignore the
+# ``--headless --log-file <path>`` head that ``launch`` injects, exactly as they
+# ignore every other argv tail.
 
 
 def _fake_engine(tmp_path: Path, body: str) -> Path:
@@ -251,15 +94,14 @@ def _fast_fake_engine(tmp_path: Path, stdout_line: str, stderr_line: str) -> Pat
     """A ``/bin/sh`` stand-in, kept for WALL-CLOCK SPEED, not correctness (#728).
 
     Diverges from ``_fake_engine`` on purpose: that one pays a fresh Python
-    interpreter's startup before it writes a byte. The one test that uses this
-    (``test_streaming_timeout_preserves_the_output_the_child_already_wrote``)
-    used to race that startup against a real deadline; that race is gone —
-    the test now controls the runner's clock directly, so a slower child could
-    no longer flip the result. ``/bin/sh`` stays anyway: the test still waits,
-    in real wall-clock time, for this REAL child to actually write its output
-    before the (now fake) deadline is allowed to cross, and a cheap shell keeps
-    that wait — and the suite — fast rather than paying a Python interpreter's
-    startup for no reason.
+    interpreter's startup before it writes a byte, which every test that races a
+    REAL deadline against the child's first output would then be racing too —
+    flaky on a loaded machine, at a ceiling short enough to keep the suite fast.
+    A cheap shell writes in milliseconds, so those tests get a wide margin without
+    a long ceiling. (``test_streaming_timeout_preserves_the_output_the_child_already_wrote``
+    additionally controls the runner's clock, and keeps this stand-in because it
+    still waits in real time for the child to write before letting the fake
+    deadline cross.)
 
     ``printf '%s\\n'``, not ``echo``: XSI ``echo`` interprets backslash
     escapes in its operand on this platform's ``/bin/sh``, so a payload
@@ -282,6 +124,114 @@ def _fast_fake_engine(tmp_path: Path, stdout_line: str, stderr_line: str) -> Pat
     )
     script.chmod(0o755)
     return script
+
+
+def test_timeout_synthesizes_a_result_that_keeps_what_the_run_produced(tmp_path):
+    # The bound gda puts on a hung engine, and the evidence it comes back with. The
+    # run below writes to both streams and then never returns; `launch` ends it at
+    # the ceiling and reports what it had already read — the whole of #714, which
+    # replaced a capture that discarded exactly this.
+    engine = _fast_fake_engine(tmp_path, "BOOTED", "wedged")
+
+    result = launch(engine, ["--version"], cwd=None, timeout=1.0)
+
+    assert result.exit_code == EXIT_TIMEOUT
+    assert result.launch_failure is LaunchFailure.TIMEOUT
+    assert result.stdout == "BOOTED\n"
+    assert result.stderr == "wedged\n"
+    # No gda prose in either stream: the classifier composes the sentence from the
+    # bound below, so mixing one in would corrupt the evidence.
+    assert "timed out" not in result.stderr
+    # The caller's own ceiling is what ended it, and the clock says so.
+    assert result.elapsed_seconds is not None
+    assert 1.0 <= result.elapsed_seconds < 3.0
+    # Default label: the sentinel channel's launch is just "Godot".
+    assert result.timeout_bound == TimeoutBound("Godot", 1.0)
+
+
+def test_the_timeout_bound_carries_the_channels_own_label(tmp_path):
+    # The export channel passes a distinct label, and the import pass another. The
+    # label rides the result rather than a synthesized stderr (#714), because the
+    # shared classifier is the only place that renders it and the runner seam hands
+    # that classifier a RunResult and nothing else.
+    engine = _fast_fake_engine(tmp_path, "packing", "")
+
+    result = launch(
+        engine,
+        ["--export-release", "Web", "out"],
+        cwd=None,
+        timeout=1.0,
+        timeout_label="Godot export",
+    )
+
+    assert result.launch_failure is LaunchFailure.TIMEOUT
+    assert result.timeout_bound == TimeoutBound("Godot export", 1.0)
+
+
+def test_builds_headless_argv_from_binary_and_tail(tmp_path):
+    # The stand-in echoes the argv it was handed, so the assertion is on the argv
+    # the OS really received rather than on a recorded call.
+    engine = _fake_engine(tmp_path, "print('\\x00'.join(sys.argv[1:]))\n")
+
+    result = launch(engine, ["--path", "/p", "--version"], cwd=None, timeout=30.0)
+
+    argv = result.stdout.rstrip("\n").split("\x00")
+    # The primitive always prepends `[--headless, --log-file <gda path>]` to the
+    # caller's tail: gda owns the engine log target on every launch (#653).
+    assert argv[:2] == ["--headless", "--log-file"]
+    assert argv[3:] == ["--path", "/p", "--version"]
+
+
+def test_engine_output_is_decoded_as_utf8_regardless_of_host_locale(tmp_path):
+    # Godot's JSON.stringify emits raw UTF-8, but decoding with the host locale
+    # would mojibake or raise UnicodeDecodeError on a non-UTF-8 locale for a
+    # non-ASCII node name or echoed path. The primitive captures BYTES and decodes
+    # UTF-8 explicitly, so user content round-trips (#33). The stand-in writes
+    # through the raw buffers so the bytes on the wire are the ones under test.
+    engine = _fake_engine(
+        tmp_path,
+        "sys.stdout.buffer.write("
+        '\'<<<GDA:RESULT>>>{"name":"\\u65e5\\u672c\\u8a9e"}<<<GDA:END>>>\''
+        ".encode('utf-8'))\n"
+        "sys.stderr.buffer.write("
+        "'\\u8b66\\u544a: \\u30ce\\u30fc\\u30c9\\u540d\\n'.encode('utf-8'))\n",
+    )
+
+    result = launch(engine, ["--version"], cwd=None, timeout=30.0)
+
+    assert "日本語" in result.stdout
+    assert "警告: ノード名" in result.stderr
+
+
+def test_cwd_is_passed_through_to_the_child(tmp_path):
+    # The export channel relies on cwd to resolve a relative output path, so the
+    # primitive must forward it — and the child must really start there.
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    engine = _fake_engine(tmp_path, "import os\nprint(os.getcwd())\n")
+
+    result = launch(engine, ["--version"], cwd=workdir, timeout=30.0)
+
+    assert Path(result.stdout.strip()).resolve() == workdir.resolve()
+
+
+def test_cwd_none_leaves_the_child_in_gdas_own_directory(tmp_path):
+    # Projectless launches pass no working directory, so the child simply inherits
+    # gda's — never a directory the primitive invented.
+    engine = _fake_engine(tmp_path, "import os\nprint(os.getcwd())\n")
+
+    result = launch(engine, ["--version"], cwd=None, timeout=30.0)
+
+    assert Path(result.stdout.strip()).resolve() == Path.cwd().resolve()
+
+
+# --- What a POLICY ``watch`` adds on top of the capture every launch gets (#655):
+# it can end a run BEFORE the timeout, and it is fed the output as it arrives. The
+# capture and the clock themselves are asserted above, on the no-watch launches
+# every other channel makes.
+#
+# The stand-in engine ignores the ``--headless --log-file <path>`` head that
+# ``launch`` injects, exactly as it ignores every other argv tail.
 
 
 class _RecordingWatch:
@@ -556,23 +506,25 @@ def test_streaming_maps_a_missing_binary_to_the_same_not_found_result():
     assert streamed.stderr == buffered.stderr
 
 
-def test_the_buffered_path_still_discards_output_and_keeps_its_diagnostic(tmp_path):
-    # The byte-identity guard for the sentinel and export channels (#655): they pass
-    # NO watch, so their timeout result must stay exactly what it was — the output
-    # discarded and the ``gda: <label> timed out after <n>s`` diagnostic standing in
-    # for it, which is published prose in their error envelopes. Moving them onto the
-    # preserving path is named follow-up work, not this change.
-    engine = _fake_engine(
-        tmp_path, "print('written but discarded', flush=True)\ntime.sleep(30)\n"
-    )
+def test_a_watchless_launch_streams_and_never_ends_a_run_early(tmp_path):
+    # The pairing that makes ``watch`` POLICY rather than strategy (#714): a launch
+    # WITHOUT one still captures and still times itself, and the only thing it gives
+    # up is the early abort. Both halves are asserted against the same engine, so a
+    # regression that made the no-watch path buffered again — or one that let it end
+    # a run on its own — fails here.
+    engine = _fast_fake_engine(tmp_path, "written and kept", "and this too")
 
+    started = time.monotonic()
     result = launch(engine, [], cwd=None, timeout=1.0, timeout_label="Godot export")
+    waited = time.monotonic() - started
 
     assert result.launch_failure is LaunchFailure.TIMEOUT
-    assert result.stdout == ""
-    assert result.stderr == "gda: Godot export timed out after 1.0s\n"
-    # And it does not time itself — the clock is the streaming path's addition.
-    assert result.elapsed_seconds is None
+    assert result.stdout == "written and kept\n"
+    assert result.stderr == "and this too\n"
+    assert result.elapsed_seconds is not None
+    assert result.timeout_bound == TimeoutBound("Godot export", 1.0)
+    # It waited out the ceiling rather than ending early on the output it saw.
+    assert waited >= 1.0
 
 
 def _capture_popen(monkeypatch) -> list:

--- a/tests/test_resource_import_commands.py
+++ b/tests/test_resource_import_commands.py
@@ -17,7 +17,7 @@ import pytest
 from typer.testing import CliRunner
 
 from gda.cli import app
-from gda.runner import LaunchFailure, RunResult
+from gda.runner import LaunchFailure, RunResult, TimeoutBound
 
 runner_cli = CliRunner()
 
@@ -269,15 +269,41 @@ def test_launch_failures_classify_through_the_shared_prefix(monkeypatch, tmp_pat
 
     def timed_out(binary, args, *, cwd, timeout, timeout_label="Godot", watch=None):
         return RunResult(
-            stdout="",
+            stdout="[  30% ] importing res://icon.png\n",
             stderr="took too long",
             exit_code=124,
             launch_failure=LaunchFailure.TIMEOUT,
+            elapsed_seconds=timeout + 0.2,
+            timeout_bound=TimeoutBound(timeout_label, timeout),
         )
 
     monkeypatch.setattr("gda.commands.resource.launch", timed_out)
     timed = json.loads(_run(project, "res://icon.png").stdout)
     assert timed["error"]["code"] == "launch_timeout"
+    # The THIRD buffered channel, on the shared branch with the other two (#714):
+    # its label, its ceiling and its own captured output, none of it forked here.
+    assert timed["error"]["message"].startswith("Godot import launched but did not")
+    assert "importing res://icon.png" in timed["error"]["diagnostics"]
+    assert "took too long" in timed["error"]["diagnostics"]
+
+
+def test_the_import_pass_declares_its_own_timeout_label(monkeypatch, tmp_path):
+    # The label is this channel's one contribution to the shared timeout envelope,
+    # and it is what tells an agent WHICH launch gave up when three of them report
+    # the same code. Pinned at the call site, because nothing else would notice it
+    # silently reverting to the sentinel channel's bare "Godot".
+    project = _project(tmp_path)
+    seen: dict[str, object] = {}
+
+    def recording(binary, args, *, cwd, timeout, timeout_label="Godot", watch=None):
+        seen["label"] = timeout_label
+        seen["timeout"] = timeout
+        return RunResult(stdout="", stderr="", exit_code=0)
+
+    monkeypatch.setattr("gda.commands.resource.launch", recording)
+    _run(project, "res://icon.png", "--timeout", "7")
+
+    assert seen == {"label": "Godot import", "timeout": 7.0}
 
     def engine_failed(binary, args, *, cwd, timeout, timeout_label="Godot", watch=None):
         return RunResult(stdout="", stderr="importer exploded", exit_code=1)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -14,35 +14,15 @@ from pathlib import Path
 
 from gda.exit_codes import EXIT_NOT_FOUND
 from gda.runner import OPERATIONS_GD, LaunchFailure, SubprocessGodotRunner
-
-
-class _RecordingRun:
-    """A ``subprocess.run`` double recording the call and returning a clean exit."""
-
-    def __init__(self) -> None:
-        self.cmd: list[str] | None = None
-        self.kwargs: dict | None = None
-
-    def __call__(self, cmd, **kwargs):
-        self.cmd = cmd
-        self.kwargs = kwargs
-
-        class _Proc:
-            # The primitive captures bytes (no text=True) and decodes UTF-8
-            # itself, so the double mirrors that real subprocess contract (#33).
-            stdout = b"<<<GDA:RESULT>>>{}<<<GDA:END>>>"
-            stderr = b""
-            returncode = 0
-
-        return _Proc()
+from tests.support import RecordingSpawn
 
 
 def test_projectless_run_builds_the_script_dispatch_tail(monkeypatch):
     # A projectless op spawns `--headless --script operations.gd -- <op> <json>`
     # with no --path and no working directory: everything after `--` reaches the
     # script verbatim via OS.get_cmdline_user_args().
-    rec = _RecordingRun()
-    monkeypatch.setattr(subprocess, "run", rec)
+    rec = RecordingSpawn("<<<GDA:RESULT>>>{}<<<GDA:END>>>")
+    monkeypatch.setattr(subprocess, "Popen", rec)
     runner = SubprocessGodotRunner(Path("/x/Godot"))
 
     runner.run("info", {"a": 1})
@@ -67,8 +47,8 @@ def test_projectless_run_builds_the_script_dispatch_tail(monkeypatch):
 def test_run_against_a_project_passes_path(monkeypatch):
     # When a project is resolved it is passed as --path so the engine runs against
     # it and res:// resolves there (#32); --path precedes the --script tail.
-    rec = _RecordingRun()
-    monkeypatch.setattr(subprocess, "run", rec)
+    rec = RecordingSpawn("<<<GDA:RESULT>>>{}<<<GDA:END>>>")
+    monkeypatch.setattr(subprocess, "Popen", rec)
     project = Path("/tmp/proj")
     runner = SubprocessGodotRunner(Path("/x/Godot"), project=project)
 

--- a/tests/test_scene_preflight_commands.py
+++ b/tests/test_scene_preflight_commands.py
@@ -67,15 +67,14 @@ def test_a_clean_start_is_ready_and_started(monkeypatch, tmp_path):
         "project_root": str(project.resolve()),
     }
     # The sentinel op was dispatched through the shared argv spelling, under the
-    # resolved project, with a watch (which is what selects the streaming capture).
-    (_binary, args, cwd, timeout, _label, watch) = calls[0]
+    # resolved project.
+    (_binary, args, cwd, timeout, _label, _watch) = calls[0]
     assert args[:2] == ["--path", str(project)]
     assert args[2] == "--script"
     assert args[4:6] == ["--", "scene-preflight"]
     assert json.loads(args[6])["path"] == "res://main.tscn"
     assert cwd is None
     assert timeout == pytest.approx(30.0)
-    assert watch is not None
 
 
 def test_a_script_error_during_startup_is_reported_though_the_scene_reached_ready(
@@ -358,23 +357,28 @@ def test_a_timeout_outranks_a_sentinel_that_arrived_before_it(monkeypatch, tmp_p
     assert json.loads(result.stdout)["status"] == "timeout"
 
 
-def test_the_watch_never_ends_a_run_which_is_what_keeps_aborted_unreachable():
-    # gda.runner documents that a watching channel must classify LaunchFailure.ABORTED
-    # itself, because the shared prefix has no honest code for "the caller's own
-    # declared condition fired". This channel declares no such condition — it takes a
-    # watch ONLY to select the streaming capture — so ABORTED is unreachable here.
-    # That invariant lives in one method, and this is what pins it: a policy added to
-    # `observe` later fails this test rather than silently degrading an abort into a
-    # contract_violation.
-    from gda.commands.scene import _CaptureOnlyWatch
+def test_this_channel_declares_no_watch_which_is_what_keeps_aborted_unreachable(
+    monkeypatch, tmp_path
+):
+    # gda.runner documents that a WATCHING channel must classify
+    # LaunchFailure.ABORTED itself, because the shared prefix has no honest code for
+    # "the caller's own declared condition fired". This channel declares no such
+    # condition — a scene that prints an error is very often still coming up, and
+    # nobody declares what a booting scene finishing looks like — so it passes no
+    # watch, and ABORTED is unreachable here. The invariant is an argument the launch
+    # does NOT get: adding a policy watch later fails this test rather than silently
+    # degrading an abort into a contract_violation.
+    project = _project(tmp_path)
+    calls = _patch_launch(monkeypatch, RunResult(stdout=READY, stderr="", exit_code=0))
 
-    watch = _CaptureOnlyWatch()
-
-    assert (
-        watch.observe(stdout="anything", stderr="ERROR: everything", elapsed=999.0)
-        is False
+    result = CliRunner().invoke(
+        app,
+        ["scene", "preflight", "res://main.tscn", "--project", str(project), "--json"],
     )
-    assert watch.observe(stdout="", stderr="", elapsed=0.0) is False
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    (*_head, watch) = calls[0]
+    assert watch is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_script_run_operation.py
+++ b/tests/test_script_run_operation.py
@@ -48,7 +48,7 @@ from gda.commands.script import (  # the single fully-bound descriptor (ADR-0023
 from gda.errors import (
     SCRIPT_OUTPUT_STDERR_HEADER,
     SCRIPT_OUTPUT_STDOUT_HEADER,
-    SCRIPT_OUTPUT_TAIL_CAP_BYTES,
+    CAPTURED_OUTPUT_TAIL_CAP_BYTES,
     Failure,
 )
 from gda.execution import ExecutionKind
@@ -820,7 +820,7 @@ def test_a_timeout_reflects_the_timeout_elapsed_and_phase_in_the_message():
     assert "elapsed 30.25s" in outcome.error.message
     assert TerminationPhase.OUTPUT_SEEN.value in outcome.error.message
     # The cap is STATED, so a reader knows the output was truncated and by how much.
-    assert str(SCRIPT_OUTPUT_TAIL_CAP_BYTES) in outcome.error.message
+    assert str(CAPTURED_OUTPUT_TAIL_CAP_BYTES) in outcome.error.message
 
 
 def test_a_timeout_carries_the_captured_partial_output_as_diagnostics():
@@ -869,8 +869,8 @@ def test_a_timeout_truncates_each_stream_to_the_stated_tail():
     assert isinstance(outcome, Failure)
     diagnostics = outcome.error.diagnostics
     assert "LAST LINE" in diagnostics
-    assert diagnostics.count("x") == SCRIPT_OUTPUT_TAIL_CAP_BYTES - len("LAST LINE\n")
-    assert diagnostics.count("y") == SCRIPT_OUTPUT_TAIL_CAP_BYTES
+    assert diagnostics.count("x") == CAPTURED_OUTPUT_TAIL_CAP_BYTES - len("LAST LINE\n")
+    assert diagnostics.count("y") == CAPTURED_OUTPUT_TAIL_CAP_BYTES
 
 
 def test_an_aborted_run_is_the_registered_early_termination_verdict():
@@ -1309,11 +1309,11 @@ def test_the_output_cap_bounds_utf8_BYTES_not_characters():
     # lands mid-character: the leading partial byte is DROPPED rather than becoming a
     # replacement character, since the truncation is gda's own and inventing a U+FFFD
     # would misreport the engine's output as malformed.
-    per_stream = SCRIPT_OUTPUT_TAIL_CAP_BYTES // len("界".encode())
+    per_stream = CAPTURED_OUTPUT_TAIL_CAP_BYTES // len("界".encode())
     assert diagnostics.count("界") == per_stream * 2
     assert "�" not in diagnostics
     # And the payload really is bounded in the unit the message names.
-    assert len(diagnostics.encode("utf-8")) <= 2 * SCRIPT_OUTPUT_TAIL_CAP_BYTES + 512
+    assert len(diagnostics.encode("utf-8")) <= 2 * CAPTURED_OUTPUT_TAIL_CAP_BYTES + 512
     assert "UTF-8 bytes (16 KiB)" in outcome.error.message
 
 

--- a/tests/test_user_data_placement.py
+++ b/tests/test_user_data_placement.py
@@ -35,7 +35,7 @@ from gda.runner import (
     set_user_data_root,
     user_data_placement,
 )
-from tests.support import VERSION_INFO, sentinel
+from tests.support import VERSION_INFO, RecordingSpawn, sentinel
 
 
 @pytest.fixture(autouse=True)
@@ -44,32 +44,6 @@ def _no_root_override():
     set_user_data_root(None)
     yield
     set_user_data_root(None)
-
-
-class _RecordingRun:
-    """A ``subprocess.run`` double recording the call and returning a clean exit.
-
-    ``payload`` is the raw stdout the fake engine writes; the CLI-seam tests pass a
-    real ADR-0002 sentinel so the command SUCCEEDS, and the argv assertion is then
-    made on a working invocation rather than on one that happened to fail late.
-    """
-
-    def __init__(self, payload: str = "") -> None:
-        self.cmd: list[str] | None = None
-        self.kwargs: dict | None = None
-        self._payload = payload.encode()
-
-    def __call__(self, cmd, **kwargs):
-        self.cmd = cmd
-        self.kwargs = kwargs
-        payload = self._payload
-
-        class _Proc:
-            stdout = payload
-            stderr = b""
-            returncode = 0
-
-        return _Proc()
 
 
 def _log_file_arg(cmd: list[str]) -> Path:
@@ -103,21 +77,17 @@ def test_default_launch_redirects_the_log_to_a_gda_owned_file(monkeypatch):
     # hands it a target it has already created.
     seen: dict[str, object] = {}
 
-    def fake_run(cmd, **kwargs):
-        log_file = _log_file_arg(cmd)
-        # Created BEFORE the spawn — that creation is the preflight, and it is what
-        # guarantees the engine's own FileAccess open cannot fail.
-        seen["name"] = log_file.name
-        seen["existed"] = log_file.exists()
+    class _Inspecting(RecordingSpawn):
+        def __call__(self, cmd, **kwargs):
+            log_file = _log_file_arg(cmd)
+            # Read DURING the spawn: the target is created BEFORE it — that creation
+            # is the preflight, and it is what guarantees the engine's own FileAccess
+            # open cannot fail.
+            seen["name"] = log_file.name
+            seen["existed"] = log_file.exists()
+            return super().__call__(cmd, **kwargs)
 
-        class _Proc:
-            stdout = b""
-            stderr = b""
-            returncode = 0
-
-        return _Proc()
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(subprocess, "Popen", _Inspecting())
 
     launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
 
@@ -127,8 +97,8 @@ def test_default_launch_redirects_the_log_to_a_gda_owned_file(monkeypatch):
 def test_default_launch_does_not_touch_the_child_environment(monkeypatch):
     # Without a root, gda redirects the LOG only: `user://`, the export templates
     # and the editor settings all stay where the engine puts them by default.
-    rec = _RecordingRun()
-    monkeypatch.setattr(subprocess, "run", rec)
+    rec = RecordingSpawn()
+    monkeypatch.setattr(subprocess, "Popen", rec)
 
     launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
 
@@ -136,21 +106,13 @@ def test_default_launch_does_not_touch_the_child_environment(monkeypatch):
 
 
 def test_default_log_target_is_removed_after_the_run(monkeypatch):
-    seen: dict[str, Path] = {}
-
-    def fake_run(cmd, **kwargs):
-        seen["log"] = _log_file_arg(cmd)
-
-        class _Proc:
-            stdout = b""
-            stderr = b""
-            returncode = 0
-
-        return _Proc()
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
+    rec = RecordingSpawn()
+    monkeypatch.setattr(subprocess, "Popen", rec)
 
     launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    assert rec.cmd is not None
+    seen = {"log": _log_file_arg(rec.cmd)}
 
     # A private temporary directory, cleaned up so repeated invocations do not
     # accumulate stale logs.
@@ -165,17 +127,12 @@ def test_concurrent_default_launches_get_distinct_log_targets(monkeypatch):
     # must never name the same target.
     targets: list[Path] = []
 
-    def fake_run(cmd, **kwargs):
-        targets.append(_log_file_arg(cmd))
+    class _Collecting(RecordingSpawn):
+        def __call__(self, cmd, **kwargs):
+            targets.append(_log_file_arg(cmd))
+            return super().__call__(cmd, **kwargs)
 
-        class _Proc:
-            stdout = b""
-            stderr = b""
-            returncode = 0
-
-        return _Proc()
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(subprocess, "Popen", _Collecting())
 
     launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
     launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
@@ -190,11 +147,11 @@ def test_concurrent_default_launches_get_distinct_log_targets(monkeypatch):
 
 def test_unwritable_log_root_is_refused_before_the_spawn(monkeypatch, tmp_path):
     # The whole point: refuse with a typed reason instead of letting the engine
-    # segfault in its logger. `subprocess.run` must never be reached.
+    # segfault in its logger. `subprocess.Popen` must never be reached.
     def _must_not_spawn(*args, **kwargs):  # pragma: no cover - guard
         raise AssertionError("the engine must not be spawned")
 
-    monkeypatch.setattr(subprocess, "run", _must_not_spawn)
+    monkeypatch.setattr(subprocess, "Popen", _must_not_spawn)
     locked = tmp_path / "locked"
     locked.mkdir()
     locked.chmod(0o555)
@@ -211,7 +168,7 @@ def test_unwritable_log_root_is_refused_before_the_spawn(monkeypatch, tmp_path):
 
 
 def test_refusal_diagnostics_name_binary_user_data_and_log_path(monkeypatch, tmp_path):
-    monkeypatch.setattr(subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: None)
     locked = tmp_path / "locked"
     locked.mkdir()
     locked.chmod(0o555)
@@ -237,7 +194,7 @@ def test_refusal_diagnostics_name_binary_user_data_and_log_path(monkeypatch, tmp
 def test_default_root_refusal_names_the_engine_resolved_user_data_dir(monkeypatch):
     # With no --user-data-root, the failure must still name where `user://` lives
     # — the engine's own resolved directory — and say gda is not redirecting it.
-    monkeypatch.setattr(subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: None)
 
     def _explode(*args, **kwargs):
         raise PermissionError(13, "Permission denied")
@@ -263,13 +220,13 @@ def test_the_two_refusal_shapes_point_at_different_directories(monkeypatch, tmp_
     # diagnostics — not the code — must disambiguate which one failed. Pinned as a
     # PAIR: the default-branch refusal must not blame the explicit root's derived
     # path, and vice versa.
-    monkeypatch.setattr(subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: None)
     monkeypatch.setattr("gda.runner.tempfile.mkdtemp", _permission_denied("gda-log-"))
 
     default_refusal = launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
 
     monkeypatch.undo()
-    monkeypatch.setattr(subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: None)
     locked = tmp_path / "locked"
     locked.mkdir()
     locked.chmod(0o555)
@@ -319,8 +276,8 @@ def test_refusal_classifies_as_the_environment_error_code():
 def test_root_redirects_both_the_log_and_the_platform_data_variable(
     monkeypatch, tmp_path
 ):
-    rec = _RecordingRun()
-    monkeypatch.setattr(subprocess, "run", rec)
+    rec = RecordingSpawn()
+    monkeypatch.setattr(subprocess, "Popen", rec)
     root = tmp_path / "udr"
     set_user_data_root(str(root))
 
@@ -345,8 +302,8 @@ def test_a_relative_root_is_absolutized_against_gda_cwd(monkeypatch, tmp_path):
     # spawns with cwd=<project>). The preflight would then pass for a file the engine
     # never opens, and the engine would die in rotate_file() on the one it did —
     # reintroducing the crash. Same bug class as the export channel's --path (#344).
-    rec = _RecordingRun()
-    monkeypatch.setattr(subprocess, "run", rec)
+    rec = RecordingSpawn()
+    monkeypatch.setattr(subprocess, "Popen", rec)
     monkeypatch.chdir(tmp_path)
     set_user_data_root("./rel")
 
@@ -363,8 +320,8 @@ def test_a_relative_root_absolutizes_the_platform_override_too(monkeypatch, tmp_
     # engine IGNORES a relative XDG_DATA_HOME outright (OS_LinuxBSD::get_data_path),
     # so a relative root would silently not redirect `user://` at all while the docs
     # promise it does.
-    rec = _RecordingRun()
-    monkeypatch.setattr(subprocess, "run", rec)
+    rec = RecordingSpawn()
+    monkeypatch.setattr(subprocess, "Popen", rec)
     monkeypatch.chdir(tmp_path)
     set_user_data_root("./rel")
 
@@ -386,7 +343,7 @@ def test_explicit_root_probes_the_platform_derived_data_path(monkeypatch, tmp_pa
     def _must_not_spawn(*args, **kwargs):  # pragma: no cover - guard
         raise AssertionError("the engine must not be spawned")
 
-    monkeypatch.setattr(subprocess, "run", _must_not_spawn)
+    monkeypatch.setattr(subprocess, "Popen", _must_not_spawn)
     root = tmp_path / "udr"
     # The probe logic is shape-agnostic; pin a NESTED derivation so this runs
     # identically on every platform (the real macOS shape nests under
@@ -427,7 +384,7 @@ def test_an_empty_explicit_flag_is_refused_not_demoted_to_the_environment(monkey
     def _must_not_spawn(*args, **kwargs):  # pragma: no cover - guard
         raise AssertionError("the engine must not be spawned")
 
-    monkeypatch.setattr(subprocess, "run", _must_not_spawn)
+    monkeypatch.setattr(subprocess, "Popen", _must_not_spawn)
     monkeypatch.setenv(USER_DATA_ROOT_ENV, "/from/env")
     set_user_data_root("")
 
@@ -541,8 +498,8 @@ def test_the_root_option_reaches_the_launch(monkeypatch, tmp_path):
     # callback's `set_user_data_root(...)` line leaves the whole suite green and the
     # flag silently inert — a live risk, since a sibling change rewrites exactly
     # those lines in `gda.cli`.
-    rec = _RecordingRun(sentinel(VERSION_INFO))
-    monkeypatch.setattr(subprocess, "run", rec)
+    rec = RecordingSpawn(sentinel(VERSION_INFO))
+    monkeypatch.setattr(subprocess, "Popen", rec)
     monkeypatch.delenv(USER_DATA_ROOT_ENV, raising=False)
     root = tmp_path / "from-the-flag"
 
@@ -560,8 +517,8 @@ def test_without_the_root_option_the_launch_keeps_the_engine_default(
     # The negative half: absent the flag (and the env twin), nothing is redirected
     # but the log — so this pair fails if the option is wired to always-on as well
     # as if it is wired to nothing.
-    rec = _RecordingRun(sentinel(VERSION_INFO))
-    monkeypatch.setattr(subprocess, "run", rec)
+    rec = RecordingSpawn(sentinel(VERSION_INFO))
+    monkeypatch.setattr(subprocess, "Popen", rec)
     monkeypatch.delenv(USER_DATA_ROOT_ENV, raising=False)
 
     result = CliRunner().invoke(app, ["info", "--json"])


### PR DESCRIPTION
## What

`gda script run` got a streaming capture in #655, so a run it ends at `--timeout`
returns what the engine had already printed. Every other launch channel kept the
buffered capture, which throws that output away: a hung sentinel op, export or
import pass came back with `gda: <label> timed out after <n>s` and nothing else —
no engine output, no wall clock, no ceiling. This moves them across and reshapes
the shared `launch_timeout` branch so all of them report the evidence.

Closes #714

## The third channel — included

The issue names two channels; there are three. `gda resource import` calls the same
`launch(...)` primitive buffered and classifies through the same
`classify_launch_or_crash` branch (`src/gda/commands/resource.py`). It is **in**:

- same mechanism, same classifier — excluding it would leave three commands that
  share one launch reporting a timeout three different ways;
- keeping it out would have required forking the shared branch, which is the wrong
  shape whichever way the decision went.

It needed no production change of its own: it already declares
`timeout_label="Godot import"` and goes through the shared branch, so it inherits
the fix. Two unit guards pin that (the envelope, and the label at the call site).

## How

- **The buffered strategy is deleted.** With the last three channels moved it had
  no caller left, and a second capture path nothing selects is a trap for the next
  channel rather than an option. `watch` is now POLICY, not strategy: a rule for
  ending a run EARLY that only that channel can state (`script run`'s
  `--completion-marker`). A channel without one passes nothing.
- **One timeout envelope, built in the shared branch.**
  `classify_launch_or_crash`'s `LaunchFailure.TIMEOUT` arm now carries both
  captured streams under `--- captured stdout ---` / `--- captured stderr ---`,
  tail-capped at the same 16 KiB per stream the `script run` verdicts use, plus the
  elapsed wall clock and the ceiling that was reached.
- **`RunResult.timeout_bound`** (label + ceiling) is how the classifier learns
  those: the runner seam hands a classifier a `RunResult` and nothing else, so two
  of the three channels could not otherwise name their own ceiling. Set only on a
  synthesized `TIMEOUT` result; both inputs degrade to a plain sentence rather than
  asserting when absent (a hand-built result at a test seam).
- **Header vocabulary:** a distinct `captured` pair rather than reusing
  `--- script stdout ---`, which would be untrue of an export or an import pass —
  and which is published `script_failed` envelope bytes that AC3 protects.
  `SCRIPT_OUTPUT_TAIL_CAP_BYTES` → `CAPTURED_OUTPUT_TAIL_CAP_BYTES`, since the cap
  is now shared by both subjects.
- **Latency:** the poll loop waits on the child instead of sleeping through the
  interval, so putting the sentinel channel — every `gda` invocation — on this loop
  costs no per-invocation latency.
- `script run` and `scene preflight` are unchanged: each still classifies its own
  timeout, because each carries something the shared branch cannot know (a
  termination phase and the recognized script errors; a `timeout` STATUS that is
  the command's answer rather than a failure).

## Byte-compat pins that moved (AC3 protects non-timeout bytes only)

The buffered-timeout stderr wording (`gda: Godot export timed out after 600.0s`)
no longer exists, so every pin on it moved, deliberately:

| File | Was | Now |
| --- | --- | --- |
| `tests/test_launch.py` | the discard + the synthesized stderr, on three arms | the capture, the clock and the `TimeoutBound` |
| `tests/test_export_runner.py` | `"gda: Godot export timed out after 600.0s\n"` | `TimeoutBound("Godot export", …)` + the export's own captured stderr |
| `tests/test_classify_export_run.py` | diagnostics byte-identical to that stderr | the export's captured output in the shared envelope |
| `tests/test_classify_launch_or_crash.py` | code only | code + label + ceiling + clock + capped capture |
| `tests/test_info_errors.py` | `"timed out" in stderr` | the forwarded engine capture, in stderr and diagnostics |
| `src/gda/export_runner.py` (comment) | declared the wording public-envelope | declares the LABEL public-envelope, via `TimeoutBound` |

Everything else keeps its bytes, including `script run --strict`'s
`script_failed` diagnostics and its `--- script stdout ---` headers.

Test doubles: the primitive no longer takes a buffer back from `subprocess.run`,
so the suites whose subject is the SPAWN SHAPE (argv, cwd, child env) move onto one
shared `tests.support.RecordingSpawn` `Popen` double instead of six local
`subprocess.run` fakes. The suites whose subject is the CAPTURE drive real child
processes, as they already did.

## CONTEXT.md (this wave's owner)

- `Headless launch`: the enumeration named four channels and omitted the import
  pass; the "two capture strategies" paragraph described a buffered strategy that
  discards output. Both corrected, with the #655 → #714 history kept.
- `Raw run`: said the streams are empty and `elapsed_seconds` is `None` on a
  buffered timeout. Both are now false; `timeout_bound` documented, and lifted out
  of the `script run` promotion beside `elapsed_seconds`.
- ADR-0031 gains a dated `> Outcome (2026-08-31, #714)` note rather than a rewrite
  of its amendment; the `launch_timeout` registry description and its ADR-0002
  mirror now say what the envelope carries.

## Validation

- `pytest -m "not e2e"`: 2241 passed. `ruff check`, `ruff format --check`,
  `pyright`: clean.
- **Real-engine e2e, one arm per channel** — `tests/test_e2e_launch_timeout.py`.
  Each wedges a genuinely hung Godot and asserts the run is bounded, the envelope
  names the ceiling and the wall clock, and the engine's own output is in the
  diagnostics. Two levers, one per engine path: a blocking autoload `_init` for the
  GAME path (sentinel), a blocking editor plugin `_enter_tree` for the EDITOR path
  (`--import`, `--export-<mode>`) — an autoload never runs there. Neither honours
  SIGTERM, so the arms cover the kill path too. 3 passed in 12.4s.
- Red-proofed, four ways: reverting the shared branch fails 6 unit guards;
  reverting the primitive's timeout result fails 6 more plus all 3 e2e arms;
  removing `timeout_label="Godot import"` fails the import guards; giving
  `scene preflight` a policy watch fails its no-watch guard.
- Targeted local e2e beyond the new file: `info`, `user_data`, `op_robustness`,
  `resource_import` (43 passed); `scene_preflight`, `script_run`, `export_run`,
  `export` (74 passed, 1 pre-existing Linux-only skip); `scene`, `script`, `node`,
  `project` (222 passed) — the sentinel channel now streams on every op, so the
  breadth is the point.

## Residual risk

Every headless launch now goes through the threaded streaming loop, so a latent
platform-specific fault in it would reach every command rather than only
`script run` / `scene preflight`. Mitigated by the breadth above (~340 real-engine
ops on macOS) — but the Linux/Windows evidence is the wave's full-e2e CI dispatch,
not this PR.
