### PR TITLE
refactor(balancing): extract shared deep modules

### DIFF
--- a/libs/gda-balancing/examples/schema2/playtest/README.md
+++ b/libs/gda-balancing/examples/schema2/playtest/README.md
@@ -155,6 +155,8 @@ ui/<application> -> content/<application> -> content/playtest_execution_coordina
 - `content/playtest_execution_coordinator.gd` coordinates service startup, Execution-session
   creation, exact-revision admission and execution, retry cleanup, deletion, and shutdown. It
   reports the failed lifecycle stage and preserves the original service or refusal payload.
+- `content/playtest_run_provenance.gd` validates shared artifact identities and projects the opaque
+  maintainer provenance that Content can include in saved feedback.
 - `systems/` is optional. It advances validated gameplay values when an application has a gameplay
   state machine. It does not parse protocol or Standard Schema structures and does not repeat
   calculations already performed by `gda-balancing`. Attack Damage Training consumes validated

--- a/libs/gda-balancing/examples/schema2/playtest/README.md
+++ b/libs/gda-balancing/examples/schema2/playtest/README.md
@@ -134,27 +134,34 @@ The project uses four downward dependency layers. Each application has a thin co
 
 ```text
 apps/<application>/main
-          |
-          v
-ui/<application> -> content/<application> -> addons/gda_balancing_client
-                              |                         |
-                              |                         v
-                              +-> systems/<application> local gda-balancing service
-                                  (when gameplay state needs one)
+          +--------------------+-----------------------------+
+          |                    |                             |
+          v                    v                             v
+ui/<application> -> content/<application> -> content/playtest_execution_coordinator
+                              |                             |
+                              v                             v
+                  systems/<application>          addons/gda_balancing_client
+                  (when gameplay state                     |
+                   needs one)                              v
+                                             local gda-balancing service
 ```
 
-- `apps/` creates one view, one Content controller, and one game-neutral execution client for each
-  application. It owns no gameplay or document rules.
+- `apps/` creates one view, one Content controller, one shared Content execution coordinator, and
+  one game-neutral execution client for each application. It owns no gameplay or document rules.
 - `ui/` owns player presentation, feature controls, feature questions, localization, and Tweens.
-- `content/` reads maintained documents, creates complete Experiment revisions, validates returned
-  relationships, projects gameplay values, coordinates application flow, and records feedback.
+- Each application module under `content/` reads maintained documents, creates complete Experiment
+  Specification documents, validates returned relationships, projects gameplay values, coordinates
+  player flow, and records feedback.
+- `content/playtest_execution_coordinator.gd` coordinates service startup, Execution-session
+  creation, exact-revision admission and execution, retry cleanup, deletion, and shutdown. It
+  reports the failed lifecycle stage and preserves the original service or refusal payload.
 - `systems/` is optional. It advances validated gameplay values when an application has a gameplay
   state machine. It does not parse protocol or Standard Schema structures and does not repeat
   calculations already performed by `gda-balancing`. Attack Damage Training consumes validated
   results directly through Content, so it intentionally has no `systems/` module.
 - `addons/gda_balancing_client/` owns executable discovery, child-process lifetime, readiness,
-  credentials, generic `/v1` requests, handles, and shutdown. It contains no Reward, Combat, or
-  Effect fields.
+  credentials, generic `/v1` requests, JSON transport, handles, and forced process stop. It
+  contains no Reward, Combat, or Effect fields.
 - `addons/playtest_feedback_file/`, `ui/playtest_shell.gd`, and `scripts/run_playtest.sh` contain
   only behavior used by multiple applications.
 

--- a/libs/gda-balancing/examples/schema2/playtest/addons/gda_balancing_client/gda_execution_client.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/addons/gda_balancing_client/gda_execution_client.gd
@@ -157,56 +157,6 @@ func run_revision(session: String, revision: String) -> Dictionary:
 	return {"ok": true, "value": value}
 
 
