### PR TITLE
feat(balancing): publish execution open host service

### DIFF
--- a/libs/gda-balancing/BALANCING-CONTEXT.md
+++ b/libs/gda-balancing/BALANCING-CONTEXT.md
@@ -1034,6 +1034,22 @@ reproduction receipt records that complete binding; the Resolved Runtime profile
 platform, Numeric, RNG, scheduler, effect, and budget choices.
 _Avoid_: random seed (ambiguous), default seed
 
+### Integration boundary
+
+**Execution Open Host Service**:
+The application-agnostic integration boundary that exposes execution capabilities through the
+`Execution Service Language`. Resource-oriented HTTP and MCP are sibling Interface adapters for
+this boundary; the OHS is not a tactical Domain Service, public-network deployment, or transport
+process (bADR-0027).
+_Avoid_: Domain Service, playtest service, HTTP service (unqualified)
+
+**Execution Service Language**:
+The Published Language for the `Execution Open Host Service`. It owns only OHS-specific integration
+contracts, such as session handles, revision selection, service-response framing, service errors,
+and lifecycle facts. It references authority-owned Standard Schema contracts and never copies or
+redefines their schemas, rules, semantics, identities, outcomes, or refusals (bADR-0027).
+_Avoid_: HTTP schema, MCP schema, second Standard Schema
+
 ### Runtime
 
 **Execution session**:

--- a/libs/gda-balancing/BALANCING-CONTEXT.md
+++ b/libs/gda-balancing/BALANCING-CONTEXT.md
@@ -1046,10 +1046,11 @@ _Avoid_: Domain Service, playtest service, HTTP service (unqualified)
 **Execution Service Language**:
 The Published Language for the `Execution Open Host Service`. It owns only OHS-specific integration
 contracts, such as session handles, revision selection, service-response framing, and shared OHS
-errors. It references authority-owned Standard Schema contracts and never copies or redefines their
-schemas, rules, semantics, identities, outcomes, or refusals. Its initial contract is `Execution
-Service Language revision 1`, a compatibility label rather than a Package Release coordinate or
-transport version (bADR-0027).
+errors. It keeps nested authority-owned Standard Schema values opaque. Domain validates or produces
+them under the applicable contracts. The language never copies or redefines their schemas, rules,
+semantics, identities, outcomes, or refusals. Its initial contract is `Execution Service Language
+revision 1`, a compatibility label rather than a Package Release coordinate or transport version
+(bADR-0027).
 _Avoid_: transport-owned schema, second Standard Schema
 
 ### Runtime

--- a/libs/gda-balancing/BALANCING-CONTEXT.md
+++ b/libs/gda-balancing/BALANCING-CONTEXT.md
@@ -1038,9 +1038,9 @@ _Avoid_: random seed (ambiguous), default seed
 
 **Execution Open Host Service**:
 The application-agnostic integration boundary that exposes execution capabilities through the
-`Execution Service Language`. Resource-oriented HTTP and MCP are sibling Interface adapters for
-this boundary; the OHS is not a tactical Domain Service, public-network deployment, or transport
-process (bADR-0027).
+`Execution Service Language`. Resource-oriented HTTP is its current Interface adapter. A future
+adapter uses the same language and Application boundary when a concrete consumer justifies it; the
+OHS is not a tactical Domain Service, public-network deployment, or transport process (bADR-0027).
 _Avoid_: Domain Service, playtest service, HTTP service (unqualified)
 
 **Execution Service Language**:
@@ -1050,7 +1050,7 @@ errors. It references authority-owned Standard Schema contracts and never copies
 schemas, rules, semantics, identities, outcomes, or refusals. Its initial contract is `Execution
 Service Language revision 1`, a compatibility label rather than a Package Release coordinate or
 transport version (bADR-0027).
-_Avoid_: HTTP schema, MCP schema, second Standard Schema
+_Avoid_: transport-owned schema, second Standard Schema
 
 ### Runtime
 

--- a/libs/gda-balancing/BALANCING-CONTEXT.md
+++ b/libs/gda-balancing/BALANCING-CONTEXT.md
@@ -1045,9 +1045,11 @@ _Avoid_: Domain Service, playtest service, HTTP service (unqualified)
 
 **Execution Service Language**:
 The Published Language for the `Execution Open Host Service`. It owns only OHS-specific integration
-contracts, such as session handles, revision selection, service-response framing, service errors,
-and lifecycle facts. It references authority-owned Standard Schema contracts and never copies or
-redefines their schemas, rules, semantics, identities, outcomes, or refusals (bADR-0027).
+contracts, such as session handles, revision selection, service-response framing, and shared OHS
+errors. It references authority-owned Standard Schema contracts and never copies or redefines their
+schemas, rules, semantics, identities, outcomes, or refusals. Its initial contract is `Execution
+Service Language revision 1`, a compatibility label rather than a Package Release coordinate or
+transport version (bADR-0027).
 _Avoid_: HTTP schema, MCP schema, second Standard Schema
 
 ### Runtime

--- a/libs/gda-balancing/docs/ARCHITECTURE.md
+++ b/libs/gda-balancing/docs/ARCHITECTURE.md
@@ -673,7 +673,7 @@ authority.
 
 - `interfaces` owns inbound protocol binding, integration contracts, and presentation. The
   `interfaces/cli` adapter owns Command descriptors, the immutable registry, schema and manifest
-  projection, argv binding, help, rendering, envelopes, and exit codes. The proposed Execution OHS
+  projection, argv binding, help, rendering, envelopes, and exit codes. The Execution OHS
   owns one Published Language for OHS-specific handles, selections, response framing, and shared OHS
   errors. It does not own or copy Standard Schema contracts. The current Resource-oriented HTTP
   adapter uses this language and calls the Application service directly. It owns routes, methods,
@@ -733,8 +733,9 @@ policy from domain-neutral storage mechanisms.
 
 The Execution OHS gives several downstream contexts one stable integration boundary. Its Published
 Language defines only concepts introduced at that boundary. Standard Schema values keep their
-Domain-owned schemas, identities, rules, semantics, and refusals. An adapter references those exact
-contracts instead of copying their fields into a transport-owned model.
+Domain-owned schemas, identities, rules, semantics, and refusals. An adapter passes those values
+without copying their fields into a transport-owned model. Domain applies the applicable
+authority-owned contracts.
 
 ```mermaid
 flowchart TB
@@ -1575,8 +1576,8 @@ owned through model/experiment operations, not independent user workflows.
 
 The ungrouped `serve` command starts the local companion host for the loopback-only,
 Resource-oriented HTTP adapter. It is a foreground operational command, not a new semantic command
-group. bADR-0026 owns its accepted `/v1` transport and lifecycle boundaries. Proposed bADR-0027
-extracts the shared Execution OHS and Published Language without changing the current HTTP protocol
+group. bADR-0026 owns its accepted `/v1` transport and lifecycle boundaries. Accepted bADR-0027
+owns the shared Execution OHS and Published Language without changing the current HTTP protocol
 contract.
 
 Each command has one structured **Command descriptor** that owns its parameters, defaults,
@@ -1616,7 +1617,7 @@ coverage from implementation proof.
 | Reliability | Deterministic profiles, atomic events/publication, typed refusals, terminal audits, immutable evidence | The bounded executable authority mechanism passed independent mutation/refusal probes; permanent publication, Evidence issuance, and full-system conformance remain open |
 | Orthogonality | Quantity facets, source/package/kernel extension test, separate authored domains, RIR/EIR split | Selected extension and authority mechanisms passed narrow mutation probes without RPG host dispatch; whole-system and cross-genre proof remain open |
 | Extensibility | Complete content-addressed Domain packages, Core Extension Invariance, and permanent cross-genre witnesses | The current #546 authority, compatible package closure, and `RPG-STAT-01` path are rebuilt, and production and independent consumers agree on the new primitive and package vectors. Earlier non-RPG and Roguelike results do not carry automatically; their current-identity evidence, the public Extension Invariance Receipt, and broader mechanic breadth remain open |
-| Operability | Descriptor-derived CLI, local Execution HTTP adapter, proposed Execution OHS and Published Language, immutable artifacts, idempotent invocation, receipts | Local descriptor, HTTP, and publication paths were exercised; the shared OHS contract, production adapter extraction, and complete public surface remain open; additional transport adapters are deferred until a concrete consumer requires one |
+| Operability | Descriptor-derived CLI, local Execution HTTP adapter, Execution OHS and Published Language, immutable artifacts, idempotent invocation, receipts | Local descriptor, HTTP, and publication paths were exercised; the shared OHS contract is extracted, the HTTP adapter consumes it, and semantic parity is covered; additional transport adapters are deferred until a concrete consumer requires one |
 
 The current evidence supports these status statements:
 

--- a/libs/gda-balancing/docs/ARCHITECTURE.md
+++ b/libs/gda-balancing/docs/ARCHITECTURE.md
@@ -27,7 +27,7 @@ module, or prototype may become an accidental second specification.
 | --- | --- | --- |
 | This `ARCHITECTURE.md` | Macro topology, subsystem responsibilities, cross-subsystem invariants, delivery order | Machine semantics, detailed decision rationale, acceptance status |
 | [`BALANCING-CONTEXT.md`](../BALANCING-CONTEXT.md) | Canonical domain terms and distinctions | Architecture planning or executable semantics |
-| [bADR-0012…0026](badr/) | Binding detailed decisions and their rationale | Consolidated system narrative or implementation status |
+| [bADR-0012…0027](badr/) | Binding detailed decisions and their rationale | Consolidated system narrative or implementation status |
 | [Product PRD #501](https://github.com/aigengame/godot-agent/issues/501) | `gda-balancing` product outcomes, milestones, and relationship to the `gda` family | Standard Schema 2.0 architecture details |
 | [PRD #534](https://github.com/aigengame/godot-agent/issues/534) | Product requirements, acceptance criteria, and live completion tracking | Macro architecture or machine semantics |
 | [`standard-schema-2.0/`](standard-schema-2.0/) | Acceptance artifacts, coverage matrices, and prototype evidence status | Language authority or proof by prose |
@@ -162,9 +162,9 @@ flowchart TB
         subgraph UI["UI / Interfaces"]
             U["Structured CLI"]
             T["Execution OHS adapters<br/>Resource-oriented HTTP · MCP"]
-            E["Execution Open Host Service<br/>Execution Service Language"]
+            E["Execution Service Language<br/>shared OHS contract"]
 
-            T -->|"projects"| E
+            E -. "defines contract used by" .-> T
         end
         subgraph APP["Application"]
             A["Public use cases<br/>one operation at a time"]
@@ -196,7 +196,7 @@ flowchart TB
         end
 
         U -->|submits| A
-        E -->|submits| A
+        T -->|submits| A
         A -->|"invokes Kernel/LDB bootstrap"| B
         A -->|"invokes Model compiler"| C
         A -->|"invokes Experiment semantics"| X
@@ -674,13 +674,14 @@ authority.
 - `interfaces` owns inbound protocol binding, integration contracts, and presentation. The
   `interfaces/cli` adapter owns Command descriptors, the immutable registry, schema and manifest
   projection, argv binding, help, rendering, envelopes, and exit codes. The proposed Execution OHS
-  owns one Published Language for OHS-specific handles, selections, response framing, service
-  errors, and lifecycle facts. It does not own or copy Standard Schema contracts. Resource-oriented
-  HTTP and MCP are sibling adapters that project this language and call the same Application
-  service. The current HTTP adapter also owns routes, methods, status mapping, authentication, and
-  other HTTP facts. Its local companion host owns the in-process server lifecycle, readiness, and
-  shutdown. An executable Interface entry point is the composition root for its process. Interface
-  adapters translate values. They do not implement language or evaluation rules (bADR-0026/0027).
+  owns one Published Language for OHS-specific handles, selections, response framing, and shared OHS
+  errors. It does not own or copy Standard Schema contracts. Resource-oriented HTTP and MCP are
+  sibling adapters that use this language and call the same Application service directly. The
+  current HTTP adapter owns routes, methods, media types, status mapping, and HTTP error projection.
+  Its local companion host owns process authentication, readiness, status, shutdown, and the
+  in-process server lifecycle. An executable Interface entry point is the composition root for its
+  process. Interface adapters translate values. They do not implement language or evaluation rules
+  (bADR-0026/0027).
 - `application` coordinates one public use case at a time. It returns typed results or refusals. It
   also coordinates process-local Execution sessions, immutable Experiment revisions, and their
   ordering. It does not parse an external protocol, write presentation channels, build Interface
@@ -714,7 +715,7 @@ policy from domain-neutral storage mechanisms.
 | Layer | Subsystem | Responsibility | Produces or exposes |
 | --- | --- | --- | --- |
 | UI / Interfaces | Inbound adapters | Bind external protocols and present public outcomes without owning execution meaning | Structured CLI commands, Resource-oriented HTTP, future MCP, Surface manifest, envelopes, and protocol responses |
-| UI / Interfaces | Execution OHS and Published Language | Define application-agnostic execution capabilities and only the OHS-specific integration contract | Session handles, revision selections, service-response framing, service errors, lifecycle facts, and derived adapter schemas |
+| UI / Interfaces | Execution OHS and Published Language | Define application-agnostic execution capabilities and only the OHS-specific integration contract | Session handles, revision selections, service-response framing, shared OHS errors, and derived adapter schemas |
 | Application | Public use cases | Coordinate each public operation and process-local Execution-session ordering without Interface protocol or presentation rules | Typed results or refusals, session/revision handles, plus publication receipts when the operation publishes artifacts |
 | Domain | Kernel/LDB bootstrap | Admit and identify the exact language definition | Kernel identity, whole-LDB identity, and admission outcome |
 | Domain | Package resolver | Select one deterministic and compatible package closure | Canonical Package Lock and resolution receipt |
@@ -742,10 +743,10 @@ flowchart TB
         direction TB
         H["Resource-oriented HTTP adapter"]
         M["MCP adapter"]
-        P["Execution Open Host Service<br/>Execution Service Language"]
+        P["Execution Service Language<br/>shared OHS contract"]
 
-        H -->|"projects"| P
-        M -->|"projects"| P
+        P -. "defines contract used by" .-> H
+        P -. "defines contract used by" .-> M
     end
 
     A["Application<br/>protocol-neutral execution use cases"]
@@ -753,7 +754,8 @@ flowchart TB
 
     C -->|"uses one adapter"| H
     C -->|"uses one adapter"| M
-    P -->|"invokes"| A
+    H -->|"invokes"| A
+    M -->|"invokes"| A
     A -->|"uses"| D
 ```
 

--- a/libs/gda-balancing/docs/ARCHITECTURE.md
+++ b/libs/gda-balancing/docs/ARCHITECTURE.md
@@ -160,7 +160,11 @@ flowchart TB
     subgraph HOST["Conforming host implementation"]
         direction TB
         subgraph UI["UI / Interfaces"]
-            U["Inbound Interfaces<br/>Structured CLI · local Execution HTTP API"]
+            U["Structured CLI"]
+            T["Execution OHS adapters<br/>Resource-oriented HTTP · MCP"]
+            E["Execution Open Host Service<br/>Execution Service Language"]
+
+            T -->|"projects"| E
         end
         subgraph APP["Application"]
             A["Public use cases<br/>one operation at a time"]
@@ -192,6 +196,7 @@ flowchart TB
         end
 
         U -->|submits| A
+        E -->|submits| A
         A -->|"invokes Kernel/LDB bootstrap"| B
         A -->|"invokes Model compiler"| C
         A -->|"invokes Experiment semantics"| X
@@ -204,15 +209,17 @@ flowchart TB
     end
 
     O["Published immutable facts<br/>Resolved Model · Metric dataset · Evaluation run<br/>Replay comparison · Evidence assertion · Locators · Receipts"]
-    S["Interface outcomes<br/>CLI envelope and channels · HTTP JSON response"]
+    S["Interface outcomes<br/>CLI envelope and channels · OHS adapter response"]
     G["Approval Record<br/>independent governance decision"]
 
     K -->|"supplies machine authority"| B
     L -->|"supplies language content"| B
     H -->|supplies| U
+    H -->|supplies| T
     Q -->|publishes| O
     O -. "supplies published comparison and prerequisites" .-> V
     U -->|renders| S
