### PR TITLE
feat(gda): dogfooding P3 — group --json, timeout capture, one traversal, graph identity, headless float precision, budget refusal

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -194,14 +194,18 @@ fallback** for anything else. One projection shared across **every value gda
 emits** — the `get` reads (`project`/`node`/`resource get`), the value echoed by
 `node set`/`resource set`, the per-entry value of `project list` and `scene
 get-exports`, and the live `game get` read — so a value reads the same
-everywhere. That sameness is of SHAPE; numeric FIDELITY is not yet uniform.
-The harness frames every reply with Godot's full-precision JSON writer, so a
-LIVE projected float crosses exactly — the one residual being that a negative
-zero reads back as `0.0` — while the headless writer still flattens small
-floats to `0.0` and rounds ordinary ones (#771). The write-side mirror on the
-live wire is a refusal: a float Godot's parser would read as `0.0` is rejected
-before a request is relayed to the harness, no decimal literal being able to
-deliver it (#752). Two controls keep the shared projection safe on the live
+everywhere. That sameness covers numeric FIDELITY as well as shape: both of
+gda's engine-side payloads frame their reply with Godot's full-precision JSON
+writer — the harness since #752, the headless operations payload since #771 —
+so a projected float is the exact binary64 the subject holds, on either
+channel, with one shared residual the engine decides before the writer is
+consulted: a negative zero reads back as `0.0`. The WRITE sides still differ.
+On the live wire it is a refusal: a float Godot's parser would read as `0.0` is
+rejected before a request is relayed to the harness, no decimal literal being
+able to deliver it (#752). Headless there is no refusal — a `--value` string is
+coerced by that same parser, which still drops the low digits of a
+many-digit literal and reads a `DBL_MIN`-scale one as `0.0` (#772). Two
+controls keep the shared projection safe on the live
 side: the whitelist bounds the Object classes whose storage properties the
 inline kind emits, and the texture kind is safe by construction — a fixed
 getter shape with its one expensive readback behind the explicit digest opt-in

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -88,24 +88,25 @@ _Avoid_: consistency, coherence, sync
 
 **Headless launch**:
 The one-shot `godot --headless` spawn primitive that the Phase-1 channels share —
-the sentinel op-dispatch runner, the native-export runner, the `gda script run`
-user-script runner (ADR-0031), and the `gda scene preflight` runner, which
-dispatches an ordinary sentinel op but calls the primitive itself for its
-streaming capture (#664). Given the binary, an argv tail, an optional working
-directory, and a timeout, it builds `[binary, --headless, --log-file <gda-owned
-path>, *args]`, captures bytes with the timeout, and normalizes the outcome into a
-`Raw run` (the single home of the spawn / timeout / launch-failure / UTF-8-decode
-handling). Each channel contributes only its argv tail and the export-only cwd. It
-also owns the launch's `User-data placement` — resolved and preflighted here, once,
-so no channel plumbs it (#653). It offers two **capture strategies**, differing only
-in how the child is read: **buffered** (the sentinel-runner and export channels),
-which discards the child's output when the timeout expires and reports the wait
-instead; and **streaming** (`gda script run`, and `gda scene preflight` — which
-dispatches a sentinel op but calls the primitive itself precisely for this
-capture), which reads both pipes as they arrive, so the output survives a timeout,
-times the launch, and lets the channel end the run early through a caller-supplied
-watch. Both share one timeout / launch-failure mapping
-(#655).
+the sentinel op-dispatch runner, the native-export runner, the `gda resource
+import` engine pass, the `gda script run` user-script runner (ADR-0031), and the
+`gda scene preflight` runner, which dispatches an ordinary sentinel op but calls
+the primitive itself because it bifurcates on the launch's own outcome, a timeout
+being its verdict rather than a failure to classify (#664). Given the binary, an
+argv tail, an optional working directory, and a timeout, it builds `[binary,
+--headless, --log-file <gda-owned path>, *args]`, captures bytes with the timeout,
+and normalizes the outcome into a `Raw run` (the single home of the spawn /
+timeout / launch-failure / UTF-8-decode handling). Each channel contributes only
+its argv tail and the export-only cwd. It also owns the launch's `User-data
+placement` — resolved and preflighted here, once, so no channel plumbs it (#653).
+Every launch **streams**: both pipes are read as they arrive, so whatever the run
+produced before gda ended it survives, and the launch is timed. #655 introduced
+that beside a **buffered** strategy which discarded the child's output at the
+timeout and reported the wait instead, keeping the other channels on it while the
+mechanism was proven; #714 moved the last three across and deleted it, so there is
+ONE strategy and no channel can be left on the discard. What a channel may still
+choose is a `LaunchWatch` — POLICY, not strategy: a rule for ending a run EARLY
+that only that channel can state (`gda script run`'s `Completion marker`).
 _Avoid_: spawn helper, subprocess wrapper
 
 **User-data placement**:
@@ -126,18 +127,23 @@ _Avoid_: log redirect, user dir, sandbox
 
 **Raw run**:
 The normalized outcome a `Headless launch` returns — `{stdout, stderr, exit_code,
-launch_failure, elapsed_seconds}`, unparsed — before any classification.
-`launch_failure` is set only when the primitive synthesized the result (binary
-missing, timed out, the `User-data placement` was refused, or a watch ended the run)
-rather than the engine returning one, so the classifier keys environment failures on
-that typed reason, not on the overloaded exit code. Under the streaming capture
-strategy the streams hold **what the run had already produced** rather than a gda
-notice, and `elapsed_seconds` carries the wall clock; under the buffered strategy they
-are empty on a timeout and `elapsed_seconds` is `None` (#655). Those launch-backed
-channels all return the one `RunResult` shape. Normally internal, it is **promoted to
-a public result by `gda script run`** — the one operation whose success result *is* a
-Raw run (minus `launch_failure`, `elapsed_seconds`, and the streams' timeout
-semantics, all of which are lifted out into an `Error envelope`; since #665 the
+launch_failure, elapsed_seconds, timeout_bound}`, unparsed — before any
+classification. `launch_failure` is set only when the primitive synthesized the
+result (binary missing, timed out, the `User-data placement` was refused, or a
+watch ended the run) rather than the engine returning one, so the classifier keys
+environment failures on that typed reason, not on the overloaded exit code. The
+streams hold **what the run had already produced** rather than a gda notice, and
+`elapsed_seconds` carries the wall clock — on every channel (#655, #714).
+`timeout_bound` is the pair a timed-out run cannot state for itself: WHICH launch
+gave up (its channel label) and the ceiling it reached. It is set only on a
+`TIMEOUT` result and it rides the result because it is the only thing that crosses
+the runner seam — the shared `launch_timeout` classifier has the raw run and
+nothing else, so without it two of the three channels could not name their own
+ceiling (#714). Those launch-backed channels all return the one `RunResult` shape.
+Normally internal, it is **promoted to a public result by `gda script run`** — the
+one operation whose success result *is* a Raw run (minus `launch_failure`,
+`elapsed_seconds`, `timeout_bound`, and the streams' timeout semantics, all of
+which are lifted out into an `Error envelope`; since #665 the
 promoted `stdout` is additionally a BOUNDED projection — verbatim up to a cap,
 above it the leading cap bytes with the complete stream spilled to a file the
 result names), so its `exit_status` can be non-zero on success (ADR-0031).

--- a/README.md
+++ b/README.md
@@ -643,7 +643,7 @@ input event.
 
 | Flag       | Description                                                          |
 | ---------- | ------------------------------------------------------------------- |
-| `--json`    | Emit the result as a single JSON object on stdout. Without it, commands print a concise human-readable rendering. Also accepted at the root: `gda --json <group> <command>` means the same as passing it after the command. |
+| `--json`    | Emit the result as a single JSON object on stdout. Without it, commands print a concise human-readable rendering. Accepted before the command too: `gda --json <group> <command>` and `gda <group> --json <command>` mean the same as passing it after the command. |
 | `--schema`  | Emit the command's input/output JSON Schema contract (no Godot spawned). |
 | `--godot`   | Path to the Godot binary (overrides `$GDA_GODOT` and the default). |
 | `--project` | Godot project directory for `res://` resolution (overrides `$GDA_PROJECT`; defaults to the current directory if it is a project). Domain commands only. Resolving a project runs that project's code — see [Project code execution](#configuration). |

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=76e086abf7307138e3a741e6d89aadab413f83570ffdb2a2ad8da2e34e2b992a -->
+<!-- gda-readme-i18n: source=README.md sha256=ff68f26d3fed2c1ef1d07cfd235ba93a282a5a9a6aecb560c6858a90794343e3 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -660,7 +660,7 @@ de entrada.
 
 | Flag       | Descripción                                                        |
 | ---------- | ------------------------------------------------------------------- |
-| `--json`    | Emite el resultado como un único objeto JSON en stdout. Sin él, los comandos imprimen una representación concisa y legible para humanos. También se acepta en la raíz: `gda --json <group> <command>` significa lo mismo que pasarlo después del comando. |
+| `--json`    | Emite el resultado como un único objeto JSON en stdout. Sin él, los comandos imprimen una representación concisa y legible para humanos. También se acepta antes del comando: `gda --json <group> <command>` y `gda <group> --json <command>` significan lo mismo que pasarlo después del comando. |
 | `--schema`  | Emite el contrato JSON Schema de entrada/salida del comando (sin lanzar Godot). |
 | `--godot`   | Ruta al binario de Godot (anula `$GDA_GODOT` y el valor por defecto). |
 | `--project` | Directorio del proyecto de Godot para la resolución de `res://` (anula `$GDA_PROJECT`; por defecto, el directorio actual si es un proyecto). Solo comandos de dominio. Resolver un proyecto ejecuta el código de ese proyecto — consulta [Ejecución del código del proyecto](#configuration). |

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=76e086abf7307138e3a741e6d89aadab413f83570ffdb2a2ad8da2e34e2b992a -->
+<!-- gda-readme-i18n: source=README.md sha256=ff68f26d3fed2c1ef1d07cfd235ba93a282a5a9a6aecb560c6858a90794343e3 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -651,7 +651,7 @@ Godot は daemon セッション内で `get_mouse_position()` /
 
 | フラグ       | 説明                                                          |
 | ---------- | ------------------------------------------------------------------- |
-| `--json`    | 結果を stdout に単一の JSON オブジェクトとして出力します。指定しない場合、コマンドは簡潔な人間可読のレンダリングを出力します。ルートでも受け付けます: `gda --json <group> <command>` はコマンドの後ろに付けた場合と同じ意味です。 |
+| `--json`    | 結果を stdout に単一の JSON オブジェクトとして出力します。指定しない場合、コマンドは簡潔な人間可読のレンダリングを出力します。コマンドの前でも受け付けます: `gda --json <group> <command>` と `gda <group> --json <command>` はコマンドの後ろに付けた場合と同じ意味です。 |
 | `--schema`  | コマンドの入出力 JSON Schema 契約を出力します(Godot は起動されません)。 |
 | `--godot`   | Godot バイナリへのパス(`$GDA_GODOT` とデフォルトを上書きします)。 |
 | `--project` | `res://` 解決のための Godot プロジェクトディレクトリ(`$GDA_PROJECT` を上書き。プロジェクトであればカレントディレクトリがデフォルト)。ドメインコマンドのみ。プロジェクトの解決はそのプロジェクトのコードを実行します — [プロジェクトコードの実行](#configuration) を参照してください。 |

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=76e086abf7307138e3a741e6d89aadab413f83570ffdb2a2ad8da2e34e2b992a -->
+<!-- gda-readme-i18n: source=README.md sha256=ff68f26d3fed2c1ef1d07cfd235ba93a282a5a9a6aecb560c6858a90794343e3 -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -612,7 +612,7 @@ Live `game set --property position` 遵循与 `node set` 相同的 `Control` 策
 
 | Flag       | 说明                                                               |
 | ---------- | ------------------------------------------------------------------- |
-| `--json`    | 在 stdout 上把结果作为单个 JSON 对象输出。不加它时，命令会打印一份简洁的、供人阅读的渲染结果。根级同样接受该 flag：`gda --json <group> <command>` 与写在命令之后含义相同。 |
+| `--json`    | 在 stdout 上把结果作为单个 JSON 对象输出。不加它时，命令会打印一份简洁的、供人阅读的渲染结果。命令之前同样接受该 flag：`gda --json <group> <command>` 与 `gda <group> --json <command>` 都与写在命令之后含义相同。 |
 | `--schema`  | 输出该命令的输入/输出 JSON Schema 契约（不会启动 Godot）。 |
 | `--godot`   | Godot 二进制文件的路径（覆盖 `$GDA_GODOT` 和默认值）。 |
 | `--project` | 用于 `res://` 解析的 Godot 项目目录（覆盖 `$GDA_PROJECT`；若当前目录本身是个项目则默认用它）。仅限领域命令。解析一个项目会运行该项目的代码——参见[项目代码执行](#configuration)。 |

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -233,7 +233,7 @@ operation, and parse codes the CLI assigns).
 | Code | Category | Source | Exit Code | Meaning |
 | --- | --- | --- | --- | --- |
 | `binary_not_found` | `environment` | `runner` | `127` | The Godot binary could not be launched. |
-| `launch_timeout` | `environment` | `runner` | `124` | Godot launched but did not return before the runner timeout. One command does not report it: `scene preflight` reports its own `timeout` status instead (#664). |
+| `launch_timeout` | `environment` | `runner` | `124` | Godot launched but did not return before the runner timeout; the envelope carries the run's captured partial output, the ceiling it reached and the elapsed wall clock. One command does not report it: `scene preflight` reports its own `timeout` status instead (#664). |
 | `user_data_unwritable` | `environment` | `runner` | `127` | The log or user-data placement for the launch could not be made usable, so the launch was refused. |
 | `unknown_command` | `usage` | `classifier` | `2` | gda has no such command; discover the surface with `gda schema` or `gda --help`. A recognized near miss also carries the supported invocation in the envelope's `hint`. |
 | `unknown_option` | `usage` | `classifier` | `2` | The command exists but has no such option; read its options with `--help` or its input contract with `--schema`. A recognized near miss also carries the supported invocation in the envelope's `hint`. |

--- a/docs/adr/0031-headless-script-run-passthrough-execution.md
+++ b/docs/adr/0031-headless-script-run-passthrough-execution.md
@@ -454,3 +454,21 @@ added incrementally under ADR-0025 if a concrete need appears.
 > status and full byte count) and the TMPDIR remediation; a post-create failure
 > releases the descriptor and unlinks the partial file before failing. `stderr`
 > and the failure envelopes' partial-output evidence keep their existing shapes.
+
+> **Outcome (2026-08-31, #714) — the buffered strategy is gone; every channel streams.**
+> The 2026-08-17 amendment above recorded the sentinel and export channels staying on the
+> buffered capture, with their published timeout envelopes byte-identical, and named moving
+> them as follow-up work. That follow-up landed. Three channels moved, not two — the
+> `resource import` engine pass calls the same primitive and classifies through the same
+> branch — which left the buffered strategy with no caller and it was deleted, so a future
+> channel cannot be silently left on the discard. The shared `launch_timeout` branch
+> (`classify_launch_or_crash`) now builds the envelope for all three: the captured partial
+> output under `--- captured stdout ---` / `--- captured stderr ---` (the script-run labels
+> above are untrue of an export or an import pass), tail-capped at the same 16 KiB per
+> stream, plus the elapsed wall clock and the ceiling that was reached. Both ride the
+> `Raw run` — the wall clock in its existing `elapsed_seconds`, the channel label and
+> ceiling in the new `timeout_bound` — because the runner seam hands a classifier a raw
+> run and nothing else. `script run` and `scene preflight` are unchanged: each still classifies its
+> own timeout, since each carries something the shared branch cannot know (a termination
+> phase and the recognized script errors; a `timeout` STATUS that is the command's answer).
+> The `--- script stdout ---` labels, and every non-timeout envelope, keep their bytes.

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -902,6 +902,32 @@ traversal itself: the two walks are one recursive walker asked two different acc
 questions. A shared traversal is not a shared universe — `project statistics` keeps
 counting the sidecars and the project file the other walk will never see.
 
+**One graph node per file, whatever a declaration spells it (#774).** One file has many
+spellings, and the three graph reads key on the file the engine resolves rather than on the
+spelling. Two spellings reach the same file, and each needs its own fold:
+
+- an **alias** of an absolute address — `res://sub/../leaf.tscn` for `res://leaf.tscn` —
+  which the engine's `simplify_path` folds;
+- a **relative** address, which the engine resolves against the directory of the file that
+  DECLARES it. `path="../shared/leaf.tscn"` in `res://scenes/main.tscn` loads
+  `res://shared/leaf.tscn`, and `preload("../shared/x.gd")` in `res://scripts/user.gd` loads
+  `res://shared/x.gd`. Such a path is anchored to that directory first, then simplified.
+
+Every harvested path is folded this way — an `[ext_resource]` line and a
+`preload()`/`load()`/`extends` argument by the rule above; `project.godot`'s main scene and
+autoload entries, and the `find-references` target, are absolute already and are only
+simplified. So `dependencies` reports the resolved path (never a bare `../…` that names no
+file), `find-references` matches whichever side is aliased or relative (a folded declaration
+with a canonical query, and the reverse), and `find-unused-resources` never reports a
+resource that something references under another spelling. `project statistics` reads
+`project.godot` through the same accessor, so the autoload paths it lists are canonical too.
+
+The echoed `target` keeps the caller's own spelling, and each reference's `context` keeps the
+line as written — only the matching is folded, so an agent still sees the text it must edit.
+A `class_name` target is no path at all. Keying on the raw spelling broke all three reads at
+once: `find-unused-resources` listed an instanced scene, which is wrong advice with a
+destructive follow-up.
+
 ---
 
 ## Phase 2 — live domain commands (served by `gda-daemon`)

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -94,10 +94,10 @@ address by (`.` for the root) — the `@export` properties the node's attached s
 each a `{name, type, hint, hint_string, value}` entry, where `type` is the export's declared
 Godot type name, `hint`/`hint_string` are the Godot `PropertyHint` enum value and its companion
 string the `@export` annotation produced, and `value` is the export's current value in the same
-JSON projection `node get` uses (its default on a freshly-loaded node) — the property-value
-introspection is reused from `node get` (#55), not re-implemented. An export is detected by its
-usage flags (`PROPERTY_USAGE_SCRIPT_VARIABLE` + `PROPERTY_USAGE_EDITOR`) on the script's own
-property list, so a node's inherited engine properties and a script's plain (non-`@export`)
+JSON projection `node get` uses (its default on a freshly-loaded node), at the same full binary64
+precision (#771) — the property-value introspection is reused from `node get` (#55), not
+re-implemented. An export is detected by its usage flags
+(`PROPERTY_USAGE_SCRIPT_VARIABLE` + `PROPERTY_USAGE_EDITOR`) on the script's own property list, so a node's inherited engine properties and a script's plain (non-`@export`)
 variables are excluded. A node with no script, or whose script declares no exports, is omitted;
 a scene with no exported variables anywhere is a valid, empty listing (`nodes == []`). Like
 `scene get`, get-exports reuses the shared load-failure ladder — a missing file is
@@ -409,6 +409,30 @@ callers can use a follow-up `game get` for domain-specific side effects. Its fai
 LIVE-category `live_unknown_property` / `live_uncoercible_value` (the harness reports them in-band,
 mapped by the live classifier — see
 [Phase 2 — live domain commands](#phase-2--live-domain-commands-served-by-gda-daemon)).
+
+**Number reporting** (#771) — the READ half, shared by every headless command that projects a
+value. `ops/operations.gd` frames each reply with Godot's **full-precision** JSON writer, so a
+projected float is the exact binary64 the project holds: `node get`, `scene get-exports`,
+`project get` / `project list`, `resource get`, and the value each `set` echoes all report
+`1e-300` as `1e-300` and `3.141592653589793` as `3.141592653589793`. They did not before #771 —
+the default writer formats fixed-point with at most 32 decimals, so it reported everything below
+about `1e-32.6` as `0.0` and rounded ordinary values to ~15 significant digits, handing the caller
+a number the project does not hold with nothing marking it approximate. The stored value was never
+the problem: `project.godot` held `3.141592653589793` while the reply said `3.14159265358979`.
+**One residual is disclosed rather than fixed**, and it is the same one the live replies carry: a
+NEGATIVE ZERO reads back as `0.0`, which the engine decides (`JSON::_stringify` returns `"0.0"`
+for anything equal to zero) before the precision argument applies. It is the same engine writer
+the live harness uses, so it is measured against the same corpus and the same partition —
+`gda.live_numbers` is the authority, and `tests/test_e2e_headless_number_reads.py` re-derives the
+verdict from a real engine.
+
+What a `--value` **string** becomes on the way IN is the other half and is **not** covered here:
+the ops coerce it with the engine's own parser (`String.to_float`), which drops the low decimal
+digits of a full-precision literal between `1e-4` and `1e-2` and reads a `DBL_MIN`-scale or
+subnormal literal as `0.0`. Unlike the live wire, headless does not refuse those — see
+[#772](https://github.com/aigengame/godot-agent/issues/772). So a `set` and a following `get`
+agree with each other on the value the project holds; that is what this catalog's round-trip
+claims mean, not that every literal survives coercion.
 
 **Structural edits** (established by #56): three commands restructure the node tree within a
 scene file, each a `load → locate → restructure → pack → save` round-trip that reuses the
@@ -741,7 +765,8 @@ valid result.
 **Reading and writing settings** (established by #111): `gda project get SECTION/KEY` reads one
 setting by its full `section/key` name (e.g. `application/config/name`) and reports it as a
 `{setting, type, value}` triple — `type` is the setting's declared Godot type name and `value` its
-JSON projection, the **same projection** `node get` reports for a node property. Compound values
+JSON projection, the **same projection** `node get` reports for a node property, at the same full
+binary64 precision (#771; see "Number reporting" under [`node`](#node)). Compound values
 arrive **structured** (ADR-0035): a `Dictionary` projects to a JSON object, an `Array` or packed
 array to a JSON array, and an embedded `Object` renders as a **reference projection**
 (`{type, resource_path}` for a Resource with a `res://` path), a **texture projection**
@@ -757,7 +782,11 @@ the CLI value to the setting's **declared type** — read off the setting's curr
 `node set` reads it off the node's property list — using the **same coercion rules** the node group
 established (#55; see "Property value coercion" under [`node`](#node)). It then persists
 `project.godot` (`ProjectSettings.save()`) and reports the coerced value in the same JSON projection
-`project get` uses, so a **`set` round-trips through a `get`**. `set` edits an **existing** setting —
+`project get` uses, so a **`set` round-trips through a `get`**: both report the value
+`ProjectSettings` now holds, at full binary64 precision (#771). The round-trip is of the STORED
+value — what the CLI string coerces to first is the engine's own parser, which can read a
+many-digit or `DBL_MIN`-scale literal as a different double (#772); see "Number reporting" under
+[`node`](#node). `set` edits an **existing** setting —
 an unknown key is `unknown_setting`, never a silent create, so the type to coerce to is always known.
 A value that cannot be coerced to the setting's type is `uncoercible_value` (exit 4, the #55 code,
 `project.godot` left untouched); a failed save is `save_failed`.
@@ -766,9 +795,9 @@ A value that cannot be coerced to the setting's type is `uncoercible_value` (exi
 `ProjectSettings` keys so an agent can **discover** which settings exist — the list half of the
 `list → get → set` workflow (`get`/`set` both require you to already know the `section/key`). Each
 entry reuses the **same** `{setting, type, value}` projection `project get` reports — so a listed
-entry round-trips through `project get` — **plus** an `is_default` boolean: `false` when the key is
-customized (written in `project.godot`), `true` when it is at the engine's built-in default. By
-default the listing is only the project's **customized** settings (small and useful); `--all` widens
+entry round-trips through `project get`, floats included (#771) — **plus** an `is_default`
+boolean: `false` when the key is customized (written in `project.godot`), `true` when it is at
+the engine's built-in default. By default the listing is only the project's **customized** settings (small and useful); `--all` widens
 it to the engine's built-in defaults too, and `--section <prefix>` restricts it to keys whose name
 begins with that `section/` prefix (e.g. `application/`, `display/`) — the two compose. Internal
 engine-bookkeeping settings and the non-setting properties the engine's property list also returns
@@ -987,12 +1016,16 @@ re-derives every verdict from a running engine.
   `0.0012345678901234567` arriving 31 doubles away and `0.00014285714285714284` 105.
   Refusing that band would reject ordinary game values, and preserving it would mean not
   sending a JSON number at all, the bespoke transport ADR-0021 rejected.
-- **Headless reads are NOT covered.** `ops/operations.gd` still frames results with the
-  default writer, so a headless `node get` / `scene get-exports` / `project list` /
-  `resource get` can still report a rounded or zeroed float
-  ([#771](https://github.com/aigengame/godot-agent/issues/771)). The live guarantee is
-  therefore stated on the live commands, never on the shared property shape they share
-  with the headless reads.
+- **The headless replies are framed by the same writer since #771.** `ops/operations.gd`
+  made the one-argument change this section describes, so a headless `node get` /
+  `scene get-exports` / `project list` / `resource get` reports the float the project
+  holds and carries the same negative-zero residual (see "Number reporting" under
+  [`node`](#node)). The two channels are still documented separately: the live sentences
+  are published per-field in help and `--schema` and name the WIRE, a leg a headless
+  reply never crosses, so they stay on the live commands rather than moving onto the
+  property shape both share. What differs in substance is the WRITE side — the live wire
+  REFUSES a value its parser would flatten, while a headless `--value` string is coerced
+  by that parser with no refusal ([#772](https://github.com/aigengame/godot-agent/issues/772)).
 
 - **`game` (the running game's scene graph):** `game tree` reads the runtime scene
   tree (shipped — the Phase-2 bootstrap tracer, #7); runtime node property `game get` /

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -71,7 +71,12 @@ they are provenance, not status markers.
 
 **Enumeration** (established by #54): `scene list` walks the project's `res://`
 tree under the same exclusion rule `script list` states below, so the two see the
-same directories and differ only in the extension they collect (#712).
+same directories and differ only in the extension they collect (#712). Since #764 they
+run the same traversal too, and both match the extension **without regard to case**, as
+the engine does — a `Level.TSCN` is a scene to `ResourceLoader`, so `scene list` reports
+it. That case rule is new: the scene walk alone used to compare case-sensitively, which
+made `project statistics` count a `Level.TSCN` as a scene that `scene list` could not
+see.
 
 **Static instance reporting** (established by #400): `scene get` reads the stored
 `SceneState` without instantiating the host scene, but an instanced node is still
@@ -540,6 +545,12 @@ both static-analysis walks (the extension-filtered one behind `find-references`,
 `find-unused-resources` and the `class_name` index, and the unfiltered one `project statistics`
 counts with) — so one project cannot answer two ways. It once did: three of the four compared the
 directory NAME, so `script list` reported a script `project statistics` counted as zero (#712).
+Since #764 the four also share ONE traversal. The scaffolding around the exclusion rule had been
+copied per collector, and the copies drifted a second time — on the extension test, where the
+`scene list` walk alone compared case-sensitively — so each collector is now a single line: the
+shared traversal plus the acceptance test it passes. What they share is the traversal and the
+exclusion rule, **not** a file universe; the two static-analysis walks below still range over
+different files.
 `gda script delete`
 removes a script file and reports the removed script's `class_name`/`extends` (parsed before
 deletion), so the result names the content, not just the path. Delete honors the same addressing
@@ -886,7 +897,10 @@ Two static walks back these, over different file universes: `find-references`,
 creation resolves through) share the extension-filtered one, while `project statistics`
 counts with an unfiltered one that also sees `.import` sidecars and `project.godot` — so
 its file total does not reconcile with the others' candidate set. What is shared is the
-directory exclusion, the rule `script list` states above (#712).
+directory exclusion, the rule `script list` states above (#712), and since #764 the
+traversal itself: the two walks are one recursive walker asked two different acceptance
+questions. A shared traversal is not a shared universe — `project statistics` keeps
+counting the sidecars and the project file the other walk will never see.
 
 ---
 

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -37,7 +37,7 @@ from gda.commands import (
     theme as theme_commands,
 )
 from gda import hints
-from gda.headless import root_json, set_root_json
+from gda.headless import adopt_group_json, ancestor_json, set_ancestor_json
 from gda.provenance import build_version_provenance, render_version_line
 from gda.runner import USER_DATA_ROOT_ENV, set_user_data_root
 
@@ -87,9 +87,9 @@ def _record_root_json(ctx: typer.Context, value: bool) -> bool:
     Recorded from the option's OWN callback rather than the group-callback body so
     the value is in place before any other root option is processed — which is what
     lets ``--version`` below render either form (#659). How the value travels is the
-    option layer's contract (``gda.headless.set_root_json``), not this module's.
+    option layer's contract (``gda.headless.set_ancestor_json``), not this module's.
     """
-    set_root_json(ctx, value)
+    set_ancestor_json(ctx, value)
     return value
 
 
@@ -103,7 +103,7 @@ def _version_callback(ctx: typer.Context, value: Optional[bool]) -> None:
     """
     if not value or ctx.resilient_parsing:
         return
-    if root_json(ctx):
+    if ancestor_json(ctx):
         typer.echo(build_version_provenance().model_dump_json())
     else:
         typer.echo(render_version_line())
@@ -161,12 +161,13 @@ def main(
     #
     # `--json` is accepted here so the ONE documented rule an agent follows —
     # "always pass --json" — never dies with exit 2 on the discovery surface
-    # (`gda --json --help`, `gda --json <group> <command> …`, #671). It is NOT
+    # (`gda --json --help`, `gda --json <group> <command> …`, #671); every group
+    # takes it for the same reason (`adopt_group_json` below, #683). It is NOT
     # inert: handing it to the shared option layer makes the invoked command's own
-    # `--json` inherit it, so the root and post-command spellings mean the same
-    # thing — accepting a flag that silently returned human text would be worse than
-    # the loud usage error it replaced. The --json hand-over happens in the
-    # option's own callback (`_record_root_json`), so it needs no line here.
+    # `--json` inherit it, so all three spellings mean the same thing — accepting a
+    # flag that silently returned human text would be worse than the loud usage
+    # error it replaced. The --json hand-over happens in the option's own callback
+    # (`_record_root_json`), so it needs no line here.
     # `--user-data-root` is a root option because it is process-wide ENVIRONMENT
     # placement, not an operation parameter: it applies to whichever command runs,
     # on every channel that spawns an engine, and the runner reads it there (#653).
@@ -175,6 +176,13 @@ def main(
 
 
 meta_commands.register(app)
+
+# Every mounted group is given the shared `--json` option, so the flag parses at the
+# THIRD parser site too: `gda <group> --json <command>` (#683). Applied here, once
+# the tree is complete, for the same reason the refusal class below is — it is one
+# property of the whole surface, not something each group module re-declares. The
+# option, and what a group does with it, are `gda.headless`.
+adopt_group_json(app)
 
 # Every group — the root included — is given gda's own click group class LAST, once
 # the tree is complete (#670). It refuses an unrecognized command or option with the

--- a/src/gda/commands/perf.py
+++ b/src/gda/commands/perf.py
@@ -42,7 +42,12 @@ from pydantic import (
 
 from gda import dispatch
 from gda.dispatch import dispatch_domain, dispatch_recipe, params_or_bad_parameter
-from gda.errors import Failure, classify_live, make_failure
+from gda.errors import (
+    Failure,
+    classify_live,
+    make_failure,
+    validation_error_message,
+)
 from gda.execution import ExecutionKind
 from gda.headless import (
     HeadlessCommand,
@@ -808,8 +813,19 @@ def _load_budgets(path: Path) -> "dict[str, PerfBudget] | Failure":
         try:
             budgets[name] = PerfBudget.model_validate(entry)
         except ValidationError as exc:
+            # The SHARED renderer (#713/#754), not ``str(exc)``: the raw dump
+            # names the model class, tags each error with
+            # ``[type=..., input_value=..., input_type=...]`` — echoing the
+            # caller's own budget-file content back — and appends a
+            # ``pydantic.dev`` URL, so one ``invalid_params`` code would speak
+            # two languages depending on which surface produced it (#759).
+            # ``name`` stays in the message because it is what the caller must
+            # fix, and it is already bounded by ``PERF_MONITOR_NAMES`` above —
+            # a known monitor name, never arbitrary caller content.
             return make_failure(
-                "invalid_params", f"budget entry {name!r} is invalid: {exc}", ""
+                "invalid_params",
+                f"budget entry {name!r} is invalid: {validation_error_message(exc)}",
+                "",
             )
     return budgets
 

--- a/src/gda/commands/scene.py
+++ b/src/gda/commands/scene.py
@@ -937,26 +937,6 @@ def render_scene_preflight(preflight: "ScenePreflightResult") -> str:
     return "\n".join(lines)
 
 
-class _CaptureOnlyWatch:
-    """``scene preflight``'s :class:`~gda.runner.LaunchWatch`: stream, never abort (#664).
-
-    Passing a watch is what switches the launch primitive from BUFFERED capture to
-    STREAMING (see :class:`gda.runner.LaunchWatch`), and streaming is what this
-    channel needs: a buffered timeout DISCARDS everything the child wrote, and for a
-    scene that never came up that discarded text is the entire evidence — the
-    verdict would say "timeout" and carry nothing.
-
-    It observes and never ends a run, which is deliberate rather than unfinished.
-    ``script run``'s watch can end one because its caller DECLARED what finishing
-    looks like (``--completion-marker``); nobody declares that for a booting scene,
-    and a scene that prints an error is very often still coming up. So the only
-    bound here is the caller's ``--timeout``, and what the watch buys is the capture.
-    """
-
-    def observe(self, *, stdout: str, stderr: str, elapsed: float) -> bool:
-        return False
-
-
 def run_scene_preflight_operation(
     params: ScenePreflightParams,
     *,
@@ -973,10 +953,10 @@ def run_scene_preflight_operation(
     It dispatches an ordinary ADR-0002 sentinel op — the entry script is gda's own
     ``operations.gd``, so the engine can and does report a structured verdict — but
     it calls :func:`gda.runner.launch` directly instead of going through the runner
-    seam, for ONE reason: the seam's buffered capture throws the child's output away
-    at a timeout, and a scene that never came up leaves nothing else behind. The argv
-    is still the shared :func:`gda.runner.sentinel_args` spelling, so the two
-    channels cannot drift on how an op is dispatched.
+    seam, for ONE reason: it bifurcates on the launch's OWN outcome, since a run gda
+    ended at the bound is this command's verdict rather than a failure to classify.
+    The argv is still the shared :func:`gda.runner.sentinel_args` spelling, so the
+    two channels cannot drift on how an op is dispatched.
 
     The outcome bifurcates by WHOSE failure it is, which is where this command
     departs from every other launch-backed channel:
@@ -1020,7 +1000,6 @@ def run_scene_preflight_operation(
         cwd=None,
         timeout=params.timeout,
         timeout_label="Godot scene preflight",
-        watch=_CaptureOnlyWatch(),
     )
     # Forward the engine's own stream, exactly as the sentinel channel does
     # (``HeadlessCommand.execute``): a preflight's stderr is where the booted scene's

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -1563,12 +1563,11 @@ def run_script_run_operation(
     # via --path, so no working directory is needed (unlike the export channel,
     # whose relative output path needs cwd=project).
     args = ["--path", str(project), "--script", script]
-    # Pass a watch, which is what switches the shared primitive from buffered
-    # capture to STREAMING capture (#655): whatever the run produced survives a
-    # timeout, the wall clock is measured, and — only when the caller declared a
-    # completion marker — a run whose script died can be ended in seconds instead
-    # of at the ceiling. The watch is inert without a marker, so the no-marker
-    # invocation gains the captured output and nothing else.
+    # Pass a watch, this channel's POLICY over the shared primitive (#655): only
+    # when the caller declared a completion marker can a run whose script died be
+    # ended in seconds instead of at the ceiling. The watch is inert without a
+    # marker; the captured output and the measured wall clock come from the launch
+    # itself, which every channel gets.
     raw = run_launch(
         binary,
         args,

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -95,9 +95,10 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         # wall-clock bound of its own and reports exceeding it as a `timeout`
         # STATUS on a successful result, so an agent that branches on this code
         # alone would never see that command's timeout.
-        "Godot launched but did not return before the runner timeout. One command "
-        "does not report it: `scene preflight` reports its own `timeout` status "
-        "instead.",
+        "Godot launched but did not return before the runner timeout; the envelope "
+        "carries the run's captured partial output, the ceiling it reached and "
+        "the elapsed wall clock. One command does not report it: `scene "
+        "preflight` reports its own `timeout` status instead.",
     ),
     ErrorCodeSpec(
         "user_data_unwritable",

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -137,10 +137,14 @@ def _is_too_deep(exc: ValidationError) -> bool:
 def validation_error_message(exc: ValidationError) -> str:
     """Render a ``ValidationError`` as the sentence(s) its checks actually wrote.
 
-    The shared home for BOTH input channels that build a params model directly
-    from caller-supplied values and must translate a construction failure into a
-    human message (ADR-0015): the argv path's :func:`~gda.dispatch.params_or_bad_parameter`
-    and the ``--params-json`` path's ``invoke()`` (:mod:`gda.headless`). Lives
+    The shared home for every channel that builds a model directly from
+    caller-supplied values and must translate a construction failure into a
+    human message: the two ADR-0015 input channels — the argv path's
+    :func:`~gda.dispatch.params_or_bad_parameter` and the ``--params-json``
+    path's ``invoke()`` (:mod:`gda.headless`) — and the caller-supplied FILE
+    channel, ``perf --budget``'s per-entry refusal (#759, the third consumer;
+    ``tests/support.py``'s leak-fragment guard treats this function as the
+    authority for all of them). Lives
     here, below both, because ``gda.dispatch`` imports ``gda.headless`` — a
     ``gda.headless``-side import of ``gda.dispatch`` would cycle — while both
     already import :mod:`gda.errors` for their own failure taxonomy (#713

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -19,7 +19,8 @@ engine. The decision tree, top to bottom (``code`` in parentheses; the four
 
 - launch NOT_FOUND → environment / binary_not_found  (runner could not launch it)
 - launch TIMEOUT   → environment / launch_timeout     (runner launched it but it
-  hung past the timeout)
+  hung past the timeout; the envelope carries the captured partial output, the
+  ceiling it reached and the elapsed wall clock, #714)
 - launch USER_DATA_UNWRITABLE → environment / user_data_unwritable (the engine log
   target gda owns could not be created, so the launch was refused, #653)
 - exit < 0  → operation   / engine_crashed         (engine killed by a signal)
@@ -57,7 +58,7 @@ from gda.models import (
     OperationErrorEnvelope,
 )
 from gda.parser import parse_result
-from gda.runner import LaunchFailure, RunResult
+from gda.runner import DEFAULT_TIMEOUT_LABEL, LaunchFailure, RunResult
 
 # The minimum supported Godot version (ADR-0003): the floor where the modern
 # features gda relies on exist. Resolved from the version gda info reports; the
@@ -244,16 +245,154 @@ def invalid_params_json_failure(detail: str) -> Failure:
     )
 
 
+# --- What a failure reports of the output a run had already produced. Shared by
+# the ``script run`` verdicts that own a script's output (#651, #655) and, since
+# #714, by the ``launch_timeout`` envelope every launch-backed channel reports.
+# ---------------------------------------------------------------------------
+
+# The section headers of a `script_failed` envelope's ``diagnostics`` (#651). The
+# layout is fixed and both sections are ALWAYS emitted — an empty stream yields an
+# empty section rather than a missing one — so a consumer can split on the headers
+# without first discovering which streams the script happened to write to.
+SCRIPT_OUTPUT_STDOUT_HEADER = "--- script stdout ---"
+SCRIPT_OUTPUT_STDERR_HEADER = "--- script stderr ---"
+
+# The same two sections for a failure whose subject is the LAUNCH rather than a
+# script (#714). A distinct pair, because "script" would be untrue of an export or
+# an import pass — and because the script-run headers are published envelope bytes
+# that AC3 keeps unchanged. The `captured` wording names what these sections are:
+# what gda had read when it stopped waiting, not a stream the run finished writing.
+CAPTURED_STDOUT_HEADER = "--- captured stdout ---"
+CAPTURED_STDERR_HEADER = "--- captured stderr ---"
+
+
+def _labelled_output(
+    stdout: str, stderr: str, *, stdout_header: str, stderr_header: str
+) -> str:
+    """Both of the child's streams as one labelled ``diagnostics`` string (#651).
+
+    ``GdaError.diagnostics`` is a free-form ``str`` (ADR-0004), and for a failure
+    that IS the script's own — ``script_failed`` — the script's own output is the
+    diagnostic. A GDScript test runner reports through ``print()``, i.e. stdout, so
+    carrying stderr alone would hand a ``--strict`` CI caller a failure with no
+    content. Both streams are labelled rather than concatenated so the caller can
+    still tell which is which. The headers are the caller's because the same layout
+    serves two subjects — a script's own output, and a launch's capture (#714).
+    """
+    parts = []
+    for header, stream in ((stdout_header, stdout), (stderr_header, stderr)):
+        # Keep each section's payload verbatim, only guaranteeing the newline that
+        # puts the next header on its own line.
+        body = stream if stream.endswith("\n") or not stream else stream + "\n"
+        parts.append(f"{header}\n{body}")
+    return "".join(parts)
+
+
+def _labelled_script_output(stdout: str, stderr: str) -> str:
+    """:func:`_labelled_output` under the ``script run`` headers (#651)."""
+    return _labelled_output(
+        stdout,
+        stderr,
+        stdout_header=SCRIPT_OUTPUT_STDOUT_HEADER,
+        stderr_header=SCRIPT_OUTPUT_STDERR_HEADER,
+    )
+
+
+# How much of each stream a failure carries into its ``diagnostics`` when it
+# reports what a run had already produced (#655). Such a run can have produced
+# arbitrarily much output — a test suite that looped for two minutes — and
+# ``diagnostics`` is serialized inline in the JSON result, so it is bounded. The cap
+# is FIXED rather than an option: one more knob to reason about buys nothing an
+# agent wants, and a stated constant is something a caller can rely on. The TAIL is
+# kept, not the head: the interesting part of a run that did not finish is where it
+# got to.
+#
+# The bound is in **UTF-8 bytes**, not characters, because bytes are what actually
+# costs: a character cap of the same number let non-ASCII output through at up to
+# 3-4x the intended size (16Ki CJK characters encode to ~48KiB), so a bound meant to
+# keep a result payload small silently did not. Bytes also make the stated figure
+# mean one thing to a reader measuring the JSON.
+CAPTURED_OUTPUT_TAIL_CAP_BYTES = 16 * 1024
+
+
+def _tail(stream: str) -> str:
+    """The last :data:`CAPTURED_OUTPUT_TAIL_CAP_BYTES` UTF-8 bytes of a stream.
+
+    Slicing bytes can land inside a multi-byte sequence, so the decode uses
+    ``errors="ignore"`` to drop a leading partial character rather than emit a
+    replacement character for it: the truncation is gda's own doing, and inventing a
+    ``U+FFFD`` would misreport the engine's output as malformed. Only that boundary
+    is affected — anything genuinely malformed was already replaced when the capture
+    was decoded, and survives here as the replacement character it became.
+    """
+    encoded = stream.encode("utf-8")
+    if len(encoded) <= CAPTURED_OUTPUT_TAIL_CAP_BYTES:
+        return stream
+    return encoded[-CAPTURED_OUTPUT_TAIL_CAP_BYTES:].decode("utf-8", errors="ignore")
+
+
+def launch_timeout_failure(raw: RunResult) -> Failure:
+    """The ``launch_timeout`` envelope for a run gda stopped waiting for (#714).
+
+    The ONE place a launch's timeout becomes an error envelope, and the
+    reason it is a function of the raw result alone: the sentinel, export and
+    import channels reach it through three different classifiers, and two of them
+    cannot see the ceiling their runner was given — the runner seam hands them a
+    :class:`~gda.runner.RunResult` and nothing else. So the primitive puts the
+    ceiling ON the result (:class:`~gda.runner.TimeoutBound`) and this builder reads
+    it, instead of every ``classify_run`` call site plumbing a timeout through.
+
+    What the envelope carries is the evidence the discard used to destroy: the
+    partial output both streams held when gda ended the run, tail-capped with the
+    cap stated, plus the elapsed wall clock beside the ceiling — which is what tells
+    a run that was merely slow from one that was stuck (GDA-DF-012/GDA-DF-032, the
+    dogfooding pair that #655 fixed for ``script run`` and this closes for the rest).
+
+    ``script run`` and ``scene preflight`` do NOT come here: each classifies its own
+    timeout, because each has something to add this cannot know — a termination
+    phase and the recognized script errors, or a ``timeout`` status that is the
+    command's ANSWER rather than a failure at all.
+
+    Both optional inputs degrade rather than crash. A hand-built ``RunResult`` at a
+    test seam carries neither bound nor clock, and reporting a timeout is a better
+    answer to that than an assertion that would kill the command.
+    """
+    bound = raw.timeout_bound
+    label = bound.label if bound is not None else DEFAULT_TIMEOUT_LABEL
+    ceiling = "" if bound is None else f" of {bound.seconds}s"
+    elapsed = (
+        "" if raw.elapsed_seconds is None else f" (elapsed {raw.elapsed_seconds:.2f}s)"
+    )
+    return make_failure(
+        "launch_timeout",
+        f"{label} launched but did not return before the timeout"
+        f"{ceiling}{elapsed}. The captured output is in diagnostics, truncated to "
+        f"the last {CAPTURED_OUTPUT_TAIL_CAP_BYTES} UTF-8 bytes (16 KiB) of each "
+        f"stream.",
+        _labelled_output(
+            _tail(raw.stdout),
+            _tail(raw.stderr),
+            stdout_header=CAPTURED_STDOUT_HEADER,
+            stderr_header=CAPTURED_STDERR_HEADER,
+        ),
+    )
+
+
 def classify_launch_or_crash(raw: RunResult, binary: Path | None) -> Failure | None:
-    """The env/crash classifier prefix shared by both headless channels (#185).
+    """The env/crash classifier prefix shared by the headless channels (#185).
 
     The single home of the launch-failure and signal-death mapping that the
-    sentinel channel (``classify_run``) and the native-export channel
-    (``classify_export_run``) both open with, so a missing binary, a hung run,
-    or a signal death is classified identically across both (ADR-0010 — reuse
-    the machinery rather than duplicate it). Returns the env/crash ``Failure``
-    for the three modes below, or ``None`` to let the caller's channel-specific
-    tail (sentinel parse+validate vs synthesize-from-exit-code) take over.
+    sentinel channel (``classify_run``), the native-export channel
+    (``classify_export_run``) and the ``resource import`` pass all open with, so a
+    missing binary, a hung run, or a signal death is classified identically across
+    every one of them (ADR-0010 — reuse the machinery rather than duplicate it).
+    Returns the env/crash ``Failure`` for the three modes below, or ``None`` to let
+    the caller's channel-specific tail (sentinel parse+validate vs
+    synthesize-from-exit-code) take over.
+
+    Being the single home is what makes the timeout evidence a property of every
+    channel rather than of whichever one was fixed last: the hung-run branch is
+    written ONCE, so all three report the same envelope (#714).
 
     Environment failures key on the runner's typed ``launch_failure`` reason,
     not the exit code, so an engine (or shell/AppImage wrapper) that *genuinely*
@@ -267,11 +406,7 @@ def classify_launch_or_crash(raw: RunResult, binary: Path | None) -> Failure | N
             raw.stderr,
         )
     if raw.launch_failure is LaunchFailure.TIMEOUT:
-        return make_failure(
-            "launch_timeout",
-            "Godot launched but did not return before the timeout",
-            raw.stderr,
-        )
+        return launch_timeout_failure(raw)
     if raw.launch_failure is LaunchFailure.USER_DATA_UNWRITABLE:
         # Refused before the spawn (issue #653): the engine builds its file logger
         # ahead of any project code and dies with signal 11 when it cannot open the
@@ -584,36 +719,6 @@ def script_did_not_run_failure(
     )
 
 
-# The section headers of a `script_failed` envelope's ``diagnostics`` (#651). The
-# layout is fixed and both sections are ALWAYS emitted — an empty stream yields an
-# empty section rather than a missing one — so a consumer can split on the headers
-# without first discovering which streams the script happened to write to.
-SCRIPT_OUTPUT_STDOUT_HEADER = "--- script stdout ---"
-SCRIPT_OUTPUT_STDERR_HEADER = "--- script stderr ---"
-
-
-def _labelled_script_output(stdout: str, stderr: str) -> str:
-    """Both of the child's streams as one labelled ``diagnostics`` string (#651).
-
-    ``GdaError.diagnostics`` is a free-form ``str`` (ADR-0004), and for a failure
-    that IS the script's own — ``script_failed`` — the script's own output is the
-    diagnostic. A GDScript test runner reports through ``print()``, i.e. stdout, so
-    carrying stderr alone would hand a ``--strict`` CI caller a failure with no
-    content. Both streams are labelled rather than concatenated so the caller can
-    still tell which is which.
-    """
-    parts = []
-    for header, stream in (
-        (SCRIPT_OUTPUT_STDOUT_HEADER, stdout),
-        (SCRIPT_OUTPUT_STDERR_HEADER, stderr),
-    ):
-        # Keep each section's payload verbatim, only guaranteeing the newline that
-        # puts the next header on its own line.
-        body = stream if stream.endswith("\n") or not stream else stream + "\n"
-        parts.append(f"{header}\n{body}")
-    return "".join(parts)
-
-
 def script_exit_status_failure(
     script: str, exit_status: int, stdout: str, stderr: str
 ) -> Failure:
@@ -639,38 +744,6 @@ def script_exit_status_failure(
         f"script run --strict: {script} exited with status {exit_status}",
         _labelled_script_output(stdout, stderr),
     )
-
-
-# How much of each stream a gda-ENDED ``script run`` carries into its
-# ``diagnostics`` (#655). A run gda cut short can have produced arbitrarily much
-# output — a test suite that looped for two minutes — and ``diagnostics`` is
-# serialized inline in the JSON result, so it is bounded. The cap is FIXED rather
-# than an option: one more knob to reason about buys nothing an agent wants, and a
-# stated constant is something a caller can rely on. The TAIL is kept, not the
-# head: the interesting part of a run that did not finish is where it got to.
-#
-# The bound is in **UTF-8 bytes**, not characters, because bytes are what actually
-# costs: a character cap of the same number let non-ASCII output through at up to
-# 3-4x the intended size (16Ki CJK characters encode to ~48KiB), so a bound meant to
-# keep a result payload small silently did not. Bytes also make the stated figure
-# mean one thing to a reader measuring the JSON.
-SCRIPT_OUTPUT_TAIL_CAP_BYTES = 16 * 1024
-
-
-def _tail(stream: str) -> str:
-    """The last :data:`SCRIPT_OUTPUT_TAIL_CAP_BYTES` UTF-8 bytes of a stream.
-
-    Slicing bytes can land inside a multi-byte sequence, so the decode uses
-    ``errors="ignore"`` to drop a leading partial character rather than emit a
-    replacement character for it: the truncation is gda's own doing, and inventing a
-    ``U+FFFD`` would misreport the engine's output as malformed. Only that boundary
-    is affected — anything genuinely malformed was already replaced when the capture
-    was decoded, and survives here as the replacement character it became.
-    """
-    encoded = stream.encode("utf-8")
-    if len(encoded) <= SCRIPT_OUTPUT_TAIL_CAP_BYTES:
-        return stream
-    return encoded[-SCRIPT_OUTPUT_TAIL_CAP_BYTES:].decode("utf-8", errors="ignore")
 
 
 def _ended_run_diagnostics(
@@ -734,7 +807,7 @@ def script_run_timeout_failure(
         f"script run: {script} did not return before the --timeout of {timeout}s "
         f"(elapsed {elapsed:.2f}s, termination phase '{phase}'). The captured "
         f"output is in diagnostics, truncated to the last "
-        f"{SCRIPT_OUTPUT_TAIL_CAP_BYTES} UTF-8 bytes (16 KiB) of each stream; raise "
+        f"{CAPTURED_OUTPUT_TAIL_CAP_BYTES} UTF-8 bytes (16 KiB) of each stream; raise "
         f"--timeout for a run that is merely slow, or declare "
         f"--completion-marker to end an aborted run early.",
         _ended_run_diagnostics("the timeout", script_errors, stdout, stderr),
@@ -793,7 +866,7 @@ def script_run_aborted_failure(
         f"should print progress during them, or run without a marker. "
         f"The --timeout of {timeout}s was not reached. The captured "
         f"output is in diagnostics, truncated to the last "
-        f"{SCRIPT_OUTPUT_TAIL_CAP_BYTES} UTF-8 bytes (16 KiB) of each stream; "
+        f"{CAPTURED_OUTPUT_TAIL_CAP_BYTES} UTF-8 bytes (16 KiB) of each stream; "
         f"termination phase '{phase}'.",
         _ended_run_diagnostics("the abort", script_errors, stdout, stderr),
     )

--- a/src/gda/export_runner.py
+++ b/src/gda/export_runner.py
@@ -93,10 +93,11 @@ class SubprocessExportRunner:
         if project is not None:
             args += ["--path", str(project)]
         args += [flag, preset, output_path]
-        # Pass the export-specific timeout label: on a timeout the primitive's
-        # stderr is carried into GdaError.diagnostics and serialized in
-        # `export run --json`, so it is part of the public error envelope and must
-        # stay byte-compatible with the pre-#185 "Godot export timed out" wording.
+        # Pass the export-specific timeout label: it rides a timed-out result as
+        # part of its `TimeoutBound` and names this channel in the public
+        # `launch_timeout` message that `export run --json` serializes (#714, which
+        # replaced the synthesized "Godot export timed out" stderr this label used
+        # to compose with the export's own captured output).
         return launch(
             self.binary,
             args,

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -86,26 +86,29 @@ def command_constraints(
     )
 
 
-# The context-meta key a root ``--json`` is recorded under (#671). ``ctx.meta`` is
-# ONE dict shared by every context in the tree (click nests it from the parent), so
-# what the root callback records is readable from the invoked command's context.
-# Dotted and package-scoped, per click's documented convention for the namespace.
-ROOT_JSON_META_KEY = "gda.root_json"
+# The context-meta key a ``--json`` given ABOVE the invoked command is recorded
+# under (#671, #683). ``ctx.meta`` is ONE dict shared by every context in the tree
+# (click nests it from the parent), so what an ancestor parser records — the root
+# callback, or a group's — is readable from the invoked command's context. Dotted
+# and package-scoped, per click's documented convention for the namespace.
+ANCESTOR_JSON_META_KEY = "gda.ancestor_json"
 
 
-def set_root_json(ctx: typer.Context, value: bool) -> None:
-    """Record a root ``--json`` for the command the root is about to invoke.
+def set_ancestor_json(ctx: typer.Context, value: bool) -> None:
+    """Record a ``--json`` an ANCESTOR parser bound, for the command it invokes.
 
-    The write half of the root-flag contract, owned HERE next to the options that
-    read it (:func:`_inherit_root_json`, :func:`root_json`), so the knowledge runs
-    downward: the CLI composition root CALLS this to hand the flag over, instead of
-    this module reaching up into that module's private parameter names.
+    The write half of the contract, owned HERE next to the options that read it
+    (:func:`_inherit_ancestor_json`, :func:`ancestor_json`), so the knowledge runs
+    downward: the CLI composition root CALLS this to hand its root flag over,
+    instead of this module reaching up into that module's private parameter names.
+    A group hands its own flag over the same way (:func:`adopt_group_json`), which
+    is what makes the three parser sites one contract rather than three.
     """
-    ctx.meta[ROOT_JSON_META_KEY] = bool(value)
+    ctx.meta[ANCESTOR_JSON_META_KEY] = bool(value)
 
 
-def root_json(ctx: ClickContext) -> bool:
-    """Whether a root ``--json`` was recorded for this invocation (#659).
+def ancestor_json(ctx: ClickContext) -> bool:
+    """Whether a ``--json`` above the invoked command was recorded (#659, #683).
 
     The read half of the same contract, for the readers that are not a command: the
     root's own ``--version``, which renders either a human line or the structured
@@ -118,38 +121,107 @@ def root_json(ctx: ClickContext) -> bool:
     ``typer.Context`` is a subclass, so every existing caller still fits, and this
     function only ever reads ``ctx.meta``.
     """
-    return bool(ctx.meta.get(ROOT_JSON_META_KEY, False))
+    return bool(ctx.meta.get(ANCESTOR_JSON_META_KEY, False))
 
 
-def _inherit_root_json(
+def _inherit_ancestor_json(
     ctx: typer.Context, param: typer.CallbackParam, value: bool
 ) -> bool:
-    """Let a root ``--json`` stand for the command's own (#671).
+    """Let a ``--json`` written above the command stand for the command's own.
 
     The Skill teaches ONE rule — "always pass ``--json``" — and an agent may spell
-    it at the root (``gda --json node get …``) or after the command
-    (``gda node get … --json``). The two must MEAN the same thing, or accepting the
-    root flag would be worse than rejecting it: a silently inert flag returns human
-    text to a caller that asked for JSON, where the old ``No such option`` at least
-    failed loudly.
+    it at the root (``gda --json node get …``), between the group and the command
+    (``gda node --json get …``, #683), or after the command
+    (``gda node get … --json``). All three must MEAN the same thing, or accepting
+    the outer ones would be worse than rejecting them: a silently inert flag returns
+    human text to a caller that asked for JSON, where the old ``No such option`` at
+    least failed loudly.
 
-    A command's own flag wins when given; otherwise the value the root recorded
-    through :func:`set_root_json` applies — click runs the group's callback before
-    it parses the subcommand, so the record is already in place. Living on the
-    shared :func:`json_option` means every call site inherits it with no per-command
-    wiring, including the ``--params-json`` dispatch path, which reads
+    A command's own flag wins when given; otherwise the value an ancestor recorded
+    through :func:`set_ancestor_json` applies — click binds a parser's own options
+    before it parses the subcommand, so the record is already in place. Living on
+    the shared :func:`json_option` means every call site inherits it with no
+    per-command wiring, including the ``--params-json`` dispatch path, which reads
     ``ctx.params`` after this callback has run.
     """
-    return bool(value) or root_json(ctx)
+    return bool(value) or ancestor_json(ctx)
 
 
 def json_option() -> bool:
     return typer.Option(
         False,
         "--json",
-        callback=_inherit_root_json,
+        callback=_inherit_ancestor_json,
         help="Emit the result as a single JSON object.",
     )
+
+
+def _record_group_json(
+    ctx: typer.Context, param: typer.CallbackParam, value: bool
+) -> bool:
+    """Hand a GROUP's ``--json`` down to the command that group is about to run.
+
+    Bound from the option's OWN callback rather than from the group callback's body,
+    so the record is in place before click parses the subcommand no matter what the
+    group body later grows — the shape the root already uses (``gda.cli``).
+
+    Only a GIVEN flag is recorded: the option's ``False`` default must not erase a
+    root ``--json`` the outer parser recorded, or the outer spelling would depend on
+    the inner one.
+    """
+    if value:
+        set_ancestor_json(ctx, True)
+    return value
+
+
+def _group_json(
+    ctx: typer.Context,
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        callback=_record_group_json,
+        help="Emit the invoked command's result as JSON — the same as passing "
+        "--json after the command.",
+    ),
+) -> None:
+    """The callback every command group is given, so ``--json`` parses there too.
+
+    One function shared by all of them: the flag means the same thing under every
+    group, and the same rule written once per group would be that many chances to
+    drift. Its body has nothing to do — the option's own callback did the work — but
+    the function must exist, because a group's options ARE its callback's parameters.
+    """
+
+
+def adopt_group_json(app: typer.Typer) -> None:
+    """Give every group mounted below ``app`` the shared ``--json`` option (#683).
+
+    The third parser site. ``gda --json <group> <command>`` and
+    ``gda <group> <command> --json`` already meant the same thing; the spelling in
+    between died with ``No such option``, so the one rule the Skill teaches broke on
+    a line an agent composes naturally. Applied once from the composition root,
+    AFTER every group has mounted itself, for the reason ``gda.hints.adopt`` is: it
+    is one property of the WHOLE surface, so a group added later inherits the option
+    by being mounted rather than by remembering to declare it. The walk RECURSES for
+    the same reason that one does — a sub-group of a group would otherwise be missed
+    silently.
+
+    Installing the option means installing the callback that carries it, so a group
+    that declares a callback of its own is refused rather than silently replaced:
+    such a group must declare the shared option on that callback itself.
+    """
+    for group in app.registered_groups:
+        instance = group.typer_instance
+        if instance is None:
+            continue
+        if instance.registered_callback is not None:
+            raise RuntimeError(
+                f"command group {group.name!r} declares its own callback; declare "
+                "the shared --json option on it instead of letting "
+                "gda.headless.adopt_group_json replace it."
+            )
+        instance.callback()(_group_json)
+        adopt_group_json(instance)
 
 
 def godot_option() -> Optional[str]:

--- a/src/gda/hints.py
+++ b/src/gda/hints.py
@@ -55,7 +55,7 @@ from typer._click.exceptions import NoSuchOption, UsageError
 from typer._click.globals import get_current_context
 
 from gda.errors import Failure, make_failure
-from gda.headless import emit_failure, root_json
+from gda.headless import ancestor_json, emit_failure
 
 # The two registered codes this module reports (ADR-0002, the `usage` category).
 UNKNOWN_COMMAND = "unknown_command"
@@ -139,28 +139,15 @@ NEAR_MISSES: dict[tuple[str, ...], NearMiss] = {
 }
 
 
-def near_miss(
-    path: tuple[str, ...], token: str, *, on_group: bool
-) -> Optional[NearMiss]:
+def near_miss(path: tuple[str, ...], token: str) -> Optional[NearMiss]:
     """The curated correction for ``token`` under ``path``, or ``None``.
 
-    The table is consulted first. The one rule that is NOT a spelling row follows: a
-    ``--json`` rejected by a GROUP's own parser. Its correction depends on which group
-    was addressed rather than on the group's name, and every group (including any
-    added later) has it, so it is keyed on that SHAPE instead of on fifteen identical
-    rows. It is also the spelling the bundled Skill documents as a usage error, which
-    is how an agent that reads the guidance still ends up here.
+    Table lookups only. A group's ``--json`` was once corrected here by a rule keyed
+    on the tree SHAPE rather than on a spelling; #683 gave every group the option, so
+    the rule went with it — a hint pointing away from an invocation that now works
+    would be worse than none.
     """
-    hit = NEAR_MISSES.get((*path, token))
-    if hit is not None:
-        return hit
-    if on_group and token == "--json" and path:
-        return NearMiss(
-            f"gda {' '.join(path)} <command> --json",
-            "a group's own parser takes only `--help`; `--json` belongs to the "
-            "command, or to the root before it",
-        )
-    return None
+    return NEAR_MISSES.get((*path, token))
 
 
 def _context_path(ctx: ClickContext) -> tuple[str, ...]:
@@ -197,10 +184,11 @@ def _json_in_effect(ctx: ClickContext) -> bool:
 
     1. The command's OWN resolved flag, when the refusal is decided after its parse —
        which is the case for ``gda help <unknown>``. It already carries an inherited
-       root ``--json`` (``gda.headless._inherit_root_json``), so it answers for both
-       spellings wherever it exists.
-    2. The root ``--json``, recorded when the root callback bound it (#671) — the
-       reading available at parse time, before any command's params exist.
+       ancestor ``--json`` (``gda.headless._inherit_ancestor_json``), so it answers
+       for every spelling wherever it exists.
+    2. The ancestor ``--json``, recorded when the root callback (#671) or a group's
+       (#683) bound it — the reading available at parse time, before any command's
+       params exist.
     3. The literal token in the recorded argv. A ``--json`` written AFTER the
        offending token never parses, because the command or option it would have
        belonged to does not exist, so the token itself is the only evidence of the
@@ -209,7 +197,7 @@ def _json_in_effect(ctx: ClickContext) -> bool:
     """
     if bool(ctx.params.get("json_output")):
         return True
-    if root_json(ctx):
+    if ancestor_json(ctx):
         return True
     return "--json" in ctx.meta.get(RAW_ARGV_META_KEY, ())
 
@@ -249,7 +237,7 @@ def unknown_command(path: tuple[str, ...], token: str) -> Refusal:
     two arms agree verbatim even under ``python -m gda``, whose own name is
     ``python -m gda``.
     """
-    hit = near_miss(path, token, on_group=False)
+    hit = near_miss(path, token)
     named = " ".join([CLI_NAME, *path, token])
     return Refusal(
         UNKNOWN_COMMAND,
@@ -261,11 +249,11 @@ def unknown_command(path: tuple[str, ...], token: str) -> Refusal:
 def unknown_option(path: tuple[str, ...], token: str, *, on_group: bool) -> Refusal:
     """The refusal for option ``token`` on the command ``path`` names.
 
-    ``on_group`` picks the remedy, not the wording: a GROUP has only ``--help`` to
-    read, while a leaf command also has ``--schema`` — its machine-readable input
+    ``on_group`` picks the remedy, not the wording: a GROUP is read with ``--help``
+    alone, while a leaf command also has ``--schema`` — its machine-readable input
     contract, which is what an agent should read next.
     """
-    hit = near_miss(path, token, on_group=on_group)
+    hit = near_miss(path, token)
     named = " ".join([CLI_NAME, *path])
     fallback = f"run `{named} --help` for the options it takes"
     if not on_group:

--- a/src/gda/live_numbers.py
+++ b/src/gda/live_numbers.py
@@ -1,5 +1,10 @@
-"""The live wire's NUMBER domain — what a JSON number survives on the way to and
-from an engine session (#752).
+"""The engine's NUMBER domain — what a JSON number survives on the way to and from
+Godot (#752, #771).
+
+Named for the live wire, which is where #752 measured it; the WRITER half is the
+engine's and belongs to both channels. #771 found ``ops/operations.gd`` framing every
+HEADLESS reply with the same default writer described below, and fixed it with the
+same one argument, so the result-direction paragraph now speaks for both.
 
 The live legs carry JSON (ADR-0021): the daemon writes ``{op, params}`` with
 Python's ``json``, the harness reads it with Godot's ``JSON.parse_string``, and the
@@ -28,11 +33,20 @@ rows it split **41 exact / 15 changed / 40 flattened to ``0.0``**, and a
 ``full_precision`` mode instead renders through ``String::num_scientific``
 (grisu2, shortest round-tripping form), which was exact on **95 of the 96** corpus
 rows and on all 5500 of that sweep — the sweep drew no negative zero, and the
-single corpus miss IS that value. The harness therefore stringifies every reply with
-``full_precision`` (``gda_harness.gd``'s ``_json``), and the result direction
-carries full binary64 precision. One residual, kept in the public contract because
-it is an engine early return (``JSON::_stringify`` emits ``"0.0"`` for anything
-equal to zero): a NEGATIVE ZERO reads back as ``0.0``.
+single corpus miss IS that value. BOTH of gda's engine-side payloads therefore
+stringify every reply with ``full_precision`` — the harness (``gda_harness.gd``'s
+``_json``, #752) and the headless operations payload (``ops/operations.gd``'s
+``_json``, #771) — and the result direction carries full binary64 precision on
+either channel. One residual, kept in the public contract because it is an engine
+early return (``JSON::_stringify`` emits ``"0.0"`` for anything equal to zero): a
+NEGATIVE ZERO reads back as ``0.0``.
+
+A headless read needs no separate corpus and gets none: it is measured against the
+same rows and the same ``full_precision`` partition, re-derived from a real engine by
+``tests/test_e2e_headless_number_reads.py``. Its REQUEST half is a different
+question from the live one — a headless ``--value`` is a STRING the operation coerces
+with ``String.to_float``, not a JSON number the parser reads — and it is owned by
+#772, so nothing here is claimed about it.
 
 **The result path has TWO writers, and each float has exactly one of them.** The
 paragraph above is about the engine's: a value the game reports is stringified by
@@ -245,6 +259,17 @@ def find_unrepresentable(value: object, path: str) -> "str | None":
 # property of: the #770 review found the engine sentence inherited by fields the
 # engine never wrote, and a claim that does not say whose value it describes
 # invites exactly that.
+
+# Only the LIVE surfaces publish these. The engine-writer guarantee below became
+# true of headless replies too (#771), but the sentence is not shared onto them: it
+# names the live WIRE, a leg a headless reply never crosses, and it is attached
+# per-field by a guard that walks the LIVE result models. Sharing the string would
+# put a wire claim on a headless read; authoring a headless twin would be the
+# near-duplicate this module exists to prevent. The headless channel therefore states
+# the same fact once, in prose, on the surfaces that document headless behaviour
+# (``docs/command-catalog.md``, ``CONTEXT.md``, the bundled Skill). Publishing it in
+# ``--schema`` needs the derived discipline the live side has — a walk over the
+# headless float-bearing fields — which is a slice of its own, not a rider on #771.
 
 # For a value the ENGINE produced and its full-precision writer serialized.
 LIVE_ENGINE_PRECISION = (

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -6673,10 +6673,32 @@ func _atomic_write_text(path: String, content: String) -> int:
 	return OK
 
 
+# The ONE JSON writer for every headless reply (#771) — the same choice the live
+# harness made in #752, for the same reason, because it is the same engine
+# function. Godot's default JSON.stringify renders a float through String::num,
+# which formats FIXED-POINT with at most MAX_DECIMALS (32) decimals: it flattened
+# every value below ~1e-32.6 to 0.0 and rounded ordinary values to ~15 significant
+# digits (3.141592653589793 came back as 3.14159265358979, and an @export of
+# 1e-300 read back as 0.0). The full_precision argument switches it to
+# String::num_scientific (grisu2, shortest round-tripping form), which loses none
+# of those and still spells every float with a "." or an "e", so a JSON number
+# that was a float stays one. The measured corpus and its counts belong to the one
+# authority that owns them, `gda.live_numbers` (Python side) — not restated here.
+# The other three arguments keep their defaults ("" indent, sort_keys true), so
+# ONLY the number spelling changes. One residual, disclosed in the CLI contract:
+# the engine emits "0.0" for a NEGATIVE ZERO before this argument is consulted.
+#
+# This is the REPORTING half. What a value the caller sends becomes on the way IN
+# — the --value string the ops coerce with String.to_float(), which is the
+# engine's own parser — is a separate question, owned by #772.
+func _json(value: Variant) -> String:
+	return JSON.stringify(value, "", true, true)
+
+
 # Record a successful result: emit it through the sentinel contract and mark
 # the process to exit 0. The single quit() lives in _process.
 func _succeed(payload: Dictionary) -> void:
-	print(RESULT_BEGIN + JSON.stringify(payload) + RESULT_END)
+	print(RESULT_BEGIN + _json(payload) + RESULT_END)
 	_exit_code = 0
 
 
@@ -6687,7 +6709,7 @@ func _diag(message: String) -> void:
 # Record a structured failure through the ADR-0002 sentinel contract. The
 # process is left to exit non-zero via _process.
 func _fail(code: String, message: String) -> void:
-	print(RESULT_BEGIN + JSON.stringify({
+	print(RESULT_BEGIN + _json({
 		"error": {
 			"code": code,
 			"message": message,

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -3919,20 +3919,30 @@ func _write_text_file(path: String, source: String, noun: String) -> bool:
 
 # --- project static-analysis reads (issue #116) -----------------------------
 #
-# Four read-only, project-wide reads, all backed by a SINGLE static project scan
-# (_scan_project). The scan reads files as TEXT — it parses each .tscn/.tres for
-# its [ext_resource path="..."] entries and each .gd for its preload/load/extends
-# references — and never instantiates a scene or loads/compiles a script (the
-# read trust boundary of issue #30). Reads still run under --project, so the
-# engine constructs the project's autoloads at startup before _initialize (the
-# residual project-code execution of issue #61); the scan itself adds none.
+# Four read-only, project-wide reads, backed by TWO static scans over different
+# file universes. find-references, dependencies and find-unused-resources share
+# the extension-filtered scan (_collect_resource_paths); statistics counts with
+# the unfiltered one (_collect_all_file_paths), which also sees the .import
+# sidecars and project.godot the other excludes — so its file total does not
+# reconcile with the others' candidate set. The two scans share one traversal
+# (_collect_paths) and one directory-exclusion rule (_should_descend), which is
+# what keeps them from disagreeing about the TREE while ranging over different
+# files within it.
 #
-# All four share one reference graph so they stay consistent (acceptance
-# criterion): find-references reports the incoming references of one target;
-# dependencies reports the outgoing references of every scene/resource;
+# Both scans read files as TEXT — parsing each .tscn/.tres for its
+# [ext_resource path="..."] entries and each .gd for its preload/load/extends
+# references — and never instantiate a scene or load/compile a script (the read
+# trust boundary of issue #30). Reads still run under --project, so the engine
+# constructs the project's autoloads at startup before _initialize (the residual
+# project-code execution of issue #61); the scans themselves add none.
+#
+# The THREE reference-graph reads share one graph so they stay consistent
+# (acceptance criterion): find-references reports the incoming references of one
+# target; dependencies reports the outgoing references of every scene/resource;
 # find-unused-resources reports the resources with no incoming reference (and not
 # an entry point). A resource is "unused" exactly when find-references for it
-# would return empty — the same graph, one truth.
+# would return empty — the same graph, one truth. statistics is not on that graph:
+# it only counts what its own scan reaches.
 
 
 # project-find-references: find every project file that references the target — a
@@ -4172,8 +4182,9 @@ func _resolve_project_class_script(class_token: String) -> Dictionary:
 
 # Build (once per process) the class_name → declaring-.gd-paths index for the
 # resolver's tier-3 static scan (ADR-0032). Walks the full res:// tree skipping
-# the root cache — reusing the shared recursive walker (_collect_resource_paths,
-# which already enumerates .gd among the graph resources) — and parses each .gd's
+# the root cache — reusing the extension-filtered collector
+# (_collect_resource_paths, which already enumerates .gd among the graph
+# resources) — and parses each .gd's
 # class_name from raw source with the existing never-compiled parser
 # (_script_metadata). A class_name declared in more than one .gd maps to multiple
 # paths (sorted, so an ambiguous_class_name error is deterministic regardless of
@@ -4237,51 +4248,71 @@ func _should_descend(child: String) -> bool:
 	return child != ENGINE_CACHE_DIR
 
 
+# The ONE res:// traversal (#764). Open the directory, enumerate hidden entries,
+# loop, ask _should_descend about each child DIRECTORY, and close the listing —
+# the scaffolding that used to be copied into all four collectors below, where
+# the copies were free to drift and one pair already had (see
+# _collect_scene_paths). `accept` is the only thing a caller varies: it is asked
+# about each FILE and decides whether the walk collects it, so the four
+# collectors differ in exactly that predicate and in nothing else.
+#
+# The collectors share this TRAVERSAL, not a file universe. `accept` is what makes
+# _collect_all_file_paths count the import sidecars and project.godot that
+# _collect_resource_paths excludes: one traversal, one exclusion rule, different
+# universes.
+#
+# Navigational entries ('.', '..') stay off, so the recursion cannot loop back on
+# itself (issue #54 review). Hidden entries are enumerated, so a .hidden.tscn, or
+# any file under a dot-prefixed directory, is collected as promised — the dot
+# prefix is not the exclusion test, _should_descend is, and that decision stays
+# its alone (#712).
+#
+# `accept` is asked about the full res:// child path, not the bare entry name: it
+# is the shape the predicates the collectors reuse (_is_scene_path,
+# _is_script_path, _is_graph_resource_path) are written against. The two agree on
+# the extension anyway — String.get_extension() stops at the last '/', so a file
+# with no extension under a dotted directory (res://a.b/README) answers "" either
+# way — but only the full path can carry a test that looks at the directory too.
+func _collect_paths(dir_path: String, accept: Callable, out: Array[String]) -> void:
+	var dir := DirAccess.open(dir_path)
+	if dir == null:
+		return
+	dir.include_hidden = true
+	dir.list_dir_begin()
+	var entry := dir.get_next()
+	while not entry.is_empty():
+		var child := dir_path.path_join(entry)
+		if dir.current_is_dir():
+			if _should_descend(child):
+				_collect_paths(child, accept, out)
+		elif accept.call(child):
+			out.append(child)
+		entry = dir.get_next()
+	dir.list_dir_end()
+
+
+# The unfiltered acceptance test: every file the traversal reaches (#764). A named
+# predicate rather than an inline lambda, so the statistics walk reads as the same
+# one-line shape as the other three collectors and its universe has a name.
+func _accept_any_file(_path: String) -> bool:
+	return true
+
+
 # Recursively collect every RESOURCE-bearing file under res:// — the files that
 # can carry references (.tscn/.tres scenes & resources, .gd scripts) AND the leaf
 # asset resources (everything else except import sidecars, the project file, and
-# the .godot cache). Mirrors _collect_scene_paths: hidden entries enumerated,
-# navigational entries off, directory descent decided by _should_descend. This is
-# the universe the reference graph, find-unused and the class_name index range
-# over.
+# the .godot cache). This is the universe the reference graph, find-unused and the
+# class_name index range over.
 func _collect_resource_paths(dir_path: String, out: Array[String]) -> void:
-	var dir := DirAccess.open(dir_path)
-	if dir == null:
-		return
-	dir.include_hidden = true
-	dir.list_dir_begin()
-	var entry := dir.get_next()
-	while not entry.is_empty():
-		var child := dir_path.path_join(entry)
-		if dir.current_is_dir():
-			if _should_descend(child):
-				_collect_resource_paths(child, out)
-		elif _is_graph_resource_path(child):
-			out.append(child)
-		entry = dir.get_next()
-	dir.list_dir_end()
+	_collect_paths(dir_path, _is_graph_resource_path, out)
 
 
-# Recursively collect EVERY file under res:// (descending per _should_descend)
-# for the statistics counts — unlike _collect_resource_paths this keeps import
-# sidecars, project.godot and every asset, since statistics counts all files. The
-# two walks therefore range over DIFFERENT universes under the same exclusion.
+# Recursively collect EVERY file under res:// for the statistics counts — unlike
+# _collect_resource_paths this keeps import sidecars, project.godot and every
+# asset, since statistics counts all files. The two walks therefore range over
+# DIFFERENT universes under the same traversal and the same exclusion.
 func _collect_all_file_paths(dir_path: String, out: Array[String]) -> void:
-	var dir := DirAccess.open(dir_path)
-	if dir == null:
-		return
-	dir.include_hidden = true
-	dir.list_dir_begin()
-	var entry := dir.get_next()
-	while not entry.is_empty():
-		var child := dir_path.path_join(entry)
-		if dir.current_is_dir():
-			if _should_descend(child):
-				_collect_all_file_paths(child, out)
-		else:
-			out.append(child)
-		entry = dir.get_next()
-	dir.list_dir_end()
+	_collect_paths(dir_path, _accept_any_file, out)
 
 
 # Whether a path names a file the reference graph / find-unused treat as a
@@ -4656,10 +4687,15 @@ func _is_class_name_declaration_of(line: String, target_class: String) -> bool:
 
 
 # Whether a path names a scene file in the TEXT form gda authors and reads: a
-# .tscn. Only scene-validate asks, because it is the only op whose answer comes
-# from the file's own text rather than from the loaded resource — see the refusal
-# it raises. Every other scene op keys on loadability instead, so a .scn that
-# loads is served there as before.
+# .tscn. Two callers ask. scene-validate asks because it is the only op whose
+# answer comes from the file's own text rather than from the loaded resource —
+# see the refusal it raises. The scene walk asks because it lists exactly that
+# universe, and reusing this predicate is what keeps the listing and the refusal
+# from disagreeing about what a scene file is (#764). Every other scene op keys on
+# loadability instead, so a .scn that loads is served there as before.
+#
+# The comparison is case-insensitive because the engine's own recognition is:
+# ResourceFormatLoader::recognize_path matches the extension with nocasecmp_to.
 func _is_scene_path(path: String) -> bool:
 	return path.get_extension().to_lower() == "tscn"
 
@@ -4785,30 +4821,24 @@ func _has_project() -> bool:
 	return DirAccess.dir_exists_absolute("res://") and FileAccess.file_exists("res://project.godot")
 
 
-# Recursively collect every .tscn under res:// (issue #54), descending per
-# _should_descend. The dot prefix is not part of that test, so a legitimately
-# hidden scene (a .hidden.tscn, or one under a dot-prefixed directory) is
-# enumerated as promised (issue #54 review). Paths are returned as res:// paths
-# so they round-trip into other scene commands.
+# Recursively collect every .tscn under res:// (issue #54) over the shared
+# traversal, which enumerates hidden entries and asks _should_descend about every
+# directory. Paths are returned as res:// paths so they round-trip into other
+# scene commands.
+#
+# The acceptance test is _is_scene_path, so the extension is matched WITHOUT
+# regard to case. It used to be matched case-sensitively here and only here, and
+# that made one project answer two ways: `project statistics` counted a Level.TSCN
+# as a scene (it lowercases the extension before classifying) while `scene list`
+# could not see it at all. The engine is the arbiter and it is case-insensitive —
+# ResourceFormatLoader::recognize_path compares the extension with nocasecmp_to
+# (core/io/resource_loader.cpp), ResourceSaver does the same, and the editor's own
+# filesystem scan lowercases every extension before classifying it
+# (editor/file_system/editor_file_system.cpp). A Level.TSCN IS a scene to Godot,
+# so `scene list` now reports it; that listing is the one output this change grew
+# (#764).
 func _collect_scene_paths(dir_path: String, out: Array[String]) -> void:
-	var dir := DirAccess.open(dir_path)
-	if dir == null:
-		return
-	# Hidden entries are off by default; enable them so a .hidden.tscn or a scene
-	# under a dot-prefixed directory is enumerated. Navigational entries ('.',
-	# '..') stay off, so recursion cannot loop back on itself (issue #54 review).
-	dir.include_hidden = true
-	dir.list_dir_begin()
-	var entry := dir.get_next()
-	while not entry.is_empty():
-		var child := dir_path.path_join(entry)
-		if dir.current_is_dir():
-			if _should_descend(child):
-				_collect_scene_paths(child, out)
-		elif entry.get_extension() == "tscn":
-			out.append(child)
-		entry = dir.get_next()
-	dir.list_dir_end()
+	_collect_paths(dir_path, _is_scene_path, out)
 
 
 # Summarize one .tscn for the listing: its path plus the root node's name/type
@@ -4837,26 +4867,14 @@ func _scene_summary(path: String) -> Dictionary:
 	}
 
 
-# Recursively collect every .gd script under res:// (issue #117), descending per
-# _should_descend. Hidden entries are enumerated (a .hidden.gd, or a script under
-# a dot-prefixed directory) and navigational entries stay off. Paths are returned
-# as res:// paths so they round-trip into other script commands.
+# Recursively collect every .gd script under res:// (issue #117) over the shared
+# traversal, which enumerates hidden entries (a .hidden.gd, or a script under a
+# dot-prefixed directory) and asks _should_descend about every directory. Paths
+# are returned as res:// paths so they round-trip into other script commands. The
+# acceptance test is _is_script_path — the same predicate the script group's
+# addressing boundary uses, case-insensitive as the engine is.
 func _collect_script_paths(dir_path: String, out: Array[String]) -> void:
-	var dir := DirAccess.open(dir_path)
-	if dir == null:
-		return
-	dir.include_hidden = true
-	dir.list_dir_begin()
-	var entry := dir.get_next()
-	while not entry.is_empty():
-		var child := dir_path.path_join(entry)
-		if dir.current_is_dir():
-			if _should_descend(child):
-				_collect_script_paths(child, out)
-		elif entry.get_extension().to_lower() == "gd":
-			out.append(child)
-		entry = dir.get_next()
-	dir.list_dir_end()
+	_collect_paths(dir_path, _is_script_path, out)
 
 
 # Summarize one .gd for the listing: its path plus the class_name/extends parsed

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -3943,6 +3943,31 @@ func _write_text_file(path: String, source: String, noun: String) -> bool:
 # an entry point). A resource is "unused" exactly when find-references for it
 # would return empty — the same graph, one truth. statistics is not on that graph:
 # it only counts what its own scan reaches.
+#
+# ONE graph needs ONE identity per file, and that identity is the path the ENGINE
+# resolves a declaration to — not the string the declaration spells. Two spellings
+# reach the same file:
+#
+# - an ALIAS of an absolute address (res://leaf.tscn and res://sub/../leaf.tscn),
+#   folded by _canonical_resource_path, the engine's own simplify_path;
+# - a RELATIVE address, which the engine resolves against the DECLARING file's
+#   own directory — `path="../shared/leaf.tscn"` in res://scenes/main.tscn loads
+#   res://shared/leaf.tscn (measured on 4.6.3), and `preload("../shared/x.gd")`
+#   in res://scripts/user.gd loads res://shared/x.gd (measured likewise).
+#
+# So every path that enters the graph is folded by the owner that knows its base
+# directory: _normalize_ext_resource_path for an [ext_resource] line,
+# _resolve_ref_path for a preload/load/extends argument. Only two entrants have no
+# declaring file to anchor to and are absolute by construction — project.godot's
+# main scene and autoloads, and the caller's find-references query — and those go
+# straight to _canonical_resource_path.
+#
+# Keying on the raw spelling broke all three reads at once (#774): dependencies
+# named a node no file on disk answers to, find-references for the resolved path
+# missed the declaration, and find-unused-resources therefore advised DELETING a
+# scene the project instances — wrong advice with a destructive follow-up. The
+# other side of every comparison is canonical by construction: the walk builds each
+# path by joining directory entries, never by echoing a declaration.
 
 
 # project-find-references: find every project file that references the target — a
@@ -3971,7 +3996,11 @@ func _op_project_find_references(params: Dictionary) -> void:
 	var target_paths := {}  # res:// paths a reference may name the target by
 	var target_class := ""  # class_name token a .gd reference may name it by
 	if target.begins_with("res://"):
-		target_paths[target] = true
+		# The query is canonicalized like every harvested path (#774), so a caller
+		# that spells the target res://sub/../leaf.tscn asks about the same node
+		# the graph keys res://leaf.tscn under. The echoed "target" keeps the
+		# caller's own spelling — it also carries a class_name, which is no path.
+		target_paths[_canonical_resource_path(target)] = true
 	else:
 		# Resolve the class_name through the SAME unified resolver node add /
 		# resource create use (ADR-0032), so find-references and resource create
@@ -3981,7 +4010,7 @@ func _op_project_find_references(params: Dictionary) -> void:
 		match resolution["status"]:
 			"resolved":
 				target_class = target
-				target_paths[resolution["path"]] = true
+				target_paths[_canonical_resource_path(String(resolution["path"]))] = true
 			"ambiguous":
 				_fail(OP_ERROR_AMBIGUOUS_CLASS_NAME, _ambiguous_class_name_message(target, resolution["paths"]))
 				return
@@ -4372,19 +4401,26 @@ func _outgoing_references_of(path: String) -> Array:
 # The res:// paths an [ext_resource ... path="res://..."] line names in a
 # .tscn/.tres file — the file's external dependencies. Parsed by text: each
 # ext_resource line carries a path="..." attribute (Godot 4 also carries a uid,
-# but always the path too). Returns res:// paths in line order.
+# but always the path too). Returns res:// paths in line order, each under the
+# ONE graph identity (#774) so a file is one graph node however the line spells
+# it: _normalize_ext_resource_path anchors a relative declaration to the
+# DECLARING file's directory before it canonicalizes, because the engine resolves
+# it that way — `path="../shared/leaf.tscn"` in res://scenes/main.tscn loads
+# res://shared/leaf.tscn (measured on 4.6.3). Canonicalizing without anchoring
+# left the relative spelling as its own graph node.
 func _ext_resource_paths(path: String) -> Array[String]:
 	var out: Array[String] = []
 	var text := FileAccess.get_file_as_string(path)
 	if text.is_empty():
 		return out
+	var base_dir := path.get_base_dir()
 	for line in text.split("\n"):
 		var stripped := line.strip_edges()
 		if not stripped.begins_with("[ext_resource"):
 			continue
 		var ref := _quoted_attr(stripped, "path=")
 		if not ref.is_empty():
-			out.append(ref)
+			out.append(_normalize_ext_resource_path(ref, base_dir))
 	return out
 
 
@@ -4405,15 +4441,18 @@ func _script_outgoing_references(path: String) -> Array:
 	return out
 
 
-# Resolve a reference-path argument to a res:// path: a res:// (or uid://) path is
-# already absolute; a relative path is joined onto the referencing file's base
-# directory and simplified, so "../shared/util.gd" from res://a/b.gd becomes
-# res://shared/util.gd. uid:// references are left as-is (they round-trip through
-# Godot's UID system, not the path graph).
+# Resolve a reference-path argument to a canonical res:// path: a relative path is
+# joined onto the referencing file's base directory first, so "../shared/util.gd"
+# from res://a/b.gd becomes res://shared/util.gd. An ALREADY-prefixed argument is
+# canonicalized too and that half is the #774 fix: it used to be returned verbatim,
+# so preload("res://sub/../util.gd") and preload("res://util.gd") were two graph
+# nodes for one file. simplify_path leaves a scheme it does not own alone, so a
+# uid:// reference still passes through unchanged (it round-trips through Godot's
+# UID system, not the path graph).
 func _resolve_ref_path(ref: String, base_dir: String) -> String:
 	if ref.begins_with("res://") or ref.begins_with("uid://") or ref.begins_with("user://"):
-		return ref
-	return base_dir.path_join(ref).simplify_path()
+		return _canonical_resource_path(ref)
+	return _canonical_resource_path(base_dir.path_join(ref))
 
 
 # Find every reference to the target inside one file, appending {path, kind,
@@ -4436,12 +4475,18 @@ func _collect_references_from(path: String, target_paths: Dictionary, target_cla
 	if text.is_empty():
 		return
 	if ext == "tscn" or ext == "tres":
+		var ext_base_dir := path.get_base_dir()
 		for line in text.split("\n"):
 			var stripped := line.strip_edges()
 			if not stripped.begins_with("[ext_resource"):
 				continue
 			var ref := _quoted_attr(stripped, "path=")
-			if target_paths.has(ref):
+			# One identity on BOTH sides: target_paths is seeded canonical, and the
+			# declared spelling is folded here through the SAME owner the harvest
+			# side uses (_normalize_ext_resource_path — anchor to the declaring
+			# file's directory, then canonicalize), so an aliased OR relative
+			# declaration matches a canonical query and the reverse (#774).
+			if target_paths.has(_normalize_ext_resource_path(ref, ext_base_dir)):
 				references.append({"path": path, "kind": "ext_resource", "context": stripped})
 	elif ext == "gd":
 		var base_dir := path.get_base_dir()
@@ -4529,13 +4574,20 @@ func _project_entry_points() -> Array[String]:
 # ProjectSettings — never run.
 func _main_scene_path() -> String:
 	var value: Variant = ProjectSettings.get_setting("application/run/main_scene", "")
-	return String(value)
+	# Canonical like every other path in the graph (#774): an aliased
+	# run/main_scene left the project's entry point matching nothing the walk
+	# found, so find-unused-resources reported the MAIN SCENE as unused.
+	# simplify_path("") is "", so an unset main scene stays the empty "none".
+	return _canonical_resource_path(String(value))
 
 
 # The project's autoload singletons as {name, path} entries, read from
 # ProjectSettings's autoload/* keys (never executed). The stored value carries a
 # leading "*" enable marker for an enabled singleton; it is stripped so the path
-# is the bare res:// path the rest of the graph compares against.
+# is the bare res:// path the rest of the graph compares against, then
+# canonicalized like every other path in the graph (#774). Order matters: the
+# marker must come off FIRST, because simplify_path does not recognize a scheme
+# behind it and folds "*res://a/../b.gd" to the broken "*res:/b.gd".
 func _project_autoloads() -> Array:
 	var out: Array = []
 	for setting in ProjectSettings.get_property_list():
@@ -4544,7 +4596,7 @@ func _project_autoloads() -> Array:
 			continue
 		var autoload_name: String = key.substr("autoload/".length())
 		var value := String(ProjectSettings.get_setting(key, ""))
-		out.append({"name": autoload_name, "path": value.trim_prefix("*")})
+		out.append({"name": autoload_name, "path": _canonical_resource_path(value.trim_prefix("*"))})
 	return out
 
 

--- a/src/gda/runner.py
+++ b/src/gda/runner.py
@@ -34,6 +34,13 @@ OPERATIONS_GD = Path(__file__).parent / "ops" / "operations.gd"
 # the CLI fails loudly instead of blocking forever.
 DEFAULT_TIMEOUT_SECONDS = 60.0
 
+# How a timeout NAMES the launch it ended. Each channel passes its own
+# (``"Godot export"``, ``"Godot import"``, …); the sentinel channel keeps the bare
+# engine name it has always reported. It rides the result as part of
+# :class:`TimeoutBound` and is rendered by the shared ``launch_timeout``
+# classifier, so a caller still learns WHICH launch gave up (#185, #714).
+DEFAULT_TIMEOUT_LABEL = "Godot"
+
 # The environment variable naming a per-invocation user-data root, the env half of
 # the `--user-data-root` option (issue #653). Same flag > env precedence shape as
 # ``GDA_GODOT`` / ``GDA_PROJECT``.
@@ -58,13 +65,32 @@ class LaunchFailure(enum.Enum):
     USER_DATA_UNWRITABLE = "user_data_unwritable"
     # gda ended the run EARLY, before the timeout, because the watching channel's
     # own :class:`LaunchWatch` asked it to (issue #655). Reachable only for a
-    # caller that passes a ``watch``, which today is ``gda script run`` alone —
-    # and that channel classifies this value itself, because only it knows what
-    # its watch condition means. ``classify_launch_or_crash`` therefore does NOT
-    # map it: a shared classifier has no honest generic code for "the caller's
+    # caller that passes a POLICY ``watch``, which today is ``gda script run``
+    # alone — and that channel classifies this value itself, because only it knows
+    # what its watch condition means. ``classify_launch_or_crash`` therefore does
+    # NOT map it: a shared classifier has no honest generic code for "the caller's
     # own declared condition fired". A future watching channel must classify it
     # too rather than fall through to that shared prefix.
     ABORTED = "aborted"
+
+
+@dataclass(frozen=True)
+class TimeoutBound:
+    """The bound a synthesized ``TIMEOUT`` result was ended at (issue #714).
+
+    Set by :func:`launch` and by nothing else, because the primitive is the only
+    place that knows both halves — and it is the only thing that CROSSES the runner
+    seam: ``GodotRunner.run`` hands a channel's classifier a
+    :class:`RunResult` and nothing more, so a shared classifier cannot otherwise
+    learn which launch gave up, or after how long. Carrying the pair here is what
+    lets ONE ``launch_timeout`` branch report "Godot export … before the timeout of
+    600.0s" without every ``classify_run`` call site plumbing it (#714).
+    """
+
+    #: How this launch is NAMED in the failure — see :data:`DEFAULT_TIMEOUT_LABEL`.
+    label: str
+    #: The ceiling, in seconds, that the launch reached.
+    seconds: float
 
 
 @dataclass
@@ -79,12 +105,16 @@ class RunResult:
     # engine returning one; ``None`` means the exit_code is the engine's own
     # (issue #15).
     launch_failure: "LaunchFailure | None" = None
-    # The launch's wall clock, measured only on the STREAMING capture path (issue
-    # #655) — ``None`` under the buffered capture, which does not time itself. It is the
-    # datum that tells a merely-slow run from a hung one: a timeout at 121s of a
-    # 120s ceiling is a suite that outgrew its budget, while one that produced its
-    # last output at 2s is stuck.
+    # The launch's wall clock, measured on every launch (issue #655; every channel
+    # since #714). It is the datum that tells a merely-slow run from a hung one: a
+    # timeout at 121s of a 120s ceiling is a suite that outgrew its budget, while
+    # one that produced its last output at 2s is stuck. ``None`` only on a result
+    # the primitive did not measure — a launch refused before the spawn, or a
+    # hand-built result at a test seam.
     elapsed_seconds: float | None = None
+    # The ceiling this run reached, set only on a synthesized ``TIMEOUT`` result
+    # (issue #714) — see :class:`TimeoutBound`.
+    timeout_bound: "TimeoutBound | None" = None
 
 
 # The per-invocation user-data root the CLI resolved, or ``None`` for the engine
@@ -414,19 +444,13 @@ def _user_data_unwritable_stderr(
 
 
 class LaunchWatch(Protocol):
-    """A channel's incremental view of one streaming launch (issue #655).
+    """A channel's incremental POLICY over one launch (issue #655).
 
-    Passing a watch to :func:`launch` switches the primitive from BUFFERED capture
-    (``subprocess.run``, which discards everything the child wrote when the
-    timeout expires) to STREAMING capture, which changes three things about the
-    launch and nothing else:
-
-    - the child's stdout/stderr are read as they arrive, so **whatever the run
-      produced before gda ended it survives** into the ``RunResult`` — the
-      dogfooding defect this seam exists for (GDA-DF-012/GDA-DF-032: a 120s
-      timeout whose diagnostics held only the timeout message);
-    - the launch is timed, so ``RunResult.elapsed_seconds`` is populated;
-    - the watch can **end the run early**, before the timeout.
+    Every launch streams — the child's stdout/stderr are read as they arrive, so
+    whatever a run produced before gda ended it survives into the ``RunResult``,
+    and the launch is timed (#714 moved the last three channels across; see
+    :func:`launch`). A watch adds the one thing streaming alone cannot decide:
+    **ending a run early**, before the timeout.
 
     The primitive owns the MECHANISM (spawn, read, decode, deadline, terminate)
     and the watch owns the POLICY (what the output means, and when a run is not
@@ -435,6 +459,7 @@ class LaunchWatch(Protocol):
     completion marker did not" is ``script run``'s domain knowledge, not the
     channel-agnostic primitive's — and ADR-0031 rejected gda imposing any
     contract on a user-authored entry script, so only a caller can declare one.
+    A channel with no such rule passes no watch and gets :class:`_CaptureOnly`.
 
     :meth:`observe` is polled on a fixed cadence for the whole run, **including
     polls where no output arrived** (both arguments empty), so a policy keyed on
@@ -460,11 +485,28 @@ class LaunchWatch(Protocol):
         ...
 
 
-# How often the streaming path polls the child and its watch. It bounds the extra
-# latency an early abort or a timeout can carry (a poll may sleep through the
-# moment the condition became true), so it is small — but not so small that a
-# 120s run spends its time waking up: 0.05s is ~2400 polls over the default
-# ``script run`` ceiling.
+class _CaptureOnly:
+    """The watch of a channel that has no early-abort rule (issue #714).
+
+    Streaming is the only capture strategy, so a channel no longer opts into it —
+    it opts into a POLICY, and most channels have none. Observing without ever
+    ending a run is the honest default: gda cannot tell from outside a process
+    whether a quiet engine is stuck or working, and only a caller who declared what
+    finishing looks like (``script run``'s ``--completion-marker``) can. So the
+    ONLY bound for these channels is the caller's timeout, and what they get from
+    the loop is the capture and the clock.
+    """
+
+    def observe(self, *, stdout: str, stderr: str, elapsed: float) -> bool:
+        return False
+
+
+# How often the launch loop polls its watch. It bounds the extra latency an early
+# abort or a timeout can carry (a poll may wait through the moment the condition
+# became true), so it is small — but not so small that a 120s run spends its time
+# waking up: 0.05s is ~2400 polls over the default ``script run`` ceiling. It does
+# NOT bound how quickly a finished run is noticed: the wait ends the instant the
+# child exits (see :func:`_spawn_streamed`).
 _POLL_INTERVAL_SECONDS = 0.05
 
 # One read syscall's ceiling on the streaming path. The pipe is read with
@@ -501,8 +543,8 @@ class _StreamCapture:
     and decoding each chunk independently would turn a legitimate non-ASCII
     character into two replacement characters. Feeding one decoder across every
     chunk — and flushing it once at the end — yields exactly what decoding the
-    whole buffer at once yields, so the streaming path's text is identical to the
-    buffered strategy's for the same bytes.
+    whole buffer at once yields, so the text is identical to a whole-buffer decode
+    of the same bytes.
     """
 
     def __init__(self, pipe: IO[bytes]) -> None:
@@ -558,28 +600,31 @@ def launch(
     *,
     cwd: Path | None,
     timeout: float,
-    timeout_label: str = "Godot",
+    timeout_label: str = DEFAULT_TIMEOUT_LABEL,
     watch: Optional[LaunchWatch] = None,
 ) -> RunResult:
     """Spawn one ``godot --headless`` process and normalize its raw outcome.
 
     The single home of the headless-launch primitive: it builds
     ``[binary, --headless, *args]``, runs it with a timeout capturing raw
-    *bytes*, and returns a normalized :class:`RunResult`. Both Phase-1 channels
-    — the sentinel op-dispatch runner and the native-export runner — build only
-    their channel-specific argv tail (and the export-only ``cwd``) and delegate
+    *bytes*, and returns a normalized :class:`RunResult`. Every Phase-1 channel
+    — the sentinel op-dispatch runner, the native-export runner, the
+    ``resource import`` pass, ``script run`` and ``scene preflight`` — builds only
+    its channel-specific argv tail (and the export-only ``cwd``) and delegates
     the spawn/timeout/``OSError``/decode handling here, so a launch-handling fix
-    lands in one place rather than two copies (issue #185, ADR-0010).
+    lands in one place rather than five copies (issue #185, ADR-0010).
 
-    The mapping, identical for both channels:
+    The mapping, identical for every channel:
 
-    - ``subprocess.TimeoutExpired`` → a synthesized ``EXIT_TIMEOUT`` result
-      flagged ``LaunchFailure.TIMEOUT``: launched, but did not return before the
-      timeout (a hung engine bounded so the CLI fails loudly, #15). The diagnostic
-      names ``timeout_label`` (default ``"Godot"``; the export channel passes
-      ``"Godot export"``) — this stderr is carried into ``GdaError.diagnostics``
-      and serialized in ``--json``, so the per-channel wording is part of the
-      public error envelope and stays byte-compatible across the refactor (#185);
+    - the timeout reached → a synthesized ``EXIT_TIMEOUT`` result flagged
+      ``LaunchFailure.TIMEOUT``: launched, but did not return before the
+      timeout (a hung engine bounded so the CLI fails loudly, #15). Both streams
+      hold **what the run had already produced**, verbatim, and no gda prose: the
+      classifier composes the diagnostics from that capture, so mixing gda's own
+      sentence into the child's stderr would corrupt the very evidence the
+      streaming capture exists to preserve. What the run cannot say for itself —
+      which launch this was, and the ceiling it reached — rides the result as
+      :class:`TimeoutBound`, beside the measured ``elapsed_seconds`` (#714);
     - ``OSError`` → a synthesized ``EXIT_NOT_FOUND`` result flagged
       ``LaunchFailure.NOT_FOUND``: the configured binary could not be launched —
       ``FileNotFoundError`` (missing), ``PermissionError`` (a directory like
@@ -587,9 +632,8 @@ def launch(
       file), and any other ``OSError`` from ``exec`` are the one environment
       failure of there being no engine to run (#33). The synthesized typed
       reason lets the classifier key environment on it, not on the overloaded
-      exit code (#15). ``OSError`` does not subsume ``TimeoutExpired`` (a
-      ``SubprocessError``), so the timeout path above is preserved. The OS
-      message is kept as advisory stderr to disambiguate which mode occurred;
+      exit code (#15). The OS message is kept as advisory stderr to disambiguate
+      which mode occurred;
     - otherwise → the engine's own ``returncode`` with ``launch_failure=None``,
       and stdout/stderr decoded as UTF-8 with ``errors="replace"`` (see below).
 
@@ -603,27 +647,20 @@ def launch(
     because it is an engine option and the sentinel channel's tail ends in the
     ``--`` user-args separator.
 
-    **Two capture strategies, one mapping (issue #655).** ``watch`` selects how the
-    child's output is captured, and nothing else:
+    **One capture strategy (issue #714).** Every launch STREAMS: both pipes are
+    read as they arrive and the run is timed. #655 introduced streaming beside a
+    buffered ``subprocess.run`` capture that discarded the child's output at the
+    timeout, keeping the sentinel and export channels on the buffered one so their
+    published timeout envelopes stayed byte-identical while the mechanism was
+    proven. #714 moved those channels — and the ``resource import`` pass, the third
+    that shared the discard — across, which left the buffered strategy with no
+    caller at all; a second capture path nothing selects is a trap for the next
+    channel, not an option, so it is gone.
 
-    - ``None`` (the default, and what the sentinel and export channels pass) —
-      BUFFERED capture via ``subprocess.run``. A timeout DISCARDS whatever the
-      child wrote and synthesizes the ``gda: <label> timed out after <n>s``
-      diagnostic in its place, exactly as before.
-    - a :class:`LaunchWatch` (``gda script run``) — STREAMING capture. A timeout
-      PRESERVES the captured stdout/stderr verbatim and carries no gda prose in
-      either stream, because the watching channel composes its own diagnostics
-      from the capture; ``elapsed_seconds`` is populated; and the watch may end
-      the run early as ``LaunchFailure.ABORTED``.
-
-    Keeping the buffered strategy is deliberate rather than transitional debt: the
-    other two channels' timeout results are a published part of their error
-    envelopes, and this change had to leave them byte-identical. Moving them onto
-    the preserving path is the named follow-up the issue records, and it is a
-    one-line switch here — not a second mechanism to write. What is NOT duplicated
-    is the failure mapping: both strategies return through the same
-    :func:`_timeout_result` / :func:`_not_found_result`, so the timeout and
-    launch-failure taxonomy still has exactly one home.
+    ``watch`` is therefore POLICY, not strategy: a channel that can recognize a run
+    not worth waiting out passes one and may end the launch early as
+    ``LaunchFailure.ABORTED`` (``gda script run``, ADR-0031); a channel with no
+    such rule passes nothing and gets :class:`_CaptureOnly`.
     """
     try:
         root = resolve_user_data_root()
@@ -648,22 +685,14 @@ def launch(
         with user_data_placement(root) as placement:
             # Only the preparation above can raise UserDataUnwritable: the spawn
             # itself maps every OSError to the NOT_FOUND result below.
-            if watch is None:
-                return _spawn(
-                    binary,
-                    args,
-                    cwd=cwd,
-                    timeout=timeout,
-                    timeout_label=timeout_label,
-                    placement=placement,
-                )
             return _spawn_streamed(
                 binary,
                 args,
                 cwd=cwd,
                 timeout=timeout,
+                timeout_label=timeout_label,
                 placement=placement,
-                watch=watch,
+                watch=watch if watch is not None else _CaptureOnly(),
             )
     except UserDataUnwritable as exc:
         return RunResult(
@@ -674,81 +703,12 @@ def launch(
         )
 
 
-def _spawn(
-    binary: Path,
-    args: list[str],
-    *,
-    cwd: Path | None,
-    timeout: float,
-    timeout_label: str,
-    placement: UserDataPlacement,
-) -> RunResult:
-    """Run one prepared launch with BUFFERED capture — see :func:`launch`.
-
-    Reads both streams in one ``subprocess.run`` call, which is why a timeout here
-    has nothing left to report: the call discards what it buffered when it raises.
-    """
-    cmd = [str(binary), "--headless", "--log-file", str(placement.log_file), *args]
-    try:
-        # Capture raw bytes (no ``text=True``): Godot's ``JSON.stringify`` emits
-        # UTF-8, but ``text=True`` would decode with the host locale, which
-        # mojibakes or raises ``UnicodeDecodeError`` on a non-UTF-8 locale (e.g.
-        # Windows cp1252/cp936) for a non-ASCII node name or echoed path. We
-        # decode UTF-8 explicitly below so user content round-trips regardless of
-        # locale (issue #33).
-        proc = subprocess.run(
-            cmd,
-            capture_output=True,
-            timeout=timeout,
-            # Pass the working directory as a string (not a Path): the export
-            # channel resolves a relative output path against this CWD, and the
-            # spawn shape stays byte-identical to the pre-#185 ``str(project)``.
-            cwd=str(cwd) if cwd is not None else None,
-            # ``None`` (the common case) inherits gda's own environment; a full
-            # child environment is built only when ``--user-data-root`` overrides
-            # the platform variable Godot resolves ``user://`` from (#653).
-            env=placement.env,
-        )
-    except subprocess.TimeoutExpired:
-        return _timeout_result(timeout, timeout_label)
-    except OSError as exc:
-        return _not_found_result(binary, exc)
-    return RunResult(
-        # Decode the engine's bytes as UTF-8 with a replacement policy: a
-        # well-behaved operation emits valid UTF-8, so ``replace`` only ever
-        # fires on genuinely malformed bytes — and the runner never crashes on
-        # engine output. A malformed result then surfaces as a structured
-        # ``contract_violation`` downstream rather than an escaping
-        # ``UnicodeDecodeError`` traceback (ADR-0002).
-        stdout=proc.stdout.decode("utf-8", errors="replace"),
-        stderr=proc.stderr.decode("utf-8", errors="replace"),
-        exit_code=proc.returncode,
-    )
-
-
-def _timeout_result(timeout: float, timeout_label: str) -> RunResult:
-    """The synthesized result of a run that outlived the BUFFERED capture's timeout.
-
-    The output is gone — ``subprocess.run`` discards it when the timeout expires —
-    so the diagnostic stands in for it. That wording is carried into
-    ``GdaError.diagnostics`` and serialized in ``--json``, which makes it part of
-    the public error envelope of the sentinel and export channels; it is kept
-    byte-for-byte, and shared here, so no channel can drift from it (#185, #655).
-    """
-    return RunResult(
-        stdout="",
-        stderr=f"gda: {timeout_label} timed out after {timeout}s\n",
-        exit_code=EXIT_TIMEOUT,
-        launch_failure=LaunchFailure.TIMEOUT,
-    )
-
-
 def _not_found_result(binary: Path, exc: OSError) -> RunResult:
     """The synthesized result of a binary that could not be launched at all.
 
-    Shared by both capture strategies: an ``OSError`` from ``exec`` is the one
-    environment failure of there being no engine to run, whichever way gda was
-    going to read its output (#33, #655).
+    An ``OSError`` from ``exec`` is the one environment failure of there being no
+    engine to run; it is reported before any capture exists, so it is the same
+    result for every channel (#33).
     """
     return RunResult(
         stdout="",
@@ -764,19 +724,19 @@ def _spawn_streamed(
     *,
     cwd: Path | None,
     timeout: float,
+    timeout_label: str,
     placement: UserDataPlacement,
     watch: LaunchWatch,
 ) -> RunResult:
-    """Run one prepared launch with STREAMING capture — see :func:`launch` (#655).
+    """Run one prepared launch, reading both pipes as they arrive (#655, #714).
 
-    The same argv, cwd and child environment as :func:`_spawn`; only the reading
-    differs. Both pipes are drained on their own threads while this loop owns the
-    deadline and the watch, so:
+    Both pipes are drained on their own threads while this loop owns the deadline
+    and the watch, so:
 
     - a timeout returns the output the child had ALREADY produced, verbatim,
       instead of discarding it. This is the whole point: a script error that
-      aborted a run before its ``quit()`` had already been printed, and a
-      buffered capture threw it away (GDA-DF-012);
+      aborted a run before its ``quit()`` had already been printed, and the
+      buffered capture this replaced threw it away (GDA-DF-012);
     - the watch can end the run before the deadline, reported as
       ``LaunchFailure.ABORTED``;
     - the wall clock is measured either way, so a slow-but-live run is
@@ -791,13 +751,23 @@ def _spawn_streamed(
     cmd = [str(binary), "--headless", "--log-file", str(placement.log_file), *args]
     started = time.monotonic()
     try:
-        # Bytes, not ``text=True``, for the same locale reason as ``_spawn`` (#33);
-        # the decode happens in ``_StreamCapture``, incrementally.
+        # Capture raw bytes (no ``text=True``): Godot's ``JSON.stringify`` emits
+        # UTF-8, but ``text=True`` would decode with the host locale, which
+        # mojibakes or raises ``UnicodeDecodeError`` on a non-UTF-8 locale (e.g.
+        # Windows cp1252/cp936) for a non-ASCII node name or echoed path. The decode
+        # happens in ``_StreamCapture``, incrementally and explicitly as UTF-8, so
+        # user content round-trips regardless of locale (issue #33).
         proc = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            # Pass the working directory as a string (not a Path): the export
+            # channel resolves a relative output path against this CWD, and the
+            # spawn shape stays byte-identical to the pre-#185 ``str(project)``.
             cwd=str(cwd) if cwd is not None else None,
+            # ``None`` (the common case) inherits gda's own environment; a full
+            # child environment is built only when ``--user-data-root`` overrides
+            # the platform variable Godot resolves ``user://`` from (#653).
             env=placement.env,
         )
     except OSError as exc:
@@ -841,7 +811,17 @@ def _spawn_streamed(
                 break
             if elapsed >= timeout:
                 break
-            time.sleep(_POLL_INTERVAL_SECONDS)
+            # WAIT on the child rather than sleeping through the interval: this loop
+            # now runs on every gda invocation (#714), and a plain sleep would charge
+            # each one up to a poll interval of latency after its engine had already
+            # exited. ``wait`` returns the instant the child does, and otherwise
+            # keeps exactly the cadence the watch is promised. It cannot deadlock on
+            # a full pipe — the documented hazard for ``wait`` with ``PIPE`` — because
+            # the reader threads are what drain those pipes, not this loop.
+            try:
+                proc.wait(timeout=_POLL_INTERVAL_SECONDS)
+            except subprocess.TimeoutExpired:
+                pass
         else:
             # The loop ended because the child exited on its own, so the wall clock
             # is that exit — not the stale value from the last poll.
@@ -855,14 +835,14 @@ def _spawn_streamed(
         # The WHOLE teardown lives here, so it runs on every exit from the loop
         # above — including one by exception. A streaming launch must never outlive
         # its gda process, and the guarantee cannot be left on the happy path: the
-        # runs this strategy exists for are exactly the ones that do NOT stop on
+        # runs this loop exists for are exactly the ones that do NOT stop on
         # their own, so an orphaned engine idles forever and repeated interruptions
-        # accumulate engines contending over ``user://``. The buffered strategy gets
-        # this free (``subprocess.run`` kills its child when an exception leaves its
-        # ``with`` block), so this path owes the same.
+        # accumulate engines contending over ``user://``. (``subprocess.run`` used to
+        # give this free by killing its child when an exception left its ``with``
+        # block; owning the process means owning that guarantee too.)
         #
         # ``BaseException`` matters, not just ``Exception``: a Ctrl-C out of the poll
-        # sleep is a ``KeyboardInterrupt``, and when gda runs in its own process
+        # wait is a ``KeyboardInterrupt``, and when gda runs in its own process
         # group the signal never reaches the engine at all. A ``finally`` covers
         # both, and covers whatever a caller's ``watch`` raised.
         #
@@ -902,14 +882,18 @@ def _spawn_streamed(
     if ended_by_gda:
         return RunResult(
             # The CAPTURE, kept verbatim — no gda prose in either stream. The
-            # watching channel composes the timeout diagnostics from this, so
+            # classifying channel composes the timeout diagnostics from this, so
             # mixing gda's own sentence into the child's stderr would corrupt the
-            # very evidence the streaming path exists to preserve.
+            # very evidence the streaming capture exists to preserve.
             stdout=stdout,
             stderr=stderr,
             exit_code=EXIT_TIMEOUT,
             launch_failure=LaunchFailure.TIMEOUT,
             elapsed_seconds=elapsed,
+            # What the capture cannot say for itself, and the only way a shared
+            # classifier can learn it: which launch this was, and the ceiling it
+            # reached (#714).
+            timeout_bound=TimeoutBound(timeout_label, timeout),
         )
     return RunResult(
         stdout=stdout,
@@ -977,10 +961,11 @@ def sentinel_args(
 
     Two channels build this tail (#664): :class:`SubprocessGodotRunner`, the
     default sentinel runner, and ``scene preflight``, which dispatches the same
-    kind of op but needs :func:`launch`'s STREAMING capture — so it calls the
-    primitive itself rather than going through the runner seam. Extracting the
-    spelling keeps that second channel from re-deriving it, and keeps a change to
-    it (a new separator, another engine flag) landing in one place.
+    kind of op but calls :func:`launch` itself — it bifurcates on the launch's own
+    outcome (a timeout is its VERDICT, not an error) rather than handing the result
+    to a classifier through the runner seam. Extracting the spelling keeps that
+    second channel from re-deriving it, and keeps a change to it (a new separator,
+    another engine flag) landing in one place.
     """
     args: list[str] = []
     if project is not None:

--- a/src/gda/runner.py
+++ b/src/gda/runner.py
@@ -90,7 +90,7 @@ class RunResult:
 # The per-invocation user-data root the CLI resolved, or ``None`` for the engine
 # default. Process-wide because it is process-wide CONFIG, not an operation
 # parameter: it is set once from the root ``--user-data-root`` option (the same
-# hand-over shape as ``gda.headless.set_root_json``) and every later launch on any
+# hand-over shape as ``gda.headless.set_ancestor_json``) and every later launch on any
 # channel inherits it, so no channel has to plumb it through the runner seam.
 #
 # ``None`` means the option was ABSENT. An empty string means it was given empty,

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -132,6 +132,8 @@ JSON — use `gda help <command> --json` for a structured payload), and the flag
 | `shader` | `create`, `get`, `set` (`.gdshader` files) |
 | `theme` | `create` (a loadable `.tres` Theme) |
 
+Every headless reply carries its floats at full binary64 precision, so a value read back through `node get`, `scene get-exports`, `project get`/`project list`, `resource get`, or the echo of a `set` is the exact number the project holds — `1e-300` reads back as `1e-300`, not `0.0`; the one residual belongs to the ENGINE's writer — a negative zero reads back as `0.0` (#771). The `--value` string you send IN is a separate matter and is NOT bounded the way the live wire is: the engine's own parser coerces it, dropping the low digits of a full-precision literal between `1e-4` and `1e-2` and reading a `DBL_MIN`-scale or subnormal literal as `0.0`, with no refusal (#772). Read the `set` echo when the exact bits matter.
+
 ## Live operations (via the daemon; Godot 4.6+, macOS/Linux)
 
 Prerequisites: run `gda daemon start` first (optionally `--scene <res://...>` to boot a

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -110,13 +110,14 @@ and re-read the verdict.
 - `gda version --json` — which `gda` is installed and where from; `gda info` — the
   engine's version.
 
-**`--json` placement.** `gda --json <group> <command>` and `gda <group> <command> --json` mean the
-same thing — a root `--json` applies to the command it invokes — so either spelling works, as does
-both at once. `gda schema --json` is accepted too, and idempotent: the manifest is already JSON.
-Two limits: the `--help` FLAG always renders TEXT (`gda --json --help` returns the same help, never
-JSON — use `gda help <command> --json` for a structured payload), and two spellings are still usage
-errors (exit `2`) — `gda <group> --json` (a group's parser takes only `--help`; the structured
-refusal hints the command form) and a bare `gda --json` with no command (`Missing command.`).
+**`--json` placement.** Every parser takes it: `gda --json <group> <command>`,
+`gda <group> --json <command>` and `gda <group> <command> --json` mean the same thing — a `--json`
+written before the command applies to the command it invokes — so any spelling works, as do several
+at once. `gda schema --json` is accepted too, and idempotent: the manifest is already JSON. Two
+limits: the `--help` FLAG always renders TEXT (`gda --json --help` returns the same help, never
+JSON — use `gda help <command> --json` for a structured payload), and the flag is not a command, so
+`gda <group> --json` and a bare `gda --json` with no command are both the usage error
+`Missing command.` (exit `2`).
 
 ## Headless commands (Godot 4.4+, all platforms)
 

--- a/tests/live_number_corpus.py
+++ b/tests/live_number_corpus.py
@@ -1,22 +1,31 @@
-"""The #752 live-number differential corpus, and the verdicts a real engine gave it.
+"""The #752 number corpus, and the verdicts a real engine gave it.
 
-Both a unit test (``tests/test_live_numbers.py``, which checks gda's model of the
-engine against this table) and an e2e test
-(``tests/test_e2e_live_number_transport.py``, which re-derives the table from a
-real engine) read these rows, so the fast tier and the engine tier can never
-disagree about what the corpus says. It is also the ONE place the published
-counts come from: :data:`PARTITIONS` derives them from the rows below, and
-``tests/test_live_numbers.py`` reads back the two surfaces allowed to state
-them — ``gda.live_numbers``'s module docstring and ``docs/command-catalog.md``
-— requiring the derived strings verbatim, so a hand-edited count cannot
-survive. ADR-0041 and the harness comment quote no count at all; they point at
-``gda.live_numbers`` instead.
+Three tests read these rows, so no tier can disagree with another about what the
+corpus says: a unit test (``tests/test_live_numbers.py``, which checks gda's model
+of the engine against this table) and two e2e tests that re-derive it from a real
+engine — ``tests/test_e2e_live_number_transport.py`` for the live legs, and
+``tests/test_e2e_headless_number_reads.py`` for the headless reply (#771). It is
+also the ONE place the published counts come from: :data:`PARTITIONS` derives them
+from the rows below, and ``tests/test_live_numbers.py`` reads back the two surfaces
+allowed to state them — ``gda.live_numbers``'s module docstring and
+``docs/command-catalog.md`` — requiring the derived strings verbatim, so a
+hand-edited count cannot survive. ADR-0041 and the two engine-side writer comments
+quote no count at all; they point at ``gda.live_numbers`` instead.
+
+The corpus is named for the issue that measured it, not for a leg. The
+``default_stringify`` column records what one ENGINE FUNCTION does to a value, so
+it describes every reply Godot serializes: #752 measured it on the live wire, and
+#771 found the headless reply framed by the same default writer and fixed it with
+the same argument. That is why the headless direction reuses this table instead of
+forking a second one, and why it needs no column of its own — a headless read is
+measured against the same ``full_precision`` partition (:data:`PARTITIONS`).
 
 Measured on Godot 4.6.3.stable.official.7d41c59c4. Not a specification of the
-engine — a recording of it; the e2e test is what keeps the recording true.
+engine — a recording of it; the e2e tests are what keep the recording true.
 """
 
 import math
+import struct
 from typing import Literal, NamedTuple
 
 # What Godot's DEFAULT ``JSON.stringify`` did to a value on the way back. Three
@@ -219,3 +228,32 @@ PARTITIONS: dict[str, Partition] = {
         zero=0,
     ),
 }
+
+
+# --- The verdict helpers both engine tiers read -------------------------------
+# A second definition of "exact" would be a fork of this table's semantics, so the
+# live e2e and the headless e2e share these rather than each spelling their own.
+
+
+def value_bits(value: float) -> str:
+    """One value's IEEE-754 bytes — the only comparison that is not itself lossy."""
+    return struct.pack("<d", value).hex()
+
+
+def stringify_outcome(sent: float, arrived: float) -> DefaultStringify:
+    """The three-state verdict one direction gave one value (cf. LiveNumberCase).
+
+    ``changed`` and ``zero`` are DIFFERENT failures — a rounded value still
+    carries the caller's magnitude, a flattened one does not — so the corpus
+    records which, and the published table reports both.
+    """
+    if value_bits(arrived) == value_bits(sent):
+        return "exact"
+    if arrived == 0.0 and sent != 0.0:
+        return "zero"
+    return "changed"
+
+
+def tally_outcome(counts: list[int], sent: float, arrived: float) -> None:
+    """Add one value's verdict to an ``[exact, changed, zero]`` tally."""
+    counts[("exact", "changed", "zero").index(stringify_outcome(sent, arrived))] += 1

--- a/tests/support.py
+++ b/tests/support.py
@@ -68,6 +68,25 @@ def usage_error_text(result) -> str:
     return panel_text(result.stderr)
 
 
+# The exact fragments a pydantic ``ValidationError`` rendered with its own
+# ``str()`` adds around the checks' real sentences: the ``[type=...,
+# input_value=..., input_type=...]`` tag per error — whose ``input_value``
+# echoes the caller's own value back — and the ``errors.pydantic.dev`` URL.
+# ONE authority for every producer that must render such an error as the
+# sentence its check wrote (``gda.errors.validation_error_message``, #713/#754)
+# and for every test asserting the dump does not leak: the argv and
+# ``--params-json`` channels (tests/test_dispatch.py) and the ``perf
+# --budget`` loader (#759). A single home keeps a later pydantic dump
+# format from silently weakening half the assertions.
+PYDANTIC_DUMP_FRAGMENTS = ("pydantic.dev", "input_value=", "[type=")
+
+
+def assert_no_pydantic_dump(message: str) -> None:
+    """Assert no ``str(ValidationError)`` dump fragment reached ``message``."""
+    for fragment in PYDANTIC_DUMP_FRAGMENTS:
+        assert fragment not in message, f"{fragment!r} leaked into {message!r}"
+
+
 # The gda CLI invocation prefix for e2e subprocess tests. Resolved as the gda
 # MODULE in *this* interpreter's environment — `[sys.executable, "-m", "gda"]` —
 # never a PATH-resolved global. This is the same same-environment resolution

--- a/tests/support.py
+++ b/tests/support.py
@@ -13,7 +13,9 @@ between modules or imported test-module-to-test-module (issue #39).
 
 import json
 import re
+import subprocess
 import sys
+import tempfile
 
 from gda.runner import RunResult
 
@@ -980,3 +982,79 @@ def assert_windowed_ok(result):
         handle_no_display_code(gda_error_code(result.stdout))
     assert result.returncode == 0, result.stdout + result.stderr
     return result
+
+
+class RecordingSpawn:
+    """A ``subprocess.Popen`` double: records the spawn and replays a canned run.
+
+    Every headless launch STREAMS (#714), so the primitive reads the child's pipes
+    by file descriptor rather than taking a buffer back from ``subprocess.run``. A
+    double therefore has to have a PROCESS's shape — readable descriptors, a poll
+    that answers, a wait that returns — and it is one double rather than one per
+    suite because what the suites are actually after is the same in all of them:
+    the argv gda built, the ``cwd`` it spawned in, and the child environment it
+    passed. The canned streams are backed by temp FILES, not a pipe, so a payload
+    is not bounded by the OS pipe buffer the way a self-written pipe would be.
+
+    ``alive`` makes the child one that never returns: ``poll`` answers ``None``
+    and ``wait`` times out until ``terminate`` — a hung engine, for a test that
+    wants the launch's own bound to end the run without spending a real one.
+    """
+
+    def __init__(
+        self,
+        payload: str = "",
+        stderr: str = "",
+        returncode: int = 0,
+        *,
+        alive: bool = False,
+    ) -> None:
+        self.cmd: list[str] | None = None
+        self.kwargs: dict | None = None
+        self.spawns = 0
+        self._stdout = payload.encode()
+        self._stderr = stderr.encode()
+        self._returncode = returncode
+        self._alive = alive
+
+    def __call__(self, cmd, **kwargs):
+        self.cmd = cmd
+        self.kwargs = kwargs
+        self.spawns += 1
+        return _CannedProcess(
+            self._stdout, self._stderr, self._returncode, alive=self._alive
+        )
+
+
+class _CannedProcess:
+    """The child :class:`RecordingSpawn` hands back — see its docstring."""
+
+    def __init__(
+        self, stdout: bytes, stderr: bytes, returncode: int, *, alive: bool
+    ) -> None:
+        self.stdout = _readable(stdout)
+        self.stderr = _readable(stderr)
+        self.returncode = returncode
+        self._alive = alive
+
+    def poll(self):
+        return None if self._alive else self.returncode
+
+    def wait(self, timeout: float | None = None):
+        if self._alive:
+            raise subprocess.TimeoutExpired(cmd="fake-engine", timeout=timeout or 0.0)
+        return self.returncode
+
+    def terminate(self) -> None:
+        self._alive = False
+
+    def kill(self) -> None:
+        self._alive = False
+
+
+def _readable(data: bytes):
+    """A real readable file descriptor holding ``data``, then EOF."""
+    handle = tempfile.TemporaryFile(buffering=0)
+    handle.write(data)
+    handle.seek(0)
+    return handle

--- a/tests/test_classify_export_run.py
+++ b/tests/test_classify_export_run.py
@@ -20,7 +20,7 @@ from gda.commands.export import (
 )
 from gda.errors import Failure, export_path_unset_failure
 from gda.exit_codes import EXIT_OPERATION
-from gda.runner import LaunchFailure, RunResult
+from gda.runner import LaunchFailure, RunResult, TimeoutBound
 
 BINARY = Path("/x/Godot")
 
@@ -98,25 +98,30 @@ def test_other_nonzero_maps_to_generic_export_failed():
     assert "disk full" in outcome.error.diagnostics
 
 
-def test_export_timeout_envelope_keeps_byte_compatible_diagnostics():
-    # Regression for the #185 review: an export timeout maps to launch_timeout,
-    # and the runner-synthesized stderr is carried verbatim into the PUBLIC
-    # GdaError.diagnostics — the field serialized in `export run --json`. The
-    # refactor must keep that diagnostics string byte-compatible with the pre-#185
-    # "Godot export timed out" wording, so the error envelope is unchanged.
-    timeout_stderr = "gda: Godot export timed out after 600.0s\n"
+def test_export_timeout_envelope_carries_the_exports_own_captured_output():
+    # An export timeout maps to launch_timeout through the SHARED prefix, and since
+    # #714 the envelope carries the export's own partial output instead of the
+    # runner-synthesized "gda: Godot export timed out after 600.0s" that stood in
+    # for it. This channel keeps nothing of its own here: the pin is that it goes
+    # through the shared branch and that the export's evidence survives into the
+    # PUBLIC GdaError the `export run --json` failure serializes.
     outcome = _classify(
         RunResult(
-            stdout="",
-            stderr=timeout_stderr,
+            stdout="[  90% ] packing pck\n",
+            stderr="ERROR: the platform toolchain never answered\n",
             exit_code=124,
             launch_failure=LaunchFailure.TIMEOUT,
+            elapsed_seconds=600.4,
+            timeout_bound=TimeoutBound("Godot export", 600.0),
         )
     )
 
     assert isinstance(outcome, Failure)
     assert outcome.error.code == "launch_timeout"
-    assert outcome.error.diagnostics == timeout_stderr
+    assert outcome.error.message.startswith("Godot export launched but did not return")
+    assert "timeout of 600.0s" in outcome.error.message
+    assert "packing pck" in outcome.error.diagnostics
+    assert "the platform toolchain never answered" in outcome.error.diagnostics
 
 
 def test_export_path_unset_failure_builder():

--- a/tests/test_classify_launch_or_crash.py
+++ b/tests/test_classify_launch_or_crash.py
@@ -1,12 +1,17 @@
-"""classify_launch_or_crash — the env/crash classifier prefix (issue #185).
+"""classify_launch_or_crash — the env/crash classifier prefix (issues #185, #714).
 
-Both headless channels open classification with the same env/crash prefix: a
+Every headless channel opens classification with the same env/crash prefix: a
 synthesized ``NOT_FOUND`` launch failure → ``binary_not_found``, a synthesized
 ``TIMEOUT`` → ``launch_timeout``, and a signal death (``exit < 0``) →
 ``engine_crashed``; anything else returns ``None`` so the caller's
 channel-specific tail takes over. That mapping used to be written (and asserted)
 twice — once in ``classify_run``, once in ``classify_export_run``. It now lives in
 one shared function, tested here once; each channel's suite keeps only its tail.
+
+The ``TIMEOUT`` arm is where being ONE function pays: the sentinel, export and
+import channels reach it through three different classifiers, so the evidence a
+hung run reports — its captured output, the ceiling it reached and the wall clock
+it spent — is asserted here once and holds for all three (#714).
 
 Environment failures key on the runner's typed ``launch_failure`` reason, not the
 exit code, so an engine (or wrapper) that *genuinely* exits 124/127 falls through
@@ -17,10 +22,14 @@ fall-through is asserted here, the operation classification in each channel suit
 
 from pathlib import Path
 
-from gda.errors import Failure, classify_launch_or_crash
+from gda.errors import (
+    CAPTURED_OUTPUT_TAIL_CAP_BYTES,
+    Failure,
+    classify_launch_or_crash,
+)
 from gda.exit_codes import EXIT_NOT_FOUND, EXIT_OPERATION, EXIT_TIMEOUT
 from gda.models import ErrorCategory
-from gda.runner import LaunchFailure, RunResult
+from gda.runner import LaunchFailure, RunResult, TimeoutBound
 
 BINARY = Path("/x/Godot")
 
@@ -47,7 +56,7 @@ def test_synthesized_not_found_maps_to_binary_not_found():
 def test_synthesized_timeout_maps_to_launch_timeout_distinct_from_not_found():
     result = RunResult(
         stdout="",
-        stderr="gda: Godot timed out after 60.0s\n",
+        stderr="",
         exit_code=EXIT_TIMEOUT,
         launch_failure=LaunchFailure.TIMEOUT,
     )
@@ -58,6 +67,85 @@ def test_synthesized_timeout_maps_to_launch_timeout_distinct_from_not_found():
     assert failure.exit_code == EXIT_TIMEOUT
     assert failure.error.category == ErrorCategory.ENVIRONMENT
     assert failure.error.code == "launch_timeout"
+
+
+def test_a_timeout_carries_the_captured_output_the_ceiling_and_the_clock():
+    # THE #714 acceptance criterion, asserted on the ONE branch all three buffered
+    # channels open with. Before it, a hung sentinel op / export / import pass came
+    # back with nothing but "gda: <label> timed out after <n>s": the engine's own
+    # output was discarded by the buffered capture, and the envelope reported
+    # neither how long the run had actually taken nor how far it got.
+    result = RunResult(
+        stdout="[  50% ] exporting resources\n",
+        stderr="ERROR: the exporter wedged\n",
+        exit_code=EXIT_TIMEOUT,
+        launch_failure=LaunchFailure.TIMEOUT,
+        elapsed_seconds=601.25,
+        timeout_bound=TimeoutBound("Godot export", 600.0),
+    )
+
+    failure = classify_launch_or_crash(result, BINARY)
+
+    assert isinstance(failure, Failure)
+    assert failure.error.code == "launch_timeout"
+    # WHICH launch gave up, the ceiling it reached, and the wall clock it spent —
+    # the three numbers that tell a merely-slow run from a stuck one.
+    assert failure.error.message.startswith("Godot export launched but did not return")
+    assert "timeout of 600.0s" in failure.error.message
+    assert "elapsed 601.25s" in failure.error.message
+    # The cap is STATED, so a caller knows the diagnostics are a tail and not all.
+    assert f"{CAPTURED_OUTPUT_TAIL_CAP_BYTES} UTF-8 bytes (16 KiB)" in (
+        failure.error.message
+    )
+    # And both streams are carried under fixed labels, so one split reads either.
+    assert failure.error.diagnostics == (
+        "--- captured stdout ---\n[  50% ] exporting resources\n"
+        "--- captured stderr ---\nERROR: the exporter wedged\n"
+    )
+
+
+def test_a_timeout_tail_caps_each_captured_stream():
+    # `diagnostics` is serialized inline in the JSON result, so a run that looped for
+    # ten minutes must not put ten minutes of output in an error envelope. The TAIL
+    # is what is kept: where the run got to is the interesting end.
+    result = RunResult(
+        stdout="x" * (CAPTURED_OUTPUT_TAIL_CAP_BYTES * 2) + "LAST LINE\n",
+        stderr="y" * (CAPTURED_OUTPUT_TAIL_CAP_BYTES * 2),
+        exit_code=EXIT_TIMEOUT,
+        launch_failure=LaunchFailure.TIMEOUT,
+        elapsed_seconds=60.0,
+        timeout_bound=TimeoutBound("Godot", 60.0),
+    )
+
+    failure = classify_launch_or_crash(result, BINARY)
+
+    assert isinstance(failure, Failure)
+    diagnostics = failure.error.diagnostics
+    assert "LAST LINE" in diagnostics
+    assert diagnostics.count("x") == CAPTURED_OUTPUT_TAIL_CAP_BYTES - len("LAST LINE\n")
+    assert diagnostics.count("y") == CAPTURED_OUTPUT_TAIL_CAP_BYTES
+
+
+def test_an_unmeasured_timeout_still_reports_rather_than_crashing():
+    # A hand-built RunResult at a test seam carries neither bound nor clock. The
+    # builder degrades to the bare sentence instead of asserting on a boundary
+    # value, which would kill the command (and vanish under -O).
+    failure = classify_launch_or_crash(
+        RunResult(
+            stdout="",
+            stderr="",
+            exit_code=EXIT_TIMEOUT,
+            launch_failure=LaunchFailure.TIMEOUT,
+        ),
+        BINARY,
+    )
+
+    assert isinstance(failure, Failure)
+    assert failure.error.code == "launch_timeout"
+    assert failure.error.message.startswith(
+        "Godot launched but did not return before the timeout."
+    )
+    assert "elapsed" not in failure.error.message
 
 
 def test_signal_death_maps_to_engine_crashed_naming_the_signal():

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -31,15 +31,7 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.dispatch import params_or_bad_parameter
-from tests.support import usage_error_text
-
-# The exact dump fragments str(ValidationError) used to leak (PR #754 review).
-_FORBIDDEN_FRAGMENTS = ("pydantic.dev", "input_value=", "[type=")
-
-
-def _assert_clean(message: str) -> None:
-    for fragment in _FORBIDDEN_FRAGMENTS:
-        assert fragment not in message, f"{fragment!r} leaked into {message!r}"
+from tests.support import assert_no_pydantic_dump, usage_error_text
 
 
 def _argv_usage_error_message(result) -> str:
@@ -127,7 +119,7 @@ def test_plain_value_error_passes_through_as_the_bare_sentence():
 
     message = str(exc_info.value)
     assert message == "a plain refusal sentence."
-    _assert_clean(message)
+    assert_no_pydantic_dump(message)
 
 
 def test_model_level_validation_error_renders_the_validators_own_sentence():
@@ -136,7 +128,7 @@ def test_model_level_validation_error_renders_the_validators_own_sentence():
 
     message = str(exc_info.value)
     assert message == "'search' and 'replace' must be used together."
-    _assert_clean(message)
+    assert_no_pydantic_dump(message)
 
 
 def test_field_level_validation_error_renders_the_validators_own_sentence():
@@ -145,7 +137,7 @@ def test_field_level_validation_error_renders_the_validators_own_sentence():
 
     message = str(exc_info.value)
     assert message == "name: 'name' must not be empty."
-    _assert_clean(message)
+    assert_no_pydantic_dump(message)
 
 
 def test_multi_error_validation_error_joins_each_fields_own_message():
@@ -155,7 +147,7 @@ def test_multi_error_validation_error_joins_each_fields_own_message():
     message = str(exc_info.value)
     assert "a: " in message and "b: " in message
     assert "; " in message  # the stated join separator
-    _assert_clean(message)
+    assert_no_pydantic_dump(message)
 
 
 def test_no_caller_value_leaks_into_the_refusal():
@@ -183,7 +175,7 @@ def test_no_caller_value_leaks_into_the_refusal():
     message = str(exc_info.value)
     assert secret not in message
     assert message == "'search' and 'replace' must be used together."
-    _assert_clean(message)
+    assert_no_pydantic_dump(message)
 
 
 # --- end-to-end: --params-json through an actual command (round 3) ------------
@@ -205,7 +197,7 @@ def test_params_json_validation_error_is_also_rendered_clean():
 
     message = _params_json_invalid_params_message(result)
     assert message == "'search' and 'replace' must be used together."
-    _assert_clean(message)
+    assert_no_pydantic_dump(message)
 
 
 def test_params_json_does_not_leak_the_callers_other_field_value():
@@ -228,7 +220,7 @@ def test_params_json_does_not_leak_the_callers_other_field_value():
     message = _params_json_invalid_params_message(result)
     assert secret not in message
     assert message == "'search' and 'replace' must be used together."
-    _assert_clean(message)
+    assert_no_pydantic_dump(message)
 
 
 def test_argv_and_params_json_report_the_identical_sentence():

--- a/tests/test_e2e_headless_number_reads.py
+++ b/tests/test_e2e_headless_number_reads.py
@@ -1,0 +1,251 @@
+"""S1 (e2e): the HEADLESS read direction, measured on a real engine (#771).
+
+The live counterpart is ``tests/test_e2e_live_number_transport.py``. This module
+asks the same question of the other channel: does a headless reply report the
+float the project holds, or a rounded — sometimes zeroed — approximation of it?
+
+Both tiers read ONE table, ``tests/live_number_corpus.py``. That is not tidiness:
+the writer under test here is the same engine function #752 measured, so a second
+corpus would be a second opinion about one function. What differs is how the value
+is PLACED: the live tier sends it over the wire, while a headless read must find it
+already in the project. So the probe scene carries every corpus value as its
+IEEE-754 BYTES and reconstructs it in ``_init`` — the only placement that is not
+itself a decimal literal, which is exactly the lossy thing under test. Values such
+as ``DBL_MIN`` and ``5e-324`` cannot be spelled at all for this engine's parser
+(``gda.live_numbers``), so no literal-authored scene could hold them to be read.
+
+What the write path does to a ``--value`` STRING is a separate question, owned by
+[#772](https://github.com/aigengame/godot-agent/issues/772); nothing here claims
+anything about it.
+"""
+
+import json
+import math
+import subprocess
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+from tests.live_number_corpus import (
+    LIVE_NUMBER_CORPUS,
+    PARTITIONS,
+    Partition,
+    tally_outcome,
+    value_bits,
+)
+from tests.support import GDA_CMD
+
+GODOT = resolve_godot_binary()
+
+# One exported float per corpus row plus the whole corpus as a packed array, so
+# the scalar arm of the value projection and its element-wise arm are both read
+# through the reply under test. `_init` assigns them: an @export's declared
+# default would have to be a decimal literal.
+_PROBE_BODY = """\
+func _from_hex(h: String) -> float:
+\tvar b := PackedByteArray()
+\tb.resize(8)
+\tfor i in range(8):
+\t\tb[i] = ("0x" + h.substr(i * 2, 2)).hex_to_int()
+\treturn b.decode_double(0)
+
+
+func _init() -> void:
+\tvar packed := PackedFloat64Array()
+\tfor i in range(BITS.size()):
+\t\tvar value := _from_hex(BITS[i])
+\t\tset("v%d" % i, value)
+\t\tpacked.append(value)
+\tall_values = packed
+"""
+
+
+def _probe_source() -> str:
+    """The probe script: the corpus as bit patterns, restored into real exports."""
+    bits = ",\n".join(f'\t"{value_bits(case.value)}"' for case in LIVE_NUMBER_CORPUS)
+    exports = "\n".join(
+        f"@export var v{index}: float = 0.0" for index in range(len(LIVE_NUMBER_CORPUS))
+    )
+    return (
+        "extends Node2D\n\n"
+        f"const BITS := [\n{bits},\n]\n\n"
+        f"{exports}\n"
+        "@export var all_values: PackedFloat64Array = PackedFloat64Array()\n\n\n"
+        f"{_PROBE_BODY}"
+    )
+
+
+PROBE_TSCN = (
+    "[gd_scene load_steps=2 format=3]\n\n"
+    '[ext_resource type="Script" path="res://numbers.gd" id="1"]\n\n'
+    '[node name="Main" type="Node2D"]\n'
+    'script = ExtResource("1")\n'
+)
+
+
+def _gda(project):
+    """A bound ``gda <args> --project <p> --godot <g> --json`` runner."""
+
+    def run(*args):
+        return subprocess.run(
+            [
+                *GDA_CMD,
+                *args,
+                "--project",
+                str(project),
+                "--godot",
+                str(GODOT),
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+
+    return run
+
+
+def _probe_project(project):
+    """Write the probe scene into ``project`` and return its bound runner."""
+    (project / "numbers.gd").write_text(_probe_source(), encoding="utf-8")
+    (project / "numbers.tscn").write_text(PROBE_TSCN, encoding="utf-8")
+    return _gda(project)
+
+
+def _exports_by_name(run) -> dict:
+    """`scene get-exports` on the probe scene, indexed by export name."""
+    read = run("scene", "get-exports", "numbers.tscn")
+    assert read.returncode == 0, read.stdout + read.stderr
+    nodes = json.loads(read.stdout)["nodes"]
+    assert len(nodes) == 1, nodes
+    return {export["name"]: export["value"] for export in nodes[0]["exports"]}
+
+
+@pytest.mark.e2e
+def test_a_headless_read_reports_every_corpus_value_exactly(godot_project):
+    """The whole corpus, read back through a headless reply, bit for bit.
+
+    Before #771 this reply was framed with Godot's DEFAULT ``JSON.stringify``, so
+    40 of these rows came back as ``0.0`` and 15 more as a different double — the
+    caller was handed a number the project does not hold, unmarked.
+    """
+    run = _probe_project(godot_project)
+    values = _exports_by_name(run)
+
+    measured = [0, 0, 0]
+    for index, case in enumerate(LIVE_NUMBER_CORPUS):
+        arrived = values[f"v{index}"]
+        assert isinstance(arrived, float), (case.label, arrived)
+        tally_outcome(measured, case.value, arrived)
+        if value_bits(case.value) != value_bits(-0.0):
+            assert value_bits(arrived) == value_bits(case.value), (
+                f"{case.label}: the headless reply changed the value the project holds"
+            )
+
+    # The SAME partition the live result direction is measured against, because it
+    # is the same engine writer — derived from the corpus, never transcribed.
+    assert Partition(*measured) == PARTITIONS["full_precision"]
+
+    # The element-wise arm of the value projection reads through the same writer:
+    # a packed array's floats are not a separate spelling.
+    packed = values["all_values"]
+    assert [value_bits(item) for item in packed] == [
+        value_bits(0.0 if value_bits(case.value) == value_bits(-0.0) else case.value)
+        for case in LIVE_NUMBER_CORPUS
+    ]
+
+
+@pytest.mark.e2e
+def test_the_same_values_read_the_same_through_node_get(godot_project):
+    """`node get` and `scene get-exports` report one value, not two.
+
+    The fix is the REPLY's, not one operation's, so two commands that project the
+    same node's properties must agree — including on the rows the default writer
+    used to flatten.
+    """
+    run = _probe_project(godot_project)
+    exported = _exports_by_name(run)
+
+    read = run("node", "get", "numbers.tscn", "--node", ".")
+    assert read.returncode == 0, read.stdout + read.stderr
+    properties = {
+        entry["name"]: entry["value"] for entry in json.loads(read.stdout)["properties"]
+    }
+
+    checked = 0
+    for index, case in enumerate(LIVE_NUMBER_CORPUS):
+        name = f"v{index}"
+        if name not in properties:
+            continue
+        assert value_bits(properties[name]) == value_bits(exported[name]), case.label
+        checked += 1
+    assert checked == len(LIVE_NUMBER_CORPUS), checked
+
+
+@pytest.mark.e2e
+def test_negative_zero_is_the_one_disclosed_headless_residual(godot_project):
+    """`-0.0` reads back as `0.0` — the residual the contract states, not hides.
+
+    Not a gda choice and not fixable by the writer argument: ``JSON::_stringify``
+    returns ``"0.0"`` for anything equal to zero before the precision argument is
+    consulted. The live side discloses the same residual for the same reason.
+    """
+    run = _probe_project(godot_project)
+    values = _exports_by_name(run)
+    index = next(
+        i
+        for i, case in enumerate(LIVE_NUMBER_CORPUS)
+        if value_bits(case.value) == value_bits(-0.0)
+    )
+
+    arrived = values[f"v{index}"]
+    assert arrived == 0.0
+    assert math.copysign(1.0, arrived) > 0
+
+    # And it really is the ONLY row the reply changes.
+    changed = [
+        case.label
+        for i, case in enumerate(LIVE_NUMBER_CORPUS)
+        if value_bits(values[f"v{i}"]) != value_bits(case.value)
+    ]
+    assert changed == ["-zero"], changed
+
+
+@pytest.mark.e2e
+def test_a_project_setting_round_trips_through_set_and_get(godot_project):
+    """The issue's own reproduction: `project set` → `project get`, both exact.
+
+    `project set --value 3.141592653589793` used to answer `3.14159265358979` from
+    the `set` itself and again from the `get`, and `--value 1e-300` answered `0.0`
+    from both — while `project.godot` held the value the caller sent. These are the
+    two literals #771 quotes, and they are the round-trip the catalog promises.
+    """
+    run = _gda(godot_project)
+    setting = "physics/2d/default_gravity"
+
+    for literal, expected in (
+        ("3.141592653589793", 3.141592653589793),
+        ("1e-300", 1e-300),
+    ):
+        was_set = run("project", "set", setting, "--value", literal)
+        assert was_set.returncode == 0, was_set.stdout + was_set.stderr
+        assert value_bits(json.loads(was_set.stdout)["value"]) == value_bits(
+            expected
+        ), literal
+
+        got = run("project", "get", setting)
+        assert got.returncode == 0, got.stdout + got.stderr
+        assert value_bits(json.loads(got.stdout)["value"]) == value_bits(expected), (
+            literal
+        )
+
+        # ...and the setting the enumeration reports is the same value again.
+        listed = run("project", "list", "--section", "physics/")
+        assert listed.returncode == 0, listed.stdout + listed.stderr
+        entry = next(
+            item
+            for item in json.loads(listed.stdout)["settings"]
+            if item["setting"] == setting
+        )
+        assert value_bits(entry["value"]) == value_bits(expected), literal

--- a/tests/test_e2e_launch_timeout.py
+++ b/tests/test_e2e_launch_timeout.py
@@ -1,0 +1,225 @@
+"""S (e2e): a hung REAL engine leaves evidence on every launch channel (#714).
+
+The defect this closes is one a fake cannot show. The buffered capture discarded
+whatever the child had written when the timeout expired, so a sentinel op, an
+export or an import pass that wedged came back with nothing but ``gda: <label>
+timed out after <n>s`` — no engine output, no wall clock. Whether the engine
+really does write before it wedges, whether that output survives gda's own
+terminate-then-kill teardown, and whether the run is bounded at all are facts
+about a real Godot process; a canned ``RunResult`` would assert only the can.
+
+So each arm here wedges a REAL engine and asserts the same three things per
+channel: the run is ended at its own ceiling, the envelope names that ceiling and
+the wall clock, and the engine's own output is in the diagnostics.
+
+Two levers wedge it, one per engine path:
+
+- a blocking **autoload** ``_init`` wedges the GAME path (the sentinel channel),
+  after the engine has printed its banner and the entry script has run;
+- a blocking **editor plugin** ``_enter_tree`` wedges the EDITOR path, which both
+  ``--import`` and ``--export-<mode>`` boot. An autoload cannot do it there: the
+  editor does not instantiate autoloads.
+
+Neither can be interrupted politely — a GDScript loop never returns to the main
+loop, so the engine cannot honour the SIGTERM gda sends first — which makes these
+arms cover the kill path too, and is why each spends its ceiling plus gda's
+terminate grace.
+
+The sentinel and export channels are driven through their runner objects rather
+than through the CLI: neither exposes a timeout flag (60s and 600s, fixed), so a
+CLI arm would have to spend a real minute or ten. ``resource import`` does expose
+``--timeout``, so its arm is the full CLI round trip.
+"""
+
+import json
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+from gda.commands.export import ExportRunMode, classify_export_run
+from gda.errors import Failure, classify_run
+from gda.export_runner import SubprocessExportRunner
+from gda.models import EngineVersion
+from gda.runner import SubprocessGodotRunner
+from tests.support import GDA_CMD
+
+GODOT = resolve_godot_binary()
+
+# The ceiling every arm gives its wedged engine. Long enough for a real Godot to
+# boot and print, short enough that three arms plus gda's terminate grace stay
+# well inside a test run.
+CEILING_SECONDS = 4.0
+
+# A blocking autoload: it announces itself on BOTH streams and then never returns.
+# `printerr` matters — gda's stdout carries the ADR-0002 result object, so the
+# stderr line is the one a channel forwards, while the stdout line proves the
+# capture is not stderr-only.
+BLOCKING_AUTOLOAD_GD = """\
+extends Node
+
+
+func _init() -> void:
+	print("AUTOLOAD REACHED")
+	printerr("AUTOLOAD WEDGED")
+	while true:
+		OS.delay_msec(50)
+"""
+
+# A blocking editor plugin: the same wedge for the editor paths (`--import`,
+# `--export-<mode>`), which is where an autoload never runs.
+BLOCKING_PLUGIN_GD = """\
+@tool
+extends EditorPlugin
+
+
+func _enter_tree() -> void:
+	print("PLUGIN REACHED")
+	printerr("PLUGIN WEDGED")
+	while true:
+		OS.delay_msec(50)
+"""
+
+PLUGIN_CFG = """\
+[plugin]
+
+name="wedge"
+description="blocks editor startup so a launch has to be ended by gda"
+author="gda tests"
+version="1.0"
+script="plugin.gd"
+"""
+
+
+def _wedged_project(tmp_path: Path, *, autoload: bool, plugin: bool) -> Path:
+    """A project whose engine startup never finishes on the requested path(s)."""
+    sections = [
+        "config_version=5\n\n[application]\n\n",
+        'config/name="t714"\n\n',
+        # The e2e file-logging policy (#180): no launch here writes a shared
+        # user://logs/godot.log, so concurrent runs cannot contend over it.
+        "[debug]\n\nfile_logging/enable_file_logging=false\n"
+        "file_logging/enable_file_logging.pc=false\n\n",
+    ]
+    if autoload:
+        (tmp_path / "wedge.gd").write_text(BLOCKING_AUTOLOAD_GD, encoding="utf-8")
+        sections.append('[autoload]\n\nWedge="*res://wedge.gd"\n\n')
+    if plugin:
+        addon = tmp_path / "addons" / "wedge"
+        addon.mkdir(parents=True)
+        (addon / "plugin.gd").write_text(BLOCKING_PLUGIN_GD, encoding="utf-8")
+        (addon / "plugin.cfg").write_text(PLUGIN_CFG, encoding="utf-8")
+        sections.append(
+            "[editor_plugins]\n\n"
+            'enabled=PackedStringArray("res://addons/wedge/plugin.cfg")\n'
+        )
+    (tmp_path / "project.godot").write_text("".join(sections), encoding="utf-8")
+    return tmp_path
+
+
+def _assert_bounded(elapsed: float) -> None:
+    """The run was ended by gda's ceiling, not by the engine and not by luck."""
+    assert elapsed >= CEILING_SECONDS, f"the run ended early, at {elapsed:.1f}s"
+    # The ceiling plus gda's terminate-then-kill grace, generously. A wedged
+    # GDScript loop ignores the SIGTERM, so the grace is always spent in full.
+    assert elapsed < CEILING_SECONDS + 20, f"the run overran its bound: {elapsed:.1f}s"
+
+
+def _assert_timeout_envelope(
+    failure: Failure, label: str, *, expect: list[str]
+) -> None:
+    error = failure.error
+    assert error.code == "launch_timeout", error
+    assert error.category.value == "environment"
+    assert error.message.startswith(f"{label} launched but did not return")
+    assert f"timeout of {CEILING_SECONDS}s" in error.message
+    assert "elapsed 4." in error.message, error.message
+    assert "16384 UTF-8 bytes (16 KiB)" in error.message
+    for expected in expect:
+        assert expected in error.diagnostics, error.diagnostics
+
+
+@pytest.mark.e2e
+def test_a_wedged_sentinel_op_reports_what_the_engine_printed(tmp_path):
+    project = _wedged_project(tmp_path, autoload=True, plugin=False)
+    runner = SubprocessGodotRunner(GODOT, project=project, timeout=CEILING_SECONDS)
+
+    started = time.monotonic()
+    raw = runner.run("info", {})
+    elapsed = time.monotonic() - started
+
+    _assert_bounded(elapsed)
+    outcome = classify_run(raw, GODOT, EngineVersion)
+    assert isinstance(outcome, Failure)
+    _assert_timeout_envelope(
+        outcome,
+        "Godot",
+        # Both streams, and both from the engine itself: the banner it printed on
+        # its own, and the autoload's two lines from before it stopped returning.
+        expect=["Godot Engine v", "AUTOLOAD REACHED", "AUTOLOAD WEDGED"],
+    )
+
+
+@pytest.mark.e2e
+def test_a_wedged_export_reports_what_the_engine_printed(tmp_path):
+    project = _wedged_project(tmp_path, autoload=False, plugin=True)
+    runner = SubprocessExportRunner(GODOT, project=project, timeout=CEILING_SECONDS)
+
+    started = time.monotonic()
+    raw = runner.run("Linux/X11", "release", "build/game.x86_64")
+    elapsed = time.monotonic() - started
+
+    _assert_bounded(elapsed)
+    outcome = classify_export_run(
+        raw,
+        GODOT,
+        preset="Linux/X11",
+        platform="Linux/X11",
+        mode=ExportRunMode.RELEASE,
+        output_path="build/game.x86_64",
+        created_dirs=[],
+    )
+    assert isinstance(outcome, Failure)
+    _assert_timeout_envelope(
+        outcome, "Godot export", expect=["PLUGIN REACHED", "PLUGIN WEDGED"]
+    )
+
+
+@pytest.mark.e2e
+def test_a_wedged_import_pass_reports_what_the_engine_printed(tmp_path):
+    # The full CLI round trip, which this channel can afford: `resource import`
+    # exposes --timeout, so the ceiling is the test's to choose.
+    project = _wedged_project(tmp_path, autoload=False, plugin=True)
+    # An asset with no sidecar, so the pass is needed and really runs.
+    (project / "icon.png").write_bytes(b"\x89PNG not really an image")
+
+    started = time.monotonic()
+    run = subprocess.run(
+        [
+            *GDA_CMD,
+            "resource",
+            "import",
+            "res://icon.png",
+            "--timeout",
+            str(CEILING_SECONDS),
+            "--project",
+            str(project),
+            "--godot",
+            str(GODOT),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    elapsed = time.monotonic() - started
+
+    _assert_bounded(elapsed)
+    assert run.returncode == 124, run.stdout + run.stderr
+    error = json.loads(run.stdout)["error"]
+    assert error["code"] == "launch_timeout"
+    assert error["message"].startswith("Godot import launched but did not return")
+    assert f"timeout of {CEILING_SECONDS}s" in error["message"]
+    assert "elapsed 4." in error["message"]
+    assert "PLUGIN WEDGED" in error["diagnostics"]

--- a/tests/test_e2e_live_number_transport.py
+++ b/tests/test_e2e_live_number_transport.py
@@ -27,7 +27,14 @@ import pytest
 from gda.binary import resolve_godot_binary
 from gda.live_numbers import wire_flattens_to_zero
 
-from tests.live_number_corpus import LIVE_NUMBER_CORPUS, PARTITIONS, Partition
+from tests.live_number_corpus import (
+    LIVE_NUMBER_CORPUS,
+    PARTITIONS,
+    Partition,
+    stringify_outcome,
+    tally_outcome,
+    value_bits,
+)
 from tests.support import GDA_CMD, panel_text
 
 GODOT = resolve_godot_binary()
@@ -73,34 +80,11 @@ def _probe_source() -> str:
     """
     rows = ",\n".join(
         '\t["{bits}", "{literal}"]'.format(
-            bits=struct.pack("<d", case.value).hex(), literal=json.dumps(case.value)
+            bits=value_bits(case.value), literal=json.dumps(case.value)
         )
         for case in LIVE_NUMBER_CORPUS
     )
     return f"extends SceneTree\n\nconst CORPUS := [\n{rows},\n]\n\n\n{_PROBE_BODY}"
-
-
-def _bits(value: float) -> str:
-    return struct.pack("<d", value).hex()
-
-
-def _outcome(sent: float, arrived: float) -> str:
-    """The three-state verdict one direction gave one value (cf. LiveNumberCase).
-
-    ``changed`` and ``zero`` are DIFFERENT failures — a rounded value still
-    carries the caller's magnitude, a flattened one does not — so the corpus
-    records which, and the published table reports both.
-    """
-    if _bits(arrived) == _bits(sent):
-        return "exact"
-    if arrived == 0.0 and sent != 0.0:
-        return "zero"
-    return "changed"
-
-
-def _tally(counts: list, sent: float, arrived: float) -> None:
-    """Add one value's verdict to an [exact, changed, zero] tally."""
-    counts[("exact", "changed", "zero").index(_outcome(sent, arrived))] += 1
 
 
 def _ulp_gap(sent: float, arrived: float) -> int:
@@ -160,7 +144,7 @@ def test_the_live_number_corpus_still_describes_this_engine(godot_project):
     measured = {name: [0, 0, 0] for name in PARTITIONS}
     for case in LIVE_NUMBER_CORPUS:
         label, value = case.label, case.value
-        request, default_text, full_text = rows[_bits(value)]
+        request, default_text, full_text = rows[value_bits(value)]
 
         # --- REQUEST direction: what Godot's parser makes of gda's wire literal.
         assert request != "PARSE_NULL", label
@@ -171,7 +155,7 @@ def test_the_live_number_corpus_still_describes_this_engine(godot_project):
         )
         # ...and gda's guard predicts that verdict without asking the engine.
         assert wire_flattens_to_zero(value) is engine_zeroes, label
-        _tally(measured["request"], value, arrived)
+        tally_outcome(measured["request"], value, arrived)
         if engine_zeroes:
             parse_flattened.append(label)
             assert case.request_ulp_gap is None, label
@@ -184,15 +168,17 @@ def test_the_live_number_corpus_still_describes_this_engine(godot_project):
 
         # --- RESULT direction: the writer the harness uses is exact...
         full_arrived = float(json.loads(full_text))
-        assert _bits(full_arrived) == _bits(value) or (
+        assert value_bits(full_arrived) == value_bits(value) or (
             value == 0.0 and math.copysign(1.0, value) < 0
         ), f"{label}: full-precision stringify changed the value"
-        _tally(measured["full_precision"], value, full_arrived)
+        tally_outcome(measured["full_precision"], value, full_arrived)
 
         # ...where the DEFAULT writer, which the harness used before #752, was not.
         default_arrived = float(json.loads(default_text))
-        assert _outcome(value, default_arrived) == case.default_stringify, label
-        _tally(measured["default_stringify"], value, default_arrived)
+        assert stringify_outcome(value, default_arrived) == case.default_stringify, (
+            label
+        )
+        tally_outcome(measured["default_stringify"], value, default_arrived)
         if case.default_stringify != "exact":
             default_lost.append(label)
 
@@ -214,7 +200,7 @@ def test_the_live_number_corpus_still_describes_this_engine(godot_project):
 def test_negative_zero_is_the_one_disclosed_result_residual(godot_project):
     """`-0.0` reads back as `0.0` — the residual the CLI contract states."""
     rows = _engine_rows(godot_project)
-    _, _, full_text = rows[_bits(-0.0)]
+    _, _, full_text = rows[value_bits(-0.0)]
 
     # Not a gda choice: `JSON::_stringify` returns "0.0" for anything equal to
     # zero before the full_precision argument is consulted.
@@ -224,7 +210,8 @@ def test_negative_zero_is_the_one_disclosed_result_residual(godot_project):
     changed = [
         case.label
         for case in LIVE_NUMBER_CORPUS
-        if _bits(float(json.loads(rows[_bits(case.value)][2]))) != _bits(case.value)
+        if value_bits(float(json.loads(rows[value_bits(case.value)][2])))
+        != value_bits(case.value)
     ]
     assert changed == ["-zero"], changed
 
@@ -298,7 +285,7 @@ def test_live_reads_carry_small_and_many_digit_floats_exactly(
         precise = run("game", "get", "/root/Main", "--property", "precise")
         assert precise.returncode == 0, precise.stdout + precise.stderr
         value = json.loads(precise.stdout)["properties"][0]["value"]
-        assert _bits(value) == _bits(3.141592653589793)
+        assert value_bits(value) == value_bits(3.141592653589793)
 
         # The same writer serves a call's RETURN value.
         echoed = run(

--- a/tests/test_e2e_project_analysis.py
+++ b/tests/test_e2e_project_analysis.py
@@ -617,3 +617,304 @@ def test_project_walks_agree_on_a_nested_dot_godot_directory(tmp_path):
     # otherwise BOTH be dependency source rows and unused candidates, so this
     # arm fails if the exclusion ever widens past `res://.godot` itself.
     assert not any(p.startswith("res://.godot/") for p in [*by_source, *unused])
+
+
+# --- alias spellings are one graph node (#774) -------------------------------
+#
+# A `res://` address has many lexical spellings for one file: `res://leaf.tscn`
+# and `res://sub/../leaf.tscn` are the SAME file to the engine, which folds every
+# address through `simplify_path` before it resolves one. The three graph reads
+# used to key on the raw spelling instead, so an aliased declaration made a graph
+# node no file on disk answered to, `find-references` for the real path missed the
+# reference, and `find-unused-resources` therefore advised deleting a scene the
+# project instances. These tests pin the identity on BOTH sides of the comparison
+# — the harvested declaration and the caller's query — over every harvest site:
+# an `[ext_resource]` line, a `preload()` argument, and `project.godot`'s own
+# main-scene and autoload entries.
+
+ALIAS_PROJECT_GODOT = project_godot(
+    name="gda-alias-fixture",
+    extra="""\
+run/main_scene="res://sub/../parent.tscn"
+
+[autoload]
+
+Hud="*res://sub/../hud.tscn"
+""",
+)
+
+# The aliased [ext_resource] declaration: parent.tscn really instances leaf.tscn,
+# the engine resolves the spelling, and the graph must agree that it does. It also
+# instances nested.tscn under a RELATIVE spelling — no `res://` prefix at all, which
+# the engine resolves against parent.tscn's own directory (the project root here).
+ALIAS_PARENT_TSCN = """\
+[gd_scene load_steps=3 format=3 uid="uid://baliasparent"]
+
+[ext_resource type="PackedScene" path="res://sub/../leaf.tscn" id="1_leaf"]
+[ext_resource type="PackedScene" path="scenes/nested.tscn" id="2_nested"]
+
+[node name="Parent" type="Node2D"]
+
+[node name="Leaf" parent="." instance=ExtResource("1_leaf")]
+
+[node name="Nested" parent="." instance=ExtResource("2_nested")]
+"""
+
+ALIAS_LEAF_TSCN = """\
+[gd_scene format=3 uid="uid://baliasleaf"]
+
+[node name="Leaf" type="Node2D"]
+"""
+
+# The relative declaration that ESCAPES its own directory: nested.tscn lives in
+# res://scenes/, and the engine resolves `../shared/deep.tscn` from there to
+# res://shared/deep.tscn (measured on 4.6.3). Canonicalizing this spelling without
+# first anchoring it to the DECLARING file's directory leaves `../shared/deep.tscn`
+# unchanged — a graph node no file on disk answers to.
+ALIAS_NESTED_TSCN = """\
+[gd_scene load_steps=2 format=3 uid="uid://baliasnested"]
+
+[ext_resource type="PackedScene" path="../shared/deep.tscn" id="1_deep"]
+
+[node name="Nested" type="Node2D"]
+
+[node name="Deep" parent="." instance=ExtResource("1_deep")]
+"""
+
+ALIAS_DEEP_TSCN = """\
+[gd_scene format=3 uid="uid://baliasdeep"]
+
+[node name="Deep" type="Node2D"]
+"""
+
+# The autoload scene, named by project.godot under an aliased spelling.
+ALIAS_HUD_TSCN = """\
+[gd_scene format=3 uid="uid://baliashud"]
+
+[node name="Hud" type="Node"]
+"""
+
+# The reverse direction: a CANONICAL declaration the query aliases.
+ALIAS_CANONICAL_TSCN = """\
+[gd_scene load_steps=2 format=3 uid="uid://baliascanon"]
+
+[ext_resource type="Texture2D" path="res://icon.png" id="1_icon"]
+
+[node name="Canonical" type="Sprite2D"]
+texture = ExtResource("1_icon")
+"""
+
+# The script-side harvest site: an already-prefixed, aliased preload argument.
+ALIAS_USER_GD = """\
+extends Node
+
+const Helper = preload("res://sub/../helper.gd")
+"""
+
+ALIAS_HELPER_GD = """\
+extends RefCounted
+"""
+
+ALIAS_ORPHAN_TRES = """\
+[gd_resource type="Resource" format=3]
+
+[resource]
+"""
+
+
+@pytest.fixture
+def alias_project(tmp_path):
+    """A project whose references are declared under alias spellings (#774).
+
+    Every reference here names a file that really exists and that the engine
+    really resolves; only the SPELLING is aliased. ``sub/`` is a real directory
+    (it holds the orphan) so the aliases read as something an agent would
+    plausibly write, not as a synthetic string.
+
+    Two families of spelling are covered, because they need two different folds:
+    an ALIAS of an absolute address (``res://sub/../leaf.tscn``), which only needs
+    simplifying, and a RELATIVE address (``scenes/nested.tscn`` from the root,
+    ``../shared/deep.tscn`` from ``res://scenes/``), which must first be anchored
+    to the DECLARING file's own directory — the way the engine resolves it.
+    """
+    (tmp_path / "project.godot").write_text(ALIAS_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "parent.tscn").write_text(ALIAS_PARENT_TSCN, encoding="utf-8")
+    (tmp_path / "leaf.tscn").write_text(ALIAS_LEAF_TSCN, encoding="utf-8")
+    (tmp_path / "hud.tscn").write_text(ALIAS_HUD_TSCN, encoding="utf-8")
+    (tmp_path / "canonical.tscn").write_text(ALIAS_CANONICAL_TSCN, encoding="utf-8")
+    (tmp_path / "user.gd").write_text(ALIAS_USER_GD, encoding="utf-8")
+    (tmp_path / "helper.gd").write_text(ALIAS_HELPER_GD, encoding="utf-8")
+    (tmp_path / "icon.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "orphan.tres").write_text(ALIAS_ORPHAN_TRES, encoding="utf-8")
+    scenes = tmp_path / "scenes"
+    scenes.mkdir()
+    (scenes / "nested.tscn").write_text(ALIAS_NESTED_TSCN, encoding="utf-8")
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    (shared / "deep.tscn").write_text(ALIAS_DEEP_TSCN, encoding="utf-8")
+    return tmp_path
+
+
+@pytest.mark.e2e
+def test_dependencies_keys_an_aliased_declaration_canonically(alias_project):
+    proc = _gda(alias_project, "project", "dependencies", "--json")
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    by_source = {
+        row["path"]: row["depends_on"]
+        for row in json.loads(proc.stdout)["dependencies"]
+    }
+
+    # The aliased [ext_resource] and the aliased preload both report the file the
+    # engine resolves, not the spelling the declaration used. parent.tscn's second
+    # reference is spelled RELATIVE ("scenes/nested.tscn") and must be anchored to
+    # the declaring file's directory before it is canonicalized.
+    assert by_source["res://parent.tscn"] == [
+        {"path": "res://leaf.tscn", "kind": "ext_resource"},
+        {"path": "res://scenes/nested.tscn", "kind": "ext_resource"},
+    ]
+    # The relative reference that ESCAPES its own directory, resolved from the
+    # declaring file rather than from the project root.
+    assert by_source["res://scenes/nested.tscn"] == [
+        {"path": "res://shared/deep.tscn", "kind": "ext_resource"}
+    ]
+    assert by_source["res://user.gd"] == [
+        {"path": "res://helper.gd", "kind": "preload"}
+    ]
+    # No graph node names a path that no file on disk answers to. Both arms are
+    # load-bearing: `..` catches an unanchored `../shared/deep.tscn`, and the
+    # `res://` prefix catches an unanchored `scenes/nested.tscn`, which carries no
+    # `..` to be caught by.
+    named = {dep["path"] for deps in by_source.values() for dep in deps}
+    assert not any(".." in path.split("/") for path in named), named
+    assert all(path.startswith("res://") for path in named), named
+
+
+@pytest.mark.e2e
+def test_find_references_matches_an_aliased_declaration_from_a_canonical_query(
+    alias_project,
+):
+    scene = _gda(
+        alias_project, "project", "find-references", "res://leaf.tscn", "--json"
+    )
+    script = _gda(
+        alias_project, "project", "find-references", "res://helper.gd", "--json"
+    )
+
+    assert scene.returncode == 0, scene.stdout + scene.stderr
+    assert script.returncode == 0, script.stdout + script.stderr
+    assert [(r["path"], r["kind"]) for r in json.loads(scene.stdout)["references"]] == [
+        ("res://parent.tscn", "ext_resource")
+    ]
+    assert [
+        (r["path"], r["kind"]) for r in json.loads(script.stdout)["references"]
+    ] == [("res://user.gd", "preload")]
+
+
+@pytest.mark.e2e
+def test_find_references_matches_a_relative_declaration(alias_project):
+    # The reference is declared `../shared/deep.tscn` from res://scenes/nested.tscn;
+    # the engine loads res://shared/deep.tscn, so a query for that path must find
+    # the declaring site. Reported empty before the declaring file's directory was
+    # used to anchor the spelling.
+    deep = _gda(
+        alias_project, "project", "find-references", "res://shared/deep.tscn", "--json"
+    )
+    # And the prefix-less relative form, declared `scenes/nested.tscn` from the
+    # project root — a spelling with no `..` in it at all.
+    nested = _gda(
+        alias_project,
+        "project",
+        "find-references",
+        "res://scenes/nested.tscn",
+        "--json",
+    )
+
+    assert deep.returncode == 0, deep.stdout + deep.stderr
+    assert nested.returncode == 0, nested.stdout + nested.stderr
+    assert [(r["path"], r["kind"]) for r in json.loads(deep.stdout)["references"]] == [
+        ("res://scenes/nested.tscn", "ext_resource")
+    ]
+    assert [
+        (r["path"], r["kind"]) for r in json.loads(nested.stdout)["references"]
+    ] == [("res://parent.tscn", "ext_resource")]
+    # The context is the line as written, so the agent still sees the spelling it
+    # must edit — only the MATCHING is normalized.
+    assert (
+        '"../shared/deep.tscn"' in json.loads(deep.stdout)["references"][0]["context"]
+    )
+
+
+@pytest.mark.e2e
+def test_find_references_matches_a_canonical_declaration_from_an_aliased_query(
+    alias_project,
+):
+    proc = _gda(
+        alias_project,
+        "project",
+        "find-references",
+        "res://sub/../icon.png",
+        "--json",
+    )
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    data = json.loads(proc.stdout)
+    # The echoed target keeps the caller's own spelling; the MATCHING does not.
+    assert data["target"] == "res://sub/../icon.png"
+    assert [(r["path"], r["kind"]) for r in data["references"]] == [
+        ("res://canonical.tscn", "ext_resource")
+    ]
+
+
+@pytest.mark.e2e
+def test_find_references_matches_an_aliased_project_level_entry(alias_project):
+    # project.godot is a harvest site too: its main scene and autoloads name a
+    # resource by path the way an ext_resource line does.
+    main = _gda(
+        alias_project, "project", "find-references", "res://parent.tscn", "--json"
+    )
+    autoload = _gda(
+        alias_project, "project", "find-references", "res://hud.tscn", "--json"
+    )
+
+    assert main.returncode == 0, main.stdout + main.stderr
+    assert autoload.returncode == 0, autoload.stdout + autoload.stderr
+    assert ("project.godot", "main_scene") in {
+        (r["path"], r["kind"]) for r in json.loads(main.stdout)["references"]
+    }
+    assert ("project.godot", "autoload") in {
+        (r["path"], r["kind"]) for r in json.loads(autoload.stdout)["references"]
+    }
+
+
+@pytest.mark.e2e
+def test_find_unused_resources_never_lists_an_aliased_reference(alias_project):
+    proc = _gda(alias_project, "project", "find-unused-resources", "--json")
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    unused = json.loads(proc.stdout)["unused"]
+
+    # The destructive advice this issue is about: leaf.tscn is instanced by
+    # parent.tscn, and parent.tscn/hud.tscn are project entry points — all three
+    # under alias spellings. None of them is deletable.
+    assert "res://leaf.tscn" not in unused
+    assert "res://parent.tscn" not in unused
+    assert "res://hud.tscn" not in unused
+    assert "res://icon.png" not in unused
+    # Same advice, reached through the RELATIVE spellings: nested.tscn is instanced
+    # by the main scene and deep.tscn by nested.tscn. Before the anchor, both were
+    # reported deletable — including a scene the project's own main scene loads.
+    assert "res://scenes/nested.tscn" not in unused
+    assert "res://shared/deep.tscn" not in unused
+    # The report still works: the genuinely unreferenced resource is reported.
+    assert "res://sub/orphan.tres" in unused
+
+    # The consistency criterion holds under alias spellings too: unused means
+    # exactly "find-references returns empty".
+    for path in unused:
+        refs = json.loads(
+            _gda(alias_project, "project", "find-references", path, "--json").stdout
+        )["references"]
+        assert refs == [], f"{path} reported unused but has references {refs}"

--- a/tests/test_e2e_project_walk.py
+++ b/tests/test_e2e_project_walk.py
@@ -1,0 +1,144 @@
+"""S1 (e2e): the shared ``res://`` walk's two behavioural contracts (#764).
+
+The four project-wide collectors in ``operations.gd`` run ONE traversal. These
+tests pin the two things that consolidation had to decide or preserve, against a
+real engine:
+
+* **The acceptance test is case-insensitive.** The scene walk used to compare the
+  extension as written while the script walk lowercased it, so a ``Level.TSCN``
+  counted as a scene in ``project statistics`` (which lowercases) and was
+  invisible to ``scene list``. The engine is the arbiter and is case-insensitive
+  — ``ResourceFormatLoader::recognize_path`` matches the extension with
+  ``nocasecmp_to`` — so the listings match it, and ``scene list`` grew that entry.
+* **The two file universes survive.** A shared traversal is not a shared
+  universe: ``project statistics`` must keep counting the ``.import`` sidecars and
+  ``project.godot`` that the extension-filtered walk behind ``dependencies`` /
+  ``find-unused-resources`` excludes.
+"""
+
+import json
+import subprocess
+
+import pytest
+
+from gda.binary import resolve_godot_binary
+
+from .conftest import project_godot
+from tests.support import GDA_CMD
+
+GODOT = resolve_godot_binary()
+
+PROJECT_GODOT = project_godot(name="gda-walk-fixture")
+
+# Two scenes and two scripts, one of each written with an UPPERCASE extension.
+# The base names differ so the fixture is also valid on a case-insensitive
+# filesystem (macOS APFS preserves case but would collapse main.tscn/MAIN.TSCN).
+MAIN_TSCN = """\
+[gd_scene format=3]
+
+[node name="Main" type="Node2D"]
+"""
+
+LEVEL_TSCN = """\
+[gd_scene format=3]
+
+[node name="Level" type="Node3D"]
+"""
+
+HELPER_GD = """\
+extends RefCounted
+"""
+
+WIDGET_GD = """\
+extends Node
+"""
+
+# An import sidecar for a leaf asset — the engine's own bookkeeping, in the
+# unfiltered universe only.
+ICON_IMPORT = """\
+[remap]
+
+importer="texture"
+type="CompressedTexture2D"
+"""
+
+
+@pytest.fixture
+def walk_project(tmp_path):
+    """A project holding both extension cases and both file universes."""
+    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "Level.TSCN").write_text(LEVEL_TSCN, encoding="utf-8")
+    (tmp_path / "helper.gd").write_text(HELPER_GD, encoding="utf-8")
+    (tmp_path / "Widget.GD").write_text(WIDGET_GD, encoding="utf-8")
+    (tmp_path / "icon.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+    (tmp_path / "icon.png.import").write_text(ICON_IMPORT, encoding="utf-8")
+    return tmp_path
+
+
+def _gda(project, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _result(project, *args: str) -> dict:
+    proc = _gda(project, *args, "--json")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    return json.loads(proc.stdout)
+
+
+@pytest.mark.e2e
+def test_the_listings_accept_an_extension_in_any_case_as_the_engine_does(walk_project):
+    # AC2 (#764): the case-sensitivity drift is resolved case-INSENSITIVELY, on
+    # both sides. `Level.TSCN` is a scene to the engine (it loads as a
+    # PackedScene, reported below through root_type) so `scene list` reports it;
+    # `Widget.GD` was already accepted by the script walk and stays accepted.
+    scenes = {s["path"]: s for s in _result(walk_project, "scene", "list")["scenes"]}
+    scripts = {s["path"] for s in _result(walk_project, "script", "list")["scripts"]}
+
+    assert set(scenes) == {"res://main.tscn", "res://Level.TSCN"}
+    assert scripts == {"res://helper.gd", "res://Widget.GD"}
+
+    # The engine really reads the uppercase file AS a scene — the listing is not
+    # reporting a path it could not load.
+    assert scenes["res://Level.TSCN"]["root_type"] == "Node3D"
+
+    # And the two ends now agree, which is the point: `project statistics`
+    # classifies by a lowercased extension, so its counts match the listings.
+    # Before this change it counted a scene `scene list` could not see (#712's
+    # failure shape, on the acceptance test instead of the descent decision).
+    stats = _result(walk_project, "project", "statistics")
+    assert stats["scene_count"] == len(scenes)
+    assert stats["script_count"] == len(scripts)
+
+
+@pytest.mark.e2e
+def test_the_two_file_universes_survive_the_shared_traversal(walk_project):
+    # AC4 (#764): one traversal, two universes. `project statistics` counts every
+    # file it reaches — including the `.import` sidecar and `project.godot` — while
+    # the extension-filtered walk behind the reference graph excludes exactly
+    # those, and still sees the leaf asset beside them.
+    stats = _result(walk_project, "project", "statistics")
+    by_ext = {e["extension"]: e["files"] for e in stats["by_extension"]}
+
+    assert by_ext.get("import") == 1, by_ext  # icon.png.import
+    assert by_ext.get("godot") == 1, by_ext  # project.godot
+    assert stats["total_files"] == sum(by_ext.values())
+
+    # The filtered universe: the sidecar and the project file are not resources,
+    # so they are neither unused-resource candidates nor dependency sources...
+    unused = set(_result(walk_project, "project", "find-unused-resources")["unused"])
+    sources = {
+        d["path"]
+        for d in _result(walk_project, "project", "dependencies")["dependencies"]
+    }
+    excluded = {"res://icon.png.import", "res://project.godot"}
+    assert not (unused & excluded), unused
+    assert not (sources & excluded), sources
+
+    # ...while the leaf asset sitting right next to the sidecar still is one, so
+    # the exclusion is the acceptance test's, not an emptied walk.
+    assert "res://icon.png" in unused

--- a/tests/test_export_runner.py
+++ b/tests/test_export_runner.py
@@ -20,35 +20,15 @@ from pathlib import Path
 
 import gda.runner as runner_mod
 from gda.export_runner import SubprocessExportRunner
-
-
-class _RecordingRun:
-    """A ``subprocess.run`` double recording the call and returning a clean exit."""
-
-    def __init__(self) -> None:
-        self.cmd: list[str] | None = None
-        self.kwargs: dict | None = None
-
-    def __call__(self, cmd, **kwargs):
-        self.cmd = cmd
-        self.kwargs = kwargs
-
-        class _Proc:
-            # The primitive captures bytes (no text=True) and decodes UTF-8
-            # itself, so the double mirrors that real subprocess contract (#33).
-            stdout = b""
-            stderr = b""
-            returncode = 0
-
-        return _Proc()
+from tests.support import RecordingSpawn
 
 
 def test_export_runs_with_project_as_cwd(monkeypatch):
     # The configured export_path is relative and Godot resolves a relative output
     # path against its CWD, so the runner must spawn Godot with cwd = the project
     # for the artifact to land inside the project (the #121 acceptance behavior).
-    rec = _RecordingRun()
-    monkeypatch.setattr(runner_mod.subprocess, "run", rec)
+    rec = RecordingSpawn()
+    monkeypatch.setattr(runner_mod.subprocess, "Popen", rec)
     project = Path("/tmp/proj")
 
     runner = SubprocessExportRunner(Path("/x/Godot"), project=project)
@@ -74,8 +54,8 @@ def test_relative_project_is_absolutized_so_cwd_and_path_agree(monkeypatch):
     # empty export_failed. The runner must absolutize the project so --path and
     # cwd name the SAME absolute directory (reaching the resolution an absolute
     # --project reaches).
-    rec = _RecordingRun()
-    monkeypatch.setattr(runner_mod.subprocess, "run", rec)
+    rec = RecordingSpawn()
+    monkeypatch.setattr(runner_mod.subprocess, "Popen", rec)
     relative = Path("relproj")
     expected = str(relative.absolute())
 
@@ -103,8 +83,8 @@ def test_relative_and_absolute_project_reach_the_same_resolution(monkeypatch, tm
     abs_project.mkdir()
 
     def _spawn(project: Path) -> tuple[list[str], dict]:
-        rec = _RecordingRun()
-        monkeypatch.setattr(runner_mod.subprocess, "run", rec)
+        rec = RecordingSpawn()
+        monkeypatch.setattr(runner_mod.subprocess, "Popen", rec)
         SubprocessExportRunner(Path("/x/Godot"), project=project).run(
             "Linux/X11", "release", "build/game.x86_64"
         )
@@ -123,8 +103,8 @@ def test_relative_and_absolute_project_reach_the_same_resolution(monkeypatch, tm
 def test_export_without_project_passes_no_cwd(monkeypatch):
     # Projectless runs (no resolved project) spawn with the default cwd — there is
     # no project root to resolve a relative path against.
-    rec = _RecordingRun()
-    monkeypatch.setattr(runner_mod.subprocess, "run", rec)
+    rec = RecordingSpawn()
+    monkeypatch.setattr(runner_mod.subprocess, "Popen", rec)
 
     runner = SubprocessExportRunner(Path("/x/Godot"), project=None)
     runner.run("Linux/X11", "release", "/abs/out.x86_64")
@@ -152,25 +132,30 @@ def test_export_launch_failure_surfaces_through_the_typed_run_adapter(tmp_path):
     assert result.launch_failure is LaunchFailure.NOT_FOUND
 
 
-def test_export_timeout_keeps_the_export_worded_diagnostic(monkeypatch):
+def test_export_timeout_names_the_export_channel_and_its_ceiling(monkeypatch):
     # The export channel passes timeout_label="Godot export" to the shared
-    # primitive so its timeout stderr stays byte-compatible with the pre-#185
-    # wording. This stderr is what the classifier carries into the public
-    # GdaError.diagnostics, so the wording is part of `export run --json` (#185
-    # review). The shared launch handling itself is tested in test_launch.py.
-    import subprocess
-
+    # primitive. Since #714 that label no longer composes a synthesized stderr —
+    # the streams carry the export's own captured output — so it rides the result
+    # as its TimeoutBound, together with the ceiling. Both reach the public
+    # `launch_timeout` message of `export run --json` through the shared
+    # classifier, which is why this channel still declares a label at all. The
+    # shared launch handling itself is tested in test_launch.py.
     from gda.exit_codes import EXIT_TIMEOUT
     from gda.runner import LaunchFailure
 
-    def fake_run(*args, **kwargs):
-        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
+    monkeypatch.setattr(
+        runner_mod.subprocess,
+        "Popen",
+        RecordingSpawn(stderr="ERROR: export step wedged\n", alive=True),
+    )
 
-    monkeypatch.setattr(runner_mod.subprocess, "run", fake_run)
-
-    runner = SubprocessExportRunner(Path("/x/Godot"), timeout=600.0)
+    runner = SubprocessExportRunner(Path("/x/Godot"), timeout=0.05)
     result = runner.run("Linux/X11", "release", "out.x86_64")
 
     assert result.exit_code == EXIT_TIMEOUT
-    assert result.stderr == "gda: Godot export timed out after 600.0s\n"
     assert result.launch_failure is LaunchFailure.TIMEOUT
+    assert result.timeout_bound is not None
+    assert result.timeout_bound.label == "Godot export"
+    assert result.timeout_bound.seconds == 0.05
+    # And the export's own output survived the bound, in place of the discard.
+    assert result.stderr == "ERROR: export step wedged\n"

--- a/tests/test_harness_coercion_mirror.py
+++ b/tests/test_harness_coercion_mirror.py
@@ -1,4 +1,4 @@
-"""Drift checks for headless/live duplicated property-write policy.
+"""Drift checks for headless/live duplicated policy: property writes, and the reply writer.
 
 ``operations.gd`` (the headless op dispatcher, run via ``godot --headless
 --script <abs-fs-path>``) and ``gda_harness.gd`` (the live res:// autoload) need
@@ -88,3 +88,20 @@ def test_control_position_policy_is_byte_identical_across_the_two_gd_files():
 
     assert operations_policy, "the operations.gd Control-position policy must exist"
     assert operations_policy == harness_policy
+
+
+def test_the_reply_json_writer_is_byte_identical_across_the_two_gd_files():
+    """One writer choice, two payloads (#752 for the harness, #771 for the ops).
+
+    Each file frames its reply with Godot's FULL-PRECISION JSON writer, and that
+    one argument is the whole difference between reporting the float the project
+    holds and reporting a rounded — or, below ~1e-32.6, zeroed — approximation of
+    it. The copies are separate for the same reason the coercion block is, so an
+    edit to one that is not mirrored has a caller-visible cost: the same value
+    read back differently depending on the channel.
+    """
+    operations_writer = _top_level_function(OPERATIONS_GD, "_json")
+    harness_writer = _top_level_function(GDA_HARNESS_GD, "_json")
+
+    assert 'JSON.stringify(value, "", true, true)' in operations_writer
+    assert operations_writer == harness_writer

--- a/tests/test_info_errors.py
+++ b/tests/test_info_errors.py
@@ -13,7 +13,7 @@ import json
 from typer.testing import CliRunner
 
 from gda.cli import app
-from gda.runner import LaunchFailure, RunResult
+from gda.runner import LaunchFailure, RunResult, TimeoutBound
 from tests.support import inject_runner as _inject
 from tests.support import raw_sentinel, sentinel
 
@@ -42,16 +42,20 @@ def test_binary_not_found_maps_to_environment_error(monkeypatch):
 
 
 def test_launch_timeout_maps_to_environment_error_distinct_from_not_found(monkeypatch):
-    # A launched-but-hung engine is bounded by the runner's timeout: exit 124
-    # with a timeout diagnostic (#2). It is still an environment failure but
-    # must be distinguishable from binary-not-found.
+    # A launched-but-hung engine is bounded by the runner's timeout: exit 124 (#2).
+    # It is still an environment failure but must be distinguishable from
+    # binary-not-found. Since #714 the sentinel channel's own partial capture is
+    # what the run left behind, so that is what reaches both stderr (forwarded, as
+    # on any run) and the envelope's diagnostics.
     _inject(
         monkeypatch,
         RunResult(
             stdout="",
-            stderr="gda: Godot timed out after 60.0s\n",
+            stderr="Godot Engine v4.6.stable\n",
             exit_code=124,
             launch_failure=LaunchFailure.TIMEOUT,
+            elapsed_seconds=60.1,
+            timeout_bound=TimeoutBound("Godot", 60.0),
         ),
     )
 
@@ -62,7 +66,9 @@ def test_launch_timeout_maps_to_environment_error_distinct_from_not_found(monkey
     assert err["category"] == "environment"
     # Distinguishable from the binary-not-found case via a distinct code.
     assert err["code"] == "launch_timeout"
-    assert "timed out" in result.stderr
+    assert "did not return before the timeout of 60.0s" in err["message"]
+    assert "Godot Engine v4.6.stable" in err["diagnostics"]
+    assert "Godot Engine v4.6.stable" in result.stderr
 
 
 def test_operation_failure_maps_to_operation_error_distinct_from_environment(

--- a/tests/test_json_flag_acceptance.py
+++ b/tests/test_json_flag_acceptance.py
@@ -1,19 +1,21 @@
-"""`--json` is accepted on the discovery surfaces too (issue #671).
+"""`--json` is accepted on the discovery surfaces too (issues #671, #683).
 
 The bundled Skill teaches ONE rule — "always pass `--json`" — so a client that
 follows it must never be answered with a usage error (exit 2). Discovery used to
-break that rule at **two different parser sites**, which is why a root-only fix
+break that rule at **three different parser sites**, which is why a root-only fix
 would be incomplete:
 
 - the ROOT parser (`gda --json --help`, `gda --json <command>`): the root callback
   declared only `--version`, so the flag died before any subcommand was resolved;
 - the `schema` SUBCOMMAND parser (`gda schema --json`): it declared only
-  `--schema`, so the whole-surface JSON manifest rejected the JSON flag.
+  `--schema`, so the whole-surface JSON manifest rejected the JSON flag;
+- every mounted GROUP's parser (`gda scene --json get …`, #683): a group declared no
+  options at all, so the flag written between the group and the command exited 2.
 
-Accepting the root flag is not enough on its own: a root `--json` that parsed but
-did nothing would hand human text to a caller that asked for JSON — worse than the
-loud `No such option` it replaced. So the root flag is INHERITED by the invoked
-command (`gda.headless._inherit_root_json`), and the tests below pin that
+Accepting an outer flag is not enough on its own: a `--json` that parsed but did
+nothing would hand human text to a caller that asked for JSON — worse than the loud
+`No such option` it replaced. So an ancestor's flag is INHERITED by the invoked
+command (`gda.headless._inherit_ancestor_json`), and the tests below pin that
 equivalence, not just the exit code.
 
 The root itself later grew one payload of its own — `--version` (#659) — so the
@@ -27,15 +29,19 @@ import json
 import subprocess
 from importlib.metadata import version
 
+import pytest
+import typer
 from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.commands.meta import read_skill_text
+from gda.headless import adopt_group_json
 from gda.runner import RunResult
 from tests.support import (
     SCENE_GET_RESULT,
     GDA_CMD,
     inject_runner,
+    panel_text,
     plain_text,
     sentinel,
 )
@@ -160,18 +166,129 @@ def test_root_json_reaches_the_params_json_dispatch_path():
     assert json.loads(result.stdout)["name"] == "gda"
 
 
+# --- the GROUP parser site (issue #683) ---------------------------------------
+
+
+def _scene_get(monkeypatch, args: list[str]):
+    """Invoke ``args`` with the runner seam faked, so no Godot is spawned.
+
+    ``scene get`` is the probe for this site because it renders HUMAN text by
+    default: a flag that parsed but did not reach the command would show up here as
+    that text, which is the failure mode acceptance alone would hide.
+    """
+    inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(SCENE_GET_RESULT), stderr="", exit_code=0),
+    )
+    return CliRunner().invoke(app, args)
+
+
+def test_group_json_is_equivalent_to_the_commands_own_json(monkeypatch):
+    # The third parser site: a `--json` between the group and the command used to
+    # die with `No such option`, so the one rule the Skill teaches broke on a line
+    # an agent composes naturally. All three spellings must agree byte for byte.
+    group_spelling = _scene_get(monkeypatch, ["scene", "--json", "get", "/tmp/x.tscn"])
+    command_spelling = _scene_get(
+        monkeypatch, ["scene", "get", "/tmp/x.tscn", "--json"]
+    )
+    root_spelling = _scene_get(monkeypatch, ["--json", "scene", "get", "/tmp/x.tscn"])
+    no_flag = _scene_get(monkeypatch, ["scene", "get", "/tmp/x.tscn"])
+
+    assert group_spelling.exit_code == 0, group_spelling.stdout
+    assert group_spelling.stdout == command_spelling.stdout == root_spelling.stdout
+    assert json.loads(group_spelling.stdout)
+    # …and the default is unchanged: no flag still means human text.
+    assert no_flag.exit_code == 0
+    assert not no_flag.stdout.startswith("{")
+
+
+def test_the_three_spellings_stack_without_conflicting(monkeypatch):
+    # Belt and braces: a client that writes the flag everywhere gets one answer,
+    # not a second output shape to handle.
+    everywhere = _scene_get(
+        monkeypatch, ["--json", "scene", "--json", "get", "/tmp/x.tscn", "--json"]
+    )
+    command_only = _scene_get(monkeypatch, ["scene", "get", "/tmp/x.tscn", "--json"])
+
+    assert everywhere.exit_code == 0, everywhere.stdout
+    assert everywhere.stdout == command_only.stdout
+
+
+def test_group_json_reaches_the_params_json_dispatch_path(monkeypatch):
+    # `--params-json` is intercepted by the command class and dispatched through its
+    # own tail (ADR-0015), which reads `ctx.params` — i.e. after the inherit
+    # callback has run, so a group flag is honored there too.
+    result = _scene_get(
+        monkeypatch,
+        ["scene", "--json", "get", "--params-json", '{"path": "/tmp/x.tscn"}'],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert json.loads(result.stdout)["path"]
+
+
+def test_group_json_without_a_command_is_still_a_usage_error():
+    # Acceptance moved the failure to the honest one; it did not invent a payload.
+    # `gda <group> --json` says what a bare `gda --json` says, at the same exit code.
+    result = CliRunner().invoke(app, ["scene", "--json"])
+    bare_root = CliRunner().invoke(app, ["--json"])
+
+    assert result.exit_code == 2
+    assert bare_root.exit_code == 2
+    assert "Missing command." in panel_text(result.stderr)
+    assert "Missing command." in panel_text(bare_root.stderr)
+
+
+def test_every_group_advertises_the_json_option_in_its_help():
+    # The option is installed onto every MOUNTED group at composition
+    # (`gda.headless.adopt_group_json`), so the check walks the live tree rather than
+    # naming the groups: one added later is covered by being mounted. A group is the
+    # node with a `commands` mapping — the duck-type `gda.surface` walks with too.
+    root: object = typer.main.get_command(app)
+    groups = [
+        name
+        for name, command in getattr(root, "commands", {}).items()
+        if getattr(command, "commands", None) is not None
+    ]
+
+    assert groups, "the live tree reported no command groups"
+    for name in groups:
+        rendered = CliRunner().invoke(app, [name, "--help"])
+
+        assert rendered.exit_code == 0, rendered.stdout
+        assert "--json" in plain_text(rendered.stdout), name
+
+
+def test_the_walker_refuses_to_replace_a_groups_own_callback():
+    # Installing the option means installing the callback that carries it. No group
+    # declares one today; one that grows a callback must declare the shared option
+    # on it, so the walker says so instead of dropping that callback silently.
+    root = typer.Typer()
+    group = typer.Typer()
+
+    @group.callback()
+    def _own(ctx: typer.Context) -> None:
+        """A group with business of its own."""
+
+    root.add_typer(group, name="own")
+
+    with pytest.raises(RuntimeError, match="own"):
+        adopt_group_json(root)
+
+
 # --- the shipped guidance states the same contract ----------------------------
 
 
 def test_skill_documents_the_json_placement_contract():
     # The Skill is the guidance an agent actually reads, so the placement rule has
     # to ship WITH the behavior, not only in a PR description. Token-level checks:
-    # the two equivalent spellings are named, and so are the two that still exit 2
-    # (a group's bare parser and a root flag with no command). Prose is free to be
-    # reworded; these tokens are the contract.
+    # the three equivalent spellings are named, and so are the two that still exit 2
+    # (either flavour of "the flag, but no command"). Prose is free to be reworded;
+    # these tokens are the contract.
     text = read_skill_text()
 
     assert "`gda --json <group> <command>`" in text
+    assert "`gda <group> --json <command>`" in text
     assert "`gda <group> <command> --json`" in text
     assert "`gda schema --json`" in text
     assert "`gda --json --help`" in text
@@ -212,8 +329,8 @@ def test_root_version_without_the_flag_stays_text():
 # --- the real out-of-process CLI ---------------------------------------------
 
 
-def test_real_out_of_process_cli_accepts_json_at_both_sites():
-    # Both fixes through a REAL process (`python -m gda`, the same `app` the
+def test_real_out_of_process_cli_accepts_json_at_every_site():
+    # Every fix through a REAL process (`python -m gda`, the same `app` the
     # console script wraps), not only the in-process CliRunner. Deliberately not
     # marked `e2e`: this repo's `e2e` marker means "spawns a real Godot process",
     # and nothing here does.
@@ -236,3 +353,12 @@ def test_real_out_of_process_cli_accepts_json_at_both_sites():
     )
     assert inherited.returncode == 0, inherited.stderr
     assert json.loads(inherited.stdout)["name"] == "gda"
+
+    # The group site needs a command that spawns nothing: `--schema` answers from
+    # the command's own models, so it proves the flag PARSED between the group and
+    # the command without reaching for an engine.
+    on_a_group = subprocess.run(
+        [*GDA_CMD, "scene", "--json", "get", "--schema"], capture_output=True, text=True
+    )
+    assert on_a_group.returncode == 0, on_a_group.stderr
+    assert set(json.loads(on_a_group.stdout)) >= {"input", "output", "error"}

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -1,13 +1,19 @@
 """The headless-launch primitive maps subprocess failures to a RunResult (#185).
 
 ``launch`` is the single home of the spawn / timeout / ``OSError`` / UTF-8-decode
-handling that both Phase-1 channels (the sentinel op runner and the native-export
-runner) delegate to. A hung or missing engine must not surface as a raw Python
-traceback; it is turned into a synthesized non-zero-exit :class:`RunResult` with a
-typed ``launch_failure`` and a diagnostic on stderr — the launch-handling contract
-that used to be written (and tested) twice, now exercised once here. The
-channel-specific argv tail / export-only cwd stay tested in each runner's own
-suite.
+handling that every Phase-1 channel (the sentinel op runner, the native-export
+runner, the ``resource import`` pass, ``script run`` and ``scene preflight``)
+delegates to. A hung or missing engine must not surface as a raw Python traceback;
+it is turned into a synthesized non-zero-exit :class:`RunResult` with a typed
+``launch_failure`` — the launch-handling contract that used to be written (and
+tested) twice, now exercised once here. The channel-specific argv tail /
+export-only cwd stay tested in each runner's own suite.
+
+Since #714 there is ONE capture strategy: every launch streams. These tests drive
+REAL child processes — a small stand-in script in place of the engine — rather
+than a fake ``Popen``, because what the capture is about is what real pipes and a
+real process lifetime do. (``tests.support.RecordingSpawn`` exists for the suites
+whose subject is the SPAWN SHAPE rather than the capture.)
 """
 
 import shlex
@@ -21,7 +27,7 @@ import pytest
 
 from gda import runner
 from gda.exit_codes import EXIT_NOT_FOUND, EXIT_TIMEOUT
-from gda.runner import LaunchFailure, launch
+from gda.runner import LaunchFailure, TimeoutBound, launch
 
 
 def test_missing_binary_maps_to_not_found_not_traceback():
@@ -62,174 +68,11 @@ def test_non_executable_file_binary_maps_to_not_found_not_traceback(tmp_path):
     assert result.launch_failure is LaunchFailure.NOT_FOUND
 
 
-def test_timeout_maps_to_synthesized_timeout_result(monkeypatch):
-    def fake_run(*args, **kwargs):
-        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-
-    result = launch(Path("/any/Godot"), ["--version"], cwd=None, timeout=0.01)
-
-    assert result.exit_code == EXIT_TIMEOUT
-    # Default label is "Godot": the sentinel channel keeps its exact pre-#185
-    # timeout diagnostic wording.
-    assert result.stderr == "gda: Godot timed out after 0.01s\n"
-    assert result.launch_failure is LaunchFailure.TIMEOUT
-
-
-def test_timeout_label_customizes_the_diagnostic(monkeypatch):
-    # The export channel passes a distinct label so its timeout diagnostic stays
-    # byte-compatible with the pre-#185 "Godot export timed out" wording — the
-    # stderr the classifier carries into the public GdaError.diagnostics (#185).
-    def fake_run(*args, **kwargs):
-        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-
-    result = launch(
-        Path("/any/Godot"),
-        ["--export-release", "Web", "out"],
-        cwd=None,
-        timeout=600.0,
-        timeout_label="Godot export",
-    )
-
-    assert result.exit_code == EXIT_TIMEOUT
-    assert result.stderr == "gda: Godot export timed out after 600.0s\n"
-    assert result.launch_failure is LaunchFailure.TIMEOUT
-
-
-def test_timeout_is_passed_through_to_subprocess(monkeypatch):
-    captured = {}
-
-    def fake_run(cmd, **kwargs):
-        captured["timeout"] = kwargs.get("timeout")
-
-        class _Proc:
-            # The primitive captures bytes (no text=True) and decodes UTF-8
-            # itself, so the double mirrors that real subprocess contract (#33).
-            stdout = b""
-            stderr = b""
-            returncode = 0
-
-        return _Proc()
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-
-    result = launch(Path("/any/Godot"), ["--version"], cwd=None, timeout=42.0)
-
-    assert captured["timeout"] == 42.0
-    # An engine that actually returned has no synthesized launch failure, so its
-    # exit code is classified as the engine's own result (#15).
-    assert result.launch_failure is None
-
-
-def test_builds_headless_argv_from_binary_and_tail(monkeypatch):
-    captured = {}
-
-    def fake_run(cmd, **kwargs):
-        captured["cmd"] = cmd
-
-        class _Proc:
-            stdout = b""
-            stderr = b""
-            returncode = 0
-
-        return _Proc()
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-
-    launch(Path("/x/Godot"), ["--path", "/p", "--version"], cwd=None, timeout=60.0)
-
-    # The primitive always prepends `[binary, --headless, --log-file <gda path>]`
-    # to the caller's tail: gda owns the engine log target on every launch (#653).
-    assert captured["cmd"][:3] == ["/x/Godot", "--headless", "--log-file"]
-    assert captured["cmd"][4:] == ["--path", "/p", "--version"]
-
-
-def test_engine_output_is_decoded_as_utf8_regardless_of_host_locale(monkeypatch):
-    # Godot's JSON.stringify emits raw UTF-8, but subprocess(text=True) would
-    # decode with the host locale. On a non-UTF-8 locale a non-ASCII node name
-    # mojibakes or raises UnicodeDecodeError. The primitive must capture bytes and
-    # decode UTF-8 explicitly so user content round-trips (#33). We prove this by
-    # returning raw UTF-8 *bytes* from subprocess (the bytes mode the fix uses).
-    payload = '<<<GDA:RESULT>>>{"name":"日本語"}<<<GDA:END>>>'
-    stdout_bytes = payload.encode("utf-8")
-    stderr_bytes = "警告: ノード名\n".encode("utf-8")
-
-    def fake_run(cmd, **kwargs):
-        # The fix drops text=True and captures bytes; assert that contract here
-        # so the test fails loudly if decoding silently reverts to locale text.
-        assert kwargs.get("text") in (None, False)
-
-        class _Proc:
-            stdout = stdout_bytes
-            stderr = stderr_bytes
-            returncode = 0
-
-        return _Proc()
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-
-    result = launch(Path("/any/Godot"), ["--version"], cwd=None, timeout=60.0)
-
-    assert "日本語" in result.stdout
-    assert "警告: ノード名" in result.stderr
-
-
-def test_cwd_is_passed_through_to_subprocess_as_a_string(monkeypatch, tmp_path):
-    # The export channel relies on cwd to resolve a relative output path; the
-    # primitive must forward it (as a string, the historical spawn shape).
-    captured = {}
-
-    def fake_run(cmd, **kwargs):
-        captured["cwd"] = kwargs.get("cwd")
-
-        class _Proc:
-            stdout = b""
-            stderr = b""
-            returncode = 0
-
-        return _Proc()
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-
-    launch(Path("/x/Godot"), ["--version"], cwd=tmp_path, timeout=60.0)
-
-    assert captured["cwd"] == str(tmp_path)
-
-
-def test_cwd_none_passes_no_working_directory(monkeypatch):
-    captured = {}
-
-    def fake_run(cmd, **kwargs):
-        captured["cwd"] = kwargs.get("cwd")
-
-        class _Proc:
-            stdout = b""
-            stderr = b""
-            returncode = 0
-
-        return _Proc()
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-
-    launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
-
-    assert captured["cwd"] is None
-
-
-# --- The STREAMING capture path (#655). Selected by passing a ``watch``; without one
-# the BUFFERED behaviour asserted above is unchanged, which the
-# ``test_the_buffered_path_still_*`` guard below pins for the sentinel and export
-# channels that rely on it.
-#
-# These drive a REAL child process — a small shebang script standing in for the
-# engine — rather than a fake ``Popen``. The whole point of the streaming path is
-# what real pipes and a real process lifetime do (a buffered capture threw away the
-# output that a real Godot had already written), so faking the spawn would only
-# assert the fake. The stand-in ignores the ``--headless --log-file <path>`` head
-# that ``launch`` injects, exactly as it ignores every other argv tail.
+# The stand-in engines every test below drives. A REAL child process, not a fake
+# ``Popen``: what the capture is about is what real pipes and a real process
+# lifetime do, so faking the spawn would only assert the fake. Both ignore the
+# ``--headless --log-file <path>`` head that ``launch`` injects, exactly as they
+# ignore every other argv tail.
 
 
 def _fake_engine(tmp_path: Path, body: str) -> Path:
@@ -251,15 +94,14 @@ def _fast_fake_engine(tmp_path: Path, stdout_line: str, stderr_line: str) -> Pat
     """A ``/bin/sh`` stand-in, kept for WALL-CLOCK SPEED, not correctness (#728).
 
     Diverges from ``_fake_engine`` on purpose: that one pays a fresh Python
-    interpreter's startup before it writes a byte. The one test that uses this
-    (``test_streaming_timeout_preserves_the_output_the_child_already_wrote``)
-    used to race that startup against a real deadline; that race is gone —
-    the test now controls the runner's clock directly, so a slower child could
-    no longer flip the result. ``/bin/sh`` stays anyway: the test still waits,
-    in real wall-clock time, for this REAL child to actually write its output
-    before the (now fake) deadline is allowed to cross, and a cheap shell keeps
-    that wait — and the suite — fast rather than paying a Python interpreter's
-    startup for no reason.
+    interpreter's startup before it writes a byte, which every test that races a
+    REAL deadline against the child's first output would then be racing too —
+    flaky on a loaded machine, at a ceiling short enough to keep the suite fast.
+    A cheap shell writes in milliseconds, so those tests get a wide margin without
+    a long ceiling. (``test_streaming_timeout_preserves_the_output_the_child_already_wrote``
+    additionally controls the runner's clock, and keeps this stand-in because it
+    still waits in real time for the child to write before letting the fake
+    deadline cross.)
 
     ``printf '%s\\n'``, not ``echo``: XSI ``echo`` interprets backslash
     escapes in its operand on this platform's ``/bin/sh``, so a payload
@@ -282,6 +124,114 @@ def _fast_fake_engine(tmp_path: Path, stdout_line: str, stderr_line: str) -> Pat
     )
     script.chmod(0o755)
     return script
+
+
+def test_timeout_synthesizes_a_result_that_keeps_what_the_run_produced(tmp_path):
+    # The bound gda puts on a hung engine, and the evidence it comes back with. The
+    # run below writes to both streams and then never returns; `launch` ends it at
+    # the ceiling and reports what it had already read — the whole of #714, which
+    # replaced a capture that discarded exactly this.
+    engine = _fast_fake_engine(tmp_path, "BOOTED", "wedged")
+
+    result = launch(engine, ["--version"], cwd=None, timeout=1.0)
+
+    assert result.exit_code == EXIT_TIMEOUT
+    assert result.launch_failure is LaunchFailure.TIMEOUT
+    assert result.stdout == "BOOTED\n"
+    assert result.stderr == "wedged\n"
+    # No gda prose in either stream: the classifier composes the sentence from the
+    # bound below, so mixing one in would corrupt the evidence.
+    assert "timed out" not in result.stderr
+    # The caller's own ceiling is what ended it, and the clock says so.
+    assert result.elapsed_seconds is not None
+    assert 1.0 <= result.elapsed_seconds < 3.0
+    # Default label: the sentinel channel's launch is just "Godot".
+    assert result.timeout_bound == TimeoutBound("Godot", 1.0)
+
+
+def test_the_timeout_bound_carries_the_channels_own_label(tmp_path):
+    # The export channel passes a distinct label, and the import pass another. The
+    # label rides the result rather than a synthesized stderr (#714), because the
+    # shared classifier is the only place that renders it and the runner seam hands
+    # that classifier a RunResult and nothing else.
+    engine = _fast_fake_engine(tmp_path, "packing", "")
+
+    result = launch(
+        engine,
+        ["--export-release", "Web", "out"],
+        cwd=None,
+        timeout=1.0,
+        timeout_label="Godot export",
+    )
+
+    assert result.launch_failure is LaunchFailure.TIMEOUT
+    assert result.timeout_bound == TimeoutBound("Godot export", 1.0)
+
+
+def test_builds_headless_argv_from_binary_and_tail(tmp_path):
+    # The stand-in echoes the argv it was handed, so the assertion is on the argv
+    # the OS really received rather than on a recorded call.
+    engine = _fake_engine(tmp_path, "print('\\x00'.join(sys.argv[1:]))\n")
+
+    result = launch(engine, ["--path", "/p", "--version"], cwd=None, timeout=30.0)
+
+    argv = result.stdout.rstrip("\n").split("\x00")
+    # The primitive always prepends `[--headless, --log-file <gda path>]` to the
+    # caller's tail: gda owns the engine log target on every launch (#653).
+    assert argv[:2] == ["--headless", "--log-file"]
+    assert argv[3:] == ["--path", "/p", "--version"]
+
+
+def test_engine_output_is_decoded_as_utf8_regardless_of_host_locale(tmp_path):
+    # Godot's JSON.stringify emits raw UTF-8, but decoding with the host locale
+    # would mojibake or raise UnicodeDecodeError on a non-UTF-8 locale for a
+    # non-ASCII node name or echoed path. The primitive captures BYTES and decodes
+    # UTF-8 explicitly, so user content round-trips (#33). The stand-in writes
+    # through the raw buffers so the bytes on the wire are the ones under test.
+    engine = _fake_engine(
+        tmp_path,
+        "sys.stdout.buffer.write("
+        '\'<<<GDA:RESULT>>>{"name":"\\u65e5\\u672c\\u8a9e"}<<<GDA:END>>>\''
+        ".encode('utf-8'))\n"
+        "sys.stderr.buffer.write("
+        "'\\u8b66\\u544a: \\u30ce\\u30fc\\u30c9\\u540d\\n'.encode('utf-8'))\n",
+    )
+
+    result = launch(engine, ["--version"], cwd=None, timeout=30.0)
+
+    assert "日本語" in result.stdout
+    assert "警告: ノード名" in result.stderr
+
+
+def test_cwd_is_passed_through_to_the_child(tmp_path):
+    # The export channel relies on cwd to resolve a relative output path, so the
+    # primitive must forward it — and the child must really start there.
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    engine = _fake_engine(tmp_path, "import os\nprint(os.getcwd())\n")
+
+    result = launch(engine, ["--version"], cwd=workdir, timeout=30.0)
+
+    assert Path(result.stdout.strip()).resolve() == workdir.resolve()
+
+
+def test_cwd_none_leaves_the_child_in_gdas_own_directory(tmp_path):
+    # Projectless launches pass no working directory, so the child simply inherits
+    # gda's — never a directory the primitive invented.
+    engine = _fake_engine(tmp_path, "import os\nprint(os.getcwd())\n")
+
+    result = launch(engine, ["--version"], cwd=None, timeout=30.0)
+
+    assert Path(result.stdout.strip()).resolve() == Path.cwd().resolve()
+
+
+# --- What a POLICY ``watch`` adds on top of the capture every launch gets (#655):
+# it can end a run BEFORE the timeout, and it is fed the output as it arrives. The
+# capture and the clock themselves are asserted above, on the no-watch launches
+# every other channel makes.
+#
+# The stand-in engine ignores the ``--headless --log-file <path>`` head that
+# ``launch`` injects, exactly as it ignores every other argv tail.
 
 
 class _RecordingWatch:
@@ -556,23 +506,25 @@ def test_streaming_maps_a_missing_binary_to_the_same_not_found_result():
     assert streamed.stderr == buffered.stderr
 
 
-def test_the_buffered_path_still_discards_output_and_keeps_its_diagnostic(tmp_path):
-    # The byte-identity guard for the sentinel and export channels (#655): they pass
-    # NO watch, so their timeout result must stay exactly what it was — the output
-    # discarded and the ``gda: <label> timed out after <n>s`` diagnostic standing in
-    # for it, which is published prose in their error envelopes. Moving them onto the
-    # preserving path is named follow-up work, not this change.
-    engine = _fake_engine(
-        tmp_path, "print('written but discarded', flush=True)\ntime.sleep(30)\n"
-    )
+def test_a_watchless_launch_streams_and_never_ends_a_run_early(tmp_path):
+    # The pairing that makes ``watch`` POLICY rather than strategy (#714): a launch
+    # WITHOUT one still captures and still times itself, and the only thing it gives
+    # up is the early abort. Both halves are asserted against the same engine, so a
+    # regression that made the no-watch path buffered again — or one that let it end
+    # a run on its own — fails here.
+    engine = _fast_fake_engine(tmp_path, "written and kept", "and this too")
 
+    started = time.monotonic()
     result = launch(engine, [], cwd=None, timeout=1.0, timeout_label="Godot export")
+    waited = time.monotonic() - started
 
     assert result.launch_failure is LaunchFailure.TIMEOUT
-    assert result.stdout == ""
-    assert result.stderr == "gda: Godot export timed out after 1.0s\n"
-    # And it does not time itself — the clock is the streaming path's addition.
-    assert result.elapsed_seconds is None
+    assert result.stdout == "written and kept\n"
+    assert result.stderr == "and this too\n"
+    assert result.elapsed_seconds is not None
+    assert result.timeout_bound == TimeoutBound("Godot export", 1.0)
+    # It waited out the ceiling rather than ending early on the output it saw.
+    assert waited >= 1.0
 
 
 def _capture_popen(monkeypatch) -> list:

--- a/tests/test_live_contract_guards.py
+++ b/tests/test_live_contract_guards.py
@@ -295,8 +295,9 @@ def live_float_fields(
     A description covers its own field AND its whole subtree, which is what keeps
     the promise off the shared headless models: ``GameGetResult`` states it on
     ``properties``, so the ``NodeProperty.value`` beneath it is covered without
-    ``NodeProperty`` — which ``node get`` / ``resource get`` also use, and where
-    #771 leaves headless fidelity different — making a live-only claim. Coverage
+    ``NodeProperty`` — which ``node get`` / ``resource get`` also use, and which
+    must not inherit a sentence about the live WIRE (#771) — making a live-only
+    claim. Coverage
     is collected as a SET rather than a boolean because the caller checks it
     against the field's measured writer: a parent that blankets a mixed subtree
     with one writer's sentence is then a failure, not a pass.
@@ -766,10 +767,13 @@ def test_only_the_replies_that_carry_a_gda_number_publish_the_derived_contract(
 
 
 def test_the_headless_property_shape_makes_no_live_precision_promise():
-    # The shared NodeProperty description serves `node get` / `resource get` too,
-    # where #771 leaves the default writer in place. A live-only guarantee stated
-    # there would be false for those reads — so the live commands publish it on
-    # their OWN fields, and the subtree rule above is what lets them.
+    # The shared NodeProperty description serves `node get` / `resource get` too.
+    # Since #771 those reads carry the same full binary64 precision, but not over
+    # the same LEG: both published sentences speak about the live wire (one about
+    # the writer that frames what crosses it, one about a number that never meets
+    # it), and neither is true of a headless read as WORDED. So the live commands
+    # keep publishing them on their OWN fields, and the subtree rule above is what
+    # lets them; `gda.live_numbers` records why no headless twin was authored.
     from gda.models import NodeProperty
 
     schema = json.dumps(NodeProperty.model_json_schema(), ensure_ascii=False)

--- a/tests/test_perf_commands.py
+++ b/tests/test_perf_commands.py
@@ -21,6 +21,7 @@ from tests.support import (
     PERF_MONITOR_SIGNAL_RESULT,
     PERF_MONITORS_RESULT,
     PERF_SAMPLE_REPLY,
+    assert_no_pydantic_dump,
     error_sentinel,
     inject_live_runner,
     perf_sample_reply_all_monitors,
@@ -722,6 +723,67 @@ def test_perf_monitors_window_budget_file_problems_are_invalid_params(
         # Each case must fail for ITS OWN reason — this is what the aliased
         # single-file table could not prove (#735 recheck 2).
         assert fragment in error["message"], (name, error["message"])
+    assert fake.calls == []
+
+
+def test_perf_monitors_window_budget_entry_refusal_leaks_no_pydantic_dump(
+    monkeypatch, tmp_path
+):
+    # A broken budget ENTRY is refused by the `PerfBudget` model, and the
+    # loader used to interpolate the raw `ValidationError` (#759): the message
+    # an agent reads carried the model class name, a `[type=...,
+    # input_value=..., input_type=...]` tag echoing the caller's own budget-file
+    # content, embedded newlines, and a `pydantic.dev` URL. It now goes through
+    # the SAME shared renderer the argv and --params-json channels use
+    # (`gda.errors.validation_error_message`, #713/#754), so one
+    # `invalid_params` code speaks one language on every surface.
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(PERF_SAMPLE_REPLY), stderr="", exit_code=0),
+    )
+    # A distinctive bound value: only pydantic's own dump echoes a rejected
+    # input back, so finding it in the message proves the leak directly.
+    secret = "NOT-A-NUMBER-4d9f21"
+    cases = [
+        # A built-in check (strict float) — the message is pydantic's own `msg`.
+        (
+            "leak-builtin.json",
+            '{"fps": {"stat": "p50", "min": "%s"}}' % secret,
+            "min: Input should be a valid number",
+        ),
+        # A field-scoped enum check — the field path survives the rendering.
+        (
+            "leak-enum.json",
+            '{"fps": {"stat": "%s", "min": 60}}' % secret,
+            "stat: Input should be",
+        ),
+        # A model-level validator's own ValueError — unprefixed, untagged.
+        (
+            "leak-validator.json",
+            '{"fps": {"stat": "p50"}}',
+            "a budget entry needs 'min' and/or 'max'.",
+        ),
+    ]
+    for name, content, sentence in cases:
+        budget = _budget_file(tmp_path, name, content)
+        result = _window(tmp_path, "--frames", "5", "--budget", str(budget))
+
+        error = json.loads(result.stdout)["error"]
+        assert error["code"] == "invalid_params", (name, result.stdout)
+        assert_no_pydantic_dump(error["message"])
+        # The dump's other two tells: the model class name, and the newlines it
+        # embeds to lay one error out over three lines.
+        assert "PerfBudget" not in error["message"], (name, error["message"])
+        assert "\n" not in error["message"], (name, error["message"])
+        # The caller's own budget-file content is not echoed back...
+        assert secret not in error["message"], (name, error["message"])
+        # ...while the entry NAME — bounded by PERF_MONITOR_NAMES, and what the
+        # caller must fix — and the check's own sentence both survive.
+        assert error["message"].startswith("budget entry 'fps' is invalid: "), (
+            name,
+            error["message"],
+        )
+        assert sentence in error["message"], (name, error["message"])
     assert fake.calls == []
 
 

--- a/tests/test_project_walk.py
+++ b/tests/test_project_walk.py
@@ -1,0 +1,134 @@
+"""The ``res://`` walk contract: one traversal, four collectors (#764).
+
+``operations.gd`` walks the project's ``res://`` tree for four purposes —
+``scene list``, ``script list``, the extension-filtered static-analysis scan,
+and the unfiltered count behind ``project statistics``. The ``DirAccess``
+scaffolding around that walk used to be copied once per purpose, and the copies
+drifted twice: first on the directory-exclusion decision (#712), then on the
+file-acceptance test, where the scene walk alone compared the extension
+case-sensitively.
+
+These are the source-level guards for the consolidation. The BEHAVIOUR they
+protect — the case rule and the two surviving file universes — is pinned against
+a real engine in ``test_e2e_project_walk.py``.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+OPERATIONS_GD = ROOT / "src" / "gda" / "ops" / "operations.gd"
+
+# The four collectors, each of which must be a single delegation to the traversal.
+COLLECTORS = (
+    "_collect_resource_paths",
+    "_collect_all_file_paths",
+    "_collect_scene_paths",
+    "_collect_script_paths",
+)
+
+# The traversal they share, and the DirAccess call only it may make.
+TRAVERSAL = "_collect_paths"
+LISTING_CALL = "list_dir_begin()"
+
+# The section note that documents the two static scans over the one traversal.
+SECTION_HEADER = "# --- project static-analysis reads (issue #116) ---"
+
+# A gda helper named in prose: a ``_``-prefixed identifier that is not the tail of
+# a longer word, so ``ext_resource`` does not read as a mention of ``_resource``.
+HELPER_MENTION = re.compile(r"(?<![A-Za-z0-9_])_[a-z][A-Za-z0-9_]*")
+
+
+def _source() -> str:
+    return OPERATIONS_GD.read_text(encoding="utf-8")
+
+
+def _function_body(source: str, name: str) -> list[str]:
+    """The statement lines of top-level ``func name(...)`` — comments dropped."""
+    lines = source.splitlines()
+    start = next(
+        (i for i, line in enumerate(lines) if line.startswith(f"func {name}(")), None
+    )
+    assert start is not None, f"expected function {name} in operations.gd"
+    body: list[str] = []
+    for line in lines[start + 1 :]:
+        if line and not line.startswith(("\t", " ")):
+            break  # back at column 0: the function ended
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            body.append(stripped)
+    return body
+
+
+def _comment_block(source: str, header: str) -> list[str]:
+    """The run of comment lines starting at the line that opens with ``header``."""
+    lines = source.splitlines()
+    start = next((i for i, line in enumerate(lines) if line.startswith(header)), None)
+    assert start is not None, f"expected the comment block opening with {header!r}"
+    block: list[str] = []
+    for line in lines[start:]:
+        if not line.startswith("#"):
+            break
+        block.append(line)
+    return block
+
+
+def test_the_four_res_collectors_share_one_traversal():
+    # AC1 (#764): ONE traversal implementation. The DirAccess scaffolding exists
+    # exactly once in the payload, inside the shared walker; each collector is a
+    # single delegation to it and differs only in the acceptance test it passes.
+    source = _source()
+
+    copies = source.count(LISTING_CALL)
+    assert copies == 1, (
+        f"the res:// listing scaffolding must live only in {TRAVERSAL}; "
+        f"found {copies} copies of {LISTING_CALL}"
+    )
+    assert LISTING_CALL in "\n".join(_function_body(source, TRAVERSAL)), (
+        f"{TRAVERSAL} must be the function that holds the listing scaffolding"
+    )
+
+    accepts: dict[str, str] = {}
+    for name in COLLECTORS:
+        body = _function_body(source, name)
+        assert len(body) == 1, f"{name} must be one delegating line, got {body}"
+        call = re.fullmatch(
+            rf"{TRAVERSAL}\(\w+, (?P<accept>_[A-Za-z0-9_]+), \w+\)", body[0]
+        )
+        assert call, f"{name} must delegate to {TRAVERSAL}, got {body[0]!r}"
+        accepts[name] = call.group("accept")
+
+    # The acceptance test is the one thing they vary — four distinct predicates,
+    # each a function this file defines.
+    assert len(set(accepts.values())) == len(COLLECTORS), (
+        f"each collector must pass its own acceptance test, got {accepts}"
+    )
+    for name, accept in accepts.items():
+        assert f"func {accept}(" in source, f"{name} passes undefined {accept}"
+
+
+def test_the_static_analysis_note_names_only_helpers_that_exist():
+    # AC5 (#764): the section note used to claim a SINGLE static project scan
+    # performed by a helper named `_scan_project` — a function this file has
+    # never defined. It now describes the two scans and the traversal they share,
+    # and every gda helper it names must be a function that actually exists, so
+    # the correction cannot rot back into a phantom.
+    source = _source()
+    defined = set(re.findall(r"^func (_[A-Za-z0-9_]+)\(", source, re.MULTILINE))
+
+    assert "_scan_project" not in source, (
+        "operations.gd names _scan_project, which no function defines"
+    )
+
+    note = _comment_block(source, SECTION_HEADER)
+    mentioned = {token for line in note for token in HELPER_MENTION.findall(line)}
+    assert mentioned, "the section note must name the helpers it describes"
+    undefined = sorted(mentioned - defined)
+    assert not undefined, f"the section note names undefined helpers: {undefined}"
+
+    # The corrected fact itself: two scans over different universes, one traversal.
+    assert {
+        "_collect_resource_paths",
+        "_collect_all_file_paths",
+        TRAVERSAL,
+    } <= mentioned

--- a/tests/test_resource_import_commands.py
+++ b/tests/test_resource_import_commands.py
@@ -17,7 +17,7 @@ import pytest
 from typer.testing import CliRunner
 
 from gda.cli import app
-from gda.runner import LaunchFailure, RunResult
+from gda.runner import LaunchFailure, RunResult, TimeoutBound
 
 runner_cli = CliRunner()
 
@@ -269,15 +269,41 @@ def test_launch_failures_classify_through_the_shared_prefix(monkeypatch, tmp_pat
 
     def timed_out(binary, args, *, cwd, timeout, timeout_label="Godot", watch=None):
         return RunResult(
-            stdout="",
+            stdout="[  30% ] importing res://icon.png\n",
             stderr="took too long",
             exit_code=124,
             launch_failure=LaunchFailure.TIMEOUT,
+            elapsed_seconds=timeout + 0.2,
+            timeout_bound=TimeoutBound(timeout_label, timeout),
         )
 
     monkeypatch.setattr("gda.commands.resource.launch", timed_out)
     timed = json.loads(_run(project, "res://icon.png").stdout)
     assert timed["error"]["code"] == "launch_timeout"
+    # The THIRD buffered channel, on the shared branch with the other two (#714):
+    # its label, its ceiling and its own captured output, none of it forked here.
+    assert timed["error"]["message"].startswith("Godot import launched but did not")
+    assert "importing res://icon.png" in timed["error"]["diagnostics"]
+    assert "took too long" in timed["error"]["diagnostics"]
+
+
+def test_the_import_pass_declares_its_own_timeout_label(monkeypatch, tmp_path):
+    # The label is this channel's one contribution to the shared timeout envelope,
+    # and it is what tells an agent WHICH launch gave up when three of them report
+    # the same code. Pinned at the call site, because nothing else would notice it
+    # silently reverting to the sentinel channel's bare "Godot".
+    project = _project(tmp_path)
+    seen: dict[str, object] = {}
+
+    def recording(binary, args, *, cwd, timeout, timeout_label="Godot", watch=None):
+        seen["label"] = timeout_label
+        seen["timeout"] = timeout
+        return RunResult(stdout="", stderr="", exit_code=0)
+
+    monkeypatch.setattr("gda.commands.resource.launch", recording)
+    _run(project, "res://icon.png", "--timeout", "7")
+
+    assert seen == {"label": "Godot import", "timeout": 7.0}
 
     def engine_failed(binary, args, *, cwd, timeout, timeout_label="Godot", watch=None):
         return RunResult(stdout="", stderr="importer exploded", exit_code=1)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -14,35 +14,15 @@ from pathlib import Path
 
 from gda.exit_codes import EXIT_NOT_FOUND
 from gda.runner import OPERATIONS_GD, LaunchFailure, SubprocessGodotRunner
-
-
-class _RecordingRun:
-    """A ``subprocess.run`` double recording the call and returning a clean exit."""
-
-    def __init__(self) -> None:
-        self.cmd: list[str] | None = None
-        self.kwargs: dict | None = None
-
-    def __call__(self, cmd, **kwargs):
-        self.cmd = cmd
-        self.kwargs = kwargs
-
-        class _Proc:
-            # The primitive captures bytes (no text=True) and decodes UTF-8
-            # itself, so the double mirrors that real subprocess contract (#33).
-            stdout = b"<<<GDA:RESULT>>>{}<<<GDA:END>>>"
-            stderr = b""
-            returncode = 0
-
-        return _Proc()
+from tests.support import RecordingSpawn
 
 
 def test_projectless_run_builds_the_script_dispatch_tail(monkeypatch):
     # A projectless op spawns `--headless --script operations.gd -- <op> <json>`
     # with no --path and no working directory: everything after `--` reaches the
     # script verbatim via OS.get_cmdline_user_args().
-    rec = _RecordingRun()
-    monkeypatch.setattr(subprocess, "run", rec)
+    rec = RecordingSpawn("<<<GDA:RESULT>>>{}<<<GDA:END>>>")
+    monkeypatch.setattr(subprocess, "Popen", rec)
     runner = SubprocessGodotRunner(Path("/x/Godot"))
 
     runner.run("info", {"a": 1})
@@ -67,8 +47,8 @@ def test_projectless_run_builds_the_script_dispatch_tail(monkeypatch):
 def test_run_against_a_project_passes_path(monkeypatch):
     # When a project is resolved it is passed as --path so the engine runs against
     # it and res:// resolves there (#32); --path precedes the --script tail.
-    rec = _RecordingRun()
-    monkeypatch.setattr(subprocess, "run", rec)
+    rec = RecordingSpawn("<<<GDA:RESULT>>>{}<<<GDA:END>>>")
+    monkeypatch.setattr(subprocess, "Popen", rec)
     project = Path("/tmp/proj")
     runner = SubprocessGodotRunner(Path("/x/Godot"), project=project)
 

--- a/tests/test_scene_preflight_commands.py
+++ b/tests/test_scene_preflight_commands.py
@@ -67,15 +67,14 @@ def test_a_clean_start_is_ready_and_started(monkeypatch, tmp_path):
         "project_root": str(project.resolve()),
     }
     # The sentinel op was dispatched through the shared argv spelling, under the
-    # resolved project, with a watch (which is what selects the streaming capture).
-    (_binary, args, cwd, timeout, _label, watch) = calls[0]
+    # resolved project.
+    (_binary, args, cwd, timeout, _label, _watch) = calls[0]
     assert args[:2] == ["--path", str(project)]
     assert args[2] == "--script"
     assert args[4:6] == ["--", "scene-preflight"]
     assert json.loads(args[6])["path"] == "res://main.tscn"
     assert cwd is None
     assert timeout == pytest.approx(30.0)
-    assert watch is not None
 
 
 def test_a_script_error_during_startup_is_reported_though_the_scene_reached_ready(
@@ -358,23 +357,28 @@ def test_a_timeout_outranks_a_sentinel_that_arrived_before_it(monkeypatch, tmp_p
     assert json.loads(result.stdout)["status"] == "timeout"
 
 
-def test_the_watch_never_ends_a_run_which_is_what_keeps_aborted_unreachable():
-    # gda.runner documents that a watching channel must classify LaunchFailure.ABORTED
-    # itself, because the shared prefix has no honest code for "the caller's own
-    # declared condition fired". This channel declares no such condition — it takes a
-    # watch ONLY to select the streaming capture — so ABORTED is unreachable here.
-    # That invariant lives in one method, and this is what pins it: a policy added to
-    # `observe` later fails this test rather than silently degrading an abort into a
-    # contract_violation.
-    from gda.commands.scene import _CaptureOnlyWatch
+def test_this_channel_declares_no_watch_which_is_what_keeps_aborted_unreachable(
+    monkeypatch, tmp_path
+):
+    # gda.runner documents that a WATCHING channel must classify
+    # LaunchFailure.ABORTED itself, because the shared prefix has no honest code for
+    # "the caller's own declared condition fired". This channel declares no such
+    # condition — a scene that prints an error is very often still coming up, and
+    # nobody declares what a booting scene finishing looks like — so it passes no
+    # watch, and ABORTED is unreachable here. The invariant is an argument the launch
+    # does NOT get: adding a policy watch later fails this test rather than silently
+    # degrading an abort into a contract_violation.
+    project = _project(tmp_path)
+    calls = _patch_launch(monkeypatch, RunResult(stdout=READY, stderr="", exit_code=0))
 
-    watch = _CaptureOnlyWatch()
-
-    assert (
-        watch.observe(stdout="anything", stderr="ERROR: everything", elapsed=999.0)
-        is False
+    result = CliRunner().invoke(
+        app,
+        ["scene", "preflight", "res://main.tscn", "--project", str(project), "--json"],
     )
-    assert watch.observe(stdout="", stderr="", elapsed=0.0) is False
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    (*_head, watch) = calls[0]
+    assert watch is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_script_run_operation.py
+++ b/tests/test_script_run_operation.py
@@ -48,7 +48,7 @@ from gda.commands.script import (  # the single fully-bound descriptor (ADR-0023
 from gda.errors import (
     SCRIPT_OUTPUT_STDERR_HEADER,
     SCRIPT_OUTPUT_STDOUT_HEADER,
-    SCRIPT_OUTPUT_TAIL_CAP_BYTES,
+    CAPTURED_OUTPUT_TAIL_CAP_BYTES,
     Failure,
 )
 from gda.execution import ExecutionKind
@@ -820,7 +820,7 @@ def test_a_timeout_reflects_the_timeout_elapsed_and_phase_in_the_message():
     assert "elapsed 30.25s" in outcome.error.message
     assert TerminationPhase.OUTPUT_SEEN.value in outcome.error.message
     # The cap is STATED, so a reader knows the output was truncated and by how much.
-    assert str(SCRIPT_OUTPUT_TAIL_CAP_BYTES) in outcome.error.message
+    assert str(CAPTURED_OUTPUT_TAIL_CAP_BYTES) in outcome.error.message
 
 
 def test_a_timeout_carries_the_captured_partial_output_as_diagnostics():
@@ -869,8 +869,8 @@ def test_a_timeout_truncates_each_stream_to_the_stated_tail():
     assert isinstance(outcome, Failure)
     diagnostics = outcome.error.diagnostics
     assert "LAST LINE" in diagnostics
-    assert diagnostics.count("x") == SCRIPT_OUTPUT_TAIL_CAP_BYTES - len("LAST LINE\n")
-    assert diagnostics.count("y") == SCRIPT_OUTPUT_TAIL_CAP_BYTES
+    assert diagnostics.count("x") == CAPTURED_OUTPUT_TAIL_CAP_BYTES - len("LAST LINE\n")
+    assert diagnostics.count("y") == CAPTURED_OUTPUT_TAIL_CAP_BYTES
 
 
 def test_an_aborted_run_is_the_registered_early_termination_verdict():
@@ -1309,11 +1309,11 @@ def test_the_output_cap_bounds_utf8_BYTES_not_characters():
     # lands mid-character: the leading partial byte is DROPPED rather than becoming a
     # replacement character, since the truncation is gda's own and inventing a U+FFFD
     # would misreport the engine's output as malformed.
-    per_stream = SCRIPT_OUTPUT_TAIL_CAP_BYTES // len("界".encode())
+    per_stream = CAPTURED_OUTPUT_TAIL_CAP_BYTES // len("界".encode())
     assert diagnostics.count("界") == per_stream * 2
     assert "�" not in diagnostics
     # And the payload really is bounded in the unit the message names.
-    assert len(diagnostics.encode("utf-8")) <= 2 * SCRIPT_OUTPUT_TAIL_CAP_BYTES + 512
+    assert len(diagnostics.encode("utf-8")) <= 2 * CAPTURED_OUTPUT_TAIL_CAP_BYTES + 512
     assert "UTF-8 bytes (16 KiB)" in outcome.error.message
 
 

--- a/tests/test_unknown_invocation.py
+++ b/tests/test_unknown_invocation.py
@@ -143,18 +143,6 @@ def test_script_run_script_option_points_at_the_positional_form():
     assert error["hint"] == "gda script run <path>"
 
 
-def test_a_groups_json_flag_points_at_the_command_that_takes_it():
-    # The one refusal keyed on the tree SHAPE rather than on a spelling: a group's own
-    # parser takes only `--help`, so `gda <group> --json` is rejected there — the
-    # spelling the Skill already documents as a usage error. Keyed on shape, so every
-    # group (and any group added later) is covered without a row each.
-    result = CliRunner().invoke(app, ["scene", "--json"])
-
-    error = _envelope(result)
-    assert error["code"] == UNKNOWN_OPTION
-    assert error["hint"] == "gda scene <command> --json"
-
-
 # --- the table is the single authority, and it stays honest -------------------
 
 

--- a/tests/test_user_data_placement.py
+++ b/tests/test_user_data_placement.py
@@ -35,7 +35,7 @@ from gda.runner import (
     set_user_data_root,
     user_data_placement,
 )
-from tests.support import VERSION_INFO, sentinel
+from tests.support import VERSION_INFO, RecordingSpawn, sentinel
 
 
 @pytest.fixture(autouse=True)
@@ -44,32 +44,6 @@ def _no_root_override():
     set_user_data_root(None)
     yield
     set_user_data_root(None)
-
-
-class _RecordingRun:
-    """A ``subprocess.run`` double recording the call and returning a clean exit.
-
-    ``payload`` is the raw stdout the fake engine writes; the CLI-seam tests pass a
-    real ADR-0002 sentinel so the command SUCCEEDS, and the argv assertion is then
-    made on a working invocation rather than on one that happened to fail late.
-    """
-
-    def __init__(self, payload: str = "") -> None:
-        self.cmd: list[str] | None = None
-        self.kwargs: dict | None = None
-        self._payload = payload.encode()
-
-    def __call__(self, cmd, **kwargs):
-        self.cmd = cmd
-        self.kwargs = kwargs
-        payload = self._payload
-
-        class _Proc:
-            stdout = payload
-            stderr = b""
-            returncode = 0
-
-        return _Proc()
 
 
 def _log_file_arg(cmd: list[str]) -> Path:
@@ -103,21 +77,17 @@ def test_default_launch_redirects_the_log_to_a_gda_owned_file(monkeypatch):
     # hands it a target it has already created.
     seen: dict[str, object] = {}
 
-    def fake_run(cmd, **kwargs):
-        log_file = _log_file_arg(cmd)
-        # Created BEFORE the spawn — that creation is the preflight, and it is what
-        # guarantees the engine's own FileAccess open cannot fail.
-        seen["name"] = log_file.name
-        seen["existed"] = log_file.exists()
+    class _Inspecting(RecordingSpawn):
+        def __call__(self, cmd, **kwargs):
+            log_file = _log_file_arg(cmd)
+            # Read DURING the spawn: the target is created BEFORE it — that creation
+            # is the preflight, and it is what guarantees the engine's own FileAccess
+            # open cannot fail.
+            seen["name"] = log_file.name
+            seen["existed"] = log_file.exists()
+            return super().__call__(cmd, **kwargs)
 
-        class _Proc:
-            stdout = b""
-            stderr = b""
-            returncode = 0
-
-        return _Proc()
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(subprocess, "Popen", _Inspecting())
 
     launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
 
@@ -127,8 +97,8 @@ def test_default_launch_redirects_the_log_to_a_gda_owned_file(monkeypatch):
 def test_default_launch_does_not_touch_the_child_environment(monkeypatch):
     # Without a root, gda redirects the LOG only: `user://`, the export templates
     # and the editor settings all stay where the engine puts them by default.
-    rec = _RecordingRun()
-    monkeypatch.setattr(subprocess, "run", rec)
+    rec = RecordingSpawn()
+    monkeypatch.setattr(subprocess, "Popen", rec)
 
     launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
 
@@ -136,21 +106,13 @@ def test_default_launch_does_not_touch_the_child_environment(monkeypatch):
 
 
 def test_default_log_target_is_removed_after_the_run(monkeypatch):
-    seen: dict[str, Path] = {}
-
-    def fake_run(cmd, **kwargs):
-        seen["log"] = _log_file_arg(cmd)
-
-        class _Proc:
-            stdout = b""
-            stderr = b""
-            returncode = 0
-
-        return _Proc()
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
+    rec = RecordingSpawn()
+    monkeypatch.setattr(subprocess, "Popen", rec)
 
     launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
+
+    assert rec.cmd is not None
+    seen = {"log": _log_file_arg(rec.cmd)}
 
     # A private temporary directory, cleaned up so repeated invocations do not
     # accumulate stale logs.
@@ -165,17 +127,12 @@ def test_concurrent_default_launches_get_distinct_log_targets(monkeypatch):
     # must never name the same target.
     targets: list[Path] = []
 
-    def fake_run(cmd, **kwargs):
-        targets.append(_log_file_arg(cmd))
+    class _Collecting(RecordingSpawn):
+        def __call__(self, cmd, **kwargs):
+            targets.append(_log_file_arg(cmd))
+            return super().__call__(cmd, **kwargs)
 
-        class _Proc:
-            stdout = b""
-            stderr = b""
-            returncode = 0
-
-        return _Proc()
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(subprocess, "Popen", _Collecting())
 
     launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
     launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
@@ -190,11 +147,11 @@ def test_concurrent_default_launches_get_distinct_log_targets(monkeypatch):
 
 def test_unwritable_log_root_is_refused_before_the_spawn(monkeypatch, tmp_path):
     # The whole point: refuse with a typed reason instead of letting the engine
-    # segfault in its logger. `subprocess.run` must never be reached.
+    # segfault in its logger. `subprocess.Popen` must never be reached.
     def _must_not_spawn(*args, **kwargs):  # pragma: no cover - guard
         raise AssertionError("the engine must not be spawned")
 
-    monkeypatch.setattr(subprocess, "run", _must_not_spawn)
+    monkeypatch.setattr(subprocess, "Popen", _must_not_spawn)
     locked = tmp_path / "locked"
     locked.mkdir()
     locked.chmod(0o555)
@@ -211,7 +168,7 @@ def test_unwritable_log_root_is_refused_before_the_spawn(monkeypatch, tmp_path):
 
 
 def test_refusal_diagnostics_name_binary_user_data_and_log_path(monkeypatch, tmp_path):
-    monkeypatch.setattr(subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: None)
     locked = tmp_path / "locked"
     locked.mkdir()
     locked.chmod(0o555)
@@ -237,7 +194,7 @@ def test_refusal_diagnostics_name_binary_user_data_and_log_path(monkeypatch, tmp
 def test_default_root_refusal_names_the_engine_resolved_user_data_dir(monkeypatch):
     # With no --user-data-root, the failure must still name where `user://` lives
     # — the engine's own resolved directory — and say gda is not redirecting it.
-    monkeypatch.setattr(subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: None)
 
     def _explode(*args, **kwargs):
         raise PermissionError(13, "Permission denied")
@@ -263,13 +220,13 @@ def test_the_two_refusal_shapes_point_at_different_directories(monkeypatch, tmp_
     # diagnostics — not the code — must disambiguate which one failed. Pinned as a
     # PAIR: the default-branch refusal must not blame the explicit root's derived
     # path, and vice versa.
-    monkeypatch.setattr(subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: None)
     monkeypatch.setattr("gda.runner.tempfile.mkdtemp", _permission_denied("gda-log-"))
 
     default_refusal = launch(Path("/x/Godot"), ["--version"], cwd=None, timeout=60.0)
 
     monkeypatch.undo()
-    monkeypatch.setattr(subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: None)
     locked = tmp_path / "locked"
     locked.mkdir()
     locked.chmod(0o555)
@@ -319,8 +276,8 @@ def test_refusal_classifies_as_the_environment_error_code():
 def test_root_redirects_both_the_log_and_the_platform_data_variable(
     monkeypatch, tmp_path
 ):
-    rec = _RecordingRun()
-    monkeypatch.setattr(subprocess, "run", rec)
+    rec = RecordingSpawn()
+    monkeypatch.setattr(subprocess, "Popen", rec)
     root = tmp_path / "udr"
     set_user_data_root(str(root))
 
@@ -345,8 +302,8 @@ def test_a_relative_root_is_absolutized_against_gda_cwd(monkeypatch, tmp_path):
     # spawns with cwd=<project>). The preflight would then pass for a file the engine
     # never opens, and the engine would die in rotate_file() on the one it did —
     # reintroducing the crash. Same bug class as the export channel's --path (#344).
-    rec = _RecordingRun()
-    monkeypatch.setattr(subprocess, "run", rec)
+    rec = RecordingSpawn()
+    monkeypatch.setattr(subprocess, "Popen", rec)
     monkeypatch.chdir(tmp_path)
     set_user_data_root("./rel")
 
@@ -363,8 +320,8 @@ def test_a_relative_root_absolutizes_the_platform_override_too(monkeypatch, tmp_
     # engine IGNORES a relative XDG_DATA_HOME outright (OS_LinuxBSD::get_data_path),
     # so a relative root would silently not redirect `user://` at all while the docs
     # promise it does.
-    rec = _RecordingRun()
-    monkeypatch.setattr(subprocess, "run", rec)
+    rec = RecordingSpawn()
+    monkeypatch.setattr(subprocess, "Popen", rec)
     monkeypatch.chdir(tmp_path)
     set_user_data_root("./rel")
 
@@ -386,7 +343,7 @@ def test_explicit_root_probes_the_platform_derived_data_path(monkeypatch, tmp_pa
     def _must_not_spawn(*args, **kwargs):  # pragma: no cover - guard
         raise AssertionError("the engine must not be spawned")
 
-    monkeypatch.setattr(subprocess, "run", _must_not_spawn)
+    monkeypatch.setattr(subprocess, "Popen", _must_not_spawn)
     root = tmp_path / "udr"
     # The probe logic is shape-agnostic; pin a NESTED derivation so this runs
     # identically on every platform (the real macOS shape nests under
@@ -427,7 +384,7 @@ def test_an_empty_explicit_flag_is_refused_not_demoted_to_the_environment(monkey
     def _must_not_spawn(*args, **kwargs):  # pragma: no cover - guard
         raise AssertionError("the engine must not be spawned")
 
-    monkeypatch.setattr(subprocess, "run", _must_not_spawn)
+    monkeypatch.setattr(subprocess, "Popen", _must_not_spawn)
     monkeypatch.setenv(USER_DATA_ROOT_ENV, "/from/env")
     set_user_data_root("")
 
@@ -541,8 +498,8 @@ def test_the_root_option_reaches_the_launch(monkeypatch, tmp_path):
     # callback's `set_user_data_root(...)` line leaves the whole suite green and the
     # flag silently inert — a live risk, since a sibling change rewrites exactly
     # those lines in `gda.cli`.
-    rec = _RecordingRun(sentinel(VERSION_INFO))
-    monkeypatch.setattr(subprocess, "run", rec)
+    rec = RecordingSpawn(sentinel(VERSION_INFO))
+    monkeypatch.setattr(subprocess, "Popen", rec)
     monkeypatch.delenv(USER_DATA_ROOT_ENV, raising=False)
     root = tmp_path / "from-the-flag"
 
@@ -560,8 +517,8 @@ def test_without_the_root_option_the_launch_keeps_the_engine_default(
     # The negative half: absent the flag (and the env twin), nothing is redirected
     # but the log — so this pair fails if the option is wired to always-on as well
     # as if it is wired to nothing.
-    rec = _RecordingRun(sentinel(VERSION_INFO))
-    monkeypatch.setattr(subprocess, "run", rec)
+    rec = RecordingSpawn(sentinel(VERSION_INFO))
+    monkeypatch.setattr(subprocess, "Popen", rec)
     monkeypatch.delenv(USER_DATA_ROOT_ENV, raising=False)
 
     result = CliRunner().invoke(app, ["info", "--json"])


### PR DESCRIPTION
## P3 promotion — six slices of the gda dogfooding milestone

Promotes the third implementation wave from `feat/gda-dogfooding-dev` to `main`. Six slices, each squash-merged after independent four-axis adversarial review (three rounds on the artifact surfaces), every finding adopted with red-proofed regressions or declined with published evidence on the slice PR.

| Slice | PR | What it delivers |
|---|---|---|
| #683 | #779 | Every command group accepts `--json` (third parser site): `gda scene --json list` ≡ `gda scene list --json`, composed at the root (`adopt_group_json`); the now-wrong group-level near-miss hint retired |
| #714 | #781 | Every timed-out launch preserves its captured output: the buffered capture strategy is gone, all three buffered channels (sentinel, export, `resource import`) stream through the #655 seam, and the shared `launch_timeout` envelope carries the tail-capped streams, wall clock, and ceiling |
| #764 | #778 | The four `res://` walkers share ONE traversal (`_collect_paths`); extension matching is case-insensitive as the engine's is; the two file universes (statistics vs graph reads) pinned |
| #774 | #777 | The project reference graph keys every path — harvested, project.godot-level, and the query — through the engine's own canonical identity, with relative declarations anchored to their declaring file; `find-unused-resources` no longer advises deleting instanced scenes |
| #771 | #780 | Headless value reads report floats at full binary64 precision (the #752 writer argument at the op-reply framing), corpus-verified; negative-zero residual disclosed |
| #759 | #776 | An invalid `--budget` entry renders through the shared validation renderer — no pydantic internals, entry name preserved |

Closes #683
Closes #714
Closes #764
Closes #774
Closes #771
Closes #759

## Verification

- Wave-level full e2e on the dev tip `f91af58e`: [run 33368693688](https://github.com/aigengame/godot-agent/actions/runs/33368693688) — **gda e2e 573 passed, 19 skipped** (P2 baseline 558; this wave adds 15), **Panda 66 passed, 3 skipped**; all unit/lint/type/co-install and gda-balancing jobs green.
- Post-merge gates on the squashed tip: `2250 passed, 592 deselected` non-e2e, ruff clean, pyright 0 errors; each slice's key content verified present after the serial squash merges.
- The one predicted merge conflict (#764/#774, a shared comment region) was resolved by the stacked-PR rebase discipline with gates re-run on the rebased branch before merge.
- Review history and per-round evidence live on the six slice PRs.

Merge via **merge commit** (repo convention for promotions) so release-please sees the six per-issue commits. Note `main` has since gained `77938908` (gda-balancing #747, its own release train) — disjoint subtree, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