-static func project_run_provenance(run_result: Dictionary) -> Dictionary:
-	var artifacts_value = run_result.get("artifacts")
-	if not artifacts_value is Dictionary:
-		return {}
-	var artifacts: Dictionary = artifacts_value
-	var primary_names: Array[String] = []
-	for name in ["evaluation-run", "experiment-verdict"]:
-		var candidate = artifacts.get(name)
-		if candidate is Dictionary and candidate.get("artifact_kind") == name:
-			primary_names.append(name)
-	if primary_names.size() != 1:
-		return {}
-
-	var primary_name := primary_names[0]
-	var primary: Dictionary = artifacts[primary_name]
-	var primary_identity := str(primary.get("content_identity", ""))
-	var experiment_identity := str(primary.get("experiment_identity", ""))
-	if primary_identity.is_empty() or experiment_identity.is_empty():
-		return {}
-
-	var artifact_bindings := {
-		"event-trace": "event_trace_identity",
-		"snapshot-series": "snapshot_series_identity",
-		"metric-dataset": "metric_dataset_identity",
-		"reproduction-receipt": "reproduction_receipt_identity",
-	}
-	var projected := {
-		"primary_artifact_kind": primary_name,
-		"primary_artifact_identity": primary_identity,
-		"experiment_identity": experiment_identity,
-	}
-	for artifact_name in artifact_bindings:
-		var artifact_value = artifacts.get(artifact_name)
-		if not artifact_value is Dictionary:
-			return {}
-		var artifact: Dictionary = artifact_value
-		var identity := str(artifact.get("content_identity", ""))
-		var binding_member: String = artifact_bindings[artifact_name]
-		if (
-			artifact.get("artifact_kind") != artifact_name
-			or identity.is_empty()
-			or primary.get(binding_member) != identity
-		):
-			return {}
-		if artifact.get("experiment_identity") != experiment_identity:
-			return {}
-		projected[binding_member] = identity
-	return projected
-
-
 func delete_session(session: String) -> Dictionary:
 	return await _request_json(
 		"DELETE",

--- a/libs/gda-balancing/examples/schema2/playtest/apps/combat_cast/main.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/apps/combat_cast/main.gd
@@ -6,12 +6,16 @@ const GdaExecutionClient = preload(
 const CombatCastController = preload(
 	"res://content/combat_cast/combat_cast_controller.gd"
 )
+const PlaytestExecutionCoordinator = preload(
+	"res://content/playtest_execution_coordinator.gd"
+)
 const CombatDuel = preload("res://systems/combat_duel.gd")
 
 @onready var _view: Control = $CombatCastView
 
 var _client: GdaExecutionClient
 var _controller: CombatCastController
+var _execution: PlaytestExecutionCoordinator
 var _shutting_down := false
 
 
@@ -20,13 +24,14 @@ func _ready() -> void:
 	_client = GdaExecutionClient.new()
 	_client.name = "GdaExecutionClient"
 	add_child(_client)
+	_execution = PlaytestExecutionCoordinator.new()
+	_execution.configure(_client, _user_option("gda-balancing-executable"))
 	_controller = CombatCastController.new()
 	_controller.name = "CombatCastController"
 	add_child(_controller)
 	_view.bind(_controller)
 	_controller.configure(
-		_client,
-		_user_option("gda-balancing-executable"),
+		_execution,
 		CombatDuel.new(),
 	)
 	await _controller.start()

--- a/libs/gda-balancing/examples/schema2/playtest/apps/periodic_effect/main.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/apps/periodic_effect/main.gd
@@ -6,6 +6,9 @@ const GdaExecutionClient = preload(
 const PeriodicEffectController = preload(
 	"res://content/periodic_effect/periodic_effect_controller.gd"
 )
+const PlaytestExecutionCoordinator = preload(
+	"res://content/playtest_execution_coordinator.gd"
+)
 const PeriodicEffectTimeline = preload(
 	"res://systems/periodic_effect_timeline.gd"
 )
@@ -14,6 +17,7 @@ const PeriodicEffectTimeline = preload(
 
 var _client: GdaExecutionClient
 var _controller: PeriodicEffectController
+var _execution: PlaytestExecutionCoordinator
 var _shutting_down := false
 
 
@@ -22,13 +26,14 @@ func _ready() -> void:
 	_client = GdaExecutionClient.new()
 	_client.name = "GdaExecutionClient"
 	add_child(_client)
+	_execution = PlaytestExecutionCoordinator.new()
+	_execution.configure(_client, _user_option("gda-balancing-executable"))
 	_controller = PeriodicEffectController.new()
 	_controller.name = "PeriodicEffectController"
 	add_child(_controller)
 	_view.bind(_controller)
 	_controller.configure(
-		_client,
-		_user_option("gda-balancing-executable"),
+		_execution,
 		PeriodicEffectTimeline.new(),
 	)
 	await _controller.start()

--- a/libs/gda-balancing/examples/schema2/playtest/apps/reward_run/main.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/apps/reward_run/main.gd
@@ -6,12 +6,16 @@ const GdaExecutionClient = preload(
 const RewardRunController = preload(
 	"res://content/reward_run/reward_run_controller.gd"
 )
+const PlaytestExecutionCoordinator = preload(
+	"res://content/playtest_execution_coordinator.gd"
+)
 const RewardRun = preload("res://systems/reward_run.gd")
 
 @onready var _view: Control = $RewardRunView
 
 var _client: GdaExecutionClient
 var _controller: RewardRunController
+var _execution: PlaytestExecutionCoordinator
 var _shutting_down := false
 
 
@@ -20,13 +24,14 @@ func _ready() -> void:
 	_client = GdaExecutionClient.new()
 	_client.name = "GdaExecutionClient"
 	add_child(_client)
+	_execution = PlaytestExecutionCoordinator.new()
+	_execution.configure(_client, _user_option("gda-balancing-executable"))
 	_controller = RewardRunController.new()
 	_controller.name = "RewardRunController"
 	add_child(_controller)
 	_view.bind(_controller)
 	_controller.configure(
-		_client,
-		_user_option("gda-balancing-executable"),
+		_execution,
 		RewardRun.new(),
 	)
 	await _controller.start()

--- a/libs/gda-balancing/examples/schema2/playtest/apps/stat_composition/main.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/apps/stat_composition/main.gd
@@ -6,11 +6,15 @@ const GdaExecutionClient = preload(
 const StatCompositionController = preload(
 	"res://content/stat_composition/stat_composition_controller.gd"
 )
+const PlaytestExecutionCoordinator = preload(
+	"res://content/playtest_execution_coordinator.gd"
+)
 
 @onready var _view: Control = $StatCompositionView
 
 var _client: GdaExecutionClient
 var _controller: StatCompositionController
+var _execution: PlaytestExecutionCoordinator
 var _shutting_down := false
 
 
@@ -19,11 +23,13 @@ func _ready() -> void:
 	_client = GdaExecutionClient.new()
 	_client.name = "GdaExecutionClient"
 	add_child(_client)
+	_execution = PlaytestExecutionCoordinator.new()
+	_execution.configure(_client, _user_option("gda-balancing-executable"))
 	_controller = StatCompositionController.new()
 	_controller.name = "StatCompositionController"
 	add_child(_controller)
 	_view.bind(_controller)
-	_controller.configure(_client, _user_option("gda-balancing-executable"))
+	_controller.configure(_execution)
 	await _controller.start()
 
 

--- a/libs/gda-balancing/examples/schema2/playtest/content/combat_cast/combat_action.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/content/combat_cast/combat_action.gd
@@ -1,8 +1,8 @@
 class_name CombatAction
 extends RefCounted
 
-const GdaExecutionClient = preload(
-	"res://addons/gda_balancing_client/gda_execution_client.gd"
+const PlaytestRunProvenance = preload(
+	"res://content/playtest_run_provenance.gd"
 )
 const ACTOR_CONTRACTS := {
 	"player": {
@@ -65,7 +65,7 @@ func admit_run_result(
 		return _failure("missing_snapshot_series")
 	if metrics.get("artifact_kind") != "metric-dataset":
 		return _failure("missing_metric_dataset")
-	var provenance := GdaExecutionClient.project_run_provenance(run_result)
+	var provenance := PlaytestRunProvenance.project(run_result)
 	if provenance.is_empty():
 		return _failure("incomplete_artifact_provenance")
 

--- a/libs/gda-balancing/examples/schema2/playtest/content/combat_cast/combat_cast_controller.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/content/combat_cast/combat_cast_controller.gd
@@ -21,24 +21,21 @@ var last_feedback_path := ""
 var _actions: Array[CombatAction] = []
 var _battle_outcome := ""
 var _busy := false
-var _client: Node
+var _execution
 var _combat_state: Dictionary = {}
 var _documents := CombatCastDocuments.new()
 var _duel: CombatDuel
 var _defeat_threshold := 0
-var _executable_path := ""
 var _feedback := PlaytestFeedbackFile.new()
 var _last_state: Dictionary = {}
 var _model_source: Dictionary = {}
 var _baseline_experiment: Dictionary = {}
 var _rival_strength := "normal"
-var _session := ""
 var _spell_style := "balanced"
 
 
-func configure(client: Node, executable_path: String, duel: CombatDuel) -> void:
-	_client = client
-	_executable_path = executable_path
+func configure(execution, duel: CombatDuel) -> void:
+	_execution = execution
 	_duel = duel
 	_duel.state_changed.connect(_on_duel_state_changed)
 
@@ -47,7 +44,7 @@ func start() -> Dictionary:
 	_actions.clear()
 	_battle_outcome = ""
 	playtest_complete = false
-	return await _prepare_live_session()
+	return await _prepare_live_session(false)
 
 
 func primary_action() -> void:
@@ -102,21 +99,15 @@ func retry() -> Dictionary:
 	if _busy:
 		return _failure("action_in_flight", "a live action is already in flight")
 	_busy = true
-	if not _session.is_empty():
-		await _client.delete_session(_session)
-	await _client.shutdown()
-	_session = ""
+	var result := await _prepare_live_session(true)
 	_busy = false
-	return await _prepare_live_session()
+	return result
 
 
 func shutdown() -> Dictionary:
-	if _client == null:
+	if _execution == null:
 		return {"ok": true}
-	if not _session.is_empty():
-		await _client.delete_session(_session)
-		_session = ""
-	return await _client.shutdown()
+	return await _execution.shutdown()
 
 
 func submit_feedback(
@@ -159,7 +150,7 @@ func current_state() -> Dictionary:
 	return _last_state.duplicate(true)
 
 
-func _prepare_live_session() -> Dictionary:
+func _prepare_live_session(retrying: bool) -> Dictionary:
 	phase = "preparing"
 	_emit_state({"phase": phase})
 	var loaded: Dictionary = _documents.load_maintained()
@@ -172,17 +163,13 @@ func _prepare_live_session() -> Dictionary:
 	if not initial.get("ok", false):
 		return _fail_preparation(initial)
 	_combat_state = initial["value"]
-	var started: Dictionary = await _client.start(_executable_path)
-	if not started.get("ok", false):
-		return _fail_preparation(started)
-	var created: Dictionary = await _client.create_session(
-		_model_source,
-		_baseline_experiment,
-	)
-	if not created.get("ok", false):
-		await _client.shutdown()
-		return _fail_preparation(created)
-	_session = created["session"]
+	var established: Dictionary
+	if retrying:
+		established = await _execution.retry(_model_source, _baseline_experiment)
+	else:
+		established = await _execution.start(_model_source, _baseline_experiment)
+	if not established.get("ok", false):
+		return _fail_preparation(established)
 	_duel.start(_combat_state)
 	_log_event("combat_playtest_ready", _selected_options())
 	return {"ok": true}
@@ -204,15 +191,11 @@ func _run_action(actor: String) -> void:
 	if not authored.get("ok", false):
 		_fail_exchange(authored)
 		return
-	var admitted: Dictionary = await _client.admit_revision(_session, authored["value"])
-	if not admitted.get("ok", false):
-		_fail_exchange(admitted)
-		return
-	var revision := str(admitted["revision"])
-	var run: Dictionary = await _client.run_revision(_session, revision)
+	var run: Dictionary = await _execution.admit_and_run(authored["value"])
 	if not run.get("ok", false):
 		_fail_exchange(run)
 		return
+	var revision := str(run["revision"])
 	var action := CombatAction.new()
 	var projected: Dictionary = action.admit_run_result(
 		run["value"], _combat_state, actor, revision, _defeat_threshold

--- a/libs/gda-balancing/examples/schema2/playtest/content/combat_cast/combat_cast_controller.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/content/combat_cast/combat_cast_controller.gd
@@ -159,10 +159,12 @@ func _prepare_live_session(retrying: bool) -> Dictionary:
 	_model_source = loaded["model_source"]
 	_baseline_experiment = loaded["experiment"]
 	_defeat_threshold = loaded["defeat_threshold"]
-	var initial := _documents.initial_state_for_options(_spell_style, _rival_strength)
-	if not initial.get("ok", false):
-		return _fail_preparation(initial)
-	_combat_state = initial["value"]
+	var prepared_state := _combat_state.duplicate(true)
+	if not retrying or prepared_state.is_empty():
+		var initial := _documents.initial_state_for_options(_spell_style, _rival_strength)
+		if not initial.get("ok", false):
+			return _fail_preparation(initial)
+		prepared_state = initial["value"]
 	var established: Dictionary
 	if retrying:
 		established = await _execution.retry(_model_source, _baseline_experiment)
@@ -170,7 +172,11 @@ func _prepare_live_session(retrying: bool) -> Dictionary:
 		established = await _execution.start(_model_source, _baseline_experiment)
 	if not established.get("ok", false):
 		return _fail_preparation(established)
-	_duel.start(_combat_state)
+	_combat_state = prepared_state
+	if retrying and not _actions.is_empty():
+		_on_duel_state_changed(_duel.snapshot())
+	else:
+		_duel.start(_combat_state)
 	_log_event("combat_playtest_ready", _selected_options())
 	return {"ok": true}
 
@@ -231,7 +237,10 @@ func _fail_exchange(error: Dictionary) -> void:
 
 func _fail_preparation(error: Dictionary) -> Dictionary:
 	phase = "retry"
-	_emit_state({"phase": phase})
+	var state := {"phase": phase}
+	if not _combat_state.is_empty():
+		state["combatants"] = _combat_state.duplicate(true)
+	_emit_state(state)
 	_log_event("combat_preparation_failed", error)
 	return error
 

--- a/libs/gda-balancing/examples/schema2/playtest/content/periodic_effect/periodic_effect_controller.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/content/periodic_effect/periodic_effect_controller.gd
@@ -23,15 +23,12 @@ var phase := "loading"
 var playtest_complete := false
 var last_feedback_path := ""
 
-var _client: Node
-var _executable_path := ""
+var _execution
 var _documents := PeriodicEffectDocuments.new()
 var _feedback := PlaytestFeedbackFile.new()
 var _timeline: PeriodicEffectTimeline
 var _model_source: Dictionary = {}
 var _experiments: Dictionary = {}
-var _session := ""
-var _initial_revision := ""
 var _initial_health := 0
 var _damage_threshold := 0
 var _trials: Array[PeriodicEffectTrial] = []
@@ -40,12 +37,10 @@ var _busy := false
 
 
 func configure(
-	client: Node,
-	executable_path: String,
+	execution,
 	timeline: PeriodicEffectTimeline,
 ) -> void:
-	_client = client
-	_executable_path = executable_path
+	_execution = execution
 	_timeline = timeline
 	_timeline.state_changed.connect(_on_timeline_state_changed)
 
@@ -53,7 +48,7 @@ func configure(
 func start() -> Dictionary:
 	_trials.clear()
 	playtest_complete = false
-	return await _prepare_live_session()
+	return await _prepare_live_session(false)
 
 
 func primary_action() -> void:
@@ -83,21 +78,15 @@ func retry() -> Dictionary:
 	if _busy:
 		return _failure("trial_in_flight", "a live trial is already in flight")
 	_busy = true
-	if not _session.is_empty():
-		await _client.delete_session(_session)
-	await _client.shutdown()
-	_session = ""
+	var result := await _prepare_live_session(true)
 	_busy = false
-	return await _prepare_live_session()
+	return result
 
 
 func shutdown() -> Dictionary:
-	if _client == null:
+	if _execution == null:
 		return {"ok": true}
-	if not _session.is_empty():
-		await _client.delete_session(_session)
-		_session = ""
-	return await _client.shutdown()
+	return await _execution.shutdown()
 
 
 func submit_feedback(
@@ -138,7 +127,7 @@ func current_state() -> Dictionary:
 	return _last_state.duplicate(true)
 
 
-func _prepare_live_session() -> Dictionary:
+func _prepare_live_session(retrying: bool) -> Dictionary:
 	phase = "preparing"
 	_emit_state({"phase": phase})
 	var loaded: Dictionary = _documents.load_maintained()
@@ -151,18 +140,13 @@ func _prepare_live_session() -> Dictionary:
 		"dynamic": loaded["dynamic_experiment"],
 		"snapshot": loaded["snapshot_experiment"],
 	}
-	var started: Dictionary = await _client.start(_executable_path)
-	if not started.get("ok", false):
-		return _fail_preparation(started)
-	var created: Dictionary = await _client.create_session(
-		_model_source,
-		_experiments["dynamic"],
-	)
-	if not created.get("ok", false):
-		await _client.shutdown()
-		return _fail_preparation(created)
-	_session = created["session"]
-	_initial_revision = created["revision"]
+	var established: Dictionary
+	if retrying:
+		established = await _execution.retry(_model_source, _experiments["dynamic"])
+	else:
+		established = await _execution.start(_model_source, _experiments["dynamic"])
+	if not established.get("ok", false):
+		return _fail_preparation(established)
 	_emit_ready()
 	_log_event("periodic_playtest_ready", {"completed": _trials.size()})
 	return {"ok": true}
@@ -175,19 +159,15 @@ func _run_next_trial() -> void:
 	phase = "preparing_trial"
 	_emit_state({"phase": phase})
 	var policy := TRIAL_KINDS[_trials.size()]
-	var revision := _initial_revision
+	var run: Dictionary
 	if policy == "snapshot":
-		var admitted: Dictionary = await _client.admit_revision(
-			_session, _experiments[policy]
-		)
-		if not admitted.get("ok", false):
-			_fail_trial(admitted)
-			return
-		revision = admitted["revision"]
-	var run: Dictionary = await _client.run_revision(_session, revision)
+		run = await _execution.admit_and_run(_experiments[policy])
+	else:
+		run = await _execution.run_initial_revision()
 	if not run.get("ok", false):
 		_fail_trial(run)
 		return
+	var revision := str(run["revision"])
 	var trial := PeriodicEffectTrial.new()
 	var projected: Dictionary = trial.admit_run_result(
 		run["value"],

--- a/libs/gda-balancing/examples/schema2/playtest/content/periodic_effect/periodic_effect_trial.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/content/periodic_effect/periodic_effect_trial.gd
@@ -1,8 +1,8 @@
 class_name PeriodicEffectTrial
 extends RefCounted
 
-const GdaExecutionClient = preload(
-	"res://addons/gda_balancing_client/gda_execution_client.gd"
+const PlaytestRunProvenance = preload(
+	"res://content/playtest_run_provenance.gd"
 )
 const POLICY_OPERATIONS := {
 	"dynamic": {
@@ -44,7 +44,7 @@ func admit_run_result(
 		return _failure("missing_snapshot_series")
 	if metrics.get("artifact_kind") != "metric-dataset":
 		return _failure("missing_metric_dataset")
-	var provenance := GdaExecutionClient.project_run_provenance(run_result)
+	var provenance := PlaytestRunProvenance.project(run_result)
 	if provenance.is_empty():
 		return _failure("incomplete_artifact_provenance")
 

--- a/libs/gda-balancing/examples/schema2/playtest/content/playtest_execution_coordinator.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/content/playtest_execution_coordinator.gd
@@ -1,0 +1,200 @@
+class_name PlaytestExecutionCoordinator
+extends RefCounted
+
+var _client
+var _executable_path := ""
+var _session := ""
+var _initial_revision := ""
+var _service_started := false
+var _busy := false
+
+
+func configure(client, executable_path: String) -> void:
+	_client = client
+	_executable_path = executable_path
+
+
+func start(model_source: Dictionary, experiment: Dictionary) -> Dictionary:
+	if _busy:
+		return _local_failure(
+			"operation_in_flight",
+			"an Execution lifecycle operation is already in flight",
+			"startup",
+		)
+	if _service_started or not _session.is_empty():
+		return _local_failure(
+			"already_started",
+			"the playtest Execution session is already started",
+			"startup",
+		)
+	_busy = true
+	var result := await _start_session(model_source, experiment)
+	_busy = false
+	return result
+
+
+func admit_and_run(experiment: Dictionary) -> Dictionary:
+	var unavailable := _operation_unavailable("revision_admission")
+	if not unavailable.is_empty():
+		return unavailable
+	_busy = true
+	var admitted: Dictionary = await _client.admit_revision(_session, experiment)
+	if not admitted.get("ok", false):
+		_busy = false
+		return _stage_failure("revision_admission", admitted)
+	var revision := str(admitted.get("revision", ""))
+	if revision.is_empty():
+		_busy = false
+		return _local_failure(
+			"invalid_revision_response",
+			"revision admission returned no exact revision",
+			"revision_admission",
+		)
+	var result := await _run_exact_revision(revision)
+	_busy = false
+	return result
+
+
+func run_initial_revision() -> Dictionary:
+	var unavailable := _operation_unavailable("execution")
+	if not unavailable.is_empty():
+		return unavailable
+	if _initial_revision.is_empty():
+		return _local_failure(
+			"initial_revision_unavailable",
+			"the Execution session returned no initial revision",
+			"execution",
+		)
+	_busy = true
+	var result := await _run_exact_revision(_initial_revision)
+	_busy = false
+	return result
+
+
+func retry(model_source: Dictionary, experiment: Dictionary) -> Dictionary:
+	if _busy:
+		return _local_failure(
+			"operation_in_flight",
+			"an Execution lifecycle operation is already in flight",
+			"retry_cleanup",
+		)
+	_busy = true
+	var cleaned := await _cleanup()
+	if not cleaned.get("ok", false):
+		_busy = false
+		return cleaned
+	var result := await _start_session(model_source, experiment)
+	_busy = false
+	return result
+
+
+func shutdown() -> Dictionary:
+	if _busy:
+		return _local_failure(
+			"operation_in_flight",
+			"an Execution lifecycle operation is already in flight",
+			"shutdown",
+		)
+	_busy = true
+	var result := await _cleanup()
+	_busy = false
+	return result
+
+
+func _start_session(model_source: Dictionary, experiment: Dictionary) -> Dictionary:
+	if _client == null:
+		return _local_failure(
+			"not_configured",
+			"the playtest Execution coordinator is not configured",
+			"startup",
+		)
+	var started: Dictionary = await _client.start(_executable_path)
+	if not started.get("ok", false):
+		return _stage_failure("startup", started)
+	_service_started = true
+	var created: Dictionary = await _client.create_session(model_source, experiment)
+	if not created.get("ok", false):
+		var failed := _stage_failure("session_creation", created)
+		return _with_cleanup(failed, await _cleanup())
+	_session = str(created.get("session", ""))
+	_initial_revision = str(created.get("revision", ""))
+	if _session.is_empty() or _initial_revision.is_empty():
+		var failed := _local_failure(
+			"invalid_session_response",
+			"session creation returned no session or initial revision",
+			"session_creation",
+		)
+		return _with_cleanup(failed, await _cleanup())
+	return {"ok": true, "revision": _initial_revision}
+
+
+func _run_exact_revision(revision: String) -> Dictionary:
+	var run: Dictionary = await _client.run_revision(_session, revision)
+	if not run.get("ok", false):
+		return _stage_failure("execution", run)
+	return {
+		"ok": true,
+		"revision": revision,
+		"value": run.get("value", {}),
+	}
+
+
+func _operation_unavailable(stage: String) -> Dictionary:
+	if _busy:
+		return _local_failure(
+			"operation_in_flight",
+			"an Execution lifecycle operation is already in flight",
+			stage,
+		)
+	if not _service_started or _session.is_empty():
+		return _local_failure(
+			"session_not_ready",
+			"the playtest Execution session is not ready",
+			stage,
+		)
+	return {}
+
+
+func _cleanup() -> Dictionary:
+	var primary_failure: Dictionary = {}
+	if not _session.is_empty():
+		var deleted: Dictionary = await _client.delete_session(_session)
+		if not deleted.get("ok", false):
+			primary_failure = _stage_failure("session_deletion", deleted)
+	_session = ""
+	_initial_revision = ""
+	if _service_started:
+		var stopped: Dictionary = await _client.shutdown()
+		if not stopped.get("ok", false):
+			var shutdown_failure := _stage_failure("shutdown", stopped)
+			if primary_failure.is_empty():
+				primary_failure = shutdown_failure
+			else:
+				primary_failure["cleanup_failures"] = [shutdown_failure]
+	_service_started = false
+	return {"ok": true} if primary_failure.is_empty() else primary_failure
+
+
+func _with_cleanup(primary: Dictionary, cleanup: Dictionary) -> Dictionary:
+	if cleanup.get("ok", false):
+		return primary
+	var result := primary.duplicate(true)
+	result["cleanup_failures"] = [cleanup.duplicate(true)]
+	return result
+
+
+func _stage_failure(stage: String, failure: Dictionary) -> Dictionary:
+	var result := failure.duplicate(true)
+	result["ok"] = false
+	result["stage"] = stage
+	return result
+
+
+func _local_failure(kind: String, detail: String, stage: String) -> Dictionary:
+	return {
+		"ok": false,
+		"kind": kind,
+		"detail": detail,
+		"stage": stage,
+		"value": {},
+	}

--- a/libs/gda-balancing/examples/schema2/playtest/content/playtest_run_provenance.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/content/playtest_run_provenance.gd
@@ -1,0 +1,52 @@
+class_name PlaytestRunProvenance
+extends RefCounted
+
+
+static func project(run_result: Dictionary) -> Dictionary:
+	var artifacts_value = run_result.get("artifacts")
+	if not artifacts_value is Dictionary:
+		return {}
+	var artifacts: Dictionary = artifacts_value
+	var primary_names: Array[String] = []
+	for name in ["evaluation-run", "experiment-verdict"]:
+		var candidate = artifacts.get(name)
+		if candidate is Dictionary and candidate.get("artifact_kind") == name:
+			primary_names.append(name)
+	if primary_names.size() != 1:
+		return {}
+
+	var primary_name := primary_names[0]
+	var primary: Dictionary = artifacts[primary_name]
+	var primary_identity := str(primary.get("content_identity", ""))
+	var experiment_identity := str(primary.get("experiment_identity", ""))
+	if primary_identity.is_empty() or experiment_identity.is_empty():
+		return {}
+
+	var artifact_bindings := {
+		"event-trace": "event_trace_identity",
+		"snapshot-series": "snapshot_series_identity",
+		"metric-dataset": "metric_dataset_identity",
+		"reproduction-receipt": "reproduction_receipt_identity",
+	}
+	var projected := {
+		"primary_artifact_kind": primary_name,
+		"primary_artifact_identity": primary_identity,
+		"experiment_identity": experiment_identity,
+	}
+	for artifact_name in artifact_bindings:
+		var artifact_value = artifacts.get(artifact_name)
+		if not artifact_value is Dictionary:
+			return {}
+		var artifact: Dictionary = artifact_value
+		var identity := str(artifact.get("content_identity", ""))
+		var binding_member: String = artifact_bindings[artifact_name]
+		if (
+			artifact.get("artifact_kind") != artifact_name
+			or identity.is_empty()
+			or primary.get(binding_member) != identity
+		):
+			return {}
+		if artifact.get("experiment_identity") != experiment_identity:
+			return {}
+		projected[binding_member] = identity
+	return projected

--- a/libs/gda-balancing/examples/schema2/playtest/content/reward_run/reward_run_controller.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/content/reward_run/reward_run_controller.gd
@@ -22,8 +22,7 @@ var current_trial := ""
 var playtest_complete := false
 var last_feedback_path := ""
 
-var _client: Node
-var _executable_path := ""
+var _execution
 var _documents := RewardRunDocuments.new()
 var _feedback := PlaytestFeedbackFile.new()
 var _run: RewardRun
@@ -31,19 +30,16 @@ var _model_source: Dictionary = {}
 var _baseline_experiment: Dictionary = {}
 var _reward_frequency: Dictionary = {}
 var _selected_reward_frequency := 0
-var _session := ""
 var _trials: Array[RewardTrial] = []
 var _last_state: Dictionary = {}
 var _busy := false
 
 
 func configure(
-	client: Node,
-	executable_path: String,
+	execution,
 	run: RewardRun,
 ) -> void:
-	_client = client
-	_executable_path = executable_path
+	_execution = execution
 	_run = run
 	_run.state_changed.connect(_on_run_state_changed)
 
@@ -51,7 +47,7 @@ func configure(
 func start() -> Dictionary:
 	_trials.clear()
 	playtest_complete = false
-	return await _prepare_live_session()
+	return await _prepare_live_session(false)
 
 
 func start_trial(reward_frequency: int) -> Dictionary:
@@ -75,16 +71,7 @@ func start_trial(reward_frequency: int) -> Dictionary:
 	)
 	if not revised.get("ok", false):
 		return _fail_trial(revised)
-	var admitted: Dictionary = await _client.admit_revision(
-		_session,
-		revised["value"],
-	)
-	if not admitted.get("ok", false):
-		return _fail_trial(admitted)
-	var executed: Dictionary = await _client.run_revision(
-		_session,
-		admitted["revision"],
-	)
+	var executed: Dictionary = await _execution.admit_and_run(revised["value"])
 	if not executed.get("ok", false):
 		return _fail_trial(executed)
 	var trial := RewardTrial.new()
@@ -92,7 +79,7 @@ func start_trial(reward_frequency: int) -> Dictionary:
 		executed["value"],
 		reward_frequency,
 		TRIAL_IDS[_trials.size()],
-		admitted["revision"],
+		executed["revision"],
 	)
 	if not projected.get("ok", false):
 		return _fail_trial(projected)
@@ -145,21 +132,15 @@ func retry() -> Dictionary:
 	if _busy:
 		return _failure("trial_in_flight", "a live trial is already in flight")
 	_busy = true
-	if not _session.is_empty():
-		await _client.delete_session(_session)
-	await _client.shutdown()
-	_session = ""
+	var result := await _prepare_live_session(true)
 	_busy = false
-	return await _prepare_live_session()
+	return result
 
 
 func shutdown() -> Dictionary:
-	if _client == null:
+	if _execution == null:
 		return {"ok": true}
-	if not _session.is_empty():
-		await _client.delete_session(_session)
-		_session = ""
-	return await _client.shutdown()
+	return await _execution.shutdown()
 
 
 func submit_feedback(
@@ -200,7 +181,7 @@ func current_state() -> Dictionary:
 	return _last_state.duplicate(true)
 
 
-func _prepare_live_session() -> Dictionary:
+func _prepare_live_session(retrying: bool) -> Dictionary:
 	phase = "preparing"
 	_emit_state(
 		{
@@ -223,17 +204,13 @@ func _prepare_live_session() -> Dictionary:
 	):
 		_selected_reward_frequency = int(_reward_frequency["value"])
 
-	var started: Dictionary = await _client.start(_executable_path)
-	if not started.get("ok", false):
-		return _fail_preparation(started)
-	var created: Dictionary = await _client.create_session(
-		_model_source,
-		_baseline_experiment,
-	)
-	if not created.get("ok", false):
-		await _client.shutdown()
-		return _fail_preparation(created)
-	_session = created["session"]
+	var established: Dictionary
+	if retrying:
+		established = await _execution.retry(_model_source, _baseline_experiment)
+	else:
+		established = await _execution.start(_model_source, _baseline_experiment)
+	if not established.get("ok", false):
+		return _fail_preparation(established)
 	_emit_frequency_choice()
 	_log_event(
 		"playtest_ready",

--- a/libs/gda-balancing/examples/schema2/playtest/content/reward_run/reward_trial.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/content/reward_run/reward_trial.gd
@@ -1,8 +1,8 @@
 class_name RewardTrial
 extends RefCounted
 
-const GdaExecutionClient = preload(
-	"res://addons/gda_balancing_client/gda_execution_client.gd"
+const PlaytestRunProvenance = preload(
+	"res://content/playtest_run_provenance.gd"
 )
 const REWARD_OPERATION := "game.generation.select-reward-v1"
 const BUILD_OPERATION := "game.build.replace-reward-v1"
@@ -42,7 +42,7 @@ func admit_run_result(
 	var trace: Dictionary = artifacts.get("event-trace", {})
 	if trace.get("artifact_kind") != "event-trace":
 		return _failure("missing_event_trace")
-	var provenance := GdaExecutionClient.project_run_provenance(run_result)
+	var provenance := PlaytestRunProvenance.project(run_result)
 	if provenance.is_empty():
 		return _failure("incomplete_artifact_provenance")
 

--- a/libs/gda-balancing/examples/schema2/playtest/content/stat_composition/stat_composition_attack.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/content/stat_composition/stat_composition_attack.gd
@@ -1,8 +1,8 @@
 class_name StatCompositionAttack
 extends RefCounted
 
-const GdaExecutionClient = preload(
-	"res://addons/gda_balancing_client/gda_execution_client.gd"
+const PlaytestRunProvenance = preload(
+	"res://content/playtest_run_provenance.gd"
 )
 const METRIC_IDS: Array[String] = [
 	"attack_damage",
@@ -43,7 +43,7 @@ func admit_run_result(
 		return _failure("missing_snapshot_series")
 	if dataset.get("artifact_kind") != "metric-dataset":
 		return _failure("missing_metric_dataset")
-	var provenance := GdaExecutionClient.project_run_provenance(run_result)
+	var provenance := PlaytestRunProvenance.project(run_result)
 	if provenance.is_empty():
 		return _failure("incomplete_artifact_provenance")
 

--- a/libs/gda-balancing/examples/schema2/playtest/content/stat_composition/stat_composition_controller.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/content/stat_composition/stat_composition_controller.gd
@@ -22,25 +22,22 @@ var last_feedback_path := ""
 var _attacks: Array[StatCompositionAttack] = []
 var _baseline_experiment: Dictionary = {}
 var _busy := false
-var _client: Node
+var _execution
 var _documents := StatCompositionDocuments.new()
 var _documents_ready := false
-var _executable_path := ""
 var _feedback := PlaytestFeedbackFile.new()
 var _last_attack: Dictionary = {}
 var _last_state: Dictionary = {}
 var _model_source: Dictionary = {}
 var _rules: Dictionary = {}
-var _session := ""
 var _settings := {"buff_enabled": 1, "level": 3, "weapon_damage_bonus": 8}
 var _setting_contracts: Dictionary = {}
 var _target_health := 120
 var _target_max_health := 120
 
 
-func configure(client: Node, executable_path: String) -> void:
-	_client = client
-	_executable_path = executable_path
+func configure(execution) -> void:
+	_execution = execution
 
 
 func start() -> Dictionary:
@@ -49,7 +46,7 @@ func start() -> Dictionary:
 	playtest_complete = false
 	_documents_ready = false
 	_target_health = 120
-	return await _prepare_live_session()
+	return await _prepare_live_session(false)
 
 
 func set_playtest_options(
@@ -111,21 +108,15 @@ func retry() -> Dictionary:
 	if _busy:
 		return _failure("attack_in_flight", "an attack is already in flight")
 	_busy = true
-	if not _session.is_empty():
-		await _client.delete_session(_session)
-	await _client.shutdown()
-	_session = ""
+	var result := await _prepare_live_session(true)
 	_busy = false
-	return await _prepare_live_session()
+	return result
 
 
 func shutdown() -> Dictionary:
-	if _client == null:
+	if _execution == null:
 		return {"ok": true}
-	if not _session.is_empty():
-		await _client.delete_session(_session)
-		_session = ""
-	return await _client.shutdown()
+	return await _execution.shutdown()
 
 
 func submit_feedback(
@@ -171,7 +162,7 @@ func current_state() -> Dictionary:
 	return _last_state.duplicate(true)
 
 
-func _prepare_live_session() -> Dictionary:
+func _prepare_live_session(retrying: bool) -> Dictionary:
 	phase = "preparing"
 	_emit_state()
 	if not _documents_ready:
@@ -187,17 +178,13 @@ func _prepare_live_session() -> Dictionary:
 		for name in _settings:
 			_settings[name] = int(_setting_contracts[name]["value"])
 		_documents_ready = true
-	var started: Dictionary = await _client.start(_executable_path)
-	if not started.get("ok", false):
-		return _fail_preparation(started)
-	var created: Dictionary = await _client.create_session(
-		_model_source,
-		_baseline_experiment,
-	)
-	if not created.get("ok", false):
-		await _client.shutdown()
-		return _fail_preparation(created)
-	_session = created["session"]
+	var established: Dictionary
+	if retrying:
+		established = await _execution.retry(_model_source, _baseline_experiment)
+	else:
+		established = await _execution.start(_model_source, _baseline_experiment)
+	if not established.get("ok", false):
+		return _fail_preparation(established)
 	phase = "ready"
 	_emit_state()
 	_log_event("stat_training_ready", {"completed_attacks": _attacks.size()})
@@ -217,15 +204,11 @@ func _run_attack() -> void:
 	if not authored.get("ok", false):
 		_fail_attack(authored)
 		return
-	var admitted: Dictionary = await _client.admit_revision(_session, authored["value"])
-	if not admitted.get("ok", false):
-		_fail_attack(admitted)
-		return
-	var revision := str(admitted["revision"])
-	var run: Dictionary = await _client.run_revision(_session, revision)
+	var run: Dictionary = await _execution.admit_and_run(authored["value"])
 	if not run.get("ok", false):
 		_fail_attack(run)
 		return
+	var revision := str(run["revision"])
 	var attack := StatCompositionAttack.new()
 	var projected := attack.admit_run_result(
 		run["value"],

--- a/libs/gda-balancing/examples/schema2/playtest/tests/fake_playtest_execution_coordinator.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/tests/fake_playtest_execution_coordinator.gd
@@ -2,6 +2,7 @@ extends RefCounted
 
 var sessions_created := 0
 var return_invalid_artifacts := false
+var retry_failure: Dictionary = {}
 
 
 func start(_model_source: Dictionary, _experiment: Dictionary) -> Dictionary:
@@ -18,6 +19,8 @@ func run_initial_revision() -> Dictionary:
 
 
 func retry(_model_source: Dictionary, _experiment: Dictionary) -> Dictionary:
+	if not retry_failure.is_empty():
+		return retry_failure.duplicate(true)
 	sessions_created += 1
 	return {"ok": true, "revision": "baseline-%d" % sessions_created}
 

--- a/libs/gda-balancing/examples/schema2/playtest/tests/fake_playtest_execution_coordinator.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/tests/fake_playtest_execution_coordinator.gd
@@ -1,0 +1,42 @@
+extends RefCounted
+
+var sessions_created := 0
+var return_invalid_artifacts := false
+
+
+func start(_model_source: Dictionary, _experiment: Dictionary) -> Dictionary:
+	sessions_created += 1
+	return {"ok": true, "revision": "baseline-%d" % sessions_created}
+
+
+func admit_and_run(_experiment: Dictionary) -> Dictionary:
+	return _run_result("candidate")
+
+
+func run_initial_revision() -> Dictionary:
+	return _run_result("baseline-%d" % sessions_created)
+
+
+func retry(_model_source: Dictionary, _experiment: Dictionary) -> Dictionary:
+	sessions_created += 1
+	return {"ok": true, "revision": "baseline-%d" % sessions_created}
+
+
+func shutdown() -> Dictionary:
+	return {"ok": true}
+
+
+func _run_result(revision: String) -> Dictionary:
+	if return_invalid_artifacts:
+		return {
+			"ok": true,
+			"revision": revision,
+			"value": {"artifacts": {}},
+		}
+	return {
+		"ok": false,
+		"kind": "execution_refused",
+		"detail": "sentinel",
+		"stage": "execution",
+		"value": {"outcome": "refusal"},
+	}

--- a/libs/gda-balancing/examples/schema2/playtest/tests/test_combat_cast_controller_failure.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/tests/test_combat_cast_controller_failure.gd
@@ -4,35 +4,9 @@ const CombatCastController = preload(
 	"res://content/combat_cast/combat_cast_controller.gd"
 )
 const CombatDuel = preload("res://systems/combat_duel.gd")
-
-class RefusingClient extends Node:
-	var sessions_created := 0
-	var return_invalid_artifacts := false
-
-	func start(_executable: String) -> Dictionary:
-		return {"ok": true}
-
-	func create_session(_model: Dictionary, _experiment: Dictionary) -> Dictionary:
-		sessions_created += 1
-		return {
-			"ok": true,
-			"revision": "baseline",
-			"session": "session-%d" % sessions_created,
-		}
-
-	func admit_revision(_session: String, _experiment: Dictionary) -> Dictionary:
-		return {"ok": true, "revision": "later"}
-
-	func run_revision(_session: String, _revision: String) -> Dictionary:
-		if return_invalid_artifacts:
-			return {"ok": true, "value": {"artifacts": {}}}
-		return {"ok": false, "kind": "execution_refused", "detail": "sentinel"}
-
-	func delete_session(_session: String) -> Dictionary:
-		return {"ok": true}
-
-	func shutdown() -> Dictionary:
-		return {"ok": true}
+const FakePlaytestExecutionCoordinator = preload(
+	"res://tests/fake_playtest_execution_coordinator.gd"
+)
 
 
 func _init() -> void:
@@ -41,11 +15,10 @@ func _init() -> void:
 
 
 func _run() -> void:
-	var client := RefusingClient.new()
-	get_root().add_child(client)
+	var execution := FakePlaytestExecutionCoordinator.new()
 	var controller := CombatCastController.new()
 	get_root().add_child(controller)
-	controller.configure(client, "unused", CombatDuel.new())
+	controller.configure(execution, CombatDuel.new())
 	var started: Dictionary = await controller.start()
 	_expect(started.get("ok", false), "fake Combat preparation succeeds")
 	var before: Dictionary = controller.current_state().get(
@@ -59,8 +32,8 @@ func _run() -> void:
 	_expect(not refused.has("damage"), "run refusal publishes no damage")
 	var retried: Dictionary = await controller.retry()
 	_expect(retried.get("ok", false), "explicit retry recreates the Combat session")
-	_expect(client.sessions_created == 2, "retry creates a new isolated session")
-	client.return_invalid_artifacts = true
+	_expect(execution.sessions_created == 2, "retry creates a new isolated session")
+	execution.return_invalid_artifacts = true
 	controller.primary_action()
 	await process_frame
 	_expect(
@@ -73,5 +46,4 @@ func _run() -> void:
 	)
 	await controller.shutdown()
 	controller.queue_free()
-	client.queue_free()
 	_finish()

--- a/libs/gda-balancing/examples/schema2/playtest/tests/test_combat_cast_controller_failure.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/tests/test_combat_cast_controller_failure.gd
@@ -3,6 +3,7 @@ extends "res://tests/playtest_test_case.gd"
 const CombatCastController = preload(
 	"res://content/combat_cast/combat_cast_controller.gd"
 )
+const CombatAction = preload("res://content/combat_cast/combat_action.gd")
 const CombatDuel = preload("res://systems/combat_duel.gd")
 const FakePlaytestExecutionCoordinator = preload(
 	"res://tests/fake_playtest_execution_coordinator.gd"
@@ -17,8 +18,9 @@ func _init() -> void:
 func _run() -> void:
 	var execution := FakePlaytestExecutionCoordinator.new()
 	var controller := CombatCastController.new()
+	var duel := CombatDuel.new()
 	get_root().add_child(controller)
-	controller.configure(execution, CombatDuel.new())
+	controller.configure(execution, duel)
 	var started: Dictionary = await controller.start()
 	_expect(started.get("ok", false), "fake Combat preparation succeeds")
 	var before: Dictionary = controller.current_state().get(
@@ -43,6 +45,53 @@ func _run() -> void:
 	_expect(
 		not controller.current_state().has("damage"),
 		"projection failure publishes no Combat result",
+	)
+	var committed_state := before.duplicate(true)
+	committed_state["enemy_health"] = int(committed_state["enemy_health"]) - 10
+	var committed_action := CombatAction.new()
+	committed_action._actor = "player"
+	committed_action._terminal = committed_state.duplicate(true)
+	controller._actions.append(committed_action)
+	controller._combat_state = committed_state.duplicate(true)
+	duel.present_action(
+		{
+			"actor": "player",
+			"damage": 10,
+			"mana_cost": 1,
+			"terminal": committed_state,
+		}
+	)
+	execution.retry_failure = {
+		"ok": false,
+		"kind": "service_unavailable",
+		"detail": "delete failed",
+		"stage": "session_deletion",
+		"value": {"outcome": "failure"},
+	}
+	var cleanup_failed: Dictionary = await controller.retry()
+	_expect(not cleanup_failed.get("ok", false), "retry reports cleanup failure")
+	_expect(
+		cleanup_failed.get("stage") == "session_deletion",
+		"retry preserves the cleanup failure stage",
+	)
+	_expect(
+		controller.current_state().get("combatants") == committed_state,
+		"cleanup failure preserves committed Combat state",
+	)
+	_expect(
+		controller.current_state().get("action_index") == 1,
+		"cleanup failure preserves committed Combat history",
+	)
+	execution.retry_failure = {}
+	var recovered: Dictionary = await controller.retry()
+	_expect(recovered.get("ok", false), "retry can recover after cleanup failure")
+	_expect(
+		controller.current_state().get("combatants") == committed_state,
+		"successful retry preserves committed Combat state",
+	)
+	_expect(
+		controller.current_state().get("phase") == "player_resolved",
+		"successful retry resumes after the last committed actor",
 	)
 	await controller.shutdown()
 	controller.queue_free()

--- a/libs/gda-balancing/examples/schema2/playtest/tests/test_combat_cast_controller_live.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/tests/test_combat_cast_controller_live.gd
@@ -6,6 +6,9 @@ const GdaExecutionClient = preload(
 const CombatCastController = preload(
 	"res://content/combat_cast/combat_cast_controller.gd"
 )
+const PlaytestExecutionCoordinator = preload(
+	"res://content/playtest_execution_coordinator.gd"
+)
 const CombatDuel = preload("res://systems/combat_duel.gd")
 const WAIT_TIMEOUT_MSEC := 60000
 
@@ -18,11 +21,12 @@ func _init() -> void:
 func _run() -> void:
 	var client := GdaExecutionClient.new()
 	get_root().add_child(client)
+	var execution := PlaytestExecutionCoordinator.new()
+	execution.configure(client, OS.get_environment("GDA_BALANCING_EXECUTABLE"))
 	var controller := CombatCastController.new()
 	get_root().add_child(controller)
 	controller.configure(
-		client,
-		OS.get_environment("GDA_BALANCING_EXECUTABLE"),
+		execution,
 		CombatDuel.new(),
 	)
 	var started: Dictionary = await controller.start()

--- a/libs/gda-balancing/examples/schema2/playtest/tests/test_gda_execution_client.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/tests/test_gda_execution_client.gd
@@ -11,7 +11,6 @@ func _init() -> void:
 
 
 func _run() -> void:
-	_expect_provenance_projection()
 	var executable := OS.get_environment("GDA_BALANCING_EXECUTABLE")
 	_expect(not executable.is_empty(), "test executable is provided")
 	if executable.is_empty():
@@ -68,70 +67,6 @@ func _run() -> void:
 	_expect(stopped.get("ok", false), "client shuts down its service process")
 	client.queue_free()
 	_finish()
-
-
-func _expect_provenance_projection() -> void:
-	for primary_kind in ["evaluation-run", "experiment-verdict"]:
-		var projected := GdaExecutionClient.project_run_provenance(
-			_provenance_run(primary_kind)
-		)
-		_expect(
-			projected.get("primary_artifact_kind") == primary_kind,
-			"%s is retained as the primary artifact" % primary_kind,
-		)
-		for member in [
-			"primary_artifact_identity",
-			"experiment_identity",
-			"event_trace_identity",
-			"snapshot_series_identity",
-			"metric_dataset_identity",
-			"reproduction_receipt_identity",
-		]:
-			_expect(
-				not str(projected.get(member, "")).is_empty(),
-				"%s provenance includes %s" % [primary_kind, member],
-			)
-	var incomplete := _provenance_run("evaluation-run")
-	incomplete["artifacts"].erase("metric-dataset")
-	_expect(
-		GdaExecutionClient.project_run_provenance(incomplete).is_empty(),
-		"incomplete provenance is refused",
-	)
-
-
-func _provenance_run(primary_kind: String) -> Dictionary:
-	var artifacts := {
-		"event-trace": {
-			"artifact_kind": "event-trace",
-			"content_identity": "trace-id",
-			"experiment_identity": "experiment-id",
-		},
-		"snapshot-series": {
-			"artifact_kind": "snapshot-series",
-			"content_identity": "snapshots-id",
-			"experiment_identity": "experiment-id",
-		},
-		"metric-dataset": {
-			"artifact_kind": "metric-dataset",
-			"content_identity": "metrics-id",
-			"experiment_identity": "experiment-id",
-		},
-		"reproduction-receipt": {
-			"artifact_kind": "reproduction-receipt",
-			"content_identity": "receipt-id",
-			"experiment_identity": "experiment-id",
-		},
-	}
-	artifacts[primary_kind] = {
-		"artifact_kind": primary_kind,
-		"content_identity": "primary-id",
-		"experiment_identity": "experiment-id",
-		"event_trace_identity": "trace-id",
-		"snapshot_series_identity": "snapshots-id",
-		"metric_dataset_identity": "metrics-id",
-		"reproduction_receipt_identity": "receipt-id",
-	}
-	return {"artifacts": artifacts}
 
 
 func _expect_compatibility_gate(client: Node) -> void:

--- a/libs/gda-balancing/examples/schema2/playtest/tests/test_periodic_effect_controller_failure.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/tests/test_periodic_effect_controller_failure.gd
@@ -6,35 +6,9 @@ const PeriodicEffectController = preload(
 const PeriodicEffectTimeline = preload(
 	"res://systems/periodic_effect_timeline.gd"
 )
-
-class RefusingClient extends Node:
-	var sessions_created := 0
-	var return_invalid_artifacts := false
-
-	func start(_executable: String) -> Dictionary:
-		return {"ok": true}
-
-	func create_session(_model: Dictionary, _experiment: Dictionary) -> Dictionary:
-		sessions_created += 1
-		return {
-			"ok": true,
-			"revision": "baseline",
-			"session": "session-%d" % sessions_created,
-		}
-
-	func admit_revision(_session: String, _experiment: Dictionary) -> Dictionary:
-		return {"ok": true, "revision": "later"}
-
-	func run_revision(_session: String, _revision: String) -> Dictionary:
-		if return_invalid_artifacts:
-			return {"ok": true, "value": {"artifacts": {}}}
-		return {"ok": false, "kind": "execution_refused", "detail": "sentinel"}
-
-	func delete_session(_session: String) -> Dictionary:
-		return {"ok": true}
-
-	func shutdown() -> Dictionary:
-		return {"ok": true}
+const FakePlaytestExecutionCoordinator = preload(
+	"res://tests/fake_playtest_execution_coordinator.gd"
+)
 
 
 func _init() -> void:
@@ -43,11 +17,10 @@ func _init() -> void:
 
 
 func _run() -> void:
-	var client := RefusingClient.new()
-	get_root().add_child(client)
+	var execution := FakePlaytestExecutionCoordinator.new()
 	var controller := PeriodicEffectController.new()
 	get_root().add_child(controller)
-	controller.configure(client, "unused", PeriodicEffectTimeline.new())
+	controller.configure(execution, PeriodicEffectTimeline.new())
 	var started: Dictionary = await controller.start()
 	_expect(started.get("ok", false), "fake Periodic Effect preparation succeeds")
 	controller.primary_action()
@@ -57,8 +30,8 @@ func _run() -> void:
 	_expect(not refused.has("health"), "run refusal publishes no gameplay state")
 	var retried: Dictionary = await controller.retry()
 	_expect(retried.get("ok", false), "explicit retry recreates the Effect session")
-	_expect(client.sessions_created == 2, "retry creates a new isolated session")
-	client.return_invalid_artifacts = true
+	_expect(execution.sessions_created == 2, "retry creates a new isolated session")
+	execution.return_invalid_artifacts = true
 	controller.primary_action()
 	await process_frame
 	_expect(
@@ -71,5 +44,4 @@ func _run() -> void:
 	)
 	await controller.shutdown()
 	controller.queue_free()
-	client.queue_free()
 	_finish()

--- a/libs/gda-balancing/examples/schema2/playtest/tests/test_periodic_effect_controller_live.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/tests/test_periodic_effect_controller_live.gd
@@ -6,6 +6,9 @@ const GdaExecutionClient = preload(
 const PeriodicEffectController = preload(
 	"res://content/periodic_effect/periodic_effect_controller.gd"
 )
+const PlaytestExecutionCoordinator = preload(
+	"res://content/playtest_execution_coordinator.gd"
+)
 const PeriodicEffectTimeline = preload(
 	"res://systems/periodic_effect_timeline.gd"
 )
@@ -20,11 +23,12 @@ func _init() -> void:
 func _run() -> void:
 	var client := GdaExecutionClient.new()
 	get_root().add_child(client)
+	var execution := PlaytestExecutionCoordinator.new()
+	execution.configure(client, OS.get_environment("GDA_BALANCING_EXECUTABLE"))
 	var controller := PeriodicEffectController.new()
 	get_root().add_child(controller)
 	controller.configure(
-		client,
-		OS.get_environment("GDA_BALANCING_EXECUTABLE"),
+		execution,
 		PeriodicEffectTimeline.new(),
 	)
 	var started: Dictionary = await controller.start()

--- a/libs/gda-balancing/examples/schema2/playtest/tests/test_playtest_execution_coordinator.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/tests/test_playtest_execution_coordinator.gd
@@ -1,0 +1,205 @@
+extends "res://tests/playtest_test_case.gd"
+
+const PlaytestExecutionCoordinator = preload(
+	"res://content/playtest_execution_coordinator.gd"
+)
+
+class RecordingClient extends RefCounted:
+	var calls: Array[String] = []
+	var failures: Dictionary = {}
+	var sessions_created := 0
+
+	func start(_executable: String) -> Dictionary:
+		calls.append("start")
+		return _result("startup")
+
+	func create_session(_model: Dictionary, _experiment: Dictionary) -> Dictionary:
+		calls.append("create_session")
+		var result := _result("session_creation")
+		if not result.get("ok", false):
+			return result
+		sessions_created += 1
+		return {
+			"ok": true,
+			"session": "session-%d" % sessions_created,
+			"revision": "baseline-%d" % sessions_created,
+		}
+
+	func admit_revision(_session: String, _experiment: Dictionary) -> Dictionary:
+		calls.append("admit_revision")
+		var result := _result("revision_admission")
+		if not result.get("ok", false):
+			return result
+		return {"ok": true, "revision": "candidate-%d" % sessions_created}
+
+	func run_revision(_session: String, revision: String) -> Dictionary:
+		calls.append("run_revision:%s" % revision)
+		var result := _result("execution")
+		if not result.get("ok", false):
+			return result
+		return {"ok": true, "value": {"revision": revision}}
+
+	func delete_session(_session: String) -> Dictionary:
+		calls.append("delete_session")
+		return _result("session_deletion")
+
+	func shutdown() -> Dictionary:
+		calls.append("shutdown")
+		return _result("shutdown")
+
+	func _result(stage: String) -> Dictionary:
+		if failures.has(stage):
+			return failures[stage].duplicate(true)
+		return {"ok": true}
+
+
+func _init() -> void:
+	super()
+	call_deferred("_run")
+
+
+func _run() -> void:
+	await _verify_success_and_exact_revision()
+	await _verify_startup_and_creation_failures()
+	await _verify_admission_and_execution_failures()
+	await _verify_retry_and_cleanup_boundaries()
+	_finish()
+
+
+func _verify_success_and_exact_revision() -> void:
+	var client := RecordingClient.new()
+	var coordinator: PlaytestExecutionCoordinator = _coordinator(client)
+	var started: Dictionary = await coordinator.start({}, {})
+	_expect(started == {"ok": true, "revision": "baseline-1"}, "session starts once")
+	var duplicate: Dictionary = await coordinator.start({}, {})
+	_expect(duplicate.get("kind") == "already_started", "double start is rejected")
+	var executed: Dictionary = await coordinator.admit_and_run({"trial": 1})
+	_expect(executed.get("revision") == "candidate-1", "admitted revision is returned")
+	_expect(
+		client.calls == [
+			"start",
+			"create_session",
+			"admit_revision",
+			"run_revision:candidate-1",
+		],
+		"the exact admitted revision is run in order",
+	)
+	var stopped: Dictionary = await coordinator.shutdown()
+	_expect(stopped.get("ok", false), "successful teardown completes")
+	_expect(
+		client.calls.slice(-2) == ["delete_session", "shutdown"],
+		"teardown deletes the session before shutdown",
+	)
+
+
+func _verify_startup_and_creation_failures() -> void:
+	var startup_client := RecordingClient.new()
+	startup_client.failures["startup"] = _typed_failure("startup-sentinel")
+	var startup: Dictionary = await _coordinator(startup_client).start({}, {})
+	_expect(startup.get("stage") == "startup", "startup failure identifies its stage")
+	_expect(
+		startup.get("value", {}).get("marker") == "startup-sentinel",
+		"startup failure preserves the typed payload",
+	)
+	_expect(startup_client.calls == ["start"], "failed startup needs no cleanup")
+
+	var creation_client := RecordingClient.new()
+	creation_client.failures["session_creation"] = _typed_failure("create-sentinel")
+	var creation: Dictionary = await _coordinator(creation_client).start({}, {})
+	_expect(
+		creation.get("stage") == "session_creation",
+		"session creation failure identifies its stage",
+	)
+	_expect(
+		creation_client.calls == ["start", "create_session", "shutdown"],
+		"partial startup still shuts down the service",
+	)
+
+
+func _verify_admission_and_execution_failures() -> void:
+	var admission_client := RecordingClient.new()
+	var admission_coordinator: PlaytestExecutionCoordinator = _coordinator(
+		admission_client
+	)
+	await admission_coordinator.start({}, {})
+	admission_client.failures["revision_admission"] = _typed_failure("admit-sentinel")
+	var admission: Dictionary = await admission_coordinator.admit_and_run({})
+	_expect(
+		admission.get("stage") == "revision_admission",
+		"admission failure identifies its stage",
+	)
+	_expect(
+		admission.get("value", {}).get("marker") == "admit-sentinel",
+		"admission failure preserves the typed payload",
+	)
+	await admission_coordinator.shutdown()
+
+	var execution_client := RecordingClient.new()
+	var execution_coordinator: PlaytestExecutionCoordinator = _coordinator(
+		execution_client
+	)
+	await execution_coordinator.start({}, {})
+	execution_client.failures["execution"] = _typed_failure("run-sentinel")
+	var execution: Dictionary = await execution_coordinator.run_initial_revision()
+	_expect(execution.get("stage") == "execution", "run failure identifies its stage")
+	_expect(
+		execution_client.calls.has("run_revision:baseline-1"),
+		"the initial exact revision is used",
+	)
+	await execution_coordinator.shutdown()
+
+
+func _verify_retry_and_cleanup_boundaries() -> void:
+	var retry_client := RecordingClient.new()
+	var retry_coordinator: PlaytestExecutionCoordinator = _coordinator(retry_client)
+	await retry_coordinator.start({}, {})
+	var retried: Dictionary = await retry_coordinator.retry({}, {})
+	_expect(retried.get("revision") == "baseline-2", "retry creates a fresh session")
+	_expect(
+		retry_client.calls == [
+			"start",
+			"create_session",
+			"delete_session",
+			"shutdown",
+			"start",
+			"create_session",
+		],
+		"retry completes cleanup before starting again",
+	)
+	await retry_coordinator.shutdown()
+
+	var delete_client := RecordingClient.new()
+	var delete_coordinator: PlaytestExecutionCoordinator = _coordinator(delete_client)
+	await delete_coordinator.start({}, {})
+	delete_client.failures["session_deletion"] = _typed_failure("delete-sentinel")
+	var deletion: Dictionary = await delete_coordinator.retry({}, {})
+	_expect(
+		deletion.get("stage") == "session_deletion",
+		"session deletion is the primary cleanup failure",
+	)
+	_expect(delete_client.calls.has("shutdown"), "shutdown continues after delete failure")
+	_expect(delete_client.calls.count("start") == 1, "failed cleanup does not restart")
+
+	var shutdown_client := RecordingClient.new()
+	var shutdown_coordinator: PlaytestExecutionCoordinator = _coordinator(
+		shutdown_client
+	)
+	await shutdown_coordinator.start({}, {})
+	shutdown_client.failures["shutdown"] = _typed_failure("shutdown-sentinel")
+	var shutdown: Dictionary = await shutdown_coordinator.shutdown()
+	_expect(shutdown.get("stage") == "shutdown", "shutdown failure identifies its stage")
+
+
+func _coordinator(client: RecordingClient) -> PlaytestExecutionCoordinator:
+	var coordinator := PlaytestExecutionCoordinator.new()
+	coordinator.configure(client, "unused")
+	return coordinator
+
+
+func _typed_failure(marker: String) -> Dictionary:
+	return {
+		"ok": false,
+		"kind": "execution_refused",
+		"detail": marker,
+		"value": {"marker": marker, "outcome": "refusal"},
+	}

--- a/libs/gda-balancing/examples/schema2/playtest/tests/test_playtest_run_provenance.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/tests/test_playtest_run_provenance.gd
@@ -1,0 +1,73 @@
+extends "res://tests/playtest_test_case.gd"
+
+const PlaytestRunProvenance = preload(
+	"res://content/playtest_run_provenance.gd"
+)
+
+
+func _init() -> void:
+	super()
+	call_deferred("_run")
+
+
+func _run() -> void:
+	for primary_kind in ["evaluation-run", "experiment-verdict"]:
+		var projected := PlaytestRunProvenance.project(_provenance_run(primary_kind))
+		_expect(
+			projected.get("primary_artifact_kind") == primary_kind,
+			"%s is retained as the primary artifact" % primary_kind,
+		)
+		for member in [
+			"primary_artifact_identity",
+			"experiment_identity",
+			"event_trace_identity",
+			"snapshot_series_identity",
+			"metric_dataset_identity",
+			"reproduction_receipt_identity",
+		]:
+			_expect(
+				not str(projected.get(member, "")).is_empty(),
+				"%s provenance includes %s" % [primary_kind, member],
+			)
+	var incomplete := _provenance_run("evaluation-run")
+	incomplete["artifacts"].erase("metric-dataset")
+	_expect(
+		PlaytestRunProvenance.project(incomplete).is_empty(),
+		"incomplete provenance is refused",
+	)
+	_finish()
+
+
+func _provenance_run(primary_kind: String) -> Dictionary:
+	var artifacts := {
+		"event-trace": {
+			"artifact_kind": "event-trace",
+			"content_identity": "trace-id",
+			"experiment_identity": "experiment-id",
+		},
+		"snapshot-series": {
+			"artifact_kind": "snapshot-series",
+			"content_identity": "snapshots-id",
+			"experiment_identity": "experiment-id",
+		},
+		"metric-dataset": {
+			"artifact_kind": "metric-dataset",
+			"content_identity": "metrics-id",
+			"experiment_identity": "experiment-id",
+		},
+		"reproduction-receipt": {
+			"artifact_kind": "reproduction-receipt",
+			"content_identity": "receipt-id",
+			"experiment_identity": "experiment-id",
+		},
+	}
+	artifacts[primary_kind] = {
+		"artifact_kind": primary_kind,
+		"content_identity": "primary-id",
+		"experiment_identity": "experiment-id",
+		"event_trace_identity": "trace-id",
+		"snapshot_series_identity": "snapshots-id",
+		"metric_dataset_identity": "metrics-id",
+		"reproduction_receipt_identity": "receipt-id",
+	}
+	return {"artifacts": artifacts}

--- a/libs/gda-balancing/examples/schema2/playtest/tests/test_reward_run_controller_failure.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/tests/test_reward_run_controller_failure.gd
@@ -4,36 +4,9 @@ const RewardRunController = preload(
 	"res://content/reward_run/reward_run_controller.gd"
 )
 const RewardRun = preload("res://systems/reward_run.gd")
-
-class RefusingExecutionClient extends Node:
-	var sessions_created := 0
-
-	func start(_executable_path: String = "") -> Dictionary:
-		return {"ok": true}
-
-	func create_session(_model: Dictionary, _experiment: Dictionary) -> Dictionary:
-		sessions_created += 1
-		return {
-			"ok": true,
-			"session": "session-%d" % sessions_created,
-			"revision": "baseline",
-		}
-
-	func admit_revision(_session: String, _experiment: Dictionary) -> Dictionary:
-		return {"ok": true, "revision": "candidate"}
-
-	func run_revision(_session: String, _revision: String) -> Dictionary:
-		return {
-			"ok": false,
-			"kind": "execution_refused",
-			"value": {"outcome": "refusal"},
-		}
-
-	func delete_session(_session: String) -> Dictionary:
-		return {"ok": true}
-
-	func shutdown() -> Dictionary:
-		return {"ok": true}
+const FakePlaytestExecutionCoordinator = preload(
+	"res://tests/fake_playtest_execution_coordinator.gd"
+)
 
 
 func _init() -> void:
@@ -42,13 +15,11 @@ func _init() -> void:
 
 
 func _run() -> void:
-	var client := RefusingExecutionClient.new()
-	get_root().add_child(client)
+	var execution := FakePlaytestExecutionCoordinator.new()
 	var controller := RewardRunController.new()
 	get_root().add_child(controller)
 	controller.configure(
-		client,
-		"unused-by-boundary-test",
+		execution,
 		RewardRun.new(),
 	)
 	controller.primary_action()
@@ -66,7 +37,7 @@ func _run() -> void:
 
 	var retried: Dictionary = await controller.retry()
 	_expect(retried.get("ok", false), "explicit retry recreates the live session")
-	_expect(client.sessions_created == 2, "retry establishes a new Execution session")
+	_expect(execution.sessions_created == 2, "retry establishes a new Execution session")
 	_expect(
 		controller.current_state().get("phase") == "choose_frequency",
 		"retry returns to the player control",
@@ -74,5 +45,4 @@ func _run() -> void:
 
 	await controller.shutdown()
 	controller.queue_free()
-	client.queue_free()
 	_finish()

--- a/libs/gda-balancing/examples/schema2/playtest/tests/test_reward_run_controller_live.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/tests/test_reward_run_controller_live.gd
@@ -6,6 +6,9 @@ const GdaExecutionClient = preload(
 const RewardRunController = preload(
 	"res://content/reward_run/reward_run_controller.gd"
 )
+const PlaytestExecutionCoordinator = preload(
+	"res://content/playtest_execution_coordinator.gd"
+)
 const RewardRun = preload("res://systems/reward_run.gd")
 
 func _init() -> void:
@@ -17,11 +20,12 @@ func _run() -> void:
 	var executable := OS.get_environment("GDA_BALANCING_EXECUTABLE")
 	var client := GdaExecutionClient.new()
 	get_root().add_child(client)
+	var execution := PlaytestExecutionCoordinator.new()
+	execution.configure(client, executable)
 	var controller := RewardRunController.new()
 	get_root().add_child(controller)
 	controller.configure(
-		client,
-		executable,
+		execution,
 		RewardRun.new(),
 	)
 	var started: Dictionary = await controller.start()

--- a/libs/gda-balancing/examples/schema2/playtest/tests/test_stat_composition_controller_failure.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/tests/test_stat_composition_controller_failure.gd
@@ -3,31 +3,9 @@ extends "res://tests/playtest_test_case.gd"
 const StatCompositionController = preload(
 	"res://content/stat_composition/stat_composition_controller.gd"
 )
-
-class RefusingClient extends Node:
-	var sessions_created := 0
-	var return_invalid_artifacts := false
-
-	func start(_executable: String) -> Dictionary:
-		return {"ok": true}
-
-	func create_session(_model: Dictionary, _experiment: Dictionary) -> Dictionary:
-		sessions_created += 1
-		return {"ok": true, "session": "session-%d" % sessions_created}
-
-	func admit_revision(_session: String, _experiment: Dictionary) -> Dictionary:
-		return {"ok": true, "revision": "later"}
-
-	func run_revision(_session: String, _revision: String) -> Dictionary:
-		if return_invalid_artifacts:
-			return {"ok": true, "value": {"artifacts": {}}}
-		return {"ok": false, "kind": "execution_refused", "detail": "sentinel"}
-
-	func delete_session(_session: String) -> Dictionary:
-		return {"ok": true}
-
-	func shutdown() -> Dictionary:
-		return {"ok": true}
+const FakePlaytestExecutionCoordinator = preload(
+	"res://tests/fake_playtest_execution_coordinator.gd"
+)
 
 
 func _init() -> void:
@@ -36,11 +14,10 @@ func _init() -> void:
 
 
 func _run() -> void:
-	var client := RefusingClient.new()
-	get_root().add_child(client)
+	var execution := FakePlaytestExecutionCoordinator.new()
 	var controller := StatCompositionController.new()
 	get_root().add_child(controller)
-	controller.configure(client, "unused")
+	controller.configure(execution)
 	var started: Dictionary = await controller.start()
 	_expect(started.get("ok", false), "fake Stat Composition preparation succeeds")
 	var before := controller.current_state()
@@ -52,13 +29,12 @@ func _run() -> void:
 	_expect(refused.get("attack_count") == 0, "run refusal records no successful attack")
 	var retried: Dictionary = await controller.retry()
 	_expect(retried.get("ok", false), "explicit Retry recreates the session")
-	_expect(client.sessions_created == 2, "Retry creates a new isolated session")
-	client.return_invalid_artifacts = true
+	_expect(execution.sessions_created == 2, "Retry creates a new isolated session")
+	execution.return_invalid_artifacts = true
 	controller.primary_action()
 	await process_frame
 	_expect(controller.current_state().get("phase") == "retry", "projection failure presents Retry")
 	_expect(controller.current_state().get("attack_count") == 0, "projection failure records no attack")
 	await controller.shutdown()
 	controller.queue_free()
-	client.queue_free()
 	_finish()

--- a/libs/gda-balancing/examples/schema2/playtest/tests/test_stat_composition_controller_live.gd
+++ b/libs/gda-balancing/examples/schema2/playtest/tests/test_stat_composition_controller_live.gd
@@ -6,6 +6,9 @@ const GdaExecutionClient = preload(
 const StatCompositionController = preload(
 	"res://content/stat_composition/stat_composition_controller.gd"
 )
+const PlaytestExecutionCoordinator = preload(
+	"res://content/playtest_execution_coordinator.gd"
+)
 const WAIT_TIMEOUT_MSEC := 60000
 
 
@@ -17,9 +20,11 @@ func _init() -> void:
 func _run() -> void:
 	var client := GdaExecutionClient.new()
 	get_root().add_child(client)
+	var execution := PlaytestExecutionCoordinator.new()
+	execution.configure(client, OS.get_environment("GDA_BALANCING_EXECUTABLE"))
 	var controller := StatCompositionController.new()
 	get_root().add_child(controller)
-	controller.configure(client, OS.get_environment("GDA_BALANCING_EXECUTABLE"))
+	controller.configure(execution)
 	var started: Dictionary = await controller.start()
 	_expect(started.get("ok", false), "Attack Damage Training prepares")
 	_expect(controller.current_state().get("phase") == "ready", "the first attack is ready")

--- a/libs/gda-balancing/src/gda_balancing/domain/experiment.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/experiment.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import hashlib
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -43,6 +43,9 @@ from gda_balancing.domain.operation_program import (
     expanded_operation_body,
     operation_coordinate,
     selected_operation_index,
+)
+from gda_balancing.domain.program_reachability import (
+    project_reachable_program_structure,
 )
 from gda_balancing.domain.runtime.scheduler import RuntimeScheduler
 from gda_balancing.domain.structured_values import (
@@ -325,16 +328,7 @@ def derive_scenario_program_requirements(
     if operation["runtime_profile"] != runtime_profile:
         raise ValueError("Scenario Operation requires another Runtime profile")
     expanded_body = expanded_operation_body(root_coordinate, operations)
-    instruction_nodes = {instruction["node"] for instruction in expanded_body} | {
-        row["instruction"]["node"]
-        for phase in ("initialization", "event", "observation")
-        for program in reachable_formula_programs(
-            rir,
-            [entrypoint],
-            phase=phase,
-        )
-        for row in cast(list[dict[str, Any]], program["body"])
-    }
+    program_structure = project_reachable_program_structure(rir, [entrypoint])
     requirements = {
         "operation_kinds": sorted(
             {
@@ -348,7 +342,7 @@ def derive_scenario_program_requirements(
                 ),
             }
         ),
-        "instruction_nodes": sorted(instruction_nodes),
+        "instruction_nodes": sorted(program_structure.runtime_node_ids),
         "effects": sorted(set(operation["effects"])),
         "numeric_policies": [operation["numeric_policy"]],
         # Every Experiment declares a Seed contract. The evaluator therefore
@@ -364,45 +358,6 @@ def derive_scenario_program_requirements(
         }
     )
     return requirements, named_streams
-
-
-def reachable_formula_programs(
-    rir: Mapping[str, Any],
-    selected_entrypoints: Sequence[dict[str, Any]],
-    *,
-    phase: str,
-) -> list[dict[str, Any]]:
-    """Project one lifecycle phase to the Formula sites selected by a Scenario."""
-    programs = [
-        program
-        for program in cast(list[dict[str, Any]], rir["initialization_programs"])
-        if cast(dict[str, Any], program["site"])["context"]["phase"] == phase
-    ]
-    reachable_targets = {
-        canonical_bytes(cast(JsonValue, operand["symbol"]))
-        for entrypoint in selected_entrypoints
-        for binding in cast(list[dict[str, Any]], entrypoint["arguments"])
-        if (operand := cast(dict[str, Any], binding["operand"]))["kind"] == "symbol"
-    }
-    while True:
-        previous_targets = len(reachable_targets)
-        for program in programs:
-            target = canonical_bytes(cast(JsonValue, program["target"]))
-            if target not in reachable_targets:
-                continue
-            reachable_targets.update(
-                canonical_bytes(cast(JsonValue, operand["resolved_symbol"]))
-                for row in cast(list[dict[str, Any]], program["inputs"])
-                if (operand := cast(dict[str, Any], row["operand"]))["kind"]
-                != "literal"
-            )
-        if len(reachable_targets) == previous_targets:
-            break
-    return [
-        program
-        for program in programs
-        if canonical_bytes(cast(JsonValue, program["target"])) in reachable_targets
-    ]
 
 
 def check_experiment(

--- a/libs/gda-balancing/src/gda_balancing/domain/experiment.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/experiment.py
@@ -40,8 +40,8 @@ from gda_balancing.domain.model import (
     resolve_published_model_binding,
 )
 from gda_balancing.domain.operation_program import (
-    expanded_operation_body,
     operation_coordinate,
+    operation_body_instructions,
     selected_operation_index,
 )
 from gda_balancing.domain.program_reachability import (
@@ -327,19 +327,15 @@ def derive_scenario_program_requirements(
         raise ValueError("Scenario Operation is absent from the selected RIR")
     if operation["runtime_profile"] != runtime_profile:
         raise ValueError("Scenario Operation requires another Runtime profile")
-    expanded_body = expanded_operation_body(root_coordinate, operations)
     program_structure = project_reachable_program_structure(rir, [entrypoint])
+    reachable_operations = [
+        operations[coordinate] for coordinate in program_structure.operation_coordinates
+    ]
     requirements = {
         "operation_kinds": sorted(
             {
-                operation["operation_kind"],
-                *(
-                    operations[operation_coordinate(instruction["operation"])][
-                        "operation_kind"
-                    ]
-                    for instruction in expanded_body
-                    if instruction["node"] in {"invoke", "schedule"}
-                ),
+                reachable_operation["operation_kind"]
+                for reachable_operation in reachable_operations
             }
         ),
         "instruction_nodes": sorted(program_structure.runtime_node_ids),
@@ -353,7 +349,10 @@ def derive_scenario_program_requirements(
     named_streams = sorted(
         {
             instruction["stream"]
-            for instruction in expanded_body
+            for reachable_operation in reachable_operations
+            for instruction in operation_body_instructions(
+                cast(list[dict[str, Any]], reachable_operation["body"])
+            )
             if instruction["node"] == "draw"
         }
     )

--- a/libs/gda-balancing/src/gda_balancing/domain/experiment_artifact_replay.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/experiment_artifact_replay.py
@@ -13,8 +13,8 @@ from gda_balancing.domain.operation_program import (
     operation_coordinate,
     selected_operation_index,
 )
+from gda_balancing.domain.program_reachability import reachable_formula_programs
 from gda_balancing.domain.runtime.projections import (
-    formula_programs_reachable_from_entrypoints,
     operation_formula_evaluation_record,
     resolved_display_names,
     runtime_contract,
@@ -405,8 +405,8 @@ def evaluate_initialization_programs(
     phase: str = "initialization",
 ) -> int:
     """Independently replay closed Formula initialization programs."""
-    programs = formula_programs_reachable_from_entrypoints(
-        checked, selected_entrypoints, phase=phase
+    programs = reachable_formula_programs(
+        checked.rir, selected_entrypoints, phase=phase
     )
     if not programs:
         return consumed_steps

--- a/libs/gda-balancing/src/gda_balancing/domain/experiment_artifacts.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/experiment_artifacts.py
@@ -40,7 +40,6 @@ from gda_balancing.domain.runtime.projections import (
     evaluator_manifest as _evaluator_manifest,
     event_catalog_record as _event_catalog_record,
     extend_runtime_journal_identity as _extend_runtime_journal_identity,
-    formula_programs_reachable_from_entrypoints as _formula_programs_reachable_from_entrypoints,
     metric_definition_identity as _metric_definition_identity,
     named_value_rows as _named_value_rows,
     observation_event_id as _observation_event_id,
@@ -59,6 +58,7 @@ from gda_balancing.domain.runtime.projections import (
     scheduled_event_id as _scheduled_event_id,
     scheduler_contract as _scheduler_contract,
 )
+from gda_balancing.domain.program_reachability import reachable_formula_programs
 
 _INVALID_FORMULA_EVIDENCE = object()
 _EXPERIMENT_RUNTIME_REFUSAL_NAMES = frozenset(
@@ -1362,8 +1362,8 @@ def _formula_charge_through_evaluation_site(
 ) -> int | None:
     if evaluation_site_identity is None:
         return None
-    programs = _formula_programs_reachable_from_entrypoints(
-        checked,
+    programs = reachable_formula_programs(
+        checked.rir,
         selected_entrypoints,
         phase=phase,
     )
@@ -1794,8 +1794,8 @@ def _terminal_audit_is_valid(
         resolved_entrypoints[cast(str, event["entrypoint"])]
         for event in _scenario_transition_events(scenario)
     ]
-    event_formula_programs = _formula_programs_reachable_from_entrypoints(
-        checked,
+    event_formula_programs = reachable_formula_programs(
+        checked.rir,
         selected_entrypoints,
         phase="event",
     )

--- a/libs/gda-balancing/src/gda_balancing/domain/model/_admission.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/model/_admission.py
@@ -27,23 +27,21 @@ from gda_balancing.domain.formula.notation import (
     admit_formula_pair,
     formula_schema_version,
 )
-from gda_balancing.domain.formula.inference import (
-    infer_formula_slot_parameter_contract as _infer_formula_slot_parameter_contract,
-)
 from gda_balancing.domain.formula.types import (
     formula_contract_contains as _formula_contract_contains,
-    formula_contract_from_operation as _formula_contract_from_operation,
     formula_contract_matches as _formula_contract_matches,
     formula_contract_matches_operation as _formula_contract_matches_operation,
 )
 from gda_balancing.domain.authority.runtime_validation import (
-    fixed_operation_value_contract,
     operation_literal_context_contract as _literal_context_contract,
 )
 from gda_balancing.domain.structured_values import (
     StructuredValueFault,
     admit_typed_value,
     language_structured_value_index,
+)
+from gda_balancing.domain.operation_call_domains import (
+    project_concrete_operation_call_domains,
 )
 
 from gda_balancing.domain.model._resolution import (
@@ -68,7 +66,6 @@ from gda_balancing.domain.model._lowering import (
     _formula_operation_identity,
     _formula_symbol_dependencies,
     _package_lock,
-    _project_concrete_operation_call_closure,
     _reachable_derived_formula_sites,
     _reachable_operation_formula_dependencies,
     _resolved_alias_rows,
@@ -83,6 +80,11 @@ from gda_balancing.domain.model._lowering import (
     _symbol_initialization_contract,
     _value_contract_matches,
     _value_policy_is_valid,
+)
+from gda_balancing.domain.model._operation_call_domain_adapters import (
+    resolved_rir_entrypoint_call,
+    resolved_rir_formula_call,
+    rir_call_domain_input,
 )
 
 
@@ -968,34 +970,24 @@ def _formula_program_graph_is_admitted(
                     or set(port_ids) != set(ports)
                 ):
                     return False
-                call_arguments: dict[str, dict[str, Any]] = {}
-                known_call_arguments: dict[str, Any] = {}
-                for argument in arguments:
-                    if (
-                        set(argument) != {"port", "operand"}
-                        or (contract := operand_contract(argument.get("operand")))
-                        is None
-                    ):
-                        return False
-                    port_id = cast(str, argument["port"])
-                    if not _formula_contract_matches_operation(
-                        contract, ports[port_id]
-                    ):
-                        return False
-                    call_arguments[port_id] = contract
-                    operand = cast(dict[str, Any], argument["operand"])
-                    if operand.get("kind") == "literal":
-                        known_call_arguments[port_id] = operand.get("value")
+                concrete_call = resolved_rir_formula_call(
+                    operation,
+                    arguments,
+                    operand_contract,
+                )
+                if concrete_call is None or any(
+                    not _formula_contract_matches_operation(contract, ports[port_id])
+                    for port_id, contract in cast(
+                        dict[str, dict[str, Any]], concrete_call["arguments"]
+                    ).items()
+                ):
+                    return False
                 operation_dependencies_by_key[key].append(
                     (cast(str, operation_ref["identity"]), operation)
                 )
                 formula_operation_roots.add(coordinate)
                 concrete_operation_calls.setdefault(coordinate, []).append(
-                    {
-                        "arguments": call_arguments,
-                        "known_arguments": known_call_arguments,
-                        "result": node["result"],
-                    }
+                    concrete_call | {"result": node["result"]}
                 )
             elif node.get("node") == "conditional":
                 if set(node) != {
@@ -1123,79 +1115,30 @@ def _formula_program_graph_is_admitted(
             cast(str, operation_ref.get("id")),
         )
         operation = operations_by_coordinate.get(coordinate)
-        arguments = entrypoint.get("arguments")
-        if operation is None or not isinstance(arguments, list):
+        if operation is None:
             return False
-        call_arguments: dict[str, dict[str, Any]] = {}
-        known_call_arguments: dict[str, Any] = {}
-        for argument in arguments:
-            if not isinstance(argument, dict) or not isinstance(
-                argument.get("port"), dict
-            ):
-                return False
-            port_id = cast(str, argument["port"].get("name"))
-            operand = argument.get("operand")
-            if not isinstance(operand, dict):
-                return False
-            if operand.get("kind") == "symbol":
-                symbol = operand.get("symbol")
-                if not isinstance(symbol, dict):
-                    return False
-                contract = declarations_by_symbol.get(
-                    (
-                        cast(str, symbol.get("module")),
-                        cast(str, symbol.get("name")),
-                    )
-                )
-            elif operand.get("kind") == "literal":
-                context_type = operand.get("context_type")
-                if not isinstance(context_type, dict):
-                    return False
-                try:
-                    contract = cast(
-                        dict[str, Any],
-                        _formula_contract_from_operation(context_type),
-                    )
-                except ValueError:
-                    return False
-                value = operand.get("value")
-                if isinstance(value, int) and not isinstance(value, bool):
-                    contract = {
-                        **contract,
-                        "domain_kind": "closed-interval",
-                        "domain": {"minimum": value, "maximum": value},
-                    }
-                known_call_arguments[port_id] = value
-            elif operand.get("kind") == "event-reference":
-                event_reference_contract = fixed_operation_value_contract(
-                    kernel, "kernel-event-reference"
-                )
-                if event_reference_contract is None:
-                    return False
-                contract = cast(
-                    dict[str, Any],
-                    _formula_contract_from_operation(event_reference_contract),
-                )
-            else:
-                return False
-            if not isinstance(contract, dict):
-                return False
-            call_arguments[port_id] = contract
-        concrete_operation_calls.setdefault(coordinate, []).append(
-            {
-                "arguments": call_arguments,
-                "known_arguments": known_call_arguments,
-            }
-        )
-    try:
-        concrete_operation_calls = _project_concrete_operation_call_closure(
-            operations_by_coordinate,
-            concrete_operation_calls,
-            kernel,
-            language_bundle,
-            cast(dict[str, Any], policy["notation_conversion"]),
+        concrete_call = resolved_rir_entrypoint_call(
+            entrypoint,
+            operation,
             declarations_by_symbol,
+            kernel,
         )
+        if concrete_call is None:
+            return False
+        concrete_operation_calls.setdefault(coordinate, []).append(concrete_call)
+    try:
+        call_domain_projection = project_concrete_operation_call_domains(
+            rir_call_domain_input(
+                operations_by_coordinate,
+                concrete_operation_calls,
+                cast(list[dict[str, Any]], bindings),
+                declarations_by_symbol,
+                kernel,
+                language_bundle,
+                cast(dict[str, Any], policy["notation_conversion"]),
+            )
+        )
+        concrete_operation_calls = call_domain_projection.calls
     except (KeyError, TypeError, ValueError):
         return False
     reachable_operations = _selected_resolved_operation_coordinates(
@@ -1387,15 +1330,16 @@ def _formula_program_graph_is_admitted(
                     slot_parameter,
                 ):
                     return False
-                for call in concrete_calls:
-                    try:
-                        actual_contract = _infer_formula_slot_parameter_contract(
-                            operation,
-                            slot_parameter,
-                            call,
-                            cast(dict[str, Any], policy["notation_conversion"]),
-                        )
-                    except (KeyError, TypeError, ValueError):
+                projected_parameters = (
+                    call_domain_projection.slot_parameter_contracts.get(slot_key, [])
+                )
+                if len(projected_parameters) != len(concrete_calls):
+                    return False
+                for parameter_projection in projected_parameters:
+                    actual_contract = parameter_projection.get(
+                        cast(str, operand["parameter"])
+                    )
+                    if not isinstance(actual_contract, dict):
                         return False
                     if not _formula_contract_contains(
                         parameters[argument["parameter"]], actual_contract

--- a/libs/gda-balancing/src/gda_balancing/domain/model/_admission.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/model/_admission.py
@@ -82,9 +82,9 @@ from gda_balancing.domain.model._lowering import (
     _value_policy_is_valid,
 )
 from gda_balancing.domain.model._operation_call_domain_adapters import (
+    build_operation_call_domain_input,
     resolved_rir_entrypoint_call,
     resolved_rir_formula_call,
-    rir_call_domain_input,
 )
 
 
@@ -1128,7 +1128,7 @@ def _formula_program_graph_is_admitted(
         concrete_operation_calls.setdefault(coordinate, []).append(concrete_call)
     try:
         call_domain_projection = project_concrete_operation_call_domains(
-            rir_call_domain_input(
+            build_operation_call_domain_input(
                 operations_by_coordinate,
                 concrete_operation_calls,
                 cast(list[dict[str, Any]], bindings),

--- a/libs/gda-balancing/src/gda_balancing/domain/model/_lowering.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/model/_lowering.py
@@ -57,9 +57,9 @@ from gda_balancing.domain.model._resolution import (
     _selected_values,
 )
 from gda_balancing.domain.model._operation_call_domain_adapters import (
+    build_operation_call_domain_input,
     resolved_source_entrypoint_call,
     resolved_source_formula_call,
-    source_call_domain_input,
 )
 
 _LOWERER_IMPLEMENTATION_IDENTITY = "gda-balancing.python-lowerer-v1"
@@ -1255,7 +1255,7 @@ def _resolved_formula_programs_and_bindings_impl(
         if concrete_call is not None:
             concrete_operation_calls.setdefault(coordinate, []).append(concrete_call)
     call_domain_projection = project_concrete_operation_call_domains(
-        source_call_domain_input(
+        build_operation_call_domain_input(
             operations_by_coordinate,
             concrete_operation_calls,
             source_bindings,

--- a/libs/gda-balancing/src/gda_balancing/domain/model/_lowering.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/model/_lowering.py
@@ -16,14 +16,8 @@ from gda_balancing.domain.canonical import (
     canonical_bytes,
     content_identity,
 )
-from gda_balancing.domain.formula.inference import (
-    infer_formula_operation_local_contract as _infer_formula_operation_local_contract,
-    infer_formula_operation_result as _infer_formula_operation_result,
-    infer_formula_slot_parameter_contract as _infer_formula_slot_parameter_contract,
-)
 from gda_balancing.domain.formula.types import (
     formula_contract_contains as _formula_contract_contains,
-    formula_contract_from_operation as _formula_contract_from_operation,
     formula_contract_matches as _formula_contract_matches,
     formula_contract_matches_operation as _formula_contract_matches_operation,
     resolve_formula_contract as _resolved_formula_contract,
@@ -37,6 +31,9 @@ from gda_balancing.domain.operation_program import (
     closed_operation_coordinates,
     project_operation_program,
     record_instruction_evaluation_sites,
+)
+from gda_balancing.domain.operation_call_domains import (
+    project_concrete_operation_call_domains,
 )
 from gda_balancing.domain.structured_values import (
     StructuredValueFault,
@@ -58,6 +55,11 @@ from gda_balancing.domain.model._resolution import (
     _resolution_profile,
     _selected_source_operation_coordinates,
     _selected_values,
+)
+from gda_balancing.domain.model._operation_call_domain_adapters import (
+    resolved_source_entrypoint_call,
+    resolved_source_formula_call,
+    source_call_domain_input,
 )
 
 _LOWERER_IMPLEMENTATION_IDENTITY = "gda-balancing.python-lowerer-v1"
@@ -480,458 +482,6 @@ def _resolved_formula_operand(
         },
         contract,
     )
-
-
-def _resolved_formula_call(
-    formula: dict[str, Any],
-    node: dict[str, Any],
-    operation: dict[str, Any],
-    declarations_by_source: dict[tuple[str, str], dict[str, Any]],
-    kernel: dict[str, Any],
-    language_bundle: dict[str, Any],
-) -> dict[str, Any]:
-    """Project concrete value contracts for one resolved Formula Operation call."""
-    parameters = {
-        cast(str, parameter["id"]): parameter
-        for parameter in cast(list[dict[str, Any]], formula["parameters"])
-    }
-    locals_by_id = {
-        cast(str, item["id"]): cast(dict[str, Any], item["result"])
-        for item in cast(
-            list[dict[str, Any]], cast(dict[str, Any], formula["body"])["nodes"]
-        )
-    }
-    ports = {
-        cast(str, port["id"]): port
-        for port in cast(list[dict[str, Any]], operation["inputs"])
-    }
-    resolved: dict[str, dict[str, Any]] = {}
-    known_arguments: dict[str, Any] = {}
-    for argument in cast(list[dict[str, Any]], node["arguments"]):
-        port_id = cast(str, argument["port"])
-        operand = cast(dict[str, Any], argument["operand"])
-        operand_kind = operand.get("kind")
-        if operand_kind == "parameter":
-            contract = parameters[cast(str, operand["parameter"])]
-        elif operand_kind == "local":
-            contract = locals_by_id[cast(str, operand["local"])]
-        elif operand_kind == "symbol":
-            symbol = cast(dict[str, str], operand["resolved_symbol"])
-            contract = declarations_by_source[(symbol["module"], symbol["name"])]
-        elif operand_kind == "literal":
-            value = operand.get("value")
-            literal_context = _literal_context_contract(
-                value,
-                ports[port_id],
-                kernel,
-                {
-                    "literal_typing_profiles": [
-                        {"definition": profile}
-                        for profile in cast(
-                            list[dict[str, Any]],
-                            _language(language_bundle)["literal_typing_profiles"],
-                        )
-                    ]
-                },
-            )
-            if (
-                literal_context is None
-                or not isinstance(value, int)
-                or isinstance(value, bool)
-            ):
-                raise ValueError("Formula literal has no concrete call-site contract")
-            literal_type = cast(dict[str, str], literal_context["type"])
-            contract = {
-                "type_identity": {
-                    "package": literal_type["package"],
-                    "version": literal_type["version"],
-                    "symbol": literal_type["id"],
-                },
-                "representation": literal_context["representation"],
-                "kind": literal_context["kind"],
-                "unit": literal_context["unit"],
-                "domain_kind": "closed-interval",
-                "domain": {"minimum": value, "maximum": value},
-                "numeric_policy": literal_context["numeric_policy"],
-            }
-            known_arguments[port_id] = value
-        else:
-            raise ValueError("Formula call operand has no concrete contract")
-        resolved[port_id] = contract
-    return {"arguments": resolved, "known_arguments": known_arguments}
-
-
-def _resolved_entrypoint_call(
-    source_entrypoint: dict[str, Any],
-    operation: dict[str, Any],
-    declarations_by_source: dict[tuple[str, str], dict[str, Any]],
-    kernel: dict[str, Any],
-    language_bundle: dict[str, Any],
-) -> dict[str, Any] | None:
-    """Project one concrete source entrypoint call for Formula-slot closure."""
-    ports = {
-        cast(str, port["id"]): port
-        for port in cast(list[dict[str, Any]], operation["inputs"])
-    }
-    arguments: dict[str, dict[str, Any]] = {}
-    known_arguments: dict[str, Any] = {}
-    for argument in cast(list[dict[str, Any]], source_entrypoint["arguments"]):
-        port_id = cast(str, argument["port"])
-        formal = ports.get(port_id)
-        if formal is None:
-            return None
-        operand = cast(dict[str, Any], argument["operand"])
-        if operand.get("kind") == "symbol":
-            contract = declarations_by_source.get(
-                (cast(str, operand.get("module")), cast(str, operand.get("symbol")))
-            )
-            if contract is None:
-                return None
-        elif operand.get("kind") == "literal":
-            value = operand.get("value")
-            literal_context = _literal_context_contract(
-                value,
-                formal,
-                kernel,
-                {
-                    "literal_typing_profiles": [
-                        {"definition": profile}
-                        for profile in cast(
-                            list[dict[str, Any]],
-                            _language(language_bundle)["literal_typing_profiles"],
-                        )
-                    ]
-                },
-            )
-            if literal_context is None:
-                return None
-            contract = cast(
-                dict[str, Any], _formula_contract_from_operation(literal_context)
-            )
-            if isinstance(value, int) and not isinstance(value, bool):
-                contract = {
-                    **contract,
-                    "domain_kind": "closed-interval",
-                    "domain": {"minimum": value, "maximum": value},
-                }
-            known_arguments[port_id] = value
-        elif operand.get("kind") == "event-reference":
-            event_reference_contract = fixed_operation_value_contract(
-                kernel, "kernel-event-reference"
-            )
-            if event_reference_contract is None:
-                return None
-            contract = cast(
-                dict[str, Any],
-                _formula_contract_from_operation(event_reference_contract),
-            )
-        else:
-            return None
-        arguments[port_id] = contract
-    if set(arguments) != set(ports):
-        return None
-    return {
-        "arguments": arguments,
-        "known_arguments": known_arguments,
-    }
-
-
-def _project_concrete_operation_call_closure(
-    operations: dict[tuple[str, str, str], dict[str, Any]],
-    roots: dict[tuple[str, str, str], list[dict[str, Any]]],
-    kernel: dict[str, Any],
-    language_bundle: dict[str, Any],
-    conversion_policy: dict[str, Any],
-    declarations_by_symbol: dict[tuple[str, str], dict[str, Any]] | None = None,
-) -> dict[tuple[str, str, str], list[dict[str, Any]]]:
-    """Propagate concrete contracts through reachable Operation-valued calls."""
-    projected = {coordinate: list(calls) for coordinate, calls in roots.items()}
-    operation_node_ids = _operation_reference_node_ids(kernel)
-    slot_coordinates = {
-        coordinate
-        for coordinate, operation in operations.items()
-        if _operation_formula_slots(operation)
-    }
-    if not slot_coordinates:
-        return projected
-    reaches_slot_cache: dict[tuple[str, str, str], bool] = {}
-
-    def reaches_formula_slot(
-        coordinate: tuple[str, str, str],
-        stack: tuple[tuple[str, str, str], ...] = (),
-    ) -> bool:
-        cached = reaches_slot_cache.get(coordinate)
-        if cached is not None:
-            return cached
-        if coordinate in stack:
-            return False
-        if coordinate in slot_coordinates:
-            reaches_slot_cache[coordinate] = True
-            return True
-        operation = operations.get(coordinate)
-        if operation is None:
-            reaches_slot_cache[coordinate] = False
-            return False
-
-        def body_reaches_slot(instructions: list[dict[str, Any]]) -> bool:
-            for instruction in instructions:
-                nested = instruction.get("body")
-                if (
-                    isinstance(nested, list)
-                    and all(isinstance(row, dict) for row in nested)
-                    and body_reaches_slot(cast(list[dict[str, Any]], nested))
-                ):
-                    return True
-                operation_ref = instruction.get("operation")
-                if instruction.get("node") not in operation_node_ids or not isinstance(
-                    operation_ref, dict
-                ):
-                    continue
-                if not all(
-                    isinstance(operation_ref.get(member), str)
-                    for member in ("package", "version", "id")
-                ):
-                    raise ValueError("nested Operation reference is malformed")
-                child_coordinate = (
-                    cast(str, operation_ref["package"]),
-                    cast(str, operation_ref["version"]),
-                    cast(str, operation_ref["id"]),
-                )
-                if reaches_formula_slot(child_coordinate, (*stack, coordinate)):
-                    return True
-            return False
-
-        reaches = body_reaches_slot(cast(list[dict[str, Any]], operation["body"]))
-        reaches_slot_cache[coordinate] = reaches
-        return reaches
-
-    literal_profiles = {
-        "literal_typing_profiles": [
-            {"definition": profile}
-            for profile in cast(
-                list[dict[str, Any]],
-                _language(language_bundle)["literal_typing_profiles"],
-            )
-        ]
-    }
-
-    def visit(
-        coordinate: tuple[str, str, str],
-        call: dict[str, Any],
-        stack: tuple[tuple[str, str, str], ...],
-        *,
-        resolve_result: bool,
-    ) -> dict[str, Any]:
-        if coordinate in stack:
-            raise ValueError("concrete Operation call graph contains a cycle")
-        operation = operations.get(coordinate)
-        arguments = call.get("arguments")
-        if operation is None or not isinstance(arguments, dict):
-            raise ValueError("concrete Operation call is unresolved")
-        ports = [
-            cast(str, port["id"])
-            for port in cast(list[dict[str, Any]], operation["inputs"])
-        ]
-        if set(arguments) != set(ports):
-            raise ValueError("concrete Operation call arguments are incomplete")
-        operand_contracts = [cast(dict[str, Any], arguments[port]) for port in ports]
-        known_arguments = cast(dict[str, Any], call.get("known_arguments", {}))
-        local_contracts: dict[str, dict[str, Any]] = {}
-        local_values: dict[str, Any] = {}
-        local_intervals: dict[str, tuple[int, int]] = {}
-        result_by_site: dict[str, dict[str, Any]] = {}
-        extensions = operation.get("extensions")
-        snapshot_operands = (
-            extensions.get("standard.snapshot-operands")
-            if isinstance(extensions, dict)
-            else None
-        )
-        if isinstance(snapshot_operands, dict):
-            for operand in cast(list[dict[str, Any]], snapshot_operands["operands"]):
-                resolved_symbol = cast(dict[str, str], operand["resolved_symbol"])
-                declaration = (declarations_by_symbol or {}).get(
-                    (resolved_symbol["module"], resolved_symbol["name"])
-                )
-                if declaration is None:
-                    raise ValueError(
-                        "specialized Formula snapshot contract is unresolved"
-                    )
-                local_contracts[cast(str, operand["name"])] = declaration
-
-        def literal_contract(value: Any, formal: dict[str, Any]) -> dict[str, Any]:
-            context = _literal_context_contract(value, formal, kernel, literal_profiles)
-            if context is None:
-                raise ValueError("nested Operation literal has no concrete contract")
-            contract = cast(dict[str, Any], _formula_contract_from_operation(context))
-            if isinstance(value, int) and not isinstance(value, bool):
-                contract = {
-                    **contract,
-                    "domain_kind": "closed-interval",
-                    "domain": {"minimum": value, "maximum": value},
-                }
-            return contract
-
-        def local_contract(name: str, formal: dict[str, Any]) -> dict[str, Any]:
-            contract = local_contracts.get(name)
-            if contract is not None:
-                return contract
-            if name in local_values:
-                contract = literal_contract(local_values[name], formal)
-            elif name in local_intervals:
-                minimum, maximum = local_intervals[name]
-                contract = {
-                    **cast(dict[str, Any], _formula_contract_from_operation(formal)),
-                    "domain_kind": "closed-interval",
-                    "domain": {"minimum": minimum, "maximum": maximum},
-                }
-            else:
-                try:
-                    contract = _infer_formula_operation_local_contract(
-                        operation,
-                        ports,
-                        operand_contracts,
-                        name,
-                        cast(dict[str, Any], _formula_contract_from_operation(formal)),
-                        conversion_policy,
-                        {},
-                        known_operand_values=known_arguments,
-                        known_local_contracts=local_contracts,
-                        ignore_unmatched_instructions=True,
-                    )
-                except ValueError as error:
-                    raise ValueError(
-                        f"concrete Operation local {coordinate!r}.{name} is unresolved"
-                    ) from error
-            local_contracts[name] = contract
-            return contract
-
-        def walk(instructions: list[dict[str, Any]]) -> None:
-            for instruction in instructions:
-                node = instruction.get("node")
-                target = instruction.get("target")
-                if node == "constant" and isinstance(target, str):
-                    local_values[target] = instruction.get("literal")
-                elif node == "draw" and isinstance(target, str):
-                    minimum = instruction.get("minimum")
-                    maximum = instruction.get("maximum")
-                    if (
-                        isinstance(minimum, int)
-                        and not isinstance(minimum, bool)
-                        and isinstance(maximum, int)
-                        and not isinstance(maximum, bool)
-                    ):
-                        local_intervals[target] = (minimum, maximum)
-                nested = instruction.get("body")
-                if isinstance(nested, list) and all(
-                    isinstance(row, dict) for row in nested
-                ):
-                    walk(cast(list[dict[str, Any]], nested))
-                operation_ref = instruction.get("operation")
-                if node not in operation_node_ids or not isinstance(
-                    operation_ref, dict
-                ):
-                    continue
-                child_coordinate = (
-                    cast(str, operation_ref["package"]),
-                    cast(str, operation_ref["version"]),
-                    cast(str, operation_ref["id"]),
-                )
-                child = operations.get(child_coordinate)
-                if child is None:
-                    raise ValueError("nested Operation call target is unresolved")
-                child_ports = {
-                    cast(str, port["id"]): port
-                    for port in cast(list[dict[str, Any]], child["inputs"])
-                }
-                child_arguments: dict[str, dict[str, Any]] = {}
-                child_known_arguments: dict[str, Any] = {}
-                for authored in cast(list[dict[str, Any]], instruction["arguments"]):
-                    port_id = cast(str, authored["port"])
-                    formal = child_ports[port_id]
-                    operand = cast(dict[str, Any], authored["operand"])
-                    if operand.get("kind") == "port":
-                        parent_port = cast(str, operand["port"])
-                        contract = cast(dict[str, Any], arguments[parent_port])
-                        if parent_port in known_arguments:
-                            child_known_arguments[port_id] = known_arguments[
-                                parent_port
-                            ]
-                    elif operand.get("kind") == "local":
-                        name = cast(str, operand["local"])
-                        contract = local_contract(name, formal)
-                        if name in local_values:
-                            child_known_arguments[port_id] = local_values[name]
-                    elif operand.get("kind") == "literal":
-                        value = operand.get("literal")
-                        contract = literal_contract(value, formal)
-                        child_known_arguments[port_id] = value
-                    else:
-                        raise ValueError(
-                            "nested Operation operand has no concrete contract"
-                        )
-                    child_arguments[port_id] = contract
-                child_call = {
-                    "arguments": child_arguments,
-                    "known_arguments": child_known_arguments,
-                }
-                projected.setdefault(child_coordinate, []).append(child_call)
-                result = instruction.get("result")
-                result_kind = result.get("kind") if isinstance(result, dict) else None
-                child_result = visit(
-                    child_coordinate,
-                    child_call,
-                    (*stack, coordinate),
-                    resolve_result=result_kind in {"local", "operation-result"},
-                )
-                site = instruction.get("site")
-                if isinstance(site, str):
-                    result_by_site[site] = child_result
-                if isinstance(result, dict) and result.get("kind") == "local":
-                    local_contracts[cast(str, result["name"])] = child_result
-
-        walk(cast(list[dict[str, Any]], operation["body"]))
-        result = cast(dict[str, Any], operation["result"])
-        if not resolve_result:
-            return cast(dict[str, Any], _formula_contract_from_operation(result))
-        declared_domain = result.get("domain")
-        if (
-            isinstance(declared_domain, dict)
-            and declared_domain.get("kind") != "actual"
-        ):
-            return cast(dict[str, Any], _formula_contract_from_operation(result))
-        source = result.get("source")
-        if not isinstance(source, dict):
-            raise ValueError("concrete Operation result source is unresolved")
-        if source.get("kind") == "local":
-            return local_contract(cast(str, source["name"]), result)
-        if source.get("kind") == "operation-result":
-            resolved = result_by_site.get(cast(str, source.get("site")))
-            if resolved is None:
-                raise ValueError("nested Operation result is unresolved")
-            return resolved
-        if source.get("kind") == "unit":
-            return cast(dict[str, Any], _formula_contract_from_operation(result))
-        try:
-            return _infer_formula_operation_result(
-                operation,
-                ports,
-                operand_contracts,
-                cast(dict[str, Any], _formula_contract_from_operation(result)),
-                conversion_policy,
-                {},
-            )
-        except ValueError as error:
-            raise ValueError("concrete Operation result is unresolved") from error
-
-    initial_roots = [
-        (coordinate, call)
-        for coordinate, calls in roots.items()
-        for call in list(calls)
-    ]
-    for coordinate, call in initial_roots:
-        if reaches_formula_slot(coordinate):
-            visit(coordinate, call, (), resolve_result=False)
-    return projected
 
 
 def _derived_formula_evaluation_site(
@@ -1675,7 +1225,7 @@ def _resolved_formula_programs_and_bindings_impl(
                 cast(str, operation_ref["id"]),
             )
             concrete_operation_calls.setdefault(coordinate, []).append(
-                _resolved_formula_call(
+                resolved_source_formula_call(
                     cast(dict[str, Any], resolved_formula),
                     node,
                     operations_by_coordinate[coordinate],
@@ -1695,7 +1245,7 @@ def _resolved_formula_programs_and_bindings_impl(
         operation = operations_by_coordinate.get(coordinate)
         if operation is None:
             continue
-        concrete_call = _resolved_entrypoint_call(
+        concrete_call = resolved_source_entrypoint_call(
             source_entrypoint,
             operation,
             declarations_by_source,
@@ -1704,13 +1254,18 @@ def _resolved_formula_programs_and_bindings_impl(
         )
         if concrete_call is not None:
             concrete_operation_calls.setdefault(coordinate, []).append(concrete_call)
-    concrete_operation_calls = _project_concrete_operation_call_closure(
-        operations_by_coordinate,
-        concrete_operation_calls,
-        checked.kernel,
-        checked.language_bundle,
-        cast(dict[str, Any], policy["notation_conversion"]),
+    call_domain_projection = project_concrete_operation_call_domains(
+        source_call_domain_input(
+            operations_by_coordinate,
+            concrete_operation_calls,
+            source_bindings,
+            declarations_by_source,
+            checked.kernel,
+            checked.language_bundle,
+            cast(dict[str, Any], policy["notation_conversion"]),
+        )
     )
+    concrete_operation_calls = call_domain_projection.calls
     selected_operation_coordinates = _selected_source_operation_coordinates(
         checked.source,
         lock,
@@ -1887,20 +1442,23 @@ def _resolved_formula_programs_and_bindings_impl(
                         f"{binding_pointer}/arguments/{len(arguments)}/operand",
                         "Formula Operation-slot argument is incompatible",
                     )
-                for call in concrete_calls:
-                    try:
-                        actual_contract = _infer_formula_slot_parameter_contract(
-                            operation,
-                            slot_parameter,
-                            call,
-                            cast(dict[str, Any], policy["notation_conversion"]),
-                        )
-                    except ValueError as error:
+                projected_parameters = (
+                    call_domain_projection.slot_parameter_contracts.get(slot_key, [])
+                )
+                if len(projected_parameters) != len(concrete_calls):
+                    raise _FormulaResolutionError(
+                        _FORMULA_REASON["type-mismatch"],
+                        f"{binding_pointer}/arguments/{len(arguments)}/operand",
+                        "Formula Operation-slot call-site projection is incomplete",
+                    )
+                for parameter_projection in projected_parameters:
+                    actual_contract = parameter_projection.get(slot_parameter_id)
+                    if not isinstance(actual_contract, dict):
                         raise _FormulaResolutionError(
                             _FORMULA_REASON["type-mismatch"],
                             f"{binding_pointer}/arguments/{len(arguments)}/operand",
-                            str(error),
-                        ) from error
+                            "Formula slot source is unresolved",
+                        )
                     if not _formula_contract_contains(
                         binding_parameters[parameter_id], actual_contract
                     ):

--- a/libs/gda-balancing/src/gda_balancing/domain/model/_operation_call_domain_adapters.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/model/_operation_call_domain_adapters.py
@@ -216,7 +216,7 @@ def resolved_rir_entrypoint_call(
     }
 
 
-def source_call_domain_input(
+def build_operation_call_domain_input(
     operations: dict[OperationCoordinate, dict[str, Any]],
     roots: dict[OperationCoordinate, list[dict[str, Any]]],
     bindings: list[dict[str, Any]],
@@ -225,48 +225,7 @@ def source_call_domain_input(
     language_bundle: dict[str, Any],
     conversion_policy: dict[str, Any],
 ) -> ConcreteOperationCallDomainInput:
-    """Build the neutral projection input from checked Model Source shapes."""
-    return _call_domain_input(
-        operations,
-        roots,
-        bindings,
-        declarations_by_symbol,
-        kernel,
-        language_bundle,
-        conversion_policy,
-    )
-
-
-def rir_call_domain_input(
-    operations: dict[OperationCoordinate, dict[str, Any]],
-    roots: dict[OperationCoordinate, list[dict[str, Any]]],
-    bindings: list[dict[str, Any]],
-    declarations_by_symbol: dict[tuple[str, str], dict[str, Any]],
-    kernel: dict[str, Any],
-    language_bundle: dict[str, Any],
-    conversion_policy: dict[str, Any],
-) -> ConcreteOperationCallDomainInput:
-    """Build the neutral projection input from admitted RIR shapes."""
-    return _call_domain_input(
-        operations,
-        roots,
-        bindings,
-        declarations_by_symbol,
-        kernel,
-        language_bundle,
-        conversion_policy,
-    )
-
-
-def _call_domain_input(
-    operations: dict[OperationCoordinate, dict[str, Any]],
-    roots: dict[OperationCoordinate, list[dict[str, Any]]],
-    bindings: list[dict[str, Any]],
-    declarations_by_symbol: dict[tuple[str, str], dict[str, Any]],
-    kernel: dict[str, Any],
-    language_bundle: dict[str, Any],
-    conversion_policy: dict[str, Any],
-) -> ConcreteOperationCallDomainInput:
+    """Build one neutral projection input from normalized production shapes."""
     return ConcreteOperationCallDomainInput(
         operations=operations,
         roots=roots,

--- a/libs/gda-balancing/src/gda_balancing/domain/model/_operation_call_domain_adapters.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/model/_operation_call_domain_adapters.py
@@ -1,0 +1,403 @@
+"""Source and RIR adapters for concrete Operation call-domain propagation."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, cast
+
+from gda_balancing.domain.authority.runtime_validation import (
+    fixed_operation_value_contract,
+    operation_literal_context_contract,
+)
+from gda_balancing.domain.formula.types import formula_contract_from_operation
+from gda_balancing.domain.operation_call_domains import (
+    ConcreteOperationCallDomainInput,
+    OperationCoordinate,
+    OperationSlotCoordinate,
+)
+from gda_balancing.domain.model._resolution import (
+    _language,
+    _operation_formula_slots,
+    _operation_reference_node_ids,
+)
+
+
+def resolved_source_formula_call(
+    formula: dict[str, Any],
+    node: dict[str, Any],
+    operation: dict[str, Any],
+    declarations_by_source: dict[tuple[str, str], dict[str, Any]],
+    kernel: dict[str, Any],
+    language_bundle: dict[str, Any],
+) -> dict[str, Any]:
+    """Adapt one resolved source Formula Operation call into a concrete root."""
+    parameters = {
+        cast(str, parameter["id"]): parameter
+        for parameter in cast(list[dict[str, Any]], formula["parameters"])
+    }
+    locals_by_id = {
+        cast(str, item["id"]): cast(dict[str, Any], item["result"])
+        for item in cast(
+            list[dict[str, Any]], cast(dict[str, Any], formula["body"])["nodes"]
+        )
+    }
+    ports = {
+        cast(str, port["id"]): port
+        for port in cast(list[dict[str, Any]], operation["inputs"])
+    }
+    resolved: dict[str, dict[str, Any]] = {}
+    known_arguments: dict[str, Any] = {}
+    literal_contract = _literal_contract_resolver(kernel, language_bundle)
+    for argument in cast(list[dict[str, Any]], node["arguments"]):
+        port_id = cast(str, argument["port"])
+        operand = cast(dict[str, Any], argument["operand"])
+        operand_kind = operand.get("kind")
+        if operand_kind == "parameter":
+            contract = parameters[cast(str, operand["parameter"])]
+        elif operand_kind == "local":
+            contract = locals_by_id[cast(str, operand["local"])]
+        elif operand_kind == "symbol":
+            symbol = cast(dict[str, str], operand["resolved_symbol"])
+            contract = declarations_by_source[(symbol["module"], symbol["name"])]
+        elif operand_kind == "literal":
+            value = operand.get("value")
+            contract = literal_contract(value, ports[port_id])
+            if (
+                contract is None
+                or not isinstance(value, int)
+                or isinstance(value, bool)
+            ):
+                raise ValueError("Formula literal has no concrete call-site contract")
+            known_arguments[port_id] = value
+        else:
+            raise ValueError("Formula call operand has no concrete contract")
+        resolved[port_id] = contract
+    return {"arguments": resolved, "known_arguments": known_arguments}
+
+
+def resolved_source_entrypoint_call(
+    source_entrypoint: dict[str, Any],
+    operation: dict[str, Any],
+    declarations_by_source: dict[tuple[str, str], dict[str, Any]],
+    kernel: dict[str, Any],
+    language_bundle: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Adapt one Model Source entrypoint into a concrete root call."""
+    ports = {
+        cast(str, port["id"]): port
+        for port in cast(list[dict[str, Any]], operation["inputs"])
+    }
+    arguments: dict[str, dict[str, Any]] = {}
+    known_arguments: dict[str, Any] = {}
+    literal_contract = _literal_contract_resolver(kernel, language_bundle)
+    for argument in cast(list[dict[str, Any]], source_entrypoint["arguments"]):
+        port_id = cast(str, argument["port"])
+        formal = ports.get(port_id)
+        if formal is None:
+            return None
+        operand = cast(dict[str, Any], argument["operand"])
+        if operand.get("kind") == "symbol":
+            contract = declarations_by_source.get(
+                (cast(str, operand.get("module")), cast(str, operand.get("symbol")))
+            )
+            if contract is None:
+                return None
+        elif operand.get("kind") == "literal":
+            value = operand.get("value")
+            contract = literal_contract(value, formal)
+            if contract is None:
+                return None
+            known_arguments[port_id] = value
+        elif operand.get("kind") == "event-reference":
+            contract = _event_reference_contract(kernel)
+            if contract is None:
+                return None
+        else:
+            return None
+        arguments[port_id] = contract
+    if set(arguments) != set(ports):
+        return None
+    return {"arguments": arguments, "known_arguments": known_arguments}
+
+
+def resolved_rir_formula_call(
+    operation: dict[str, Any],
+    arguments: list[Any],
+    operand_contract: Callable[[Any], dict[str, Any] | None],
+) -> dict[str, Any] | None:
+    """Adapt one admitted RIR Formula Operation call into a concrete root."""
+    ports = {
+        cast(str, port["id"]): port
+        for port in cast(list[dict[str, Any]], operation["inputs"])
+    }
+    call_arguments: dict[str, dict[str, Any]] = {}
+    known_call_arguments: dict[str, Any] = {}
+    for argument in arguments:
+        if (
+            not isinstance(argument, dict)
+            or set(argument) != {"port", "operand"}
+            or (contract := operand_contract(argument.get("operand"))) is None
+        ):
+            return None
+        port_id = cast(str, argument["port"])
+        if port_id not in ports:
+            return None
+        call_arguments[port_id] = contract
+        operand = cast(dict[str, Any], argument["operand"])
+        if operand.get("kind") == "literal":
+            known_call_arguments[port_id] = operand.get("value")
+    return {
+        "arguments": call_arguments,
+        "known_arguments": known_call_arguments,
+    }
+
+
+def resolved_rir_entrypoint_call(
+    entrypoint: dict[str, Any],
+    operation: dict[str, Any],
+    declarations_by_symbol: dict[tuple[str, str], dict[str, Any]],
+    kernel: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Adapt one admitted RIR entrypoint into a concrete root call."""
+    arguments = entrypoint.get("arguments")
+    if not isinstance(arguments, list):
+        return None
+    call_arguments: dict[str, dict[str, Any]] = {}
+    known_call_arguments: dict[str, Any] = {}
+    ports = {
+        cast(str, port["id"])
+        for port in cast(list[dict[str, Any]], operation["inputs"])
+    }
+    for argument in arguments:
+        if not isinstance(argument, dict) or not isinstance(argument.get("port"), dict):
+            return None
+        port_id = cast(str, argument["port"].get("name"))
+        operand = argument.get("operand")
+        if port_id not in ports or not isinstance(operand, dict):
+            return None
+        if operand.get("kind") == "symbol":
+            symbol = operand.get("symbol")
+            if not isinstance(symbol, dict):
+                return None
+            contract = declarations_by_symbol.get(
+                (
+                    cast(str, symbol.get("module")),
+                    cast(str, symbol.get("name")),
+                )
+            )
+        elif operand.get("kind") == "literal":
+            context_type = operand.get("context_type")
+            if not isinstance(context_type, dict):
+                return None
+            try:
+                contract = cast(
+                    dict[str, Any], formula_contract_from_operation(context_type)
+                )
+            except ValueError:
+                return None
+            value = operand.get("value")
+            if isinstance(value, int) and not isinstance(value, bool):
+                contract = {
+                    **contract,
+                    "domain_kind": "closed-interval",
+                    "domain": {"minimum": value, "maximum": value},
+                }
+            known_call_arguments[port_id] = value
+        elif operand.get("kind") == "event-reference":
+            contract = _event_reference_contract(kernel)
+        else:
+            return None
+        if not isinstance(contract, dict):
+            return None
+        call_arguments[port_id] = contract
+    return {
+        "arguments": call_arguments,
+        "known_arguments": known_call_arguments,
+    }
+
+
+def source_call_domain_input(
+    operations: dict[OperationCoordinate, dict[str, Any]],
+    roots: dict[OperationCoordinate, list[dict[str, Any]]],
+    bindings: list[dict[str, Any]],
+    declarations_by_symbol: dict[tuple[str, str], dict[str, Any]],
+    kernel: dict[str, Any],
+    language_bundle: dict[str, Any],
+    conversion_policy: dict[str, Any],
+) -> ConcreteOperationCallDomainInput:
+    """Build the neutral projection input from checked Model Source shapes."""
+    return _call_domain_input(
+        operations,
+        roots,
+        bindings,
+        declarations_by_symbol,
+        kernel,
+        language_bundle,
+        conversion_policy,
+    )
+
+
+def rir_call_domain_input(
+    operations: dict[OperationCoordinate, dict[str, Any]],
+    roots: dict[OperationCoordinate, list[dict[str, Any]]],
+    bindings: list[dict[str, Any]],
+    declarations_by_symbol: dict[tuple[str, str], dict[str, Any]],
+    kernel: dict[str, Any],
+    language_bundle: dict[str, Any],
+    conversion_policy: dict[str, Any],
+) -> ConcreteOperationCallDomainInput:
+    """Build the neutral projection input from admitted RIR shapes."""
+    return _call_domain_input(
+        operations,
+        roots,
+        bindings,
+        declarations_by_symbol,
+        kernel,
+        language_bundle,
+        conversion_policy,
+    )
+
+
+def _call_domain_input(
+    operations: dict[OperationCoordinate, dict[str, Any]],
+    roots: dict[OperationCoordinate, list[dict[str, Any]]],
+    bindings: list[dict[str, Any]],
+    declarations_by_symbol: dict[tuple[str, str], dict[str, Any]],
+    kernel: dict[str, Any],
+    language_bundle: dict[str, Any],
+    conversion_policy: dict[str, Any],
+) -> ConcreteOperationCallDomainInput:
+    return ConcreteOperationCallDomainInput(
+        operations=operations,
+        roots=roots,
+        formula_slot_bindings=_formula_slot_bindings(bindings, operations),
+        operation_node_ids=frozenset(_operation_reference_node_ids(kernel)),
+        conversion_policy=conversion_policy,
+        literal_contract=_literal_contract_resolver(kernel, language_bundle),
+        snapshot_contracts=_snapshot_contracts(operations, declarations_by_symbol),
+        snapshot_operand_names=_snapshot_operand_names(operations),
+    )
+
+
+def _formula_slot_bindings(
+    bindings: list[dict[str, Any]],
+    operations: dict[OperationCoordinate, dict[str, Any]],
+) -> frozenset[OperationSlotCoordinate]:
+    selected: set[OperationSlotCoordinate] = set()
+    for binding in bindings:
+        site = binding.get("site") if isinstance(binding, dict) else None
+        operation_ref = site.get("operation") if isinstance(site, dict) else None
+        if (
+            not isinstance(site, dict)
+            or site.get("kind") != "operation-slot"
+            or not isinstance(operation_ref, dict)
+            or not isinstance(site.get("slot"), str)
+            or not all(
+                isinstance(operation_ref.get(member), str)
+                for member in ("package", "version", "id")
+            )
+        ):
+            continue
+        coordinate = (
+            cast(str, operation_ref["package"]),
+            cast(str, operation_ref["version"]),
+            cast(str, operation_ref["id"]),
+        )
+        operation = operations.get(coordinate)
+        if operation is None or not any(
+            slot.get("id") == site["slot"]
+            for slot in _operation_formula_slots(operation)
+        ):
+            continue
+        selected.add((*coordinate, cast(str, site["slot"])))
+    return frozenset(selected)
+
+
+def _snapshot_contracts(
+    operations: dict[OperationCoordinate, dict[str, Any]],
+    declarations_by_symbol: dict[tuple[str, str], dict[str, Any]],
+) -> dict[OperationCoordinate, dict[str, dict[str, Any]]]:
+    resolved: dict[OperationCoordinate, dict[str, dict[str, Any]]] = {}
+    for coordinate, operation in operations.items():
+        extensions = operation.get("extensions")
+        snapshot_operands = (
+            extensions.get("standard.snapshot-operands")
+            if isinstance(extensions, dict)
+            else None
+        )
+        if not isinstance(snapshot_operands, dict):
+            continue
+        contracts: dict[str, dict[str, Any]] = {}
+        for operand in snapshot_operands.get("operands", []):
+            if not isinstance(operand, dict) or not isinstance(
+                operand.get("resolved_symbol"), dict
+            ):
+                continue
+            resolved_symbol = cast(dict[str, Any], operand["resolved_symbol"])
+            declaration = declarations_by_symbol.get(
+                (
+                    cast(str, resolved_symbol.get("module")),
+                    cast(str, resolved_symbol.get("name")),
+                )
+            )
+            if isinstance(operand.get("name"), str) and isinstance(declaration, dict):
+                contracts[cast(str, operand["name"])] = declaration
+        resolved[coordinate] = contracts
+    return resolved
+
+
+def _snapshot_operand_names(
+    operations: dict[OperationCoordinate, dict[str, Any]],
+) -> dict[OperationCoordinate, frozenset[str]]:
+    names: dict[OperationCoordinate, frozenset[str]] = {}
+    for coordinate, operation in operations.items():
+        extensions = operation.get("extensions")
+        snapshot_operands = (
+            extensions.get("standard.snapshot-operands")
+            if isinstance(extensions, dict)
+            else None
+        )
+        if not isinstance(snapshot_operands, dict):
+            continue
+        names[coordinate] = frozenset(
+            cast(str, operand["name"])
+            for operand in snapshot_operands.get("operands", [])
+            if isinstance(operand, dict) and isinstance(operand.get("name"), str)
+        )
+    return names
+
+
+def _literal_contract_resolver(
+    kernel: dict[str, Any], language_bundle: dict[str, Any]
+) -> Callable[[Any, dict[str, Any]], dict[str, Any] | None]:
+    profiles = {
+        "literal_typing_profiles": [
+            {"definition": profile}
+            for profile in cast(
+                list[dict[str, Any]],
+                _language(language_bundle)["literal_typing_profiles"],
+            )
+        ]
+    }
+
+    def resolve(value: Any, formal: dict[str, Any]) -> dict[str, Any] | None:
+        context = operation_literal_context_contract(value, formal, kernel, profiles)
+        if context is None:
+            return None
+        contract = cast(dict[str, Any], formula_contract_from_operation(context))
+        if isinstance(value, int) and not isinstance(value, bool):
+            contract = {
+                **contract,
+                "domain_kind": "closed-interval",
+                "domain": {"minimum": value, "maximum": value},
+            }
+        return contract
+
+    return resolve
+
+
+def _event_reference_contract(kernel: dict[str, Any]) -> dict[str, Any] | None:
+    contract = fixed_operation_value_contract(kernel, "kernel-event-reference")
+    if contract is None:
+        return None
+    return cast(dict[str, Any], formula_contract_from_operation(contract))

--- a/libs/gda-balancing/src/gda_balancing/domain/operation_call_domains.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/operation_call_domains.py
@@ -100,14 +100,10 @@ def project_concrete_operation_call_domains(
                     and body_reaches_slot(cast(list[dict[str, Any]], nested))
                 ):
                     return True
-                operation_ref = instruction.get("operation")
-                if instruction.get(
-                    "node"
-                ) not in projection_input.operation_node_ids or not isinstance(
-                    operation_ref, dict
-                ):
+                if instruction.get("node") not in projection_input.operation_node_ids:
                     continue
-                if not all(
+                operation_ref = instruction.get("operation")
+                if not isinstance(operation_ref, dict) or not all(
                     isinstance(operation_ref.get(member), str)
                     for member in ("package", "version", "id")
                 ):
@@ -263,12 +259,10 @@ def project_concrete_operation_call_domains(
                     isinstance(row, dict) for row in nested
                 ):
                     walk(cast(list[dict[str, Any]], nested))
-                operation_ref = instruction.get("operation")
-                if node not in projection_input.operation_node_ids or not isinstance(
-                    operation_ref, dict
-                ):
+                if node not in projection_input.operation_node_ids:
                     continue
-                if not all(
+                operation_ref = instruction.get("operation")
+                if not isinstance(operation_ref, dict) or not all(
                     isinstance(operation_ref.get(member), str)
                     for member in ("package", "version", "id")
                 ):

--- a/libs/gda-balancing/src/gda_balancing/domain/operation_call_domains.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/operation_call_domains.py
@@ -1,0 +1,474 @@
+"""Concrete value-domain propagation through admitted Operation call graphs."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, cast
+
+from gda_balancing.domain.formula.inference import (
+    infer_formula_operation_local_contract,
+    infer_formula_operation_result,
+    infer_formula_slot_parameter_contract,
+)
+from gda_balancing.domain.formula.types import formula_contract_from_operation
+
+
+OperationCoordinate = tuple[str, str, str]
+OperationSlotCoordinate = tuple[str, str, str, str]
+LiteralContractResolver = Callable[[Any, dict[str, Any]], dict[str, Any] | None]
+
+
+class ConcreteOperationCallDomainError(ValueError):
+    """One typed failure while propagating a concrete Operation call domain."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        coordinate: OperationCoordinate | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.coordinate = coordinate
+
+
+@dataclass(frozen=True)
+class ConcreteOperationCallDomainInput:
+    """Neutral input for one production Operation call-domain projection."""
+
+    operations: dict[OperationCoordinate, dict[str, Any]]
+    roots: dict[OperationCoordinate, list[dict[str, Any]]]
+    formula_slot_bindings: frozenset[OperationSlotCoordinate]
+    operation_node_ids: frozenset[str]
+    conversion_policy: dict[str, Any]
+    literal_contract: LiteralContractResolver
+    snapshot_contracts: dict[OperationCoordinate, dict[str, dict[str, Any]]]
+    snapshot_operand_names: dict[OperationCoordinate, frozenset[str]]
+
+
+@dataclass(frozen=True)
+class ConcreteOperationCallDomainProjection:
+    """Concrete calls and Formula-slot parameter contracts reached from roots."""
+
+    calls: dict[OperationCoordinate, list[dict[str, Any]]]
+    slot_parameter_contracts: dict[
+        OperationSlotCoordinate, list[dict[str, dict[str, Any]]]
+    ]
+
+
+def project_concrete_operation_call_domains(
+    projection_input: ConcreteOperationCallDomainInput,
+) -> ConcreteOperationCallDomainProjection:
+    """Propagate exact contracts to every bound Operation Formula-slot call site."""
+    operations = projection_input.operations
+    projected = {
+        coordinate: [call.copy() for call in calls]
+        for coordinate, calls in projection_input.roots.items()
+    }
+    slot_coordinates = {
+        cast(OperationCoordinate, coordinate[:3])
+        for coordinate in projection_input.formula_slot_bindings
+    }
+    if not slot_coordinates:
+        return ConcreteOperationCallDomainProjection(projected, {})
+    reaches_slot_cache: dict[OperationCoordinate, bool] = {}
+
+    def reaches_formula_slot(
+        coordinate: OperationCoordinate,
+        stack: tuple[OperationCoordinate, ...] = (),
+    ) -> bool:
+        cached = reaches_slot_cache.get(coordinate)
+        if cached is not None:
+            return cached
+        if coordinate in stack:
+            return False
+        if coordinate in slot_coordinates:
+            reaches_slot_cache[coordinate] = True
+            return True
+        operation = operations.get(coordinate)
+        if operation is None:
+            reaches_slot_cache[coordinate] = False
+            return False
+
+        def body_reaches_slot(instructions: list[dict[str, Any]]) -> bool:
+            for instruction in instructions:
+                nested = instruction.get("body")
+                if (
+                    isinstance(nested, list)
+                    and all(isinstance(row, dict) for row in nested)
+                    and body_reaches_slot(cast(list[dict[str, Any]], nested))
+                ):
+                    return True
+                operation_ref = instruction.get("operation")
+                if instruction.get(
+                    "node"
+                ) not in projection_input.operation_node_ids or not isinstance(
+                    operation_ref, dict
+                ):
+                    continue
+                if not all(
+                    isinstance(operation_ref.get(member), str)
+                    for member in ("package", "version", "id")
+                ):
+                    raise ConcreteOperationCallDomainError(
+                        "malformed_operation_reference",
+                        "nested Operation reference is malformed",
+                        coordinate,
+                    )
+                child_coordinate = (
+                    cast(str, operation_ref["package"]),
+                    cast(str, operation_ref["version"]),
+                    cast(str, operation_ref["id"]),
+                )
+                if reaches_formula_slot(child_coordinate, (*stack, coordinate)):
+                    return True
+            return False
+
+        body = operation.get("body")
+        if not isinstance(body, list) or not all(
+            isinstance(instruction, dict) for instruction in body
+        ):
+            raise ConcreteOperationCallDomainError(
+                "malformed_operation_body",
+                "concrete Operation call is unresolved",
+                coordinate,
+            )
+        reaches = body_reaches_slot(cast(list[dict[str, Any]], body))
+        reaches_slot_cache[coordinate] = reaches
+        return reaches
+
+    def visit(
+        coordinate: OperationCoordinate,
+        call: dict[str, Any],
+        stack: tuple[OperationCoordinate, ...],
+        *,
+        resolve_result: bool,
+    ) -> dict[str, Any]:
+        if coordinate in stack:
+            raise ConcreteOperationCallDomainError(
+                "operation_call_cycle",
+                "concrete Operation call graph contains a cycle",
+                coordinate,
+            )
+        operation = operations.get(coordinate)
+        arguments = call.get("arguments")
+        if operation is None or not isinstance(arguments, dict):
+            raise ConcreteOperationCallDomainError(
+                "unresolved_operation_call",
+                "concrete Operation call is unresolved",
+                coordinate,
+            )
+        ports = [
+            cast(str, port["id"])
+            for port in cast(list[dict[str, Any]], operation["inputs"])
+        ]
+        if set(arguments) != set(ports):
+            raise ConcreteOperationCallDomainError(
+                "incomplete_arguments",
+                "concrete Operation call arguments are incomplete",
+                coordinate,
+            )
+        operand_contracts = [cast(dict[str, Any], arguments[port]) for port in ports]
+        known_arguments = cast(dict[str, Any], call.get("known_arguments", {}))
+        local_contracts = {
+            name: contract.copy()
+            for name, contract in projection_input.snapshot_contracts.get(
+                coordinate, {}
+            ).items()
+        }
+        if not projection_input.snapshot_operand_names.get(
+            coordinate, frozenset()
+        ) <= set(local_contracts):
+            raise ConcreteOperationCallDomainError(
+                "unresolved_snapshot_contract",
+                "specialized Formula snapshot contract is unresolved",
+                coordinate,
+            )
+        local_values: dict[str, Any] = {}
+        local_intervals: dict[str, tuple[int, int]] = {}
+        result_by_site: dict[str, dict[str, Any]] = {}
+
+        def literal_contract(value: Any, formal: dict[str, Any]) -> dict[str, Any]:
+            try:
+                contract = projection_input.literal_contract(value, formal)
+            except (KeyError, TypeError, ValueError) as error:
+                raise ConcreteOperationCallDomainError(
+                    "unresolved_literal_contract",
+                    "nested Operation literal has no concrete contract",
+                    coordinate,
+                ) from error
+            if not isinstance(contract, dict):
+                raise ConcreteOperationCallDomainError(
+                    "unresolved_literal_contract",
+                    "nested Operation literal has no concrete contract",
+                    coordinate,
+                )
+            return contract
+
+        def local_contract(name: str, formal: dict[str, Any]) -> dict[str, Any]:
+            contract = local_contracts.get(name)
+            if contract is not None:
+                return contract
+            if name in local_values:
+                contract = literal_contract(local_values[name], formal)
+            elif name in local_intervals:
+                minimum, maximum = local_intervals[name]
+                contract = {
+                    **cast(dict[str, Any], formula_contract_from_operation(formal)),
+                    "domain_kind": "closed-interval",
+                    "domain": {"minimum": minimum, "maximum": maximum},
+                }
+            else:
+                try:
+                    contract = infer_formula_operation_local_contract(
+                        operation,
+                        ports,
+                        operand_contracts,
+                        name,
+                        cast(dict[str, Any], formula_contract_from_operation(formal)),
+                        projection_input.conversion_policy,
+                        {},
+                        known_operand_values=known_arguments,
+                        known_local_contracts=local_contracts,
+                        ignore_unmatched_instructions=True,
+                    )
+                except ValueError as error:
+                    raise ConcreteOperationCallDomainError(
+                        "unresolved_local",
+                        f"concrete Operation local {coordinate!r}.{name} is unresolved",
+                        coordinate,
+                    ) from error
+            local_contracts[name] = contract
+            return contract
+
+        def walk(instructions: list[dict[str, Any]]) -> None:
+            for instruction in instructions:
+                node = instruction.get("node")
+                target = instruction.get("target")
+                if node == "constant" and isinstance(target, str):
+                    local_values[target] = instruction.get("literal")
+                elif node == "draw" and isinstance(target, str):
+                    minimum = instruction.get("minimum")
+                    maximum = instruction.get("maximum")
+                    if (
+                        isinstance(minimum, int)
+                        and not isinstance(minimum, bool)
+                        and isinstance(maximum, int)
+                        and not isinstance(maximum, bool)
+                    ):
+                        local_intervals[target] = (minimum, maximum)
+                nested = instruction.get("body")
+                if isinstance(nested, list) and all(
+                    isinstance(row, dict) for row in nested
+                ):
+                    walk(cast(list[dict[str, Any]], nested))
+                operation_ref = instruction.get("operation")
+                if node not in projection_input.operation_node_ids or not isinstance(
+                    operation_ref, dict
+                ):
+                    continue
+                if not all(
+                    isinstance(operation_ref.get(member), str)
+                    for member in ("package", "version", "id")
+                ):
+                    raise ConcreteOperationCallDomainError(
+                        "malformed_operation_reference",
+                        "nested Operation reference is malformed",
+                        coordinate,
+                    )
+                child_coordinate = (
+                    cast(str, operation_ref["package"]),
+                    cast(str, operation_ref["version"]),
+                    cast(str, operation_ref["id"]),
+                )
+                child = operations.get(child_coordinate)
+                if child is None:
+                    raise ConcreteOperationCallDomainError(
+                        "unresolved_operation_target",
+                        "nested Operation call target is unresolved",
+                        child_coordinate,
+                    )
+                child_ports = {
+                    cast(str, port["id"]): port
+                    for port in cast(list[dict[str, Any]], child["inputs"])
+                }
+                child_arguments: dict[str, dict[str, Any]] = {}
+                child_known_arguments: dict[str, Any] = {}
+                for authored in cast(list[dict[str, Any]], instruction["arguments"]):
+                    port_id = cast(str, authored["port"])
+                    formal = child_ports[port_id]
+                    operand = cast(dict[str, Any], authored["operand"])
+                    if operand.get("kind") == "port":
+                        parent_port = cast(str, operand["port"])
+                        contract = cast(dict[str, Any], arguments[parent_port])
+                        if parent_port in known_arguments:
+                            child_known_arguments[port_id] = known_arguments[
+                                parent_port
+                            ]
+                    elif operand.get("kind") == "local":
+                        name = cast(str, operand["local"])
+                        contract = local_contract(name, formal)
+                        if name in local_values:
+                            child_known_arguments[port_id] = local_values[name]
+                    elif operand.get("kind") == "literal":
+                        value = operand.get("literal")
+                        contract = literal_contract(value, formal)
+                        child_known_arguments[port_id] = value
+                    else:
+                        raise ConcreteOperationCallDomainError(
+                            "unresolved_nested_operand",
+                            "nested Operation operand has no concrete contract",
+                            coordinate,
+                        )
+                    child_arguments[port_id] = contract
+                child_call = {
+                    "arguments": child_arguments,
+                    "known_arguments": child_known_arguments,
+                }
+                projected.setdefault(child_coordinate, []).append(child_call)
+                result = instruction.get("result")
+                result_kind = result.get("kind") if isinstance(result, dict) else None
+                child_result = visit(
+                    child_coordinate,
+                    child_call,
+                    (*stack, coordinate),
+                    resolve_result=result_kind in {"local", "operation-result"},
+                )
+                site = instruction.get("site")
+                if isinstance(site, str):
+                    result_by_site[site] = child_result
+                if isinstance(result, dict) and result.get("kind") == "local":
+                    local_contracts[cast(str, result["name"])] = child_result
+
+        body = operation.get("body")
+        if not isinstance(body, list) or not all(
+            isinstance(instruction, dict) for instruction in body
+        ):
+            raise ConcreteOperationCallDomainError(
+                "malformed_operation_body",
+                "concrete Operation call is unresolved",
+                coordinate,
+            )
+        try:
+            walk(cast(list[dict[str, Any]], body))
+            result = cast(dict[str, Any], operation["result"])
+        except ConcreteOperationCallDomainError:
+            raise
+        except (KeyError, TypeError, ValueError) as error:
+            raise ConcreteOperationCallDomainError(
+                "malformed_operation_call",
+                "concrete Operation call is unresolved",
+                coordinate,
+            ) from error
+        if not resolve_result:
+            return cast(dict[str, Any], formula_contract_from_operation(result))
+        declared_domain = result.get("domain")
+        if (
+            isinstance(declared_domain, dict)
+            and declared_domain.get("kind") != "actual"
+        ):
+            return cast(dict[str, Any], formula_contract_from_operation(result))
+        source = result.get("source")
+        if not isinstance(source, dict):
+            raise ConcreteOperationCallDomainError(
+                "unresolved_result_source",
+                "concrete Operation result source is unresolved",
+                coordinate,
+            )
+        if source.get("kind") == "local":
+            return local_contract(cast(str, source["name"]), result)
+        if source.get("kind") == "operation-result":
+            resolved = result_by_site.get(cast(str, source.get("site")))
+            if resolved is None:
+                raise ConcreteOperationCallDomainError(
+                    "unresolved_nested_result",
+                    "nested Operation result is unresolved",
+                    coordinate,
+                )
+            return resolved
+        if source.get("kind") == "unit":
+            return cast(dict[str, Any], formula_contract_from_operation(result))
+        try:
+            return infer_formula_operation_result(
+                operation,
+                ports,
+                operand_contracts,
+                cast(dict[str, Any], formula_contract_from_operation(result)),
+                projection_input.conversion_policy,
+                {},
+            )
+        except ValueError as error:
+            raise ConcreteOperationCallDomainError(
+                "unresolved_result",
+                "concrete Operation result is unresolved",
+                coordinate,
+            ) from error
+
+    initial_roots = [
+        (coordinate, call)
+        for coordinate, calls in projection_input.roots.items()
+        for call in list(calls)
+    ]
+    for coordinate, call in initial_roots:
+        if reaches_formula_slot(coordinate):
+            visit(coordinate, call, (), resolve_result=False)
+
+    slot_parameter_contracts: dict[
+        OperationSlotCoordinate, list[dict[str, dict[str, Any]]]
+    ] = {}
+    for slot_coordinate in sorted(projection_input.formula_slot_bindings):
+        coordinate = cast(OperationCoordinate, slot_coordinate[:3])
+        operation = operations.get(coordinate)
+        if operation is None:
+            raise ConcreteOperationCallDomainError(
+                "unresolved_formula_slot",
+                "Formula Operation slot is unresolved",
+                coordinate,
+            )
+        extensions = operation.get("extensions")
+        slots = (
+            extensions.get("standard.formula-slots")
+            if isinstance(extensions, dict)
+            else None
+        )
+        slot = next(
+            (
+                item
+                for item in slots or []
+                if isinstance(item, dict) and item.get("id") == slot_coordinate[3]
+            ),
+            None,
+        )
+        if not isinstance(slot, dict) or not isinstance(slot.get("parameters"), list):
+            raise ConcreteOperationCallDomainError(
+                "unresolved_formula_slot",
+                "Formula Operation slot is unresolved",
+                coordinate,
+            )
+        projections: list[dict[str, dict[str, Any]]] = []
+        for call in projected.get(coordinate, []):
+            parameter_contracts: dict[str, dict[str, Any]] = {}
+            for parameter in cast(list[dict[str, Any]], slot["parameters"]):
+                parameter_id = cast(str, parameter["id"])
+                try:
+                    parameter_contracts[parameter_id] = (
+                        infer_formula_slot_parameter_contract(
+                            operation,
+                            parameter,
+                            call,
+                            projection_input.conversion_policy,
+                        )
+                    )
+                except ValueError as error:
+                    raise ConcreteOperationCallDomainError(
+                        "unresolved_formula_slot_parameter",
+                        str(error),
+                        coordinate,
+                    ) from error
+            projections.append(parameter_contracts)
+        slot_parameter_contracts[slot_coordinate] = projections
+    return ConcreteOperationCallDomainProjection(
+        projected,
+        slot_parameter_contracts,
+    )

--- a/libs/gda-balancing/src/gda_balancing/domain/operation_call_domains.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/operation_call_domains.py
@@ -12,9 +12,9 @@ from gda_balancing.domain.formula.inference import (
     infer_formula_slot_parameter_contract,
 )
 from gda_balancing.domain.formula.types import formula_contract_from_operation
+from gda_balancing.domain.operation_program import OperationCoordinate
 
 
-OperationCoordinate = tuple[str, str, str]
 OperationSlotCoordinate = tuple[str, str, str, str]
 LiteralContractResolver = Callable[[Any, dict[str, Any]], dict[str, Any] | None]
 

--- a/libs/gda-balancing/src/gda_balancing/domain/operation_call_domains.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/operation_call_domains.py
@@ -33,6 +33,30 @@ class ConcreteOperationCallDomainError(ValueError):
         self.coordinate = coordinate
 
 
+def _require_operation_coordinate(
+    reference: Any,
+    owner: OperationCoordinate,
+) -> OperationCoordinate:
+    if (
+        not isinstance(reference, dict)
+        or set(reference) != {"package", "version", "id"}
+        or not all(
+            isinstance(reference.get(member), str) and reference[member]
+            for member in ("package", "version", "id")
+        )
+    ):
+        raise ConcreteOperationCallDomainError(
+            "malformed_operation_reference",
+            "nested Operation reference is malformed",
+            owner,
+        )
+    return (
+        cast(str, reference["package"]),
+        cast(str, reference["version"]),
+        cast(str, reference["id"]),
+    )
+
+
 @dataclass(frozen=True)
 class ConcreteOperationCallDomainInput:
     """Neutral input for one production Operation call-domain projection."""
@@ -102,20 +126,9 @@ def project_concrete_operation_call_domains(
                     return True
                 if instruction.get("node") not in projection_input.operation_node_ids:
                     continue
-                operation_ref = instruction.get("operation")
-                if not isinstance(operation_ref, dict) or not all(
-                    isinstance(operation_ref.get(member), str)
-                    for member in ("package", "version", "id")
-                ):
-                    raise ConcreteOperationCallDomainError(
-                        "malformed_operation_reference",
-                        "nested Operation reference is malformed",
-                        coordinate,
-                    )
-                child_coordinate = (
-                    cast(str, operation_ref["package"]),
-                    cast(str, operation_ref["version"]),
-                    cast(str, operation_ref["id"]),
+                child_coordinate = _require_operation_coordinate(
+                    instruction.get("operation"),
+                    coordinate,
                 )
                 if reaches_formula_slot(child_coordinate, (*stack, coordinate)):
                     return True
@@ -261,20 +274,9 @@ def project_concrete_operation_call_domains(
                     walk(cast(list[dict[str, Any]], nested))
                 if node not in projection_input.operation_node_ids:
                     continue
-                operation_ref = instruction.get("operation")
-                if not isinstance(operation_ref, dict) or not all(
-                    isinstance(operation_ref.get(member), str)
-                    for member in ("package", "version", "id")
-                ):
-                    raise ConcreteOperationCallDomainError(
-                        "malformed_operation_reference",
-                        "nested Operation reference is malformed",
-                        coordinate,
-                    )
-                child_coordinate = (
-                    cast(str, operation_ref["package"]),
-                    cast(str, operation_ref["version"]),
-                    cast(str, operation_ref["id"]),
+                child_coordinate = _require_operation_coordinate(
+                    instruction.get("operation"),
+                    coordinate,
                 )
                 child = operations.get(child_coordinate)
                 if child is None:

--- a/libs/gda-balancing/src/gda_balancing/domain/operation_program.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/operation_program.py
@@ -47,34 +47,40 @@ def selected_operation_index(
     }
 
 
-def _body_instructions(body: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def operation_body_instructions(
+    body: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Flatten one admitted Operation body in authored order."""
     instructions: list[dict[str, Any]] = []
     for instruction in body:
         instructions.append(instruction)
         nested = instruction.get("body")
         if isinstance(nested, list) and all(isinstance(row, dict) for row in nested):
-            instructions.extend(_body_instructions(cast(list[dict[str, Any]], nested)))
+            instructions.extend(
+                operation_body_instructions(cast(list[dict[str, Any]], nested))
+            )
     return instructions
 
 
 def closed_operation_coordinates(
     selected: Collection[OperationCoordinate],
     operations: Mapping[OperationCoordinate, dict[str, Any]],
-    operation_node_ids: Collection[str],
+    operation_node_ids: Collection[str] | None = None,
 ) -> set[OperationCoordinate]:
-    """Close exact Operation references through every declared reference node."""
+    """Close exact Operation references through selected or all reference nodes."""
     closed = set(selected)
     pending = list(selected)
     while pending:
         operation = operations.get(pending.pop())
         if operation is None:
             continue
-        for instruction in _body_instructions(
+        for instruction in operation_body_instructions(
             cast(list[dict[str, Any]], operation.get("body", []))
         ):
             reference = instruction.get("operation")
-            if instruction.get("node") not in operation_node_ids or not isinstance(
-                reference, dict
+            if not isinstance(reference, dict) or (
+                operation_node_ids is not None
+                and instruction.get("node") not in operation_node_ids
             ):
                 continue
             dependency = operation_coordinate(reference)
@@ -132,7 +138,7 @@ def project_operation_program(
         cast(str, instruction["node"])
         for coordinate in reachable
         if (operation := operations.get(coordinate)) is not None
-        for instruction in _body_instructions(
+        for instruction in operation_body_instructions(
             cast(list[dict[str, Any]], operation["body"])
         )
     }
@@ -151,7 +157,7 @@ def project_operation_program(
         operation = operations.get(coordinate)
         if operation is None:
             raise ValueError("admitted Operation invocation target is absent")
-        for instruction in _body_instructions(
+        for instruction in operation_body_instructions(
             cast(list[dict[str, Any]], operation["body"])
         ):
             reference = instruction.get("operation")
@@ -178,7 +184,9 @@ def project_operation_program(
             return cached
         effects = set(cast(list[str], operation["effects"]))
         refusals = set(cast(list[str], operation["refusals"]))
-        instructions = _body_instructions(cast(list[dict[str, Any]], operation["body"]))
+        instructions = operation_body_instructions(
+            cast(list[dict[str, Any]], operation["body"])
+        )
         charge = len(instructions)
         for instruction in instructions:
             reference = instruction.get("operation")

--- a/libs/gda-balancing/src/gda_balancing/domain/program_reachability.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/program_reachability.py
@@ -9,7 +9,9 @@ from typing import Any, cast
 from gda_balancing.domain.canonical import JsonValue, canonical_bytes
 from gda_balancing.domain.operation_program import (
     OperationCoordinate,
+    closed_operation_coordinates,
     operation_coordinate,
+    operation_body_instructions,
     selected_operation_index,
 )
 
@@ -39,16 +41,6 @@ class ReachableProgramStructure:
     operation_coordinates: frozenset[OperationCoordinate]
     runtime_node_ids: frozenset[str]
     formula_programs: LifecycleFormulaPrograms
-
-
-def _body_instructions(body: Sequence[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
-    instructions: list[Mapping[str, Any]] = []
-    for instruction in body:
-        instructions.append(instruction)
-        nested = instruction.get("body")
-        if isinstance(nested, list) and all(isinstance(row, dict) for row in nested):
-            instructions.extend(_body_instructions(cast(list[dict[str, Any]], nested)))
-    return instructions
 
 
 def reachable_formula_programs(
@@ -99,29 +91,23 @@ def project_reachable_program_structure(
     """Project Operation and Formula structure without applying consumer policy."""
     selected = cast(Mapping[str, Any], rir["selected_semantics"])
     operations = selected_operation_index(selected)
-    reachable_operations: set[OperationCoordinate] = set()
-    operation_node_ids: set[str] = set()
-    pending = [
+    roots = {
         operation_coordinate(cast(Mapping[str, Any], entrypoint["operation"]))
         for entrypoint in selected_entrypoints
-    ]
-    while pending:
-        coordinate = pending.pop()
-        if coordinate in reachable_operations:
-            continue
-        operation = operations.get(coordinate)
-        if operation is None:
-            raise ValueError(
-                "selected Model entrypoint Operation is absent from the RIR"
-            )
-        reachable_operations.add(coordinate)
-        for instruction in _body_instructions(
-            cast(list[dict[str, Any]], operation["body"])
-        ):
-            operation_node_ids.add(cast(str, instruction["node"]))
-            reference = instruction.get("operation")
-            if isinstance(reference, Mapping):
-                pending.append(operation_coordinate(reference))
+    }
+    reachable_operations = closed_operation_coordinates(roots, operations)
+    if missing := reachable_operations - operations.keys():
+        raise ValueError(
+            "selected Model entrypoint Operation is absent from the RIR: "
+            f"{sorted(missing)!r}"
+        )
+    operation_node_ids = {
+        cast(str, instruction["node"])
+        for coordinate in reachable_operations
+        for instruction in operation_body_instructions(
+            cast(list[dict[str, Any]], operations[coordinate]["body"])
+        )
+    }
 
     formula_programs = LifecycleFormulaPrograms(
         initialization=reachable_formula_programs(

--- a/libs/gda-balancing/src/gda_balancing/domain/program_reachability.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/program_reachability.py
@@ -1,0 +1,145 @@
+"""Structural reachability for selected RIR Operation and Formula programs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, cast
+
+from gda_balancing.domain.canonical import JsonValue, canonical_bytes
+from gda_balancing.domain.operation_program import (
+    OperationCoordinate,
+    operation_coordinate,
+    selected_operation_index,
+)
+
+
+LIFECYCLE_PHASES = ("initialization", "event", "observation")
+
+
+@dataclass(frozen=True)
+class LifecycleFormulaPrograms:
+    """Reachable Formula programs grouped by their admitted lifecycle phase."""
+
+    initialization: tuple[dict[str, Any], ...]
+    event: tuple[dict[str, Any], ...]
+    observation: tuple[dict[str, Any], ...]
+
+    def for_phase(self, phase: str) -> tuple[dict[str, Any], ...]:
+        """Return the reachable Formula programs for one lifecycle phase."""
+        if phase not in LIFECYCLE_PHASES:
+            raise ValueError(f"unsupported Formula lifecycle phase: {phase}")
+        return cast(tuple[dict[str, Any], ...], getattr(self, phase))
+
+
+@dataclass(frozen=True)
+class ReachableProgramStructure:
+    """Deterministic structural facts for one exact Model-entrypoint set."""
+
+    operation_coordinates: frozenset[OperationCoordinate]
+    runtime_node_ids: frozenset[str]
+    formula_programs: LifecycleFormulaPrograms
+
+
+def _body_instructions(body: Sequence[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
+    instructions: list[Mapping[str, Any]] = []
+    for instruction in body:
+        instructions.append(instruction)
+        nested = instruction.get("body")
+        if isinstance(nested, list) and all(isinstance(row, dict) for row in nested):
+            instructions.extend(_body_instructions(cast(list[dict[str, Any]], nested)))
+    return instructions
+
+
+def reachable_formula_programs(
+    rir: Mapping[str, Any],
+    selected_entrypoints: Sequence[Mapping[str, Any]],
+    *,
+    phase: str,
+) -> tuple[dict[str, Any], ...]:
+    """Return Formula sites structurally reachable in one lifecycle phase."""
+    if phase not in LIFECYCLE_PHASES:
+        raise ValueError(f"unsupported Formula lifecycle phase: {phase}")
+    programs = [
+        program
+        for program in cast(list[dict[str, Any]], rir["initialization_programs"])
+        if cast(dict[str, Any], program["site"])["context"]["phase"] == phase
+    ]
+    reachable_targets = {
+        canonical_bytes(cast(JsonValue, operand["symbol"]))
+        for entrypoint in selected_entrypoints
+        for binding in cast(list[dict[str, Any]], entrypoint["arguments"])
+        if (operand := cast(dict[str, Any], binding["operand"]))["kind"] == "symbol"
+    }
+    while True:
+        previous_targets = len(reachable_targets)
+        for program in programs:
+            target = canonical_bytes(cast(JsonValue, program["target"]))
+            if target not in reachable_targets:
+                continue
+            reachable_targets.update(
+                canonical_bytes(cast(JsonValue, operand["resolved_symbol"]))
+                for row in cast(list[dict[str, Any]], program["inputs"])
+                if (operand := cast(dict[str, Any], row["operand"]))["kind"]
+                != "literal"
+            )
+        if len(reachable_targets) == previous_targets:
+            break
+    return tuple(
+        program
+        for program in programs
+        if canonical_bytes(cast(JsonValue, program["target"])) in reachable_targets
+    )
+
+
+def project_reachable_program_structure(
+    rir: Mapping[str, Any],
+    selected_entrypoints: Sequence[Mapping[str, Any]],
+) -> ReachableProgramStructure:
+    """Project Operation and Formula structure without applying consumer policy."""
+    selected = cast(Mapping[str, Any], rir["selected_semantics"])
+    operations = selected_operation_index(selected)
+    reachable_operations: set[OperationCoordinate] = set()
+    operation_node_ids: set[str] = set()
+    pending = [
+        operation_coordinate(cast(Mapping[str, Any], entrypoint["operation"]))
+        for entrypoint in selected_entrypoints
+    ]
+    while pending:
+        coordinate = pending.pop()
+        if coordinate in reachable_operations:
+            continue
+        operation = operations.get(coordinate)
+        if operation is None:
+            raise ValueError(
+                "selected Model entrypoint Operation is absent from the RIR"
+            )
+        reachable_operations.add(coordinate)
+        for instruction in _body_instructions(
+            cast(list[dict[str, Any]], operation["body"])
+        ):
+            operation_node_ids.add(cast(str, instruction["node"]))
+            reference = instruction.get("operation")
+            if isinstance(reference, Mapping):
+                pending.append(operation_coordinate(reference))
+
+    formula_programs = LifecycleFormulaPrograms(
+        initialization=reachable_formula_programs(
+            rir, selected_entrypoints, phase="initialization"
+        ),
+        event=reachable_formula_programs(rir, selected_entrypoints, phase="event"),
+        observation=reachable_formula_programs(
+            rir, selected_entrypoints, phase="observation"
+        ),
+    )
+    formula_node_ids = {
+        cast(str, row["instruction"]["node"])
+        for phase in LIFECYCLE_PHASES
+        for program in formula_programs.for_phase(phase)
+        for row in cast(list[dict[str, Any]], program["body"])
+    }
+    return ReachableProgramStructure(
+        operation_coordinates=frozenset(reachable_operations),
+        runtime_node_ids=frozenset(operation_node_ids | formula_node_ids),
+        formula_programs=formula_programs,
+    )

--- a/libs/gda-balancing/src/gda_balancing/domain/runtime/execution.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/runtime/execution.py
@@ -37,7 +37,6 @@ from gda_balancing.domain.runtime.projections import (
     event_catalog_record as _event_catalog_record,
     extend_runtime_journal_identity as _extend_runtime_journal_identity,
     external_input_identity as _external_input_identity,
-    formula_programs_reachable_from_entrypoints as _formula_programs_reachable_from_entrypoints,
     metric_definition_identity as _metric_definition_identity,
     observation_event_id as _observation_event_id,
     operation_formula_evaluation_record as _operation_formula_evaluation_record,
@@ -59,6 +58,7 @@ from gda_balancing.domain.runtime.projections import (
     scheduled_event_id as _scheduled_event_id,
     scheduler_contract as _scheduler_contract,
 )
+from gda_balancing.domain.program_reachability import reachable_formula_programs
 from gda_balancing.domain.runtime.scheduler import RuntimeScheduler
 from gda_balancing.domain.experiment import (
     CheckedExperiment,
@@ -734,8 +734,8 @@ def _evaluate_initialization_programs(
     phase: str = "initialization",
 ) -> int:
     """Evaluate closed generic programs in one authority-owned lifecycle frame."""
-    programs = _formula_programs_reachable_from_entrypoints(
-        checked,
+    programs = reachable_formula_programs(
+        checked.rir,
         selected_entrypoints,
         phase=phase,
     )

--- a/libs/gda-balancing/src/gda_balancing/domain/runtime/projections.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/runtime/projections.py
@@ -16,12 +16,9 @@ from gda_balancing.domain.experiment import (
     CheckedExperiment,
     _ordered_root_events_under,
     _scenario_root_events,
-    reachable_formula_programs,
 )
-from gda_balancing.domain.operation_program import (
-    operation_coordinate,
-    project_operation_program,
-    selected_operation_index,
+from gda_balancing.domain.program_reachability import (
+    project_reachable_program_structure,
 )
 from gda_balancing.domain.publication import PublicationMember
 from gda_balancing.domain.runtime.scheduler import RuntimeScheduler
@@ -598,20 +595,6 @@ def canonical_metric_dataset(
     return identities, ordered
 
 
-def formula_programs_reachable_from_entrypoints(
-    checked: CheckedExperiment,
-    selected_entrypoints: Sequence[dict[str, Any]],
-    *,
-    phase: str,
-) -> list[dict[str, Any]]:
-    """Project one lifecycle phase to the sites selected by a Scenario."""
-    return reachable_formula_programs(
-        checked.rir,
-        selected_entrypoints,
-        phase=phase,
-    )
-
-
 @cache
 def evaluator_build_identity() -> str:
     """Bind evaluator provenance to the installed Python source build."""
@@ -642,44 +625,19 @@ def evaluator_build_identity() -> str:
 def evaluator_manifest(checked: CheckedExperiment) -> PublicationMember:
     """Project the evaluator's authority-derived capability manifest."""
     runtime = runtime_contract(checked)
-    operations = selected_operation_index(checked.rir["selected_semantics"])
     entrypoints = {row["id"]: row for row in checked.rir["entrypoints"]}
-    operation_node_ids = {
-        cast(str, row["id"])
-        for row in runtime["nodes"]
-        if row["semantics"]["operator"] in {"invoke-operation", "schedule-operation"}
-    }
-    invocation_node_ids = {
-        cast(str, row["id"])
-        for row in runtime["nodes"]
-        if row["semantics"]["operator"] == "invoke-operation"
-    }
-    reachable_nodes = set().union(
-        *(
-            project_operation_program(
-                operation_coordinate(entrypoints[event["entrypoint"]]["operation"]),
-                operations,
-                operation_node_ids=operation_node_ids,
-                invocation_node_ids=invocation_node_ids,
-            ).node_ids
-            for scenario in checked.value["scenarios"]
+    reachable_nodes: set[str] = set()
+    for scenario in checked.value["scenarios"]:
+        selected_entrypoints = [
+            entrypoints[event["entrypoint"]]
             for event in scenario_transition_events(scenario)
+        ]
+        reachable_nodes.update(
+            project_reachable_program_structure(
+                checked.rir,
+                selected_entrypoints,
+            ).runtime_node_ids
         )
-    )
-    reachable_nodes.update(
-        row["instruction"]["node"]
-        for scenario in checked.value["scenarios"]
-        for phase in ("initialization", "event", "observation")
-        for program in formula_programs_reachable_from_entrypoints(
-            checked,
-            [
-                entrypoints[event["entrypoint"]]
-                for event in scenario_transition_events(scenario)
-            ],
-            phase=phase,
-        )
-        for row in cast(list[dict[str, Any]], program["body"])
-    )
     nodes = sorted(
         row["id"]
         for row in runtime["nodes"]

--- a/libs/gda-balancing/tests/test_operation_call_domains.py
+++ b/libs/gda-balancing/tests/test_operation_call_domains.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import pytest
+
+from gda_balancing.domain.authority.context import packaged_authority_context
+from gda_balancing.domain.formula.types import formula_contract_from_operation
+from gda_balancing.domain.model._operation_call_domain_adapters import (
+    resolved_rir_entrypoint_call,
+    resolved_source_entrypoint_call,
+)
+from gda_balancing.domain.model._resolution import _formula_policy
+from gda_balancing.domain.operation_call_domains import (
+    ConcreteOperationCallDomainError,
+    ConcreteOperationCallDomainInput,
+    project_concrete_operation_call_domains,
+)
+
+
+ROOT = ("test.calls", "1.0.0", "root")
+MIDDLE = ("test.calls", "1.0.0", "middle")
+LEAF = ("test.calls", "1.0.0", "leaf")
+LEAF_SLOT = (*LEAF, "scale-policy")
+
+
+def test_projects_nested_schedule_guard_results_literals_and_snapshot_domains() -> None:
+    projection = project_concrete_operation_call_domains(_projection_input())
+
+    assert list(projection.calls) == [ROOT, MIDDLE, LEAF]
+    assert len(projection.calls[LEAF]) == 2
+    assert projection.calls[LEAF][0]["known_arguments"] == {"factor": 2}
+    assert projection.slot_parameter_contracts[LEAF_SLOT] == [
+        {"scaled": _quantity_formula_contract(8, 12)},
+        {"scaled": _quantity_formula_contract(24, 36)},
+    ]
+
+
+def test_projects_the_reproduced_nested_formula_domain_mismatch() -> None:
+    projection = project_concrete_operation_call_domains(_projection_input())
+    actual = projection.slot_parameter_contracts[LEAF_SLOT][1]["scaled"]
+
+    assert actual["domain"] == {"minimum": 24, "maximum": 36}
+    assert not (0 <= actual["domain"]["minimum"] and actual["domain"]["maximum"] <= 20)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected_code", "expected_coordinate"),
+    [
+        (
+            lambda inp: inp.roots[ROOT][0].update({"arguments": {}}),
+            "incomplete_arguments",
+            ROOT,
+        ),
+        (
+            lambda inp: inp.operations[MIDDLE]["body"].insert(
+                0,
+                {
+                    "node": "invoke",
+                    "site": "cycle",
+                    "operation": _operation_ref(ROOT),
+                    "arguments": [
+                        {
+                            "port": "value",
+                            "operand": {"kind": "port", "port": "value"},
+                        }
+                    ],
+                    "result": {"kind": "local", "name": "cycle_result"},
+                },
+            ),
+            "operation_call_cycle",
+            ROOT,
+        ),
+    ],
+)
+def test_returns_typed_failures_for_incomplete_calls_and_cycles(
+    mutate: Any,
+    expected_code: str,
+    expected_coordinate: tuple[str, str, str],
+) -> None:
+    projection_input = _projection_input()
+    mutate(projection_input)
+
+    with pytest.raises(ConcreteOperationCallDomainError) as failure:
+        project_concrete_operation_call_domains(projection_input)
+
+    assert failure.value.code == expected_code
+    assert failure.value.coordinate == expected_coordinate
+
+
+def test_source_and_rir_adapters_resolve_the_same_event_reference_contract() -> None:
+    context = packaged_authority_context()
+    operation = {"inputs": [{"id": "event"}]}
+    source_call = resolved_source_entrypoint_call(
+        {"arguments": [{"port": "event", "operand": {"kind": "event-reference"}}]},
+        operation,
+        {},
+        context.kernel,
+        context.language_bundle,
+    )
+    rir_call = resolved_rir_entrypoint_call(
+        {
+            "arguments": [
+                {
+                    "port": {"name": "event"},
+                    "operand": {"kind": "event-reference"},
+                }
+            ]
+        },
+        operation,
+        {},
+        context.kernel,
+    )
+
+    assert source_call is not None
+    assert rir_call is not None
+    assert source_call["arguments"] == rir_call["arguments"]
+    assert source_call["known_arguments"] == rir_call["known_arguments"] == {}
+
+
+def _projection_input() -> ConcreteOperationCallDomainInput:
+    context = packaged_authority_context()
+    operations = _operations()
+    return ConcreteOperationCallDomainInput(
+        operations=operations,
+        roots={
+            ROOT: [
+                {
+                    "arguments": {"value": _quantity_formula_contract(4, 6)},
+                    "known_arguments": {},
+                }
+            ]
+        },
+        formula_slot_bindings=frozenset({LEAF_SLOT}),
+        operation_node_ids=frozenset({"invoke", "schedule"}),
+        conversion_policy=deepcopy(
+            _formula_policy(context.language_bundle)["notation_conversion"]
+        ),
+        literal_contract=_literal_contract,
+        snapshot_contracts={MIDDLE: {"bonus": _quantity_formula_contract(3, 3)}},
+        snapshot_operand_names={MIDDLE: frozenset({"bonus"})},
+    )
+
+
+def _operations() -> dict[tuple[str, str, str], dict[str, Any]]:
+    leaf = {
+        "id": LEAF[2],
+        "inputs": [
+            _quantity_operation_contract("value"),
+            _quantity_operation_contract("factor"),
+        ],
+        "body": [
+            {
+                "node": "multiply",
+                "left": "value",
+                "right": "factor",
+                "target": "scaled",
+            }
+        ],
+        "result": {
+            **_quantity_operation_contract("result"),
+            "source": {"kind": "local", "name": "scaled"},
+        },
+        "extensions": {
+            "standard.formula-slots": [
+                {
+                    "id": LEAF_SLOT[3],
+                    "parameters": [
+                        {
+                            **_quantity_operation_contract("scaled"),
+                            "source": {"kind": "local", "name": "scaled"},
+                        }
+                    ],
+                }
+            ]
+        },
+    }
+    middle = {
+        "id": MIDDLE[2],
+        "inputs": [_quantity_operation_contract("value")],
+        "body": [
+            {
+                "node": "invoke",
+                "site": "literal-scale",
+                "operation": _operation_ref(LEAF),
+                "arguments": [
+                    {
+                        "port": "value",
+                        "operand": {"kind": "port", "port": "value"},
+                    },
+                    {
+                        "port": "factor",
+                        "operand": {"kind": "literal", "literal": 2},
+                    },
+                ],
+                "result": {"kind": "local", "name": "first"},
+            },
+            {
+                "node": "invoke",
+                "site": "snapshot-scale",
+                "operation": _operation_ref(LEAF),
+                "arguments": [
+                    {
+                        "port": "value",
+                        "operand": {"kind": "local", "local": "first"},
+                    },
+                    {
+                        "port": "factor",
+                        "operand": {"kind": "local", "local": "bonus"},
+                    },
+                ],
+                "result": {"kind": "local", "name": "final"},
+            },
+        ],
+        "result": {
+            **_quantity_operation_contract("result"),
+            "source": {"kind": "local", "name": "final"},
+        },
+        "extensions": {
+            "standard.snapshot-operands": {
+                "operands": [
+                    {
+                        "name": "bonus",
+                        "resolved_symbol": {"module": "test", "name": "bonus"},
+                    }
+                ]
+            }
+        },
+    }
+    root = {
+        "id": ROOT[2],
+        "inputs": [_quantity_operation_contract("value")],
+        "body": [
+            {
+                "node": "guard",
+                "body": [
+                    {
+                        "node": "schedule",
+                        "site": "scheduled-middle",
+                        "operation": _operation_ref(MIDDLE),
+                        "arguments": [
+                            {
+                                "port": "value",
+                                "operand": {"kind": "port", "port": "value"},
+                            }
+                        ],
+                        "result": {"kind": "local", "name": "scheduled"},
+                    }
+                ],
+            }
+        ],
+        "result": {
+            **_quantity_operation_contract("result"),
+            "source": {"kind": "local", "name": "scheduled"},
+        },
+    }
+    return {ROOT: root, MIDDLE: middle, LEAF: leaf}
+
+
+def _operation_ref(coordinate: tuple[str, str, str]) -> dict[str, str]:
+    return {
+        "package": coordinate[0],
+        "version": coordinate[1],
+        "id": coordinate[2],
+    }
+
+
+def _quantity_operation_contract(name: str) -> dict[str, Any]:
+    return {
+        "id": name,
+        "type": {
+            "package": "core.quantity",
+            "version": "2.2.0",
+            "id": "Quantity",
+        },
+        "representation": "Int",
+        "kind": "scalar",
+        "unit": "1",
+        "domain": {"kind": "actual"},
+        "numeric_policy": "exact-int64",
+    }
+
+
+def _quantity_formula_contract(minimum: int, maximum: int) -> dict[str, Any]:
+    return {
+        "type_identity": {
+            "package": "core.quantity",
+            "version": "2.2.0",
+            "symbol": "Quantity",
+        },
+        "representation": "Int",
+        "kind": "scalar",
+        "unit": "1",
+        "domain_kind": "closed-interval",
+        "domain": {"minimum": minimum, "maximum": maximum},
+        "numeric_policy": "exact-int64",
+    }
+
+
+def _literal_contract(value: Any, formal: dict[str, Any]) -> dict[str, Any] | None:
+    if not isinstance(value, int) or isinstance(value, bool):
+        return None
+    return {
+        **formula_contract_from_operation(formal),
+        "domain_kind": "closed-interval",
+        "domain": {"minimum": value, "maximum": value},
+    }

--- a/libs/gda-balancing/tests/test_operation_call_domains.py
+++ b/libs/gda-balancing/tests/test_operation_call_domains.py
@@ -72,6 +72,13 @@ def test_projects_the_reproduced_nested_formula_domain_mismatch() -> None:
             "operation_call_cycle",
             ROOT,
         ),
+        (
+            lambda inp: inp.operations[MIDDLE]["body"][0].update(
+                {"operation": "malformed"}
+            ),
+            "malformed_operation_reference",
+            MIDDLE,
+        ),
     ],
 )
 def test_returns_typed_failures_for_incomplete_calls_and_cycles(

--- a/libs/gda-balancing/tests/test_operation_call_domains.py
+++ b/libs/gda-balancing/tests/test_operation_call_domains.py
@@ -95,7 +95,7 @@ def test_projects_the_reproduced_nested_formula_domain_mismatch() -> None:
         ),
     ],
 )
-def test_returns_typed_failures_for_incomplete_calls_and_cycles(
+def test_returns_typed_failures_with_stable_operation_coordinates(
     mutate: Any,
     expected_code: str,
     expected_coordinate: tuple[str, str, str],

--- a/libs/gda-balancing/tests/test_operation_call_domains.py
+++ b/libs/gda-balancing/tests/test_operation_call_domains.py
@@ -79,6 +79,20 @@ def test_projects_the_reproduced_nested_formula_domain_mismatch() -> None:
             "malformed_operation_reference",
             MIDDLE,
         ),
+        (
+            lambda inp: inp.operations[MIDDLE]["body"][0].update(
+                {"operation": _operation_ref(LEAF) | {"extra": "member"}}
+            ),
+            "malformed_operation_reference",
+            MIDDLE,
+        ),
+        (
+            lambda inp: inp.operations[MIDDLE]["body"][0].update(
+                {"operation": _operation_ref(LEAF) | {"id": ""}}
+            ),
+            "malformed_operation_reference",
+            MIDDLE,
+        ),
     ],
 )
 def test_returns_typed_failures_for_incomplete_calls_and_cycles(

--- a/libs/gda-balancing/tests/test_program_reachability.py
+++ b/libs/gda-balancing/tests/test_program_reachability.py
@@ -1,0 +1,125 @@
+"""Domain tests for structural RIR program reachability."""
+
+from typing import Any
+
+import gda_balancing.domain.program_reachability as program_reachability_module
+
+
+def test_projects_nested_operation_only_structure():
+    rir = {
+        "selected_semantics": {
+            "packages": [{"id": "example.program", "version": "1.0.0"}],
+            "operations": [
+                {
+                    "package": "example.program",
+                    "definition": {
+                        "id": "root",
+                        "body": [
+                            {
+                                "node": "invoke",
+                                "operation": {
+                                    "package": "example.program",
+                                    "version": "1.0.0",
+                                    "id": "invoked",
+                                },
+                            },
+                            {
+                                "node": "schedule",
+                                "operation": {
+                                    "package": "example.program",
+                                    "version": "1.0.0",
+                                    "id": "scheduled",
+                                },
+                            },
+                        ],
+                    },
+                },
+                {
+                    "package": "example.program",
+                    "definition": {"id": "invoked", "body": [{"node": "add"}]},
+                },
+                {
+                    "package": "example.program",
+                    "definition": {
+                        "id": "scheduled",
+                        "body": [{"node": "subtract"}],
+                    },
+                },
+            ],
+        },
+        "initialization_programs": [],
+    }
+    entrypoint = {
+        "operation": {
+            "package": "example.program",
+            "version": "1.0.0",
+            "id": "root",
+        },
+        "arguments": [],
+    }
+
+    projected = program_reachability_module.project_reachable_program_structure(
+        rir, [entrypoint]
+    )
+
+    assert projected.operation_coordinates == {
+        ("example.program", "1.0.0", "root"),
+        ("example.program", "1.0.0", "invoked"),
+        ("example.program", "1.0.0", "scheduled"),
+    }
+    assert projected.runtime_node_ids == {"add", "invoke", "schedule", "subtract"}
+    assert all(
+        projected.formula_programs.for_phase(phase) == ()
+        for phase in program_reachability_module.LIFECYCLE_PHASES
+    )
+
+
+def test_groups_formula_programs_by_lifecycle_phase():
+    target = {"model": "example", "module": "main", "name": "derived"}
+
+    def formula_program(phase: str, node: str) -> dict[str, Any]:
+        return {
+            "site": {"context": {"phase": phase}},
+            "target": target,
+            "inputs": [],
+            "body": [{"instruction": {"node": node}}],
+        }
+
+    rir = {
+        "selected_semantics": {
+            "packages": [{"id": "example.program", "version": "1.0.0"}],
+            "operations": [
+                {
+                    "package": "example.program",
+                    "definition": {"id": "root", "body": [{"node": "copy"}]},
+                }
+            ],
+        },
+        "initialization_programs": [
+            formula_program("initialization", "add"),
+            formula_program("event", "multiply"),
+            formula_program("observation", "subtract"),
+        ],
+    }
+    entrypoint = {
+        "operation": {
+            "package": "example.program",
+            "version": "1.0.0",
+            "id": "root",
+        },
+        "arguments": [{"operand": {"kind": "symbol", "symbol": target}}],
+    }
+
+    projected = program_reachability_module.project_reachable_program_structure(
+        rir, [entrypoint]
+    )
+
+    assert projected.runtime_node_ids == {"add", "copy", "multiply", "subtract"}
+    for phase, node in (
+        ("initialization", "add"),
+        ("event", "multiply"),
+        ("observation", "subtract"),
+    ):
+        programs = projected.formula_programs.for_phase(phase)
+        assert len(programs) == 1
+        assert programs[0]["body"][0]["instruction"]["node"] == node

--- a/libs/gda-balancing/tests/test_schema2_experiment_cli.py
+++ b/libs/gda-balancing/tests/test_schema2_experiment_cli.py
@@ -19,6 +19,7 @@ import gda_balancing.domain.artifacts as artifacts_module
 import gda_balancing.domain.experiment_artifacts as experiment_artifacts_module
 import gda_balancing.domain.experiment_artifact_replay as experiment_artifact_replay_module
 import gda_balancing.domain.operation_program as operation_program_module
+import gda_balancing.domain.program_reachability as program_reachability_module
 import gda_balancing.domain.runtime.projections as runtime_projection_module
 import gda_balancing.domain.runtime.execution as experiment_runtime_module
 import schema2_operation_execution_conformance_support as operation_conformance_module
@@ -7796,6 +7797,126 @@ def test_required_evaluator_must_exactly_close_the_selected_program(tmp_path, ru
     )
 
 
+def test_program_reachability_projects_nested_operation_only_structure():
+    rir = {
+        "selected_semantics": {
+            "packages": [{"id": "example.program", "version": "1.0.0"}],
+            "operations": [
+                {
+                    "package": "example.program",
+                    "definition": {
+                        "id": "root",
+                        "body": [
+                            {
+                                "node": "invoke",
+                                "operation": {
+                                    "package": "example.program",
+                                    "version": "1.0.0",
+                                    "id": "invoked",
+                                },
+                            },
+                            {
+                                "node": "schedule",
+                                "operation": {
+                                    "package": "example.program",
+                                    "version": "1.0.0",
+                                    "id": "scheduled",
+                                },
+                            },
+                        ],
+                    },
+                },
+                {
+                    "package": "example.program",
+                    "definition": {"id": "invoked", "body": [{"node": "add"}]},
+                },
+                {
+                    "package": "example.program",
+                    "definition": {
+                        "id": "scheduled",
+                        "body": [{"node": "subtract"}],
+                    },
+                },
+            ],
+        },
+        "initialization_programs": [],
+    }
+    entrypoint = {
+        "operation": {
+            "package": "example.program",
+            "version": "1.0.0",
+            "id": "root",
+        },
+        "arguments": [],
+    }
+
+    projected = program_reachability_module.project_reachable_program_structure(
+        rir, [entrypoint]
+    )
+
+    assert projected.operation_coordinates == {
+        ("example.program", "1.0.0", "root"),
+        ("example.program", "1.0.0", "invoked"),
+        ("example.program", "1.0.0", "scheduled"),
+    }
+    assert projected.runtime_node_ids == {"add", "invoke", "schedule", "subtract"}
+    assert all(
+        projected.formula_programs.for_phase(phase) == ()
+        for phase in program_reachability_module.LIFECYCLE_PHASES
+    )
+
+
+def test_program_reachability_groups_formula_programs_by_lifecycle_phase():
+    target = {"model": "example", "module": "main", "name": "derived"}
+
+    def formula_program(phase: str, node: str) -> dict[str, Any]:
+        return {
+            "site": {"context": {"phase": phase}},
+            "target": target,
+            "inputs": [],
+            "body": [{"instruction": {"node": node}}],
+        }
+
+    rir = {
+        "selected_semantics": {
+            "packages": [{"id": "example.program", "version": "1.0.0"}],
+            "operations": [
+                {
+                    "package": "example.program",
+                    "definition": {"id": "root", "body": [{"node": "copy"}]},
+                }
+            ],
+        },
+        "initialization_programs": [
+            formula_program("initialization", "add"),
+            formula_program("event", "multiply"),
+            formula_program("observation", "subtract"),
+        ],
+    }
+    entrypoint = {
+        "operation": {
+            "package": "example.program",
+            "version": "1.0.0",
+            "id": "root",
+        },
+        "arguments": [{"operand": {"kind": "symbol", "symbol": target}}],
+    }
+
+    projected = program_reachability_module.project_reachable_program_structure(
+        rir, [entrypoint]
+    )
+
+    assert projected.runtime_node_ids == {"add", "copy", "multiply", "subtract"}
+    for phase, node in (
+        ("initialization", "add"),
+        ("event", "multiply"),
+        ("observation", "subtract"),
+    ):
+        programs = projected.formula_programs.for_phase(phase)
+        assert len(programs) == 1
+        assert programs[0]["body"][0]["instruction"]["node"] == node
+
+
 def test_evaluator_manifest_binds_the_selected_runtime_profile(tmp_path, run_cli):
     specification = _write_built_experiment(tmp_path, run_cli)
 
@@ -7827,37 +7948,16 @@ def test_evaluator_manifest_uses_selected_operation_closure_and_build_provenance
     assert isinstance(checked, experiment_admission_module.CheckedExperiment)
 
     first = runtime_projection_module.evaluator_manifest(checked)
-    operations = operation_program_module.selected_operation_index(
-        checked.rir["selected_semantics"]
-    )
     entrypoints = {row["id"]: row for row in checked.rir["entrypoints"]}
     selected_entrypoints = [
         entrypoints[event["entrypoint"]]
         for scenario in checked.value["scenarios"]
         for event in runtime_projection_module.scenario_transition_events(scenario)
     ]
-    formula_nodes = {
-        row["instruction"]["node"]
-        for phase in ("initialization", "event", "observation")
-        for program in runtime_projection_module.formula_programs_reachable_from_entrypoints(
-            checked,
-            selected_entrypoints,
-            phase=phase,
-        )
-        for row in program["body"]
-    }
-    operation_nodes = {
-        instruction["node"]
-        for scenario in checked.value["scenarios"]
-        for event in scenario["event_plan"]
-        for instruction in operation_program_module.expanded_operation_body(
-            operation_program_module.operation_coordinate(
-                entrypoints[event["entrypoint"]]["operation"]
-            ),
-            operations,
-        )
-    }
-    assert set(first.value["instruction_nodes"]) == formula_nodes | operation_nodes
+    projected = program_reachability_module.project_reachable_program_structure(
+        checked.rir, selected_entrypoints
+    )
+    assert set(first.value["instruction_nodes"]) == projected.runtime_node_ids
     assert first.value["evaluator_build_identity"] == (
         runtime_projection_module.evaluator_build_identity()
     )
@@ -7872,6 +7972,81 @@ def test_evaluator_manifest_uses_selected_operation_closure_and_build_provenance
         != (first.value["implementation_identity"])
     )
     assert changed_build.content_identity != first.content_identity
+
+
+def test_program_reachability_keeps_required_and_supported_policies_separate(
+    tmp_path, run_cli, monkeypatch
+):
+    specification = _write_built_experiment(tmp_path, run_cli)
+    checked = experiment_admission_module.check_experiment(str(specification))
+    assert isinstance(checked, experiment_admission_module.CheckedExperiment)
+    entrypoints = {row["id"]: row for row in checked.rir["entrypoints"]}
+    scenario = checked.value["scenarios"][0]
+    event = runtime_projection_module.scenario_transition_events(scenario)[0]
+    selected_entrypoints = [entrypoints[event["entrypoint"]]]
+    baseline = program_reachability_module.project_reachable_program_structure(
+        checked.rir, selected_entrypoints
+    )
+    phase, program = next(
+        (phase, programs[0])
+        for phase in program_reachability_module.LIFECYCLE_PHASES
+        if (programs := baseline.formula_programs.for_phase(phase))
+    )
+    added_contract = next(
+        row
+        for row in checked.kernel["meta_format"]["runtime_program"]["nodes"]
+        if row["semantics"]["operator"]
+        in runtime_projection_module.SUPPORTED_RUNTIME_OPERATORS
+        and row["id"] not in baseline.runtime_node_ids
+    )
+    added_node = added_contract["id"]
+    mutated_rir = deepcopy(checked.rir)
+    program_index = checked.rir["initialization_programs"].index(program)
+    added_instruction = deepcopy(program["body"][0])
+    added_instruction["instruction"]["node"] = added_node
+    mutated_rir["initialization_programs"][program_index]["body"].append(
+        added_instruction
+    )
+    projected = program_reachability_module.project_reachable_program_structure(
+        mutated_rir, selected_entrypoints
+    )
+    assert added_node in projected.runtime_node_ids
+    assert added_node in {
+        row["instruction"]["node"]
+        for row in projected.formula_programs.for_phase(phase)[0]["body"]
+    }
+
+    requirements, _named_streams = (
+        experiment_admission_module.derive_scenario_program_requirements(
+            mutated_rir,
+            event["entrypoint"],
+            checked.value["runtime"]["profile"],
+            checked.value["seed"]["algorithm"],
+        )
+    )
+    assert added_node in requirements["instruction_nodes"]
+    mutated_value = deepcopy(checked.value)
+    mutated_value["runtime"]["required_evaluator"] = requirements
+    mutated_checked = replace(checked, rir=mutated_rir, value=mutated_value)
+    assert (
+        added_node
+        in runtime_projection_module.evaluator_manifest(mutated_checked).value[
+            "instruction_nodes"
+        ]
+    )
+
+    monkeypatch.setattr(
+        runtime_projection_module,
+        "SUPPORTED_RUNTIME_OPERATORS",
+        runtime_projection_module.SUPPORTED_RUNTIME_OPERATORS
+        - {added_contract["semantics"]["operator"]},
+    )
+    refused = experiment_runtime_module.prepare_experiment(mutated_checked)
+    assert isinstance(refused, Schema2RefusalReport)
+    assert refused.stage == "resolution"
+    assert refused.diagnostics[0].primary.pointer == (
+        "/runtime/required_evaluator/instruction_nodes"
+    )
 
 
 def test_evaluator_build_identity_covers_only_domain_implementation(monkeypatch):

--- a/libs/gda-balancing/tests/test_schema2_experiment_cli.py
+++ b/libs/gda-balancing/tests/test_schema2_experiment_cli.py
@@ -7797,126 +7797,6 @@ def test_required_evaluator_must_exactly_close_the_selected_program(tmp_path, ru
     )
 
 
-def test_program_reachability_projects_nested_operation_only_structure():
-    rir = {
-        "selected_semantics": {
-            "packages": [{"id": "example.program", "version": "1.0.0"}],
-            "operations": [
-                {
-                    "package": "example.program",
-                    "definition": {
-                        "id": "root",
-                        "body": [
-                            {
-                                "node": "invoke",
-                                "operation": {
-                                    "package": "example.program",
-                                    "version": "1.0.0",
-                                    "id": "invoked",
-                                },
-                            },
-                            {
-                                "node": "schedule",
-                                "operation": {
-                                    "package": "example.program",
-                                    "version": "1.0.0",
-                                    "id": "scheduled",
-                                },
-                            },
-                        ],
-                    },
-                },
-                {
-                    "package": "example.program",
-                    "definition": {"id": "invoked", "body": [{"node": "add"}]},
-                },
-                {
-                    "package": "example.program",
-                    "definition": {
-                        "id": "scheduled",
-                        "body": [{"node": "subtract"}],
-                    },
-                },
-            ],
-        },
-        "initialization_programs": [],
-    }
-    entrypoint = {
-        "operation": {
-            "package": "example.program",
-            "version": "1.0.0",
-            "id": "root",
-        },
-        "arguments": [],
-    }
-
-    projected = program_reachability_module.project_reachable_program_structure(
-        rir, [entrypoint]
-    )
-
-    assert projected.operation_coordinates == {
-        ("example.program", "1.0.0", "root"),
-        ("example.program", "1.0.0", "invoked"),
-        ("example.program", "1.0.0", "scheduled"),
-    }
-    assert projected.runtime_node_ids == {"add", "invoke", "schedule", "subtract"}
-    assert all(
-        projected.formula_programs.for_phase(phase) == ()
-        for phase in program_reachability_module.LIFECYCLE_PHASES
-    )
-
-
-def test_program_reachability_groups_formula_programs_by_lifecycle_phase():
-    target = {"model": "example", "module": "main", "name": "derived"}
-
-    def formula_program(phase: str, node: str) -> dict[str, Any]:
-        return {
-            "site": {"context": {"phase": phase}},
-            "target": target,
-            "inputs": [],
-            "body": [{"instruction": {"node": node}}],
-        }
-
-    rir = {
-        "selected_semantics": {
-            "packages": [{"id": "example.program", "version": "1.0.0"}],
-            "operations": [
-                {
-                    "package": "example.program",
-                    "definition": {"id": "root", "body": [{"node": "copy"}]},
-                }
-            ],
-        },
-        "initialization_programs": [
-            formula_program("initialization", "add"),
-            formula_program("event", "multiply"),
-            formula_program("observation", "subtract"),
-        ],
-    }
-    entrypoint = {
-        "operation": {
-            "package": "example.program",
-            "version": "1.0.0",
-            "id": "root",
-        },
-        "arguments": [{"operand": {"kind": "symbol", "symbol": target}}],
-    }
-
-    projected = program_reachability_module.project_reachable_program_structure(
-        rir, [entrypoint]
-    )
-
-    assert projected.runtime_node_ids == {"add", "copy", "multiply", "subtract"}
-    for phase, node in (
-        ("initialization", "add"),
-        ("event", "multiply"),
-        ("observation", "subtract"),
-    ):
-        programs = projected.formula_programs.for_phase(phase)
-        assert len(programs) == 1
-        assert programs[0]["body"][0]["instruction"]["node"] == node
-
-
 def test_evaluator_manifest_binds_the_selected_runtime_profile(tmp_path, run_cli):
     specification = _write_built_experiment(tmp_path, run_cli)
 
@@ -7974,7 +7854,7 @@ def test_evaluator_manifest_uses_selected_operation_closure_and_build_provenance
     assert changed_build.content_identity != first.content_identity
 
 
-def test_program_reachability_keeps_required_and_supported_policies_separate(
+def test_experiment_keeps_required_and_supported_evaluator_policies_separate(
     tmp_path, run_cli, monkeypatch
 ):
     specification = _write_built_experiment(tmp_path, run_cli)

--- a/libs/gda-balancing/tests/test_schema2_experiment_cli.py
+++ b/libs/gda-balancing/tests/test_schema2_experiment_cli.py
@@ -8044,9 +8044,9 @@ def test_program_reachability_keeps_required_and_supported_policies_separate(
     refused = experiment_runtime_module.prepare_experiment(mutated_checked)
     assert isinstance(refused, Schema2RefusalReport)
     assert refused.stage == "resolution"
-    assert refused.diagnostics[0].primary.pointer == (
-        "/runtime/required_evaluator/instruction_nodes"
-    )
+    primary = refused.diagnostics[0].primary
+    assert isinstance(primary, ArtifactLocation)
+    assert primary.pointer == "/runtime/required_evaluator/instruction_nodes"
 
 
 def test_evaluator_build_identity_covers_only_domain_implementation(monkeypatch):

--- a/libs/gda-balancing/tests/test_schema2_model_cli.py
+++ b/libs/gda-balancing/tests/test_schema2_model_cli.py
@@ -2568,6 +2568,104 @@ def test_resolved_model_admission_rejects_reidentified_nested_formula_domain_esc
     assert admission.diagnostics == ("language.resolved_authority_mismatch",)
 
 
+@pytest.mark.parametrize(
+    "mutation",
+    (
+        "nested-argument",
+        "nested-result-source",
+        "missing-slot-binding",
+        "changed-slot-binding",
+    ),
+)
+def test_resolved_model_admission_rejects_reidentified_call_domain_mutations(
+    mutation,
+):
+    source = (
+        Path(__file__).parents[1] / "examples/schema2/rpg-combat-cast/model-source.json"
+    )
+    checked = model_checking_module.check_model_source(str(source))
+    assert isinstance(checked, model_module.CheckedModel)
+    lowered = model_compilation_module.lower_checked_model(checked)
+    artifacts = {
+        name: deepcopy(lowered[name])
+        for name in ("package-lock", "rir-semantic-payload", "resolved-model")
+    }
+    rir = cast(dict[str, Any], artifacts["rir-semantic-payload"])
+    kernel, language_bundle = mutable_authorities()
+    policy = model_lowering_module._formula_policy(language_bundle)
+    domains = cast(dict[str, str], policy["identity_domains"])
+    selected_operations = {
+        row["definition"]["id"]: row["definition"]
+        for row in rir["selected_semantics"]["operations"]
+    }
+    damage = selected_operations["game.combat.damage-v1"]
+    cast_operation = selected_operations["game.combat.cast-v1"]
+    damage_call = next(
+        instruction
+        for instruction in cast_operation["body"]
+        if instruction.get("operation", {}).get("id") == "game.combat.damage-v1"
+    )
+    slot_binding = next(
+        binding
+        for binding in rir["formula_bindings"]
+        if binding["site"].get("kind") == "operation-slot"
+        and binding["site"]["operation"]["id"] == "game.combat.damage-v1"
+    )
+
+    if mutation == "nested-argument":
+        base_damage = next(
+            argument
+            for argument in damage_call["arguments"]
+            if argument["port"] == "base_damage"
+        )
+        base_damage["operand"] = {"kind": "literal", "literal": 1001}
+    elif mutation == "nested-result-source":
+        damage["result"]["source"] = {
+            "kind": "operation-result",
+            "site": "missing-site",
+        }
+    elif mutation == "missing-slot-binding":
+        rir["formula_bindings"].remove(slot_binding)
+    else:
+        slot_binding["site"]["slot"] = "missing-slot"
+        site_body = {
+            key: value
+            for key, value in slot_binding["site"].items()
+            if key != "identity"
+        }
+        slot_binding["site"]["identity"] = content_identity(
+            domains["evaluation_site"], cast(JsonValue, site_body)
+        )
+        binding_body = {
+            key: value for key, value in slot_binding.items() if key != "identity"
+        }
+        slot_binding["identity"] = content_identity(
+            domains["binding"], cast(JsonValue, binding_body)
+        )
+
+    assert (
+        model_admission_module._formula_program_graph_is_admitted(
+            kernel,
+            language_bundle,
+            rir["declarations"],
+            rir["formulas"],
+            rir["formula_bindings"],
+            rir["entrypoints"],
+            rir["selected_semantics"],
+        )
+        is False
+    )
+    _reidentify(rir, "rir-semantic-payload-v2")
+    resolved_model = cast(dict[str, Any], artifacts["resolved-model"])
+    resolved_model["rir_identity"] = rir["content_identity"]
+    _reidentify(resolved_model, "resolved-model-v2")
+
+    admission = model_admission_module.admit_resolved_model(artifacts)
+
+    assert admission.admitted is False
+    assert admission.diagnostics == ("language.resolved_authority_mismatch",)
+
+
 def test_model_check_reaches_operations_called_by_bound_formulas(run_cli):
     exit_code, stdout, stderr = run_cli(
         ["model", "check", str(_RPG_STAT_COMPOSITION_SOURCE)]

--- a/libs/gda-balancing/tests/test_schema2_playtest.py
+++ b/libs/gda-balancing/tests/test_schema2_playtest.py
@@ -288,11 +288,23 @@ def test_playtest_common_modules_have_multiple_real_app_consumers():
         _PLAYTEST / "addons/gda_balancing_client/gda_execution_client.gd"
     ).read_text()
     assert re.search(r"\b(reward|combat|effect)\b", client, re.IGNORECASE) is None
+    assert "project_run_provenance" not in client
     coordinator = (_PLAYTEST / "content/playtest_execution_coordinator.gd").read_text()
     assert re.search(r"\b(reward|combat|effect)\b", coordinator, re.IGNORECASE) is None
     shell = (_PLAYTEST / "ui/playtest_shell.gd").read_text()
     assert 'DisplayServer.clipboard_set(JSON.stringify(payload, "\\t"))' in shell
     assert "ProjectSettings.globalize_path(path)" in shell
+
+
+def test_playtest_content_does_not_bind_the_concrete_transport_adapter():
+    for script in (_PLAYTEST / "content").rglob("*.gd"):
+        source = script.read_text(encoding="utf-8")
+        assert "res://addons/gda_balancing_client" not in source, script
+
+    projector = (_PLAYTEST / "content/playtest_run_provenance.gd").read_text(
+        encoding="utf-8"
+    )
+    assert "static func project(run_result: Dictionary)" in projector
 
 
 def test_playtest_documentation_covers_each_player_and_maintainer_path():
@@ -348,6 +360,7 @@ def test_playtest_keeps_focused_runtime_behavior_proofs():
         "test_combat_cast_main_live.gd",
         "test_combat_cast_view.gd",
         "test_playtest_execution_coordinator.gd",
+        "test_playtest_run_provenance.gd",
         "test_playtest.gd",
         "test_reward_run_controller_failure.gd",
         "test_reward_run_controller_live.gd",

--- a/libs/gda-balancing/tests/test_schema2_playtest.py
+++ b/libs/gda-balancing/tests/test_schema2_playtest.py
@@ -238,6 +238,7 @@ def test_each_playtest_has_an_explicit_thin_application_entry():
         assert (app / "main.tscn").is_file()
         source = (app / "main.gd").read_text(encoding="utf-8")
         assert "GdaExecutionClient" in source
+        assert "PlaytestExecutionCoordinator" in source
         assert controller_name in source
         if system_name is None:
             assert "res://systems/" not in source
@@ -265,6 +266,16 @@ def test_playtest_common_modules_have_multiple_real_app_consumers():
         path.read_text() for path in (_PLAYTEST / "content").glob("*/*_controller.gd")
     ]
     assert sum("GdaExecutionClient" in source for source in app_sources) == 4
+    assert sum("PlaytestExecutionCoordinator" in source for source in app_sources) == 4
+    assert all("_execution" in source for source in controller_sources)
+    for source in controller_sources:
+        for transport_call in (
+            "admit_revision(",
+            "create_session(",
+            "delete_session(",
+            "run_revision(",
+        ):
+            assert transport_call not in source
     assert sum("PlaytestFeedbackFile" in source for source in controller_sources) == 4
     assert (
         sum(
@@ -277,6 +288,8 @@ def test_playtest_common_modules_have_multiple_real_app_consumers():
         _PLAYTEST / "addons/gda_balancing_client/gda_execution_client.gd"
     ).read_text()
     assert re.search(r"\b(reward|combat|effect)\b", client, re.IGNORECASE) is None
+    coordinator = (_PLAYTEST / "content/playtest_execution_coordinator.gd").read_text()
+    assert re.search(r"\b(reward|combat|effect)\b", coordinator, re.IGNORECASE) is None
     shell = (_PLAYTEST / "ui/playtest_shell.gd").read_text()
     assert 'DisplayServer.clipboard_set(JSON.stringify(payload, "\\t"))' in shell
     assert "ProjectSettings.globalize_path(path)" in shell
@@ -334,6 +347,7 @@ def test_playtest_keeps_focused_runtime_behavior_proofs():
         "test_combat_cast_controller_failure.gd",
         "test_combat_cast_main_live.gd",
         "test_combat_cast_view.gd",
+        "test_playtest_execution_coordinator.gd",
         "test_playtest.gd",
         "test_reward_run_controller_failure.gd",
         "test_reward_run_controller_live.gd",

--- a/libs/gda-balancing/tools/ci.py
+++ b/libs/gda-balancing/tools/ci.py
@@ -51,6 +51,7 @@ SHARDS: Final[dict[str, tuple[str, ...]]] = {
     ),
     "model": (
         "test_exact_resolved_model_binding.py",
+        "test_operation_call_domains.py",
         "test_schema2_model_cli.py",
         "test_schema2_model_lowerer_conformance.py",
     ),

--- a/libs/gda-balancing/tools/ci.py
+++ b/libs/gda-balancing/tools/ci.py
@@ -29,6 +29,7 @@ SHARDS: Final[dict[str, tuple[str, ...]]] = {
         "test_formula_seam.py",
         "test_isolation.py",
         "test_layer_dependencies.py",
+        "test_program_reachability.py",
         "test_schema2_playtest.py",
         "test_schema2_authority_lifecycle.py",
         "test_schema2_bootstrap_authority.py",


### PR DESCRIPTION
## Summary

- centralize deterministic RIR program reachability for Experiment requirements, Evaluator Capability Manifest projection, and Runtime lifecycle consumers
- centralize the shared local Execution lifecycle used by the four maintained Godot playtests while keeping transport and product state machines in their existing owners
- place shared Standard Schema artifact validation and maintainer-provenance projection with Content-owned result interpretation, outside the process/HTTP transport Add-on
- extract concrete Operation call-domain propagation into one domain module with separate Source and RIR adapters, typed failures, and reverse-admission mutation coverage

## Design boundaries

- requirement mapping and supported-capability mapping remain separate policy functions
- `GdaExecutionClient` remains the transport/process adapter; Content owns artifact and result interpretation, and each playtest controller still owns gameplay, player flow, documents, and feedback
- Formula graph closure, mixed Formula/Operation cycles, refusal/resource closure, RIR parsing, and public artifact projection remain with their existing owners
- independent bootstrap, lowerer, evaluator, and conformance consumers do not import the new production projectors
- no new authority, protocol, endpoint, registry, cache, service locator, request queue, or generic game state machine is introduced

Each issue received independent Domain Modular Architecture and Standards/Spec review. The review fixes close Combat retry state preservation, exact malformed Operation-reference validation, Content ownership of playtest result interpretation, and test-contract/readability residues.

## Validation

- branch head: `e3f08d0de24c7faac0857ee8eb93c1fa24e676a5`
- Ruff 0.15.20: pass
- Pyright: pass
- inventory closure: 1,730 tests and 385 Package Release vectors; no missing, overlapping, uncovered, or unexpected entries
- Fast: 543 passed
- Authority: 82 passed
- Language: 158 passed
- Model: 225 passed
- Experiment: 191 passed locally in 256.46s before the Content-only review fix and remotely in 418s at the branch head
- Composition: 477 passed, 25 allowed skips
- wheel and subprocess smoke: 29 passed
- direct Operation call-domain, mutation, and layer checks cover nested `invoke`, `schedule`, guard bodies, locals, literals, snapshots, result sources, slot bindings, exact coordinates, and malformed-reference shapes
- base/head comparison across all five maintained Schema 2 examples preserves RIR semantic identity, RIR content identity, and Resolved Model identity
- playtest Content structure checks reject concrete transport Add-on bindings; the shared provenance projector passes 15 Godot assertions and the transport client passes 34
- local real-Godot HTTP evidence passes for Reward Run (13 assertions), Arcane Duel (33), Curse Timing (17), and Attack Damage Training (39); hosted Godot E2E availability remains reported separately by CI
- no timeout threshold was changed
- remote required checks: 15 passed, 1 expected hosted Godot E2E skip, 0 failed, and 0 pending

Closes #782
Closes #783
Closes #784