+    T -->|renders| S
     O -. "Evidence assertion informs" .-> G
 ```
 
@@ -664,13 +671,16 @@ flowchart TB
 The diagram shows allowed cross-layer imports. It does not show processing or Standard Schema
 authority.
 
-- `interfaces` owns inbound protocol binding and presentation. The `interfaces/cli` adapter owns
-  Command descriptors, the immutable registry, schema and manifest projection, argv binding, help,
-  rendering, envelopes, and exit codes. The loopback HTTP adapter owns its versioned routes, closed
-  transport schemas, authentication, and status mapping. Its local companion host owns the
-  in-process server lifecycle, readiness, and shutdown. An executable Interface entry point is the
-  composition root for its process. Interface adapters translate values. They do not implement
-  language or evaluation rules (bADR-0026).
+- `interfaces` owns inbound protocol binding, integration contracts, and presentation. The
+  `interfaces/cli` adapter owns Command descriptors, the immutable registry, schema and manifest
+  projection, argv binding, help, rendering, envelopes, and exit codes. The proposed Execution OHS
+  owns one Published Language for OHS-specific handles, selections, response framing, service
+  errors, and lifecycle facts. It does not own or copy Standard Schema contracts. Resource-oriented
+  HTTP and MCP are sibling adapters that project this language and call the same Application
+  service. The current HTTP adapter also owns routes, methods, status mapping, authentication, and
+  other HTTP facts. Its local companion host owns the in-process server lifecycle, readiness, and
+  shutdown. An executable Interface entry point is the composition root for its process. Interface
+  adapters translate values. They do not implement language or evaluation rules (bADR-0026/0027).
 - `application` coordinates one public use case at a time. It returns typed results or refusals. It
   also coordinates process-local Execution sessions, immutable Experiment revisions, and their
   ordering. It does not parse an external protocol, write presentation channels, build Interface
@@ -703,7 +713,8 @@ policy from domain-neutral storage mechanisms.
 
 | Layer | Subsystem | Responsibility | Produces or exposes |
 | --- | --- | --- | --- |
-| UI / Interfaces | Inbound adapters | Bind external protocols and present public outcomes | Structured CLI commands, the loopback Execution HTTP API, Surface manifest, envelopes, and exit codes |
+| UI / Interfaces | Inbound adapters | Bind external protocols and present public outcomes without owning execution meaning | Structured CLI commands, Resource-oriented HTTP, future MCP, Surface manifest, envelopes, and protocol responses |
+| UI / Interfaces | Execution OHS and Published Language | Define application-agnostic execution capabilities and only the OHS-specific integration contract | Session handles, revision selections, service-response framing, service errors, lifecycle facts, and derived adapter schemas |
 | Application | Public use cases | Coordinate each public operation and process-local Execution-session ordering without Interface protocol or presentation rules | Typed results or refusals, session/revision handles, plus publication receipts when the operation publishes artifacts |
 | Domain | Kernel/LDB bootstrap | Admit and identify the exact language definition | Kernel identity, whole-LDB identity, and admission outcome |
 | Domain | Package resolver | Select one deterministic and compatible package closure | Canonical Package Lock and resolution receipt |
@@ -715,6 +726,41 @@ policy from domain-neutral storage mechanisms.
 | Domain | Artifact policy | Define artifact identity, set completeness, publication, retrieval, and recovery | Artifact envelopes, Locators, and Receipts |
 | Infrastructure | Input and resource access | Read bounded input, packaged resources, and distribution metadata | Bytes, technical metadata, or explicit I/O failures |
 | Infrastructure | Atomic filesystem mechanisms | Lock, stage, materialize, and atomically commit files | Atomic file-operation outcomes |
+
+### 4.3 Execution open host boundary
+
+The Execution OHS gives several downstream contexts one stable integration boundary. Its Published
+Language defines only concepts introduced at that boundary. Standard Schema values keep their
+Domain-owned schemas, identities, rules, semantics, and refusals. An adapter references those exact
+contracts instead of copying their fields into a transport-owned model.
+
+```mermaid
+flowchart TB
+    C["Local applications · future local web applications · agent clients"]
+
+    subgraph IF["UI / Interfaces"]
+        direction TB
+        H["Resource-oriented HTTP adapter"]
+        M["MCP adapter"]
+        P["Execution Open Host Service<br/>Execution Service Language"]
+
+        H -->|"projects"| P
+        M -->|"projects"| P
+    end
+
+    A["Application<br/>protocol-neutral execution use cases"]
+    D["Domain<br/>Standard Schema authorities and execution meaning"]
+
+    C -->|"uses one adapter"| H
+    C -->|"uses one adapter"| M
+    P -->|"invokes"| A
+    A -->|"uses"| D
+```
+
+The HTTP and MCP adapters are peers. Neither calls the other. The current HTTP API is
+Resource-oriented; it does not claim complete REST conformance. A demonstrated consumer need can
+justify additional REST constraints or a versioned contract change. MCP can add task-oriented tools
+or immutable resources without becoming a second execution service (bADR-0027).
 
 ## 5. Language and semantic model
 
@@ -1527,9 +1573,10 @@ The Standard Schema 2.x CLI follows artifact ownership rather than internal impl
 There is no public `runtime` or `metrics` command group: those are execution and artifact concepts
 owned through model/experiment operations, not independent user workflows.
 
-The ungrouped `serve` command starts the loopback-only Execution HTTP Interface. It is a foreground
-operational command, not a new semantic command group. bADR-0026 owns its transport and lifecycle
-boundaries.
+The ungrouped `serve` command starts the local companion host for the loopback-only,
+Resource-oriented HTTP adapter. It is a foreground operational command, not a new semantic command
+group. bADR-0026 owns its accepted `/v1` transport and lifecycle boundaries. Proposed bADR-0027
+extracts the shared Execution OHS and Published Language without changing the current wire contract.
 
 Each command has one structured **Command descriptor** that owns its parameters, defaults,
 channels, outcome decoding, and schema reference. Help, structured parameter schema, `--schema`, and
@@ -1568,7 +1615,7 @@ coverage from implementation proof.
 | Reliability | Deterministic profiles, atomic events/publication, typed refusals, terminal audits, immutable evidence | The bounded executable authority mechanism passed independent mutation/refusal probes; permanent publication, Evidence issuance, and full-system conformance remain open |
 | Orthogonality | Quantity facets, source/package/kernel extension test, separate authored domains, RIR/EIR split | Selected extension and authority mechanisms passed narrow mutation probes without RPG host dispatch; whole-system and cross-genre proof remain open |
 | Extensibility | Complete content-addressed Domain packages, Core Extension Invariance, and permanent cross-genre witnesses | The current #546 authority, compatible package closure, and `RPG-STAT-01` path are rebuilt, and production and independent consumers agree on the new primitive and package vectors. Earlier non-RPG and Roguelike results do not carry automatically; their current-identity evidence, the public Extension Invariance Receipt, and broader mechanic breadth remain open |
-| Operability | Descriptor-derived CLI, local Execution HTTP Interface, immutable artifacts, idempotent invocation, receipts | Local descriptor, HTTP, and publication paths were exercised; production adapters and complete public surface remain open |
+| Operability | Descriptor-derived CLI, local Execution HTTP adapter, proposed Execution OHS and Published Language, immutable artifacts, idempotent invocation, receipts | Local descriptor, HTTP, and publication paths were exercised; the shared OHS contract, MCP adapter, production adapters, and complete public surface remain open |
 
 The current evidence supports these status statements:
 
@@ -2039,6 +2086,7 @@ Use this map when a macro statement needs its detailed decision or live acceptan
 | Canonical Formula notation | [bADR-0024](badr/0024-canonical-reversible-formula-notation.md) | Formula pairing, parse/render, and JSON contract vectors |
 | Host implementation dependencies | [bADR-0025](badr/0025-dependency-directed-implementation-layers.md) | Import-direction gate, Interface-boundary regressions, and source/wheel parity |
 | Local Execution HTTP Interface | [bADR-0026](badr/0026-local-http-execution-service.md) | Loopback service, closed protocol, exact revisions, and CLI/HTTP parity vectors |
+| Execution OHS and Published Language | [bADR-0027](badr/0027-execution-open-host-service-and-published-language.md) | Issue #789 design acceptance, shared-contract extraction, adapter parity, and MCP tracer |
 
 PRD #534 remains the live answer to “is this accepted and complete?” This document answers “what
 system are we building, where does each responsibility belong, and in what order can we prove it?”

--- a/libs/gda-balancing/docs/ARCHITECTURE.md
+++ b/libs/gda-balancing/docs/ARCHITECTURE.md
@@ -161,7 +161,7 @@ flowchart TB
         direction TB
         subgraph UI["UI / Interfaces"]
             U["Structured CLI"]
-            T["Execution OHS adapters<br/>Resource-oriented HTTP · MCP"]
+            T["Execution OHS adapter<br/>Resource-oriented HTTP"]
             E["Execution Service Language<br/>shared OHS contract"]
 
             E -. "defines contract used by" .-> T
@@ -675,12 +675,13 @@ authority.
   `interfaces/cli` adapter owns Command descriptors, the immutable registry, schema and manifest
   projection, argv binding, help, rendering, envelopes, and exit codes. The proposed Execution OHS
   owns one Published Language for OHS-specific handles, selections, response framing, and shared OHS
-  errors. It does not own or copy Standard Schema contracts. Resource-oriented HTTP and MCP are
-  sibling adapters that use this language and call the same Application service directly. The
-  current HTTP adapter owns routes, methods, media types, status mapping, and HTTP error projection.
-  Its local companion host owns process authentication, readiness, status, shutdown, and the
-  in-process server lifecycle. An executable Interface entry point is the composition root for its
-  process. Interface adapters translate values. They do not implement language or evaluation rules
+  errors. It does not own or copy Standard Schema contracts. The current Resource-oriented HTTP
+  adapter uses this language and calls the Application service directly. It owns routes, methods,
+  media types, status mapping, and HTTP error projection. Its local companion host owns process
+  authentication, readiness, status, shutdown, and the in-process server lifecycle. An executable
+  Interface entry point is the composition root for its process. Interface adapters translate
+  values. They do not implement language or evaluation rules. Any future adapter must use the same
+  language and Application boundary rather than wrap HTTP or add another semantic path
   (bADR-0026/0027).
 - `application` coordinates one public use case at a time. It returns typed results or refusals. It
   also coordinates process-local Execution sessions, immutable Experiment revisions, and their
@@ -714,7 +715,7 @@ policy from domain-neutral storage mechanisms.
 
 | Layer | Subsystem | Responsibility | Produces or exposes |
 | --- | --- | --- | --- |
-| UI / Interfaces | Inbound adapters | Bind external protocols and present public outcomes without owning execution meaning | Structured CLI commands, Resource-oriented HTTP, future MCP, Surface manifest, envelopes, and protocol responses |
+| UI / Interfaces | Inbound adapters | Bind external protocols and present public outcomes without owning execution meaning | Structured CLI commands, Resource-oriented HTTP, Surface manifest, envelopes, and protocol responses |
 | UI / Interfaces | Execution OHS and Published Language | Define application-agnostic execution capabilities and only the OHS-specific integration contract | Session handles, revision selections, service-response framing, shared OHS errors, and derived adapter schemas |
 | Application | Public use cases | Coordinate each public operation and process-local Execution-session ordering without Interface protocol or presentation rules | Typed results or refusals, session/revision handles, plus publication receipts when the operation publishes artifacts |
 | Domain | Kernel/LDB bootstrap | Admit and identify the exact language definition | Kernel identity, whole-LDB identity, and admission outcome |
@@ -737,32 +738,29 @@ contracts instead of copying their fields into a transport-owned model.
 
 ```mermaid
 flowchart TB
-    C["Local applications · future local web applications · agent clients"]
+    C["Local applications · future local web applications"]
 
     subgraph IF["UI / Interfaces"]
         direction TB
         H["Resource-oriented HTTP adapter"]
-        M["MCP adapter"]
         P["Execution Service Language<br/>shared OHS contract"]
 
         P -. "defines contract used by" .-> H
-        P -. "defines contract used by" .-> M
     end
 
     A["Application<br/>protocol-neutral execution use cases"]
     D["Domain<br/>Standard Schema authorities and execution meaning"]
 
-    C -->|"uses one adapter"| H
-    C -->|"uses one adapter"| M
+    C -->|"uses"| H
     H -->|"invokes"| A
-    M -->|"invokes"| A
     A -->|"uses"| D
 ```
 
-The HTTP and MCP adapters are peers. Neither calls the other. The current HTTP API is
-Resource-oriented; it does not claim complete REST conformance. A demonstrated consumer need can
-justify additional REST constraints or a versioned contract change. MCP can add task-oriented tools
-or immutable resources without becoming a second execution service (bADR-0027).
+The current HTTP API is Resource-oriented; it does not claim complete REST conformance. A
+demonstrated consumer need can justify additional REST constraints or a versioned contract change.
+Another transport adapter, including MCP, is deferred until a concrete consumer requires it. A
+future adapter uses the same Published Language and calls Application directly; it does not wrap
+HTTP or become a second execution service (bADR-0027).
 
 ## 5. Language and semantic model
 
@@ -1578,7 +1576,8 @@ owned through model/experiment operations, not independent user workflows.
 The ungrouped `serve` command starts the local companion host for the loopback-only,
 Resource-oriented HTTP adapter. It is a foreground operational command, not a new semantic command
 group. bADR-0026 owns its accepted `/v1` transport and lifecycle boundaries. Proposed bADR-0027
-extracts the shared Execution OHS and Published Language without changing the current wire contract.
+extracts the shared Execution OHS and Published Language without changing the current HTTP protocol
+contract.
 
 Each command has one structured **Command descriptor** that owns its parameters, defaults,
 channels, outcome decoding, and schema reference. Help, structured parameter schema, `--schema`, and
@@ -1617,7 +1616,7 @@ coverage from implementation proof.
 | Reliability | Deterministic profiles, atomic events/publication, typed refusals, terminal audits, immutable evidence | The bounded executable authority mechanism passed independent mutation/refusal probes; permanent publication, Evidence issuance, and full-system conformance remain open |
 | Orthogonality | Quantity facets, source/package/kernel extension test, separate authored domains, RIR/EIR split | Selected extension and authority mechanisms passed narrow mutation probes without RPG host dispatch; whole-system and cross-genre proof remain open |
 | Extensibility | Complete content-addressed Domain packages, Core Extension Invariance, and permanent cross-genre witnesses | The current #546 authority, compatible package closure, and `RPG-STAT-01` path are rebuilt, and production and independent consumers agree on the new primitive and package vectors. Earlier non-RPG and Roguelike results do not carry automatically; their current-identity evidence, the public Extension Invariance Receipt, and broader mechanic breadth remain open |
-| Operability | Descriptor-derived CLI, local Execution HTTP adapter, proposed Execution OHS and Published Language, immutable artifacts, idempotent invocation, receipts | Local descriptor, HTTP, and publication paths were exercised; the shared OHS contract, MCP adapter, production adapters, and complete public surface remain open |
+| Operability | Descriptor-derived CLI, local Execution HTTP adapter, proposed Execution OHS and Published Language, immutable artifacts, idempotent invocation, receipts | Local descriptor, HTTP, and publication paths were exercised; the shared OHS contract, production adapter extraction, and complete public surface remain open; additional transport adapters are deferred until a concrete consumer requires one |
 
 The current evidence supports these status statements:
 
@@ -2088,7 +2087,7 @@ Use this map when a macro statement needs its detailed decision or live acceptan
 | Canonical Formula notation | [bADR-0024](badr/0024-canonical-reversible-formula-notation.md) | Formula pairing, parse/render, and JSON contract vectors |
 | Host implementation dependencies | [bADR-0025](badr/0025-dependency-directed-implementation-layers.md) | Import-direction gate, Interface-boundary regressions, and source/wheel parity |
 | Local Execution HTTP Interface | [bADR-0026](badr/0026-local-http-execution-service.md) | Loopback service, closed protocol, exact revisions, and CLI/HTTP parity vectors |
-| Execution OHS and Published Language | [bADR-0027](badr/0027-execution-open-host-service-and-published-language.md) | Issue #789 design acceptance, shared-contract extraction, adapter parity, and MCP tracer |
+| Execution OHS and Published Language | [bADR-0027](badr/0027-execution-open-host-service-and-published-language.md) | Issue #789 design acceptance, shared-contract extraction, authority conformance, and semantic HTTP parity |
 
 PRD #534 remains the live answer to “is this accepted and complete?” This document answers “what
 system are we building, where does each responsibility belong, and in what order can we prove it?”

--- a/libs/gda-balancing/docs/badr/0026-local-http-execution-service.md
+++ b/libs/gda-balancing/docs/badr/0026-local-http-execution-service.md
@@ -11,12 +11,12 @@ filesystem-publication workflow is not a suitable coordination protocol for a ru
 new interface must reuse the existing Application and Domain behavior without creating another
 Model, Experiment, Runtime, artifact, identity, or refusal authority.
 
-> **Follow-up design:** proposed bADR-0027 extracts the shared Execution Open Host Service and its
-> Published Language from transport-specific ownership. Until that decision is accepted and
-> implemented, this bADR remains the authority for the current `/v1` protocol contract and local host.
-> The follow-up changes integration ownership, not the Standard Schema authorities or the accepted
-> HTTP behavior recorded here. It classifies `/v1/status`, like `/v1/shutdown`, as a local-host
-> operation rather than a shared OHS capability while preserving both routes and response shapes.
+> **Follow-up decision:** accepted bADR-0027 extracts the shared Execution Open Host Service and its
+> Published Language from transport-specific ownership. This bADR remains the authority for the
+> current `/v1` protocol contract and local host. The follow-up changes integration ownership, not
+> the Standard Schema authorities or the accepted HTTP behavior recorded here. It classifies
+> `/v1/status`, like `/v1/shutdown`, as a local-host operation rather than a shared OHS capability
+> while preserving both routes and response shapes.
 
 ## Decision
 
@@ -24,10 +24,10 @@ Model, Experiment, Runtime, artifact, identity, or refusal authority.
 
 - The design separates two Interface responsibilities. The **Execution HTTP API** owns the
   application-agnostic execution protocol. The **local companion host** owns the in-process server
-  lifecycle, loopback binding, its process capability, readiness state, and shutdown. The owning
-  client remains responsible for executable discovery, child-process launch, and forced termination
-  after its own timeout. This separation does not add a framework or substitution interface; it
-  prevents local process control from becoming execution meaning.
+  lifecycle, loopback binding, its process capability, readiness state, status, and shutdown. The
+  owning client remains responsible for executable discovery, child-process launch, and forced
+  termination after its own timeout. This separation does not add a framework or substitution
+  interface; it prevents local process control from becoming execution meaning.
 - The service ships in the existing gda-balancing wheel and runs as a local foreground process. It
   is not a machine-wide daemon, remote multi-tenant service, or separately packaged application.
 - One client application starts and owns each service process, its capability token, and its
@@ -116,14 +116,13 @@ Model, Experiment, Runtime, artifact, identity, or refusal authority.
 ### Versioned HTTP protocol
 
 - The application-agnostic Execution HTTP API contains exactly:
-  - `GET /v1/status`;
   - `POST /v1/execution-sessions`;
   - `POST /v1/execution-sessions/{session_id}/experiment-revisions`;
   - `POST /v1/execution-sessions/{session_id}/runs`;
   - `DELETE /v1/execution-sessions/{session_id}`.
-- The local companion host adds `POST /v1/shutdown` as its authenticated process-control endpoint.
-  It is versioned with the transport, but it is not an Experiment execution operation and a later
-  local host is not required to expose it.
+- The local companion host adds `GET /v1/status` and `POST /v1/shutdown`. They are versioned with the
+  transport, but they are not Experiment execution operations. A later local host is not required to
+  expose the same operational endpoints.
 - Session creation receives a complete Model Source Package and initial Experiment Specification.
   A run names one exact revision identifier. The first protocol has no session/revision listing,
   implicit revision, partial update, artifact query, progress, cancellation, or streaming endpoint.
@@ -133,8 +132,9 @@ Model, Experiment, Runtime, artifact, identity, or refusal authority.
   unsupported methods, and undeclared trailing-slash variants use the same closed service-error
   envelope as other protocol failures. The first routes declare no query parameters and reject any
   non-empty query input.
-- Pydantic request and response models are the single executable source for the first HTTP schemas.
-  bADR-0026 and `docs/ARCHITECTURE.md` describe meaning and boundaries without copying every field.
+- The Execution Service Language models are the single executable source for shared OHS shapes. The
+  local companion host owns the status and shutdown models. bADR-0026, bADR-0027, and
+  `docs/ARCHITECTURE.md` describe meaning and boundaries without copying every field.
   The existing Command-descriptor `--schema` convention describes the `serve` command and readiness
   result only; the first protocol adds no `/v1/schema`, OpenAPI surface, schema registry, schema
   identity, client generator, or general negotiation framework.
@@ -189,12 +189,12 @@ Model, Experiment, Runtime, artifact, identity, or refusal authority.
   command-registry owner. `interfaces/cli/serve` binds the operational descriptor, integrates the
   foreground runner, assembles the server components, emits the readiness record on standard
   output, and maps operational logs to standard error.
-- `interfaces/http/api_v1` owns the five Execution HTTP API routes, closed schemas, JSON transport,
+- `interfaces/http/api_v1` owns the four Execution OHS routes, JSON transport,
   and HTTP status mapping. `interfaces/http/local_host` owns the in-process ASGI server, loopback
-  binding, process-capability authentication, server lifecycle, the shutdown route, and the typed
-  readiness state consumed by `interfaces/cli/serve`. These names state responsibility boundaries;
-  they do not require an abstract interface or plugin mechanism. None of these modules owns
-  Standard Schema meaning.
+  binding, process-capability authentication, server lifecycle, the status and shutdown routes, and
+  the typed readiness state consumed by `interfaces/cli/serve`. These names state responsibility
+  boundaries; they do not require an abstract interface or plugin mechanism. None of these modules
+  owns Standard Schema meaning.
 - `application/execution_sessions` owns ephemeral session/revision coordination, idempotent
   admission order, per-session ordering, and the process-wide execution gate without knowing HTTP
   or CLI. `application/experiment_execution` coordinates the publication-independent use-case
@@ -206,8 +206,8 @@ Model, Experiment, Runtime, artifact, identity, or refusal authority.
   construction, Evidence, identity, and refusal policy.
   Infrastructure receives only demonstrated domain-neutral mechanisms. This work adds no generic
   Repository, port hierarchy, dependency-injection container, service locator, or event bus.
-- The HTTP Interface uses Starlette to implement the five execution routes, the local control
-  route, middleware, JSON responses, and exception mapping. The local host owns readiness and
+- The HTTP Interface uses Starlette to implement the four execution routes, two local-host routes,
+  middleware, JSON responses, and exception mapping. The local host owns readiness, status, and
   shutdown directly, so ASGI lifespan handling is disabled. Uvicorn provides the single-worker ASGI
   server and graceful lifecycle. Existing Pydantic models define closed request and response
   schemas with unknown fields refused. Reload, WebSockets, proxy-header trust, CORS, and default

--- a/libs/gda-balancing/docs/badr/0026-local-http-execution-service.md
+++ b/libs/gda-balancing/docs/badr/0026-local-http-execution-service.md
@@ -13,7 +13,7 @@ Model, Experiment, Runtime, artifact, identity, or refusal authority.
 
 > **Follow-up design:** proposed bADR-0027 extracts the shared Execution Open Host Service and its
 > Published Language from transport-specific ownership. Until that decision is accepted and
-> implemented, this bADR remains the authority for the current `/v1` wire contract and local host.
+> implemented, this bADR remains the authority for the current `/v1` protocol contract and local host.
 > The follow-up changes integration ownership, not the Standard Schema authorities or the accepted
 > HTTP behavior recorded here. It classifies `/v1/status`, like `/v1/shutdown`, as a local-host
 > operation rather than a shared OHS capability while preserving both routes and response shapes.

--- a/libs/gda-balancing/docs/badr/0026-local-http-execution-service.md
+++ b/libs/gda-balancing/docs/badr/0026-local-http-execution-service.md
@@ -15,7 +15,8 @@ Model, Experiment, Runtime, artifact, identity, or refusal authority.
 > Published Language from transport-specific ownership. Until that decision is accepted and
 > implemented, this bADR remains the authority for the current `/v1` wire contract and local host.
 > The follow-up changes integration ownership, not the Standard Schema authorities or the accepted
-> HTTP behavior recorded here.
+> HTTP behavior recorded here. It classifies `/v1/status`, like `/v1/shutdown`, as a local-host
+> operation rather than a shared OHS capability while preserving both routes and response shapes.
 
 ## Decision
 

--- a/libs/gda-balancing/docs/badr/0026-local-http-execution-service.md
+++ b/libs/gda-balancing/docs/badr/0026-local-http-execution-service.md
@@ -11,6 +11,12 @@ filesystem-publication workflow is not a suitable coordination protocol for a ru
 new interface must reuse the existing Application and Domain behavior without creating another
 Model, Experiment, Runtime, artifact, identity, or refusal authority.
 
+> **Follow-up design:** proposed bADR-0027 extracts the shared Execution Open Host Service and its
+> Published Language from transport-specific ownership. Until that decision is accepted and
+> implemented, this bADR remains the authority for the current `/v1` wire contract and local host.
+> The follow-up changes integration ownership, not the Standard Schema authorities or the accepted
+> HTTP behavior recorded here.
+
 ## Decision
 
 ### Service and authority boundary

--- a/libs/gda-balancing/docs/badr/0027-execution-open-host-service-and-published-language.md
+++ b/libs/gda-balancing/docs/badr/0027-execution-open-host-service-and-published-language.md
@@ -29,29 +29,46 @@ choice would make a transport an accidental owner of execution meaning.
 
 - The OHS uses one **Execution Service Language** as its Published Language. This language contains
   only the integration concepts introduced by the OHS: explicit session handles, revision
-  selection, service-response framing, service errors, lifecycle facts, and their contract schema.
+  selection, service-response framing, shared OHS errors, and their contract schema.
 - The Interface layer owns the executable OHS-specific contract. That owner is protocol-neutral
   and sits outside the HTTP and MCP adapters. The Application layer remains responsible for use-case
   coordination, and the Domain layer remains responsible for Standard Schema meaning.
-- The Execution Service Language has an explicit contract revision. That revision is not the HTTP
-  path major, an MCP protocol revision, a toolkit release, or a Standard Schema version. The first
-  implementation records how the shared contract maps to the preserved `/v1` HTTP surface. A
-  breaking integration change selects a new contract revision and an explicit adapter migration;
-  compatible additions do not create another language or schema owner.
+- The initial contract is **Execution Service Language revision 1**. This is a compatibility label,
+  not a Package Release coordinate, HTTP path major, MCP protocol revision, toolkit release, or
+  Standard Schema version. A breaking integration change selects a new contract revision and an
+  explicit adapter migration. Compatible additions do not create another language or schema owner.
 - The Published Language does not become a Standard Schema authority. Kernel, LDB, Model,
   Experiment, Runtime, Evidence, and other accepted authorities continue to own their schemas,
   rules, semantics, identities, and refusals. The Execution Service Language references their
   exact normative contracts and versions. It does not copy their fields, emit a peer schema,
   reinterpret them, or expose an implementation-private Domain model.
 - The OHS-specific integration shapes have one executable owner outside the HTTP and MCP adapters.
-  JSON Schema, REST documentation, and MCP input or output schema for those shapes are derived
-  projections. A projection is not a second authority.
+  JSON Schema, HTTP contract documentation, and MCP input or output schema for those shapes are
+  derived projections. A projection is not a second authority.
 - An integration schema refers to an authority-owned Standard Schema value instead of expanding a
   duplicate definition. The first implementation slice must prove that a changed authority-owned
   schema cannot leave a stale accepted copy in the Published Language.
 - Human documentation defines lifecycle, identity, refusal, ordering, and evolution semantics that
   cannot be expressed by JSON Schema alone. It references the relevant bADR or specification rather
   than copying the normative algorithm or field inventory.
+
+### Initial contract and `/v1` projection
+
+Execution Service Language revision 1 contains four execution capabilities. The following table
+maps the shared contract to the current Pydantic shapes and routes without copying their complete
+schemas. Model Source Packages, Experiment Specifications, artifact members, and
+`Schema2RefusalReport` remain references to their authority-owned contracts.
+
+| Shared capability | Shared input and result | Current HTTP shape | Current route |
+| --- | --- | --- | --- |
+| `establish-session` | Input: one Model Source Package and initial Experiment Specification. Result: session handle, exact Resolved Model identity, and admitted revision identity, or an authority-owned admission refusal. | `CreateExecutionSessionRequest` to `ExecutionSessionCreatedResponse` or `RefusalResponse` | `POST /v1/execution-sessions` |
+| `admit-experiment-revision` | Input: session handle and complete Experiment Specification. Result: revision identity and whether it was newly admitted, an admission refusal, or `unknown_execution_session`. | Path `session_id` plus `AdmitExperimentRevisionRequest` to `ExperimentRevisionAdmittedResponse`, `RefusalResponse`, or the shared OHS error | `POST /v1/execution-sessions/{session_id}/experiment-revisions` |
+| `run-experiment-revision` | Input: session handle and exact revision identity. Result: authority-owned success, verdict, or refusal artifacts, or an unknown-handle error. | Path `session_id` plus `RunExperimentRequest` to `RunSuccessResponse`, `RunVerdictResponse`, `RunRefusalResponse`, or a shared OHS error | `POST /v1/execution-sessions/{session_id}/runs` |
+| `release-session` | Input: session handle. Result: released session handle or `unknown_execution_session`. | Path `session_id` and an empty body to `ExecutionSessionDeletedResponse` or the shared OHS error | `DELETE /v1/execution-sessions/{session_id}` |
+
+`GET /v1/status` and `POST /v1/shutdown` are not OHS capabilities. They are local-companion-host
+operations. The former projects `StatusResponse`; the latter projects `ShutdownResponse`. Their
+paths and response bytes remain unchanged during contract extraction.
 
 ### Sibling Interface adapters
 
@@ -61,14 +78,30 @@ choice would make a transport an accidental owner of execution meaning.
 - The MCP adapter does not wrap or call the HTTP adapter. The HTTP adapter does not import MCP.
   Neither adapter owns Model, Experiment, Runtime, artifact, identity, outcome, or refusal meaning.
 - Adapter-specific facts remain local. HTTP owns resource identifiers, methods, status codes,
-  headers, media types, and local process authentication. MCP owns its protocol messages, tool and
-  resource descriptions, capability metadata, and model-facing presentation.
+  headers, media types, and HTTP error projection. MCP owns its protocol messages, tool and resource
+  descriptions, capability metadata, and model-facing presentation. The local companion host owns
+  process authentication and lifecycle.
 - MCP tools are designed around complete agent tasks. They are not generated mechanically from
   HTTP routes. MCP resources can expose immutable contract or artifact representations when a
   demonstrated client need exists. MCP prompts are optional interaction aids and never own
   execution semantics.
 - The selected MCP specification revision is pinned when implementation starts. It is an external
   protocol authority for MCP messages only. It cannot define local Domain meaning.
+
+### Responsibility partition
+
+| Owner | Owns | Current error or refusal mapping |
+| --- | --- | --- |
+| Execution Service Language | Capability names, OHS handles and selections, response framing, and shared OHS errors | `unknown_execution_session` and `unknown_experiment_revision` |
+| Application | Session and revision state, admission order, execution order, and the conditions behind unknown-handle errors | Raises typed conditions; owns no wire code or response envelope |
+| Domain | Standard Schema admission, execution, artifacts, identities, outcomes, and refusals | `Schema2RefusalReport` and execution success, verdict, or refusal meaning |
+| Resource-oriented HTTP adapter | Routes, methods, media types, request bounds, HTTP status, and HTTP error projection | `invalid_request`, `request_too_large`, `unsupported_media_type`, `unknown_endpoint`, `method_not_allowed`, and `internal_error` |
+| MCP adapter | Tools, resources, optional prompts, MCP schemas, structured content, and MCP error projection | Maps shared results and errors to the selected MCP revision without HTTP codes |
+| Local companion host | Process capability authentication, readiness, status, shutdown, request-admission closure, and process fault lifecycle | `authentication_required` and `service_shutting_down`; a fatal fault uses the HTTP adapter's sanitized `internal_error` projection before process exit when possible |
+
+The current `ServiceErrorCode` union is a transport-local mixture of these categories. The first
+extraction splits ownership without changing its accepted `/v1` spelling or status mapping. A
+shared OHS error remains distinct from a Domain refusal and from an adapter parsing failure.
 
 ### Resource-oriented HTTP and REST evolution
 
@@ -99,7 +132,7 @@ choice would make a transport an accidental owner of execution meaning.
     -> Standard Schema authorities plus the OHS integration contract
     -> derived executable schemas and conformance cases
     -> protocol-neutral Application service
-    -> REST and MCP Interface adapters
+    -> Resource-oriented HTTP and MCP Interface adapters
     -> parity and end-to-end evidence
     -> human acceptance
   ```
@@ -130,7 +163,7 @@ choice would make a transport an accidental owner of execution meaning.
   routes, and transport models the hidden owner of a future MCP surface.
 - **Implement MCP as an HTTP client** was rejected. It adds a second serialization and failure
   boundary and prevents in-process adapters from sharing one Application service directly.
-- **Define independent REST and MCP schemas** was rejected. They can drift in identities, outcomes,
+- **Define independent HTTP and MCP schemas** was rejected. They can drift in identities, outcomes,
   refusals, and authority references.
 - **Publish the internal Domain model** was rejected. It freezes implementation structure and lets
   integration needs change Domain ownership.
@@ -143,9 +176,9 @@ choice would make a transport an accidental owner of execution meaning.
 
 - The current HTTP Pydantic models will no longer be the permanent owner of shared OHS integration
   shapes. The first implementation slice moves only the shared contract and preserves the wire.
-- A later REST or MCP schema projection must be generated from the one Published-Language owner and
+- A later HTTP or MCP schema projection must be generated from the one Published-Language owner and
   must refer to authority-owned Standard Schema contracts.
-- REST and MCP can evolve their protocol presentation independently while retaining the same
+- HTTP and MCP can evolve their protocol presentation independently while retaining the same
   execution meaning.
 - Existing playtests remain HTTP consumers. They gain no Kernel, LDB, artifact, or MCP awareness.
 - bADR-0026 remains accepted for the current local host and `/v1` behavior. This decision refines
@@ -156,8 +189,8 @@ choice would make a transport an accidental owner of execution meaning.
 1. **Design acceptance**: reconcile this bADR, bADR-0026, `BALANCING-CONTEXT.md`,
    `docs/ARCHITECTURE.md`, and issue #789. A human accepts the boundary before implementation.
 2. **Published-Language extraction**: move the OHS-specific contract to one protocol-neutral owner.
-   Identify its contract revision and preserve `/v1` bytes, status behavior, identities, outcomes,
-   refusals, ordering, and playtest use.
+   Start from a before-change HTTP wire corpus and preserve `/v1` bytes, status behavior, identities,
+   outcomes, refusals, ordering, and playtest use under Execution Service Language revision 1.
 3. **Authority conformance**: prove that integration schemas reference authority-owned Standard
    Schema contracts and cannot retain a copied stale shape. Include positive, refusal, boundary,
    and mutation cases.
@@ -171,7 +204,13 @@ choice would make a transport an accidental owner of execution meaning.
 7. **Reopen on evidence**: consider deeper REST, asynchronous Runs, Runtime interaction, discovery,
    or schema delivery only when a concrete consumer exposes that gap.
 
-The load-bearing claim is falsified if REST and MCP require different execution identities,
-outcomes, refusals, or ordering, or if either adapter must copy Standard Schema semantics to work.
-Such evidence reopens the Published-Language boundary instead of permitting an adapter-specific
-semantic escape hatch.
+While this bADR is Proposed, three load-bearing claims remain open: one language can serve HTTP and
+MCP without copied Standard Schema contracts; extraction can preserve the accepted `/v1` wire
+corpus; and MCP can call the Application service without an HTTP proxy or second semantic path.
+Mutation and conformance tests, the before/after HTTP corpus, and the minimal MCP tracer close these
+claims during the ordered delivery gates.
+
+The decision is falsified if HTTP and MCP require different execution identities, outcomes,
+refusals, or ordering, or if either adapter must copy Standard Schema semantics to work. Such
+evidence reopens the Published-Language boundary instead of permitting an adapter-specific semantic
+escape hatch.

--- a/libs/gda-balancing/docs/badr/0027-execution-open-host-service-and-published-language.md
+++ b/libs/gda-balancing/docs/badr/0027-execution-open-host-service-and-published-language.md
@@ -1,14 +1,14 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # Publish the Execution Open Host Service through one Published Language
 
 Issue #789 records the next integration boundary for gda-balancing. The existing local Execution
-HTTP API already reuses Application and Domain behavior, preserves exact identities, and supports
-several application-agnostic clients. Its integration contract still belongs to the HTTP adapter.
-Leaving that contract transport-owned would make HTTP an accidental owner of execution meaning and
-would force any later adapter either to copy the contract or to call HTTP.
+HTTP API already reused Application and Domain behavior, preserved exact identities, and supported
+several application-agnostic clients. Its integration contract still belonged to the HTTP adapter.
+Leaving that contract transport-owned would have made HTTP an accidental owner of execution meaning
+and forced any later adapter either to copy the contract or to call HTTP.
 
 ## Decision
 
@@ -39,15 +39,21 @@ would force any later adapter either to copy the contract or to call HTTP.
   explicit adapter migration. Compatible additions do not create another language or schema owner.
 - The Published Language does not become a Standard Schema authority. Kernel, LDB, Model,
   Experiment, Runtime, Evidence, and other accepted authorities continue to own their schemas,
-  rules, semantics, identities, and refusals. The Execution Service Language references their
-  exact normative contracts and versions. It does not copy their fields, emit a peer schema,
-  reinterpret them, or expose an implementation-private Domain model.
+  rules, semantics, identities, and refusals. The Execution Service Language carries their values
+  opaquely, and the Domain applies the applicable authority-owned contracts. The language does not
+  copy their fields, emit a peer schema, reinterpret them, or expose an implementation-private
+  Domain model.
 - The OHS-specific integration shapes have one executable owner outside transport adapters. JSON
   Schema and HTTP contract documentation for those shapes are derived projections. Any future
   adapter projection must derive from the same owner. A projection is not a second authority.
-- An integration schema refers to an authority-owned Standard Schema value instead of expanding a
-  duplicate definition. The first implementation slice must prove that a changed authority-owned
-  schema cannot leave a stale accepted copy in the Published Language.
+- Revision 1 closes only the OHS envelopes. Nested Model Source, Experiment, and artifact values
+  remain opaque to its Pydantic schemas. Domain validates or produces these values under the
+  applicable authority-owned contracts, so the Published Language cannot retain a stale accepted
+  copy of their internal shape.
+- Revision 1 does not publish a combined Standard Schema. If a later consumer requires one, its
+  projection must use resolvable references to authority-owned Standard Schema values instead of
+  expanding duplicate definitions. That need must not introduce a peer schema authority or an
+  otherwise unnecessary schema registry.
 - Human documentation defines lifecycle, identity, refusal, ordering, and evolution semantics that
   cannot be expressed by JSON Schema alone. It references the relevant bADR or specification rather
   than copying the normative algorithm or field inventory.
@@ -56,15 +62,16 @@ would force any later adapter either to copy the contract or to call HTTP.
 
 Execution Service Language revision 1 contains four execution capabilities. The following table
 maps the shared contract to the current Pydantic shapes and routes without copying their complete
-schemas. Model Source Packages, Experiment Specifications, artifact members, and
-`Schema2RefusalReport` remain references to their authority-owned contracts.
+schemas. Model Source Packages, Experiment Specifications, and artifact members remain opaque
+values governed by their authority-owned contracts. `Schema2RefusalReport` remains the reused
+authority-owned refusal contract.
 
 | Shared capability | Shared input and result | Current HTTP shape | Current route |
 | --- | --- | --- | --- |
-| `establish-session` | Input: one Model Source Package and initial Experiment Specification. Result: session handle, exact Resolved Model identity, and admitted revision identity, or an authority-owned admission refusal. | `CreateExecutionSessionRequest` to `ExecutionSessionCreatedResponse` or `RefusalResponse` | `POST /v1/execution-sessions` |
-| `admit-experiment-revision` | Input: session handle and complete Experiment Specification. Result: revision identity and whether it was newly admitted, an admission refusal, or `unknown_execution_session`. | Path `session_id` plus `AdmitExperimentRevisionRequest` to `ExperimentRevisionAdmittedResponse`, `RefusalResponse`, or the shared OHS error | `POST /v1/execution-sessions/{session_id}/experiment-revisions` |
-| `run-experiment-revision` | Input: session handle and exact revision identity. Result: authority-owned success, verdict, or refusal artifacts, `unknown_execution_session`, or `unknown_experiment_revision`. | Path `session_id` plus `RunExperimentRequest` to `RunSuccessResponse`, `RunVerdictResponse`, `RunRefusalResponse`, `unknown_execution_session`, or `unknown_experiment_revision` | `POST /v1/execution-sessions/{session_id}/runs` |
-| `release-session` | Input: session handle. Result: released session handle or `unknown_execution_session`. | Path `session_id` and an empty body to `ExecutionSessionDeletedResponse` or the shared OHS error | `DELETE /v1/execution-sessions/{session_id}` |
+| `establish-session` | Input: one Model Source Package and initial Experiment Specification. Result: session handle, exact Resolved Model identity, and admitted revision identity, or an authority-owned admission refusal. | `EstablishExecutionSessionRequest` to `ExecutionSessionEstablishedResponse` or `RefusalResponse` | `POST /v1/execution-sessions` |
+| `admit-experiment-revision` | Input: session handle and complete Experiment Specification. Result: revision identity and whether it was newly admitted, an admission refusal, or `unknown_execution_session`. | Path `session_id` and body `experiment_specification` project to `AdmitExperimentRevisionRequest`, then to `ExperimentRevisionAdmittedResponse`, `RefusalResponse`, or the shared OHS error | `POST /v1/execution-sessions/{session_id}/experiment-revisions` |
+| `run-experiment-revision` | Input: session handle and exact revision identity. Result: authority-owned success, verdict, or refusal artifacts, `unknown_execution_session`, or `unknown_experiment_revision`. | Path `session_id` and body `revision_id` project to `RunExperimentRequest`, then to `RunSuccessResponse`, `RunVerdictResponse`, `RunRefusalResponse`, `unknown_execution_session`, or `unknown_experiment_revision` | `POST /v1/execution-sessions/{session_id}/runs` |
+| `release-session` | Input: session handle. Result: released session handle or `unknown_execution_session`. | Path `session_id` and an empty body project to `ReleaseExecutionSessionRequest`, then to `ExecutionSessionReleasedResponse` or the shared OHS error | `DELETE /v1/execution-sessions/{session_id}` |
 
 `GET /v1/status` and `POST /v1/shutdown` are not OHS capabilities. They are local-companion-host
 operations. The former projects `StatusResponse`; the latter projects `ShutdownResponse`. Their
@@ -97,9 +104,9 @@ paths and response contracts remain unchanged during contract extraction.
 | Resource-oriented HTTP adapter | Routes, methods, media types, request bounds, HTTP status, and HTTP error projection | `invalid_request`, `request_too_large`, `unsupported_media_type`, `unknown_endpoint`, `method_not_allowed`, and `internal_error` |
 | Local companion host | Process capability authentication, readiness, status, shutdown, request-admission closure, and process fault lifecycle | `authentication_required` and `service_shutting_down`; a fatal fault uses the HTTP adapter's sanitized `internal_error` projection before process exit when possible |
 
-The current `ServiceErrorCode` union is a transport-local mixture of these categories. The first
-extraction splits ownership without changing its accepted `/v1` spelling or status mapping. A
-shared OHS error remains distinct from a Domain refusal and from an adapter parsing failure.
+The extraction separates the shared `ExecutionServiceErrorCode` values from transport-local and
+local-host errors without changing their accepted `/v1` spelling or status mapping. A shared OHS
+error remains distinct from a Domain refusal and from an adapter parsing failure.
 
 ### Resource-oriented HTTP and REST evolution
 
@@ -113,7 +120,7 @@ shared OHS error remains distinct from a Domain refusal and from an adapter pars
 - The product does not claim full REST conformance while required REST constraints remain absent.
   It does not add hypermedia, persistent Run resources, a generic Repository, background jobs, or
   other machinery only to obtain a REST label.
-- The first Published-Language extraction preserves the accepted `/v1` protocol behavior: routes,
+- The Published-Language extraction preserves the accepted `/v1` protocol behavior: routes,
   methods, normative headers, statuses, closed decoded JSON shapes and values, identities, error
   codes, ordering, authentication, and lifecycle. It does not freeze JSON key order, whitespace, or
   other serializer details unless an authority or demonstrated consumer requires byte stability.
@@ -166,37 +173,41 @@ shared OHS error remains distinct from a Domain refusal and from an adapter pars
 
 ## Consequences
 
-- The current HTTP Pydantic models will no longer be the permanent owner of shared OHS integration
-  shapes. The first implementation slice moves only the shared contract and preserves semantic HTTP
-  behavior.
+- The HTTP adapter no longer owns the shared OHS integration shapes. The implementation moves only
+  the shared contract and preserves semantic HTTP behavior.
 - The HTTP projection and any later adapter projection must derive from the one Published-Language
-  owner and must refer to authority-owned Standard Schema contracts.
+  owner. Revision 1 keeps nested Standard Schema values opaque. Domain validates or produces these
+  values under the applicable authority-owned contracts. A later combined schema must use
+  resolvable references if a demonstrated consumer requires that projection.
 - Existing playtests remain HTTP consumers. They gain no Kernel, LDB, or artifact awareness.
 - bADR-0026 remains accepted for the current local host and `/v1` behavior. This decision refines
   only the shared integration ownership and the rule for future adapters.
 
-## Validation and delivery gates
+## Validation and delivery evidence
 
-1. **Design acceptance**: reconcile this bADR, bADR-0026, `BALANCING-CONTEXT.md`,
-   `docs/ARCHITECTURE.md`, and issue #789. A human accepts the boundary before implementation.
-2. **Published-Language extraction**: move the OHS-specific contract to one protocol-neutral owner.
-   Start from before-change HTTP contract cases and preserve `/v1` routes, methods, normative
-   headers, statuses, closed decoded JSON shapes and values, identities, error codes, ordering,
-   authentication, lifecycle, and playtest use under Execution Service Language revision 1.
-3. **Authority conformance**: prove that integration schemas reference authority-owned Standard
-   Schema contracts and cannot retain a copied stale shape. Include positive, refusal, boundary,
-   and mutation cases.
-4. **HTTP adoption**: make the Resource-oriented HTTP adapter consume the shared contract. Retain
-   bADR-0026 lifecycle, security, failure, and source/wheel evidence.
-5. **Stop at the accepted scope**: add no MCP-specific production artifact or gate. Deeper REST,
-   asynchronous Runs, Runtime interaction, discovery, schema delivery, or another transport adapter
-   requires a concrete consumer and a separate approved delivery scope.
+1. **Design acceptance**: the maintainer accepted the reconciled boundary before implementation.
+   This bADR, bADR-0026, `BALANCING-CONTEXT.md`, `docs/ARCHITECTURE.md`, and issue #789 record the
+   same decision.
+2. **Published-Language extraction**: `interfaces/execution_service_language.py` owns the
+   OHS-specific contract. HTTP contract tests preserve `/v1` routes, methods, normative headers,
+   statuses, closed decoded JSON shapes and values, identities, error codes, ordering,
+   authentication, lifecycle, and playtest use under revision 1.
+3. **Authority conformance**: contract tests prove that the integration schemas close OHS
+   envelopes, leave nested authority-owned values opaque and unchanged, and let Domain validate or
+   produce those values under the applicable authority-owned contracts. Positive, refusal,
+   boundary, and mutation cases cover the current contract. A later combined schema must use
+   resolvable authority-owned references if a demonstrated consumer requires it.
+4. **HTTP adoption**: the Resource-oriented HTTP adapter consumes the shared contract and retains
+   bADR-0026 lifecycle, security, failure, and source/wheel evidence. The local companion host owns
+   status and shutdown outside the four OHS capabilities.
+5. **Accepted scope**: the implementation adds no MCP-specific production artifact or gate. Deeper
+   REST, asynchronous Runs, Runtime interaction, discovery, schema delivery, or another transport
+   adapter requires a concrete consumer and a separate approved delivery scope.
 
-While this bADR is Proposed, two load-bearing claims remain open: the Published Language can own the
-OHS-specific contract without copying Standard Schema contracts, and extraction can preserve the
-accepted semantic `/v1` protocol behavior. Mutation and conformance tests plus before/after HTTP
-contract cases close these claims during the ordered delivery gates. The reserved future-adapter
-seam is not implementation evidence.
+The implementation closes the two load-bearing claims: the Published Language owns the OHS-specific
+contract without copying Standard Schema contracts, and extraction preserves the accepted semantic
+`/v1` protocol behavior. Published-Language, HTTP, authority, mutation, CLI-parity, and wheel tests
+provide the evidence. The reserved future-adapter seam is not implementation evidence.
 
 The decision is falsified if the HTTP adapter must copy Standard Schema semantics to consume the
 Published Language or if extraction changes the accepted `/v1` protocol behavior. Such evidence

--- a/libs/gda-balancing/docs/badr/0027-execution-open-host-service-and-published-language.md
+++ b/libs/gda-balancing/docs/badr/0027-execution-open-host-service-and-published-language.md
@@ -7,8 +7,8 @@ status: proposed
 Issue #789 records the next integration boundary for gda-balancing. The existing local Execution
 HTTP API already reuses Application and Domain behavior, preserves exact identities, and supports
 several application-agnostic clients. Its integration contract still belongs to the HTTP adapter.
-A future MCP adapter would therefore have to copy that contract or call the HTTP adapter. Either
-choice would make a transport an accidental owner of execution meaning.
+Leaving that contract transport-owned would make HTTP an accidental owner of execution meaning and
+would force any later adapter either to copy the contract or to call HTTP.
 
 ## Decision
 
@@ -21,7 +21,7 @@ choice would make a transport an accidental owner of execution meaning.
 - The OHS is a strategic integration boundary. It is not a tactical Domain Service, Python service
   class, public-network deployment, machine-wide daemon, or game-specific endpoint.
 - The protocol-neutral Application service coordinates the OHS use cases and returns typed results
-  or refusals. It does not know HTTP, MCP, Starlette, JSON-RPC, Godot, or a consumer product.
+  or refusals. It does not know Interface protocols, frameworks, Godot, or a consumer product.
 - Domain remains the sole owner of Model and Experiment admission, Runtime execution, Evidence,
   artifact construction, identities, and refusals. The OHS adds no parallel semantic path.
 
@@ -31,20 +31,20 @@ choice would make a transport an accidental owner of execution meaning.
   only the integration concepts introduced by the OHS: explicit session handles, revision
   selection, service-response framing, shared OHS errors, and their contract schema.
 - The Interface layer owns the executable OHS-specific contract. That owner is protocol-neutral
-  and sits outside the HTTP and MCP adapters. The Application layer remains responsible for use-case
+  and sits outside transport adapters. The Application layer remains responsible for use-case
   coordination, and the Domain layer remains responsible for Standard Schema meaning.
 - The initial contract is **Execution Service Language revision 1**. This is a compatibility label,
-  not a Package Release coordinate, HTTP path major, MCP protocol revision, toolkit release, or
-  Standard Schema version. A breaking integration change selects a new contract revision and an
+  not a Package Release coordinate, HTTP path major, toolkit release, transport-protocol revision,
+  or Standard Schema version. A breaking integration change selects a new contract revision and an
   explicit adapter migration. Compatible additions do not create another language or schema owner.
 - The Published Language does not become a Standard Schema authority. Kernel, LDB, Model,
   Experiment, Runtime, Evidence, and other accepted authorities continue to own their schemas,
   rules, semantics, identities, and refusals. The Execution Service Language references their
   exact normative contracts and versions. It does not copy their fields, emit a peer schema,
   reinterpret them, or expose an implementation-private Domain model.
-- The OHS-specific integration shapes have one executable owner outside the HTTP and MCP adapters.
-  JSON Schema, HTTP contract documentation, and MCP input or output schema for those shapes are
-  derived projections. A projection is not a second authority.
+- The OHS-specific integration shapes have one executable owner outside transport adapters. JSON
+  Schema and HTTP contract documentation for those shapes are derived projections. Any future
+  adapter projection must derive from the same owner. A projection is not a second authority.
 - An integration schema refers to an authority-owned Standard Schema value instead of expanding a
   duplicate definition. The first implementation slice must prove that a changed authority-owned
   schema cannot leave a stale accepted copy in the Published Language.
@@ -68,35 +68,33 @@ schemas. Model Source Packages, Experiment Specifications, artifact members, and
 
 `GET /v1/status` and `POST /v1/shutdown` are not OHS capabilities. They are local-companion-host
 operations. The former projects `StatusResponse`; the latter projects `ShutdownResponse`. Their
-paths and response bytes remain unchanged during contract extraction.
+paths and response contracts remain unchanged during contract extraction.
 
-### Sibling Interface adapters
+### Current adapter and deferred extensions
 
-- Resource-oriented HTTP and MCP are sibling inbound Interface adapters. Both project the same OHS
-  capabilities and Execution Service Language. Both call the same Application service directly
-  when they run in the same process.
-- The MCP adapter does not wrap or call the HTTP adapter. The HTTP adapter does not import MCP.
-  Neither adapter owns Model, Experiment, Runtime, artifact, identity, outcome, or refusal meaning.
+- Resource-oriented HTTP is the current inbound Interface adapter. It projects the OHS capabilities
+  and Execution Service Language and calls the Application service directly.
 - Adapter-specific facts remain local. HTTP owns resource identifiers, methods, status codes,
-  headers, media types, and HTTP error projection. MCP owns its protocol messages, tool and resource
-  descriptions, capability metadata, and model-facing presentation. The local companion host owns
-  process authentication and lifecycle.
-- MCP tools are designed around complete agent tasks. They are not generated mechanically from
-  HTTP routes. MCP resources can expose immutable contract or artifact representations when a
-  demonstrated client need exists. MCP prompts are optional interaction aids and never own
-  execution semantics.
-- The selected MCP specification revision is pinned when implementation starts. It is an external
-  protocol authority for MCP messages only. It cannot define local Domain meaning.
+  headers, media types, and HTTP error projection. The local companion host owns process
+  authentication and lifecycle. Neither owns Model, Experiment, Runtime, artifact, identity,
+  outcome, or refusal meaning.
+- An MCP adapter is deferred. The current delivery adds no MCP module, placeholder interface, tool,
+  resource, prompt, schema projection, compatibility layer, protocol dependency, specification pin,
+  tracer, or parity gate. A named agent consumer, a concrete tool workflow, or a separately approved
+  MCP delivery issue can reopen that work.
+- If MCP is later selected, it is a peer Interface adapter that uses the Execution Service Language
+  and calls Application directly. It does not wrap HTTP or create a second semantic path. The future
+  delivery pins the then-current MCP specification and designs only the behavior justified by its
+  concrete consumer. This deferral is not a permanent prohibition.
 
 ### Responsibility partition
 
 | Owner | Owns | Current error or refusal mapping |
 | --- | --- | --- |
 | Execution Service Language | Capability names, OHS handles and selections, response framing, and shared OHS errors | `unknown_execution_session` and `unknown_experiment_revision` |
-| Application | Session and revision state, admission order, execution order, and the conditions behind `unknown_execution_session` and `unknown_experiment_revision` | Raises typed conditions; owns no wire code or response envelope |
+| Application | Session and revision state, admission order, execution order, and the conditions behind `unknown_execution_session` and `unknown_experiment_revision` | Raises typed conditions; owns no transport code or response envelope |
 | Domain | Standard Schema admission, execution, artifacts, identities, outcomes, and refusals | `Schema2RefusalReport` and execution success, verdict, or refusal meaning |
 | Resource-oriented HTTP adapter | Routes, methods, media types, request bounds, HTTP status, and HTTP error projection | `invalid_request`, `request_too_large`, `unsupported_media_type`, `unknown_endpoint`, `method_not_allowed`, and `internal_error` |
-| MCP adapter | Tools, resources, optional prompts, MCP schemas, structured content, and MCP error projection | Maps shared results and errors to the selected MCP revision without HTTP codes |
 | Local companion host | Process capability authentication, readiness, status, shutdown, request-admission closure, and process fault lifecycle | `authentication_required` and `service_shutting_down`; a fatal fault uses the HTTP adapter's sanitized `internal_error` projection before process exit when possible |
 
 The current `ServiceErrorCode` union is a transport-local mixture of these categories. The first
@@ -106,8 +104,8 @@ shared OHS error remains distinct from a Domain refusal and from an adapter pars
 ### Resource-oriented HTTP and REST evolution
 
 - The existing `/v1` surface remains a Resource-oriented HTTP API. bADR-0026 continues to own its
-  routes, loopback host, process capability, readiness, shutdown, request limits, and current wire
-  behavior.
+  routes, loopback host, process capability, readiness, shutdown, request limits, and current
+  protocol behavior.
 - Resource orientation is an initial architecture boundary, not a permanent restriction. A
   demonstrated consumer need can add applicable REST constraints, such as richer resource
   representations, links, cache semantics, or a complete REST architecture. A breaking change uses
@@ -115,9 +113,10 @@ shared OHS error remains distinct from a Domain refusal and from an adapter pars
 - The product does not claim full REST conformance while required REST constraints remain absent.
   It does not add hypermedia, persistent Run resources, a generic Repository, background jobs, or
   other machinery only to obtain a REST label.
-- The first Published-Language extraction preserves the accepted `/v1` wire contract. It can expose
-  the existing contract from a new owner before a later decision changes any public resource or
-  representation.
+- The first Published-Language extraction preserves the accepted `/v1` protocol behavior: routes,
+  methods, normative headers, statuses, closed decoded JSON shapes and values, identities, error
+  codes, ordering, authentication, and lifecycle. It does not freeze JSON key order, whitespace, or
+  other serializer details unless an authority or demonstrated consumer requires byte stability.
 
 ### Evolution boundary
 
@@ -132,8 +131,8 @@ shared OHS error remains distinct from a Domain refusal and from an adapter pars
     -> Standard Schema authorities plus the OHS integration contract
     -> derived executable schemas and conformance cases
     -> protocol-neutral Application service
-    -> Resource-oriented HTTP and MCP Interface adapters
-    -> parity and end-to-end evidence
+    -> Resource-oriented HTTP Interface adapter
+    -> semantic parity and end-to-end evidence
     -> human acceptance
   ```
 
@@ -152,65 +151,55 @@ shared OHS error remains distinct from a Domain refusal and from an adapter pars
   (2000) defines REST through constraints that include stateless interaction, cache, a uniform
   interface, self-descriptive messages, and hypermedia. This bADR therefore describes the current
   HTTP surface as Resource-oriented and makes no full-REST claim.
-- The official [MCP 2026-07-28 release](https://blog.modelcontextprotocol.io/posts/2026-07-28/)
-  is research evidence for a stateless protocol core and explicit application handles. It is not a
-  runtime dependency or a compatibility promise. The implementation gate must pin and recheck the
-  then-selected MCP revision.
 
 ## Considered options
 
 - **Keep the HTTP contract as the common service contract** was rejected. It makes HTTP status,
-  routes, and transport models the hidden owner of a future MCP surface.
-- **Implement MCP as an HTTP client** was rejected. It adds a second serialization and failure
-  boundary and prevents in-process adapters from sharing one Application service directly.
-- **Define independent HTTP and MCP schemas** was rejected. They can drift in identities, outcomes,
-  refusals, and authority references.
+  routes, and transport models the hidden owner of any later adapter.
 - **Publish the internal Domain model** was rejected. It freezes implementation structure and lets
   integration needs change Domain ownership.
 - **Adopt full REST immediately** was rejected. No current consumer requires the additional
   hypermedia, cache, or persistent resource machinery.
-- **Extract one Published Language and use sibling adapters** was selected. It removes transport
-  ownership without changing Standard Schema authority or current `/v1` behavior.
+- **Extract one Published Language and make the current HTTP adapter consume it** was selected. It
+  removes transport ownership without changing Standard Schema authority or current `/v1`
+  behavior. Additional adapters remain deferred until a concrete consumer requires one.
 
 ## Consequences
 
 - The current HTTP Pydantic models will no longer be the permanent owner of shared OHS integration
-  shapes. The first implementation slice moves only the shared contract and preserves the wire.
-- A later HTTP or MCP schema projection must be generated from the one Published-Language owner and
-  must refer to authority-owned Standard Schema contracts.
-- HTTP and MCP can evolve their protocol presentation independently while retaining the same
-  execution meaning.
-- Existing playtests remain HTTP consumers. They gain no Kernel, LDB, artifact, or MCP awareness.
+  shapes. The first implementation slice moves only the shared contract and preserves semantic HTTP
+  behavior.
+- The HTTP projection and any later adapter projection must derive from the one Published-Language
+  owner and must refer to authority-owned Standard Schema contracts.
+- Existing playtests remain HTTP consumers. They gain no Kernel, LDB, or artifact awareness.
 - bADR-0026 remains accepted for the current local host and `/v1` behavior. This decision refines
-  only the shared integration ownership and future adapter topology.
+  only the shared integration ownership and the rule for future adapters.
 
 ## Validation and delivery gates
 
 1. **Design acceptance**: reconcile this bADR, bADR-0026, `BALANCING-CONTEXT.md`,
    `docs/ARCHITECTURE.md`, and issue #789. A human accepts the boundary before implementation.
 2. **Published-Language extraction**: move the OHS-specific contract to one protocol-neutral owner.
-   Start from a before-change HTTP wire corpus and preserve `/v1` bytes, status behavior, identities,
-   outcomes, refusals, ordering, and playtest use under Execution Service Language revision 1.
+   Start from before-change HTTP contract cases and preserve `/v1` routes, methods, normative
+   headers, statuses, closed decoded JSON shapes and values, identities, error codes, ordering,
+   authentication, lifecycle, and playtest use under Execution Service Language revision 1.
 3. **Authority conformance**: prove that integration schemas reference authority-owned Standard
    Schema contracts and cannot retain a copied stale shape. Include positive, refusal, boundary,
    and mutation cases.
 4. **HTTP adoption**: make the Resource-oriented HTTP adapter consume the shared contract. Retain
    bADR-0026 lifecycle, security, failure, and source/wheel evidence.
-5. **MCP tracer**: implement one minimal end-to-end MCP path against the same Application service
-   and Published Language. Compare its semantic artifacts, identities, outcomes, and refusals with
-   equivalent CLI and HTTP use cases after transport facts are excluded.
-6. **MCP completion**: add only the tools, resources, documentation, and operational behavior proven
-   by the tracer and named consumer stories.
-7. **Reopen on evidence**: consider deeper REST, asynchronous Runs, Runtime interaction, discovery,
-   or schema delivery only when a concrete consumer exposes that gap.
+5. **Stop at the accepted scope**: add no MCP-specific production artifact or gate. Deeper REST,
+   asynchronous Runs, Runtime interaction, discovery, schema delivery, or another transport adapter
+   requires a concrete consumer and a separate approved delivery scope.
 
-While this bADR is Proposed, three load-bearing claims remain open: one language can serve HTTP and
-MCP without copied Standard Schema contracts; extraction can preserve the accepted `/v1` wire
-corpus; and MCP can call the Application service without an HTTP proxy or second semantic path.
-Mutation and conformance tests, the before/after HTTP corpus, and the minimal MCP tracer close these
-claims during the ordered delivery gates.
+While this bADR is Proposed, two load-bearing claims remain open: the Published Language can own the
+OHS-specific contract without copying Standard Schema contracts, and extraction can preserve the
+accepted semantic `/v1` protocol behavior. Mutation and conformance tests plus before/after HTTP
+contract cases close these claims during the ordered delivery gates. The reserved future-adapter
+seam is not implementation evidence.
 
-The decision is falsified if HTTP and MCP require different execution identities, outcomes,
-refusals, or ordering, or if either adapter must copy Standard Schema semantics to work. Such
-evidence reopens the Published-Language boundary instead of permitting an adapter-specific semantic
-escape hatch.
+The decision is falsified if the HTTP adapter must copy Standard Schema semantics to consume the
+Published Language or if extraction changes the accepted `/v1` protocol behavior. Such evidence
+reopens the Published-Language boundary instead of permitting a transport-specific semantic escape
+hatch. A later adapter must define and validate its own delivery evidence when its concrete need is
+approved.

--- a/libs/gda-balancing/docs/badr/0027-execution-open-host-service-and-published-language.md
+++ b/libs/gda-balancing/docs/badr/0027-execution-open-host-service-and-published-language.md
@@ -1,0 +1,177 @@
+---
+status: proposed
+---
+
+# Publish the Execution Open Host Service through one Published Language
+
+Issue #789 records the next integration boundary for gda-balancing. The existing local Execution
+HTTP API already reuses Application and Domain behavior, preserves exact identities, and supports
+several application-agnostic clients. Its integration contract still belongs to the HTTP adapter.
+A future MCP adapter would therefore have to copy that contract or call the HTTP adapter. Either
+choice would make a transport an accidental owner of execution meaning.
+
+## Decision
+
+### Execution Open Host Service
+
+- gda-balancing publishes one **Execution Open Host Service**. It exposes a small set of
+  application-agnostic execution capabilities to downstream contexts. The initial capabilities
+  establish an Execution session, admit an Experiment revision, run an exact revision, and release
+  the session.
+- The OHS is a strategic integration boundary. It is not a tactical Domain Service, Python service
+  class, public-network deployment, machine-wide daemon, or game-specific endpoint.
+- The protocol-neutral Application service coordinates the OHS use cases and returns typed results
+  or refusals. It does not know HTTP, MCP, Starlette, JSON-RPC, Godot, or a consumer product.
+- Domain remains the sole owner of Model and Experiment admission, Runtime execution, Evidence,
+  artifact construction, identities, and refusals. The OHS adds no parallel semantic path.
+
+### Execution Service Language
+
+- The OHS uses one **Execution Service Language** as its Published Language. This language contains
+  only the integration concepts introduced by the OHS: explicit session handles, revision
+  selection, service-response framing, service errors, lifecycle facts, and their contract schema.
+- The Interface layer owns the executable OHS-specific contract. That owner is protocol-neutral
+  and sits outside the HTTP and MCP adapters. The Application layer remains responsible for use-case
+  coordination, and the Domain layer remains responsible for Standard Schema meaning.
+- The Execution Service Language has an explicit contract revision. That revision is not the HTTP
+  path major, an MCP protocol revision, a toolkit release, or a Standard Schema version. The first
+  implementation records how the shared contract maps to the preserved `/v1` HTTP surface. A
+  breaking integration change selects a new contract revision and an explicit adapter migration;
+  compatible additions do not create another language or schema owner.
+- The Published Language does not become a Standard Schema authority. Kernel, LDB, Model,
+  Experiment, Runtime, Evidence, and other accepted authorities continue to own their schemas,
+  rules, semantics, identities, and refusals. The Execution Service Language references their
+  exact normative contracts and versions. It does not copy their fields, emit a peer schema,
+  reinterpret them, or expose an implementation-private Domain model.
+- The OHS-specific integration shapes have one executable owner outside the HTTP and MCP adapters.
+  JSON Schema, REST documentation, and MCP input or output schema for those shapes are derived
+  projections. A projection is not a second authority.
+- An integration schema refers to an authority-owned Standard Schema value instead of expanding a
+  duplicate definition. The first implementation slice must prove that a changed authority-owned
+  schema cannot leave a stale accepted copy in the Published Language.
+- Human documentation defines lifecycle, identity, refusal, ordering, and evolution semantics that
+  cannot be expressed by JSON Schema alone. It references the relevant bADR or specification rather
+  than copying the normative algorithm or field inventory.
+
+### Sibling Interface adapters
+
+- Resource-oriented HTTP and MCP are sibling inbound Interface adapters. Both project the same OHS
+  capabilities and Execution Service Language. Both call the same Application service directly
+  when they run in the same process.
+- The MCP adapter does not wrap or call the HTTP adapter. The HTTP adapter does not import MCP.
+  Neither adapter owns Model, Experiment, Runtime, artifact, identity, outcome, or refusal meaning.
+- Adapter-specific facts remain local. HTTP owns resource identifiers, methods, status codes,
+  headers, media types, and local process authentication. MCP owns its protocol messages, tool and
+  resource descriptions, capability metadata, and model-facing presentation.
+- MCP tools are designed around complete agent tasks. They are not generated mechanically from
+  HTTP routes. MCP resources can expose immutable contract or artifact representations when a
+  demonstrated client need exists. MCP prompts are optional interaction aids and never own
+  execution semantics.
+- The selected MCP specification revision is pinned when implementation starts. It is an external
+  protocol authority for MCP messages only. It cannot define local Domain meaning.
+
+### Resource-oriented HTTP and REST evolution
+
+- The existing `/v1` surface remains a Resource-oriented HTTP API. bADR-0026 continues to own its
+  routes, loopback host, process capability, readiness, shutdown, request limits, and current wire
+  behavior.
+- Resource orientation is an initial architecture boundary, not a permanent restriction. A
+  demonstrated consumer need can add applicable REST constraints, such as richer resource
+  representations, links, cache semantics, or a complete REST architecture. A breaking change uses
+  an explicit versioned decision and migration path.
+- The product does not claim full REST conformance while required REST constraints remain absent.
+  It does not add hypermedia, persistent Run resources, a generic Repository, background jobs, or
+  other machinery only to obtain a REST label.
+- The first Published-Language extraction preserves the accepted `/v1` wire contract. It can expose
+  the existing contract from a new owner before a later decision changes any public resource or
+  representation.
+
+### Evolution boundary
+
+- Current complete-run, fixed-Model, synchronous, process-local, and loopback boundaries remain
+  changeable. A concrete need for Runtime input, stepping, observation, progress, cancellation,
+  browser access, or another interaction reopens the smallest affected contract.
+- A new capability must preserve the one-way authority flow:
+
+  ```text
+  requirements
+    -> OHS and Published Language decision
+    -> Standard Schema authorities plus the OHS integration contract
+    -> derived executable schemas and conformance cases
+    -> protocol-neutral Application service
+    -> REST and MCP Interface adapters
+    -> parity and end-to-end evidence
+    -> human acceptance
+  ```
+
+- The architecture does not prebuild a service locator, dependency-injection container, event bus,
+  schema registry, generic service framework, or speculative extension point. A real substitution,
+  discovery, or asynchronous interaction need must justify the smallest new seam.
+
+## Theory and external references
+
+- Eric Evans' [*Domain-Driven Design Reference*](https://www.domainlanguage.com/wp-content/uploads/2016/05/DDD_Reference_2015-03.pdf)
+  (2015) motivates an Open Host Service when several downstream contexts need one coherent
+  integration protocol. It motivates a Published Language as a documented interchange language
+  instead of freezing an internal model. This bADR adopts those two mechanisms. It does not make
+  the external terminology a local semantic authority.
+- Roy Fielding's [REST dissertation chapter](https://www.ics.uci.edu/~fielding/pubs/dissertation/rest_arch_style.htm)
+  (2000) defines REST through constraints that include stateless interaction, cache, a uniform
+  interface, self-descriptive messages, and hypermedia. This bADR therefore describes the current
+  HTTP surface as Resource-oriented and makes no full-REST claim.
+- The official [MCP 2026-07-28 release](https://blog.modelcontextprotocol.io/posts/2026-07-28/)
+  is research evidence for a stateless protocol core and explicit application handles. It is not a
+  runtime dependency or a compatibility promise. The implementation gate must pin and recheck the
+  then-selected MCP revision.
+
+## Considered options
+
+- **Keep the HTTP contract as the common service contract** was rejected. It makes HTTP status,
+  routes, and transport models the hidden owner of a future MCP surface.
+- **Implement MCP as an HTTP client** was rejected. It adds a second serialization and failure
+  boundary and prevents in-process adapters from sharing one Application service directly.
+- **Define independent REST and MCP schemas** was rejected. They can drift in identities, outcomes,
+  refusals, and authority references.
+- **Publish the internal Domain model** was rejected. It freezes implementation structure and lets
+  integration needs change Domain ownership.
+- **Adopt full REST immediately** was rejected. No current consumer requires the additional
+  hypermedia, cache, or persistent resource machinery.
+- **Extract one Published Language and use sibling adapters** was selected. It removes transport
+  ownership without changing Standard Schema authority or current `/v1` behavior.
+
+## Consequences
+
+- The current HTTP Pydantic models will no longer be the permanent owner of shared OHS integration
+  shapes. The first implementation slice moves only the shared contract and preserves the wire.
+- A later REST or MCP schema projection must be generated from the one Published-Language owner and
+  must refer to authority-owned Standard Schema contracts.
+- REST and MCP can evolve their protocol presentation independently while retaining the same
+  execution meaning.
+- Existing playtests remain HTTP consumers. They gain no Kernel, LDB, artifact, or MCP awareness.
+- bADR-0026 remains accepted for the current local host and `/v1` behavior. This decision refines
+  only the shared integration ownership and future adapter topology.
+
+## Validation and delivery gates
+
+1. **Design acceptance**: reconcile this bADR, bADR-0026, `BALANCING-CONTEXT.md`,
+   `docs/ARCHITECTURE.md`, and issue #789. A human accepts the boundary before implementation.
+2. **Published-Language extraction**: move the OHS-specific contract to one protocol-neutral owner.
+   Identify its contract revision and preserve `/v1` bytes, status behavior, identities, outcomes,
+   refusals, ordering, and playtest use.
+3. **Authority conformance**: prove that integration schemas reference authority-owned Standard
+   Schema contracts and cannot retain a copied stale shape. Include positive, refusal, boundary,
+   and mutation cases.
+4. **HTTP adoption**: make the Resource-oriented HTTP adapter consume the shared contract. Retain
+   bADR-0026 lifecycle, security, failure, and source/wheel evidence.
+5. **MCP tracer**: implement one minimal end-to-end MCP path against the same Application service
+   and Published Language. Compare its semantic artifacts, identities, outcomes, and refusals with
+   equivalent CLI and HTTP use cases after transport facts are excluded.
+6. **MCP completion**: add only the tools, resources, documentation, and operational behavior proven
+   by the tracer and named consumer stories.
+7. **Reopen on evidence**: consider deeper REST, asynchronous Runs, Runtime interaction, discovery,
+   or schema delivery only when a concrete consumer exposes that gap.
+
+The load-bearing claim is falsified if REST and MCP require different execution identities,
+outcomes, refusals, or ordering, or if either adapter must copy Standard Schema semantics to work.
+Such evidence reopens the Published-Language boundary instead of permitting an adapter-specific
+semantic escape hatch.

--- a/libs/gda-balancing/docs/badr/0027-execution-open-host-service-and-published-language.md
+++ b/libs/gda-balancing/docs/badr/0027-execution-open-host-service-and-published-language.md
@@ -63,7 +63,7 @@ schemas. Model Source Packages, Experiment Specifications, artifact members, and
 | --- | --- | --- | --- |
 | `establish-session` | Input: one Model Source Package and initial Experiment Specification. Result: session handle, exact Resolved Model identity, and admitted revision identity, or an authority-owned admission refusal. | `CreateExecutionSessionRequest` to `ExecutionSessionCreatedResponse` or `RefusalResponse` | `POST /v1/execution-sessions` |
 | `admit-experiment-revision` | Input: session handle and complete Experiment Specification. Result: revision identity and whether it was newly admitted, an admission refusal, or `unknown_execution_session`. | Path `session_id` plus `AdmitExperimentRevisionRequest` to `ExperimentRevisionAdmittedResponse`, `RefusalResponse`, or the shared OHS error | `POST /v1/execution-sessions/{session_id}/experiment-revisions` |
-| `run-experiment-revision` | Input: session handle and exact revision identity. Result: authority-owned success, verdict, or refusal artifacts, or an unknown-handle error. | Path `session_id` plus `RunExperimentRequest` to `RunSuccessResponse`, `RunVerdictResponse`, `RunRefusalResponse`, or a shared OHS error | `POST /v1/execution-sessions/{session_id}/runs` |
+| `run-experiment-revision` | Input: session handle and exact revision identity. Result: authority-owned success, verdict, or refusal artifacts, `unknown_execution_session`, or `unknown_experiment_revision`. | Path `session_id` plus `RunExperimentRequest` to `RunSuccessResponse`, `RunVerdictResponse`, `RunRefusalResponse`, `unknown_execution_session`, or `unknown_experiment_revision` | `POST /v1/execution-sessions/{session_id}/runs` |
 | `release-session` | Input: session handle. Result: released session handle or `unknown_execution_session`. | Path `session_id` and an empty body to `ExecutionSessionDeletedResponse` or the shared OHS error | `DELETE /v1/execution-sessions/{session_id}` |
 
 `GET /v1/status` and `POST /v1/shutdown` are not OHS capabilities. They are local-companion-host
@@ -93,7 +93,7 @@ paths and response bytes remain unchanged during contract extraction.
 | Owner | Owns | Current error or refusal mapping |
 | --- | --- | --- |
 | Execution Service Language | Capability names, OHS handles and selections, response framing, and shared OHS errors | `unknown_execution_session` and `unknown_experiment_revision` |
-| Application | Session and revision state, admission order, execution order, and the conditions behind unknown-handle errors | Raises typed conditions; owns no wire code or response envelope |
+| Application | Session and revision state, admission order, execution order, and the conditions behind `unknown_execution_session` and `unknown_experiment_revision` | Raises typed conditions; owns no wire code or response envelope |
 | Domain | Standard Schema admission, execution, artifacts, identities, outcomes, and refusals | `Schema2RefusalReport` and execution success, verdict, or refusal meaning |
 | Resource-oriented HTTP adapter | Routes, methods, media types, request bounds, HTTP status, and HTTP error projection | `invalid_request`, `request_too_large`, `unsupported_media_type`, `unknown_endpoint`, `method_not_allowed`, and `internal_error` |
 | MCP adapter | Tools, resources, optional prompts, MCP schemas, structured content, and MCP error projection | Maps shared results and errors to the selected MCP revision without HTTP codes |

--- a/libs/gda-balancing/src/gda_balancing/interfaces/cli/serve.py
+++ b/libs/gda-balancing/src/gda_balancing/interfaces/cli/serve.py
@@ -11,8 +11,12 @@ from gda_balancing.interfaces.cli.descriptors import (
     CommandDescriptor,
     ConformanceFixtures,
 )
-from gda_balancing.interfaces.http.api_v1 import PROTOCOL_VERSION, create_api_v1
-from gda_balancing.interfaces.http.local_host import LocalHostReadiness, run_local_host
+from gda_balancing.interfaces.http.api_v1 import create_api_v1
+from gda_balancing.interfaces.http.local_host import (
+    PROTOCOL_VERSION,
+    LocalHostReadiness,
+    run_local_host,
+)
 
 
 class ServeInput(BaseModel):

--- a/libs/gda-balancing/src/gda_balancing/interfaces/execution_service_language.py
+++ b/libs/gda-balancing/src/gda_balancing/interfaces/execution_service_language.py
@@ -1,0 +1,223 @@
+"""Published Language for the Execution Open Host Service (bADR-0027).
+
+Revision 1 closes OHS envelopes only. Nested Model Source, Experiment, and
+artifact values remain opaque here. Domain admits or produces them under the
+applicable authority-owned contracts. This module publishes no combined
+Standard Schema.
+"""
+
+from copy import deepcopy
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from gda_balancing.application.execution_sessions import (
+    ExecutionSessionCreated,
+    ExecutionSessionNotFound,
+    ExperimentRevisionAdmitted,
+    ExperimentRevisionNotFound,
+)
+from gda_balancing.application.experiment_execution import (
+    ExperimentExecutionOutcome,
+    ExperimentExecutionRefusal,
+    ExperimentExecutionSuccess,
+    ExperimentExecutionVerdict,
+)
+from gda_balancing.domain.diagnostics import Schema2RefusalReport
+
+
+EXECUTION_SERVICE_LANGUAGE_REVISION = 1
+ExecutionServiceErrorCode = Literal[
+    "unknown_execution_session",
+    "unknown_experiment_revision",
+]
+
+_ERROR_MESSAGES: dict[ExecutionServiceErrorCode, str] = {
+    "unknown_execution_session": "the Execution session does not exist",
+    "unknown_experiment_revision": "the Experiment revision does not exist",
+}
+
+
+class ExecutionServiceError(BaseModel):
+    """One OHS-specific error independent of transport status."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    category: Literal["service"] = "service"
+    code: ExecutionServiceErrorCode
+    message: str
+
+
+class ExecutionServiceErrorEnvelope(BaseModel):
+    """Shared OHS error framing."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    error: ExecutionServiceError
+
+
+def execution_service_error(
+    code: ExecutionServiceErrorCode,
+) -> ExecutionServiceErrorEnvelope:
+    """Return the contract-owned representation of one shared OHS error."""
+    return ExecutionServiceErrorEnvelope(
+        error=ExecutionServiceError(code=code, message=_ERROR_MESSAGES[code])
+    )
+
+
+def execution_service_error_from_condition(
+    condition: ExecutionSessionNotFound | ExperimentRevisionNotFound,
+) -> ExecutionServiceErrorEnvelope:
+    """Frame one Application selection condition as a shared OHS error."""
+    if isinstance(condition, ExecutionSessionNotFound):
+        return execution_service_error("unknown_execution_session")
+    return execution_service_error("unknown_experiment_revision")
+
+
+class EstablishExecutionSessionRequest(BaseModel):
+    """Complete authored values required to establish one session."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    model_source: dict[str, Any]
+    experiment_specification: dict[str, Any]
+
+
+class ExecutionSessionEstablishedResponse(BaseModel):
+    """Exact identities established by successful session admission."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    outcome: Literal["success"] = "success"
+    session_id: str
+    resolved_model_identity: str
+    revision_id: str
+
+
+class RefusalResponse(BaseModel):
+    """An authority-owned Domain refusal returned by the OHS."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    outcome: Literal["refusal"] = "refusal"
+    refusal: Schema2RefusalReport
+
+
+def establish_session_response(
+    result: ExecutionSessionCreated | Schema2RefusalReport,
+) -> ExecutionSessionEstablishedResponse | RefusalResponse:
+    """Frame one Application result for the establish-session capability."""
+    if isinstance(result, Schema2RefusalReport):
+        return RefusalResponse(refusal=result)
+    return ExecutionSessionEstablishedResponse(
+        session_id=result.session_id,
+        resolved_model_identity=result.resolved_model_identity,
+        revision_id=result.revision_id,
+    )
+
+
+class AdmitExperimentRevisionRequest(BaseModel):
+    """One complete Experiment value for an existing session."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    session_id: str
+    experiment_specification: dict[str, Any]
+
+
+class ExperimentRevisionAdmittedResponse(BaseModel):
+    """Identity and insertion state of an admitted revision."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    outcome: Literal["success"] = "success"
+    revision_id: str
+    created: bool
+
+
+def admit_experiment_revision_response(
+    result: ExperimentRevisionAdmitted | Schema2RefusalReport,
+) -> ExperimentRevisionAdmittedResponse | RefusalResponse:
+    """Frame one Application result for the revision-admission capability."""
+    if isinstance(result, Schema2RefusalReport):
+        return RefusalResponse(refusal=result)
+    return ExperimentRevisionAdmittedResponse(
+        revision_id=result.revision_id,
+        created=result.created,
+    )
+
+
+class RunExperimentRequest(BaseModel):
+    """The exact immutable revision selected for one run."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    session_id: str
+    revision_id: str
+
+
+class RunSuccessResponse(BaseModel):
+    """A successful execution with its existing artifacts inline."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    outcome: Literal["success"] = "success"
+    artifacts: dict[str, dict[str, Any]]
+
+
+class RunVerdictResponse(BaseModel):
+    """A metric verdict with its existing artifacts inline."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    outcome: Literal["verdict"] = "verdict"
+    failed_metrics: list[str]
+    artifacts: dict[str, dict[str, Any]]
+
+
+class RunRefusalResponse(BaseModel):
+    """A typed refusal with any terminal-audit artifacts inline."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    outcome: Literal["refusal"] = "refusal"
+    refusal: Schema2RefusalReport
+    artifacts: dict[str, dict[str, Any]]
+
+
+def run_experiment_revision_response(
+    result: ExperimentExecutionOutcome,
+) -> RunSuccessResponse | RunVerdictResponse | RunRefusalResponse:
+    """Frame one Application result for the run-revision capability."""
+    artifacts = {
+        name: deepcopy(member.value) for name, member in result.members.items()
+    }
+    if isinstance(result, ExperimentExecutionSuccess):
+        return RunSuccessResponse(artifacts=artifacts)
+    if isinstance(result, ExperimentExecutionVerdict):
+        return RunVerdictResponse(
+            failed_metrics=list(result.failed_metrics),
+            artifacts=artifacts,
+        )
+    assert isinstance(result, ExperimentExecutionRefusal)
+    return RunRefusalResponse(
+        refusal=result.report,
+        artifacts=artifacts,
+    )
+
+
+class ExecutionSessionReleasedResponse(BaseModel):
+    """Acknowledgement that one process-local session was released."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    outcome: Literal["success"] = "success"
+    session_id: str
+
+
+class ReleaseExecutionSessionRequest(BaseModel):
+    """The session selected for release."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    session_id: str

--- a/libs/gda-balancing/src/gda_balancing/interfaces/http/api_v1.py
+++ b/libs/gda-balancing/src/gda_balancing/interfaces/http/api_v1.py
@@ -1,10 +1,10 @@
 """The versioned, application-agnostic local Execution HTTP API."""
 
-from copy import deepcopy
+from collections.abc import Mapping
 import json
-from typing import Any, Literal, TypeVar, cast
+from typing import Any, TypeVar, cast
 
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import BaseModel, ValidationError
 from starlette.applications import Starlette
 from starlette.concurrency import run_in_threadpool
 from starlette.exceptions import HTTPException
@@ -14,20 +14,22 @@ from starlette.routing import Route
 from starlette.types import ASGIApp
 
 from gda_balancing.application.execution_sessions import (
-    ExecutionSessionCreated,
     ExecutionSessionNotFound,
     ExecutionSessions,
     ExperimentRevisionNotFound,
-    ExperimentRevisionAdmitted,
-)
-from gda_balancing.application.experiment_execution import (
-    ExperimentExecutionRefusal,
-    ExperimentExecutionSuccess,
-    ExperimentExecutionVerdict,
 )
 from gda_balancing.domain.authority.context import packaged_authority_context
-from gda_balancing.domain.diagnostics import Schema2RefusalReport
-from gda_balancing.infrastructure.distribution import distribution_version
+from gda_balancing.interfaces.execution_service_language import (
+    AdmitExperimentRevisionRequest,
+    EstablishExecutionSessionRequest,
+    ExecutionSessionReleasedResponse,
+    ReleaseExecutionSessionRequest,
+    RunExperimentRequest,
+    admit_experiment_revision_response,
+    establish_session_response,
+    execution_service_error_from_condition,
+    run_experiment_revision_response,
+)
 from gda_balancing.interfaces.http.service_errors import (
     SMALL_HTTP_REQUEST_BYTES,
     HttpRequestTooLarge,
@@ -39,17 +41,24 @@ from gda_balancing.interfaces.http.service_errors import (
     read_bounded_request_body,
     request_too_large_response,
     require_empty_request,
-    service_error_response,
     unsupported_media_type_response,
 )
 
-PROTOCOL_VERSION = "v1"
 _PROTOCOL_ENVELOPE_BYTES = 65_536
 RequestModel = TypeVar("RequestModel", bound=BaseModel)
 
 
 class _DuplicateObjectMember(ValueError):
     """A JSON object repeats a member name before schema admission."""
+
+
+def _execution_service_error_response(
+    condition: ExecutionSessionNotFound | ExperimentRevisionNotFound,
+) -> JSONResponse:
+    return JSONResponse(
+        execution_service_error_from_condition(condition).model_dump(mode="json"),
+        status_code=404,
+    )
 
 
 def _closed_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -66,6 +75,7 @@ async def _request_model(
     model: type[RequestModel],
     *,
     max_bytes: int,
+    bound_members: Mapping[str, Any] | None = None,
 ) -> RequestModel:
     media_type = request.headers.get("content-type", "").partition(";")[0].strip()
     if media_type.lower() != "application/json":
@@ -73,6 +83,12 @@ async def _request_model(
     body = await read_bounded_request_body(request, max_bytes=max_bytes)
     try:
         value = json.loads(body, object_pairs_hook=_closed_json_object)
+        if bound_members:
+            if not isinstance(value, dict) or any(
+                name in value for name in bound_members
+            ):
+                raise InvalidHttpRequest
+            value = {**value, **bound_members}
         return model.model_validate(value)
     except (
         _DuplicateObjectMember,
@@ -83,130 +99,18 @@ async def _request_model(
         raise InvalidHttpRequest from error
 
 
-class StatusResponse(BaseModel):
-    """Technical status of one ready local service process."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    status: Literal["ready"] = "ready"
-    protocol: Literal["v1"] = PROTOCOL_VERSION
-    toolkit_version: str
-
-
-class CreateExecutionSessionRequest(BaseModel):
-    """Complete authored values required to establish one session."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    model_source: dict[str, Any]
-    experiment_specification: dict[str, Any]
-
-
-class ExecutionSessionCreatedResponse(BaseModel):
-    """Exact identities established by successful session admission."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    outcome: Literal["success"] = "success"
-    session_id: str
-    resolved_model_identity: str
-    revision_id: str
-
-
-class RefusalResponse(BaseModel):
-    """Existing Domain refusal returned through the HTTP transport."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    outcome: Literal["refusal"] = "refusal"
-    refusal: Schema2RefusalReport
-
-
-class AdmitExperimentRevisionRequest(BaseModel):
-    """One complete Experiment value for an existing session."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    experiment_specification: dict[str, Any]
-
-
-class ExperimentRevisionAdmittedResponse(BaseModel):
-    """Identity and insertion state of an admitted revision."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    outcome: Literal["success"] = "success"
-    revision_id: str
-    created: bool
-
-
-class RunExperimentRequest(BaseModel):
-    """The exact immutable revision selected for one run."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    revision_id: str
-
-
-class RunSuccessResponse(BaseModel):
-    """A successful execution with its existing artifacts inline."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    outcome: Literal["success"] = "success"
-    artifacts: dict[str, dict[str, Any]]
-
-
-class RunVerdictResponse(BaseModel):
-    """A metric verdict with its existing artifacts inline."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    outcome: Literal["verdict"] = "verdict"
-    failed_metrics: list[str]
-    artifacts: dict[str, dict[str, Any]]
-
-
-class RunRefusalResponse(BaseModel):
-    """A typed refusal with any terminal-audit artifacts inline."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    outcome: Literal["refusal"] = "refusal"
-    refusal: Schema2RefusalReport
-    artifacts: dict[str, dict[str, Any]]
-
-
-class ExecutionSessionDeletedResponse(BaseModel):
-    """Acknowledgement that one process-local session was released."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    outcome: Literal["success"] = "success"
-    session_id: str
-
-
 def create_api_v1() -> ASGIApp:
     """Create execution routes without local-host lifecycle or authentication."""
-    toolkit_version = distribution_version("gda-balancing")
     sessions = ExecutionSessions()
     max_source_bytes = cast(
         int,
         packaged_authority_context().language_bundle["resources"]["max_source_bytes"],
     )
 
-    async def status(request: Request) -> Response:
-        if request.method != "GET":
-            raise HTTPException(status_code=405, headers={"Allow": "GET"})
-        await require_empty_request(request)
-        return JSONResponse(
-            StatusResponse(toolkit_version=toolkit_version).model_dump(mode="json")
-        )
-
     async def create_execution_session(request: Request) -> Response:
         payload = await _request_model(
             request,
-            CreateExecutionSessionRequest,
+            EstablishExecutionSessionRequest,
             max_bytes=(2 * max_source_bytes) + _PROTOCOL_ENVELOPE_BYTES,
         )
         result = await run_in_threadpool(
@@ -214,15 +118,7 @@ def create_api_v1() -> ASGIApp:
             payload.model_source,
             payload.experiment_specification,
         )
-        if isinstance(result, Schema2RefusalReport):
-            body = RefusalResponse(refusal=result)
-        else:
-            assert isinstance(result, ExecutionSessionCreated)
-            body = ExecutionSessionCreatedResponse(
-                session_id=result.session_id,
-                resolved_model_identity=result.resolved_model_identity,
-                revision_id=result.revision_id,
-            )
+        body = establish_session_response(result)
         return JSONResponse(body.model_dump(mode="json"))
 
     async def admit_experiment_revision(request: Request) -> Response:
@@ -230,27 +126,17 @@ def create_api_v1() -> ASGIApp:
             request,
             AdmitExperimentRevisionRequest,
             max_bytes=max_source_bytes + _PROTOCOL_ENVELOPE_BYTES,
+            bound_members={"session_id": request.path_params["session_id"]},
         )
         try:
             result = await run_in_threadpool(
                 sessions.admit_revision,
-                request.path_params["session_id"],
+                payload.session_id,
                 payload.experiment_specification,
             )
-        except ExecutionSessionNotFound:
-            return service_error_response(
-                code="unknown_execution_session",
-                message="the Execution session does not exist",
-                status_code=404,
-            )
-        if isinstance(result, Schema2RefusalReport):
-            body = RefusalResponse(refusal=result)
-        else:
-            assert isinstance(result, ExperimentRevisionAdmitted)
-            body = ExperimentRevisionAdmittedResponse(
-                revision_id=result.revision_id,
-                created=result.created,
-            )
+        except ExecutionSessionNotFound as error:
+            return _execution_service_error_response(error)
+        body = admit_experiment_revision_response(result)
         return JSONResponse(body.model_dump(mode="json"))
 
     async def run_experiment_revision(request: Request) -> Response:
@@ -258,56 +144,32 @@ def create_api_v1() -> ASGIApp:
             request,
             RunExperimentRequest,
             max_bytes=SMALL_HTTP_REQUEST_BYTES,
+            bound_members={"session_id": request.path_params["session_id"]},
         )
         try:
             result = await run_in_threadpool(
                 sessions.run,
-                request.path_params["session_id"],
+                payload.session_id,
                 payload.revision_id,
             )
-        except ExecutionSessionNotFound:
-            return service_error_response(
-                code="unknown_execution_session",
-                message="the Execution session does not exist",
-                status_code=404,
-            )
-        except ExperimentRevisionNotFound:
-            return service_error_response(
-                code="unknown_experiment_revision",
-                message="the Experiment revision does not exist",
-                status_code=404,
-            )
-        artifacts = {
-            name: deepcopy(member.value) for name, member in result.members.items()
-        }
-        if isinstance(result, ExperimentExecutionSuccess):
-            body = RunSuccessResponse(artifacts=artifacts)
-        elif isinstance(result, ExperimentExecutionVerdict):
-            body = RunVerdictResponse(
-                failed_metrics=list(result.failed_metrics),
-                artifacts=artifacts,
-            )
-        else:
-            assert isinstance(result, ExperimentExecutionRefusal)
-            body = RunRefusalResponse(
-                refusal=result.report,
-                artifacts=artifacts,
-            )
+        except ExecutionSessionNotFound as error:
+            return _execution_service_error_response(error)
+        except ExperimentRevisionNotFound as error:
+            return _execution_service_error_response(error)
+        body = run_experiment_revision_response(result)
         return JSONResponse(body.model_dump(mode="json"))
 
     async def delete_execution_session(request: Request) -> Response:
         await require_empty_request(request)
-        session_id = request.path_params["session_id"]
+        payload = ReleaseExecutionSessionRequest(
+            session_id=request.path_params["session_id"]
+        )
         try:
-            await run_in_threadpool(sessions.delete, session_id)
-        except ExecutionSessionNotFound:
-            return service_error_response(
-                code="unknown_execution_session",
-                message="the Execution session does not exist",
-                status_code=404,
-            )
+            await run_in_threadpool(sessions.delete, payload.session_id)
+        except ExecutionSessionNotFound as error:
+            return _execution_service_error_response(error)
         return JSONResponse(
-            ExecutionSessionDeletedResponse(session_id=session_id).model_dump(
+            ExecutionSessionReleasedResponse(session_id=payload.session_id).model_dump(
                 mode="json"
             )
         )
@@ -328,7 +190,6 @@ def create_api_v1() -> ASGIApp:
             Exception: unexpected_internal_error,
         },
         routes=[
-            Route("/v1/status", status, methods=["GET"]),
             Route(
                 "/v1/execution-sessions",
                 create_execution_session,

--- a/libs/gda-balancing/src/gda_balancing/interfaces/http/local_host.py
+++ b/libs/gda-balancing/src/gda_balancing/interfaces/http/local_host.py
@@ -17,6 +17,7 @@ from starlette.responses import JSONResponse, Response
 from starlette.routing import Mount, Route
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
+from gda_balancing.infrastructure.distribution import distribution_version
 from gda_balancing.interfaces.http.service_errors import (
     HttpRequestTooLarge,
     InvalidHttpRequest,
@@ -27,6 +28,8 @@ from gda_balancing.interfaces.http.service_errors import (
     require_empty_request,
     service_error_response,
 )
+
+PROTOCOL_VERSION = "v1"
 
 
 @dataclass(frozen=True)
@@ -46,6 +49,35 @@ class ShutdownResponse(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     status: Literal["shutting-down"] = "shutting-down"
+
+
+class StatusResponse(BaseModel):
+    """Technical status of one ready local service process."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    status: Literal["ready"] = "ready"
+    protocol: Literal["v1"] = PROTOCOL_VERSION
+    toolkit_version: str
+
+
+class _StatusEndpoint:
+    """Bind the exact local-host method before the catch-all mount."""
+
+    def __init__(self, toolkit_version: str) -> None:
+        self._toolkit_version = toolkit_version
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        request = Request(scope, receive)
+        if request.method != "GET":
+            raise HTTPException(status_code=405, headers={"Allow": "GET"})
+        await require_empty_request(request)
+        response = JSONResponse(
+            StatusResponse(toolkit_version=self._toolkit_version).model_dump(
+                mode="json"
+            )
+        )
+        await response(scope, receive, send)
 
 
 class _ShutdownEndpoint:
@@ -150,6 +182,10 @@ def _local_companion_app(
             Exception: unexpected_internal_error,
         },
         routes=[
+            Route(
+                "/v1/status",
+                _StatusEndpoint(distribution_version("gda-balancing")),
+            ),
             Route("/v1/shutdown", _ShutdownEndpoint(request_shutdown)),
             Mount("/", app=execution_api),
         ],

--- a/libs/gda-balancing/src/gda_balancing/interfaces/http/service_errors.py
+++ b/libs/gda-balancing/src/gda_balancing/interfaces/http/service_errors.py
@@ -12,7 +12,7 @@ from starlette.responses import JSONResponse, Response
 SMALL_HTTP_REQUEST_BYTES = 65_536
 
 
-ServiceErrorCode = Literal[
+HttpServiceErrorCode = Literal[
     "authentication_required",
     "internal_error",
     "invalid_request",
@@ -21,8 +21,6 @@ ServiceErrorCode = Literal[
     "service_shutting_down",
     "unsupported_media_type",
     "unknown_endpoint",
-    "unknown_execution_session",
-    "unknown_experiment_revision",
 ]
 
 
@@ -42,7 +40,7 @@ class ServiceError(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     category: Literal["service"] = "service"
-    code: ServiceErrorCode
+    code: HttpServiceErrorCode
     message: str
 
 
@@ -54,7 +52,7 @@ class ServiceErrorEnvelope(BaseModel):
 
 def service_error_response(
     *,
-    code: ServiceErrorCode,
+    code: HttpServiceErrorCode,
     message: str,
     status_code: int,
     headers: Mapping[str, str] | None = None,

--- a/libs/gda-balancing/tests/test_execution_service_language.py
+++ b/libs/gda-balancing/tests/test_execution_service_language.py
@@ -1,0 +1,333 @@
+"""Executable contract of Execution Service Language revision 1."""
+
+import pytest
+from pydantic import ValidationError
+
+from gda_balancing.application.execution_sessions import (
+    ExecutionSessionCreated,
+    ExecutionSessionNotFound,
+    ExperimentRevisionAdmitted,
+    ExperimentRevisionNotFound,
+)
+from gda_balancing.application.experiment_execution import (
+    ExperimentExecutionRefusal,
+    ExperimentExecutionSuccess,
+    ExperimentExecutionVerdict,
+)
+from gda_balancing.domain.diagnostics import (
+    ArtifactLocation,
+    Schema2Diagnostic,
+    Schema2RefusalReport,
+)
+from gda_balancing.domain.publication_types import PublicationMember
+from gda_balancing.interfaces.execution_service_language import (
+    EXECUTION_SERVICE_LANGUAGE_REVISION,
+    AdmitExperimentRevisionRequest,
+    EstablishExecutionSessionRequest,
+    ExecutionServiceErrorCode,
+    ExecutionSessionEstablishedResponse,
+    ExecutionSessionReleasedResponse,
+    ExperimentRevisionAdmittedResponse,
+    RefusalResponse,
+    ReleaseExecutionSessionRequest,
+    RunExperimentRequest,
+    RunRefusalResponse,
+    RunSuccessResponse,
+    RunVerdictResponse,
+    admit_experiment_revision_response,
+    establish_session_response,
+    execution_service_error,
+    execution_service_error_from_condition,
+    run_experiment_revision_response,
+)
+
+
+def _example_refusal() -> Schema2RefusalReport:
+    return Schema2RefusalReport(
+        stage="ingress",
+        diagnostics=(
+            Schema2Diagnostic(
+                code="language.invalid_source",
+                message="the source is invalid",
+                primary=ArtifactLocation(
+                    content_identity="sha256:source",
+                    pointer="/",
+                ),
+            ),
+        ),
+        truncated=False,
+    )
+
+
+def test_establish_session_contract_is_closed() -> None:
+    payload = {
+        "model_source": {"schema_version": "2.0.0"},
+        "experiment_specification": {"schema_version": "2.0.0"},
+    }
+
+    request = EstablishExecutionSessionRequest.model_validate(payload)
+    response = ExecutionSessionEstablishedResponse(
+        session_id="session-1",
+        resolved_model_identity="sha256:resolved-model",
+        revision_id="sha256:experiment",
+    )
+
+    assert EXECUTION_SERVICE_LANGUAGE_REVISION == 1
+    assert request.model_dump(mode="json") == payload
+    assert response.model_dump(mode="json") == {
+        "outcome": "success",
+        "session_id": "session-1",
+        "resolved_model_identity": "sha256:resolved-model",
+        "revision_id": "sha256:experiment",
+    }
+    with pytest.raises(ValidationError):
+        EstablishExecutionSessionRequest.model_validate(
+            {**payload, "implicit_active_revision": True}
+        )
+
+
+def test_establish_session_results_are_framed() -> None:
+    created = ExecutionSessionCreated(
+        session_id="session-1",
+        resolved_model_identity="sha256:resolved-model",
+        revision_id="sha256:experiment",
+    )
+    refusal = _example_refusal()
+
+    success = establish_session_response(created)
+    refused = establish_session_response(refusal)
+
+    assert success == ExecutionSessionEstablishedResponse(
+        session_id="session-1",
+        resolved_model_identity="sha256:resolved-model",
+        revision_id="sha256:experiment",
+    )
+    assert refused == RefusalResponse(refusal=refusal)
+
+
+def test_admit_revision_contract_is_closed() -> None:
+    payload = {
+        "session_id": "session-1",
+        "experiment_specification": {"schema_version": "2.0.0"},
+    }
+
+    request = AdmitExperimentRevisionRequest.model_validate(payload)
+    response = ExperimentRevisionAdmittedResponse(
+        revision_id="sha256:experiment",
+        created=True,
+    )
+
+    assert request.model_dump(mode="json") == payload
+    assert response.model_dump(mode="json") == {
+        "outcome": "success",
+        "revision_id": "sha256:experiment",
+        "created": True,
+    }
+    with pytest.raises(ValidationError):
+        AdmitExperimentRevisionRequest.model_validate(
+            {**payload, "replace_active_revision": True}
+        )
+
+
+def test_revision_admission_results_are_framed() -> None:
+    admitted = ExperimentRevisionAdmitted(
+        revision_id="sha256:experiment",
+        created=True,
+    )
+    refusal = _example_refusal()
+
+    success = admit_experiment_revision_response(admitted)
+    refused = admit_experiment_revision_response(refusal)
+
+    assert success == ExperimentRevisionAdmittedResponse(
+        revision_id="sha256:experiment",
+        created=True,
+    )
+    assert refused == RefusalResponse(refusal=refusal)
+
+
+def test_run_success_contract_is_closed() -> None:
+    payload = {
+        "session_id": "session-1",
+        "revision_id": "sha256:experiment",
+    }
+    artifacts = {"evaluation-run": {"artifact_kind": "evaluation-run"}}
+
+    request = RunExperimentRequest.model_validate(payload)
+    response = RunSuccessResponse(artifacts=artifacts)
+
+    assert request.model_dump(mode="json") == payload
+    assert response.model_dump(mode="json") == {
+        "outcome": "success",
+        "artifacts": artifacts,
+    }
+    with pytest.raises(ValidationError):
+        RunExperimentRequest.model_validate({**payload, "latest": True})
+
+
+def test_run_results_are_framed() -> None:
+    artifact = {"artifact_kind": "evaluation-run", "events": [{"value": 7}]}
+    member = PublicationMember(
+        value=artifact,
+        artifact_kind="evaluation-run",
+        wire_schema_identity="sha256:wire-schema",
+        content_identity="sha256:artifact",
+    )
+    refusal = _example_refusal()
+
+    success = run_experiment_revision_response(
+        ExperimentExecutionSuccess(members={"evaluation-run": member})
+    )
+    verdict = run_experiment_revision_response(
+        ExperimentExecutionVerdict(
+            failed_metrics=("damage-floor",),
+            members={"evaluation-run": member},
+        )
+    )
+    refused = run_experiment_revision_response(
+        ExperimentExecutionRefusal(
+            report=refusal,
+            members={"evaluation-run": member},
+        )
+    )
+
+    assert success == RunSuccessResponse(
+        artifacts={"evaluation-run": artifact},
+    )
+    assert verdict == RunVerdictResponse(
+        failed_metrics=["damage-floor"],
+        artifacts={"evaluation-run": artifact},
+    )
+    assert refused == RunRefusalResponse(
+        refusal=refusal,
+        artifacts={"evaluation-run": artifact},
+    )
+    artifact["events"][0]["value"] = 99
+    assert success.artifacts["evaluation-run"]["events"] == [{"value": 7}]
+
+
+def test_domain_refusal_contract_is_reused() -> None:
+    refusal = _example_refusal()
+
+    response = RefusalResponse(refusal=refusal)
+    mutated = response.model_dump(mode="json")
+    mutated["refusal"]["transport_extension"] = True
+
+    assert response.refusal is refusal
+    assert "Schema2RefusalReport" in RefusalResponse.model_json_schema()["$defs"]
+    with pytest.raises(ValidationError):
+        RefusalResponse.model_validate(mutated)
+
+
+def test_nested_standard_schema_values_remain_opaque_to_the_language() -> None:
+    request = EstablishExecutionSessionRequest(
+        model_source={"authority_owned_member": {"model": True}},
+        experiment_specification={"authority_owned_member": {"experiment": True}},
+    )
+    response = RunSuccessResponse(
+        artifacts={"result": {"authority_owned_member": {"artifact": True}}}
+    )
+
+    request_schema = EstablishExecutionSessionRequest.model_json_schema()["properties"]
+    response_schema = RunSuccessResponse.model_json_schema()["properties"]
+
+    assert request.model_source["authority_owned_member"] == {"model": True}
+    assert request.experiment_specification["authority_owned_member"] == {
+        "experiment": True
+    }
+    assert response.artifacts["result"]["authority_owned_member"] == {"artifact": True}
+    assert request_schema["model_source"]["additionalProperties"] is True
+    assert request_schema["experiment_specification"]["additionalProperties"] is True
+    assert (
+        response_schema["artifacts"]["additionalProperties"]["additionalProperties"]
+        is True
+    )
+
+
+def test_run_outcomes_share_one_artifact_shape() -> None:
+    artifacts = {"evaluation-run": {"artifact_kind": "evaluation-run"}}
+    refusal = _example_refusal()
+
+    verdict = RunVerdictResponse(
+        failed_metrics=["damage-per-turn"],
+        artifacts=artifacts,
+    )
+    refused = RunRefusalResponse(refusal=refusal, artifacts=artifacts)
+
+    assert verdict.model_dump(mode="json") == {
+        "outcome": "verdict",
+        "failed_metrics": ["damage-per-turn"],
+        "artifacts": artifacts,
+    }
+    assert refused.model_dump(mode="json") == {
+        "outcome": "refusal",
+        "refusal": refusal.model_dump(mode="json"),
+        "artifacts": artifacts,
+    }
+    assert refused.refusal is refusal
+
+
+def test_release_session_contract_is_closed() -> None:
+    request = ReleaseExecutionSessionRequest(session_id="session-1")
+    response = ExecutionSessionReleasedResponse(session_id="session-1")
+
+    assert request.model_dump(mode="json") == {"session_id": "session-1"}
+    assert response.model_dump(mode="json") == {
+        "outcome": "success",
+        "session_id": "session-1",
+    }
+    with pytest.raises(ValidationError):
+        ExecutionSessionReleasedResponse.model_validate(
+            {
+                "outcome": "success",
+                "session_id": "session-1",
+                "remaining_revisions": 0,
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    ("code", "message"),
+    [
+        (
+            "unknown_execution_session",
+            "the Execution session does not exist",
+        ),
+        (
+            "unknown_experiment_revision",
+            "the Experiment revision does not exist",
+        ),
+    ],
+)
+def test_shared_selection_errors_are_owned(
+    code: ExecutionServiceErrorCode,
+    message: str,
+) -> None:
+    error = execution_service_error(code)
+
+    assert error.model_dump(mode="json") == {
+        "error": {
+            "category": "service",
+            "code": code,
+            "message": message,
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    ("condition", "code"),
+    [
+        (ExecutionSessionNotFound("session-1"), "unknown_execution_session"),
+        (
+            ExperimentRevisionNotFound("sha256:experiment"),
+            "unknown_experiment_revision",
+        ),
+    ],
+)
+def test_application_selection_conditions_are_mapped(
+    condition: ExecutionSessionNotFound | ExperimentRevisionNotFound,
+    code: ExecutionServiceErrorCode,
+) -> None:
+    error = execution_service_error_from_condition(condition)
+
+    assert error.error.code == code

--- a/libs/gda-balancing/tests/test_http_service.py
+++ b/libs/gda-balancing/tests/test_http_service.py
@@ -17,6 +17,8 @@ from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 import pytest
+from starlette.applications import Starlette
+from starlette.routing import Route
 from starlette.types import Receive, Scope, Send
 
 from gda_balancing.application.execution_sessions import (
@@ -81,6 +83,20 @@ def shared_execution_http_service() -> Iterator[ExecutionHttpTestService]:
     """Keep one real process for tests that exercise only session semantics."""
     with running_execution_http_service() as service:
         yield service
+
+
+def test_execution_api_factory_exposes_only_the_four_ohs_capabilities() -> None:
+    app = create_api_v1()
+
+    assert isinstance(app, Starlette)
+    routes = [route for route in app.routes if isinstance(route, Route)]
+    assert len(routes) == len(app.routes)
+    assert [route.path for route in routes] == [
+        "/v1/execution-sessions",
+        "/v1/execution-sessions/{session_id:str}/experiment-revisions",
+        "/v1/execution-sessions/{session_id:str}/runs",
+        "/v1/execution-sessions/{session_id:str}",
+    ]
 
 
 def test_serve_reports_status_and_shuts_down() -> None:
@@ -374,6 +390,30 @@ def test_closed_request_schema_rejects_unknown_members_before_application() -> N
                 "model_source": model_source,
                 "experiment_specification": experiment,
                 "implicit_active_revision": True,
+            },
+        )
+
+        assert status == 400
+        assert error == {
+            "error": {
+                "category": "service",
+                "code": "invalid_request",
+                "message": "the request does not match the closed HTTP schema",
+            }
+        }
+
+
+def test_http_body_cannot_repeat_the_path_owned_session_selection() -> None:
+    model_source, experiment = _roguelike_documents()
+
+    with running_execution_http_service() as service:
+        created = service.create_session(model_source, experiment)
+        status, error = service.request_error(
+            f"/v1/execution-sessions/{created['session_id']}/experiment-revisions",
+            method="POST",
+            body={
+                "session_id": created["session_id"],
+                "experiment_specification": experiment,
             },
         )
 
@@ -723,6 +763,32 @@ def test_cli_publication_and_http_inline_execution_are_semantically_identical(
     }
 
 
+def test_cli_and_http_return_the_same_authority_owned_refusal(
+    tmp_path: Path,
+    shared_execution_http_service: ExecutionHttpTestService,
+) -> None:
+    model_source, experiment = _roguelike_documents()
+    model_source["unknown_member"] = True
+    source_path = tmp_path / "model-source.json"
+    source_path.write_text(json.dumps(model_source), encoding="utf-8")
+
+    cli_check = _run_console("model", "check", str(source_path))
+    http_result = shared_execution_http_service.create_session(
+        model_source,
+        experiment,
+    )
+
+    assert (cli_check.returncode, cli_check.stderr) == (2, "")
+    assert http_result["outcome"] == "refusal"
+    cli_refusal = json.loads(cli_check.stdout)["error"]
+    assert cli_refusal.pop("category") == "refusal"
+    assert {
+        name: value
+        for name, value in http_result["refusal"].items()
+        if value is not None
+    } == cli_refusal
+
+
 def test_aggregate_http_limit_preserves_the_model_source_ingress_refusal(
     shared_execution_http_service: ExecutionHttpTestService,
 ) -> None:
@@ -949,7 +1015,7 @@ def test_post_readiness_application_fault_stops_the_local_host() -> None:
         readiness = readiness_queue.get(timeout=10)
         try:
             request = Request(
-                f"http://{readiness.host}:{readiness.port}/v1/status",
+                f"http://{readiness.host}:{readiness.port}/v1/execution-sessions",
                 headers={
                     "Authorization": f"Bearer {readiness.capability_token}",
                 },

--- a/libs/gda-balancing/tools/ci.py
+++ b/libs/gda-balancing/tools/ci.py
@@ -25,6 +25,7 @@ SHARDS: Final[dict[str, tuple[str, ...]]] = {
         "test_emit.py",
         "test_engine_parity.py",
         "test_envelope_schema.py",
+        "test_execution_service_language.py",
         "test_format_roundtrip.py",
         "test_formula_seam.py",
         "test_isolation.py",


### PR DESCRIPTION
## Summary

- publish the gda-balancing **Execution Open Host Service** through one versioned
  **Execution Service Language**
- implement revision 1 with four capabilities: establish a session, admit an Experiment revision,
  run an exact revision, and release a session
- move the shared execution contract out of the HTTP adapter while preserving direct
  Interface-to-Application calls and Domain ownership of Standard Schema meaning
- keep nested Model Source, Experiment, and artifact values opaque to the Published Language so
  their existing Kernel, LDB, Model, Experiment, Runtime, Evidence, and artifact authorities remain
  the only schema, rule, semantic, identity, outcome, and refusal owners
- preserve the accepted semantic `/v1` HTTP contract and its current Resource-oriented shape

## Implemented boundary

- `interfaces/execution_service_language.py` owns the protocol-neutral OHS request, response, and
  shared-error contract.
- The Resource-oriented HTTP adapter projects its four execution routes onto that contract and
  calls the Application service directly.
- The local companion host continues to own authentication, readiness, status, shutdown, request
  admission, and process lifecycle. `/v1/status` and `/v1/shutdown` are not OHS capabilities.
- Domain continues to validate or produce nested authority-owned values. The Published Language
  does not copy their schemas or expose an implementation-private Domain model.
- bADR-0027 is Accepted and records the implemented ownership, evolution, and validation boundary.
  bADR-0026 continues to own the current local HTTP transport and lifecycle contract.
- MCP remains deferred until a named consumer, concrete tool workflow, or separately approved
  delivery issue demonstrates the need. This PR adds no MCP artifact, placeholder, dependency, or
  parity gate.
- The implementation adds no service locator, dependency-injection container, event bus, schema
  registry, parallel semantic model, or speculative full-REST machinery.

## Validation

- 53 Published-Language and HTTP contract tests passed.
- 18 layer and dependency tests passed.
- Test inventory closure covers 1,747 tests with no missing, overlapping, uncovered, or
  unexpected-shard entries.
- Ruff, Pyright, package build, co-install, wheel/subprocess smoke, and all six gda-balancing test
  shards pass on the combined PR head.
- Independent Artifact, domain-modular-architecture, Standards, Spec, and entropy reviews have no
  remaining actionable findings.
- Godot E2E is skipped by scope; this execution-service boundary is engine-agnostic and does not
  change a Godot runtime path.

Closes #789
