### PR TITLE
refactor(gda): one walk for the mounted-group tree, and the nested-tree proof (#788)

### DIFF
--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -269,7 +269,11 @@ def walk_mounted_groups(app: typer.Typer) -> Iterator[TyperInfo]:
     Typer refuses to build such a group into a command at all. A visitor that needs the
     instance says so itself; the walk does not decide that for it.
     """
-    for group in app.registered_groups:
+    # Snapshot, so the docstring's "what is mounted at the moment it runs" is
+    # literally true: a visitor that mounts a group MID-WALK is excluded rather
+    # than lazily swept in (#792 review P3-2 — no visitor does this today; the
+    # snapshot makes the documented boundary the actual one).
+    for group in list(app.registered_groups):
         yield group
         instance = group.typer_instance
         if instance is not None:

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -8,7 +8,7 @@ classification, failure output, and JSON rendering.
 """
 
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Generic, NoReturn, Optional, TypeVar
@@ -17,6 +17,7 @@ import typer
 from pydantic import BaseModel, ValidationError
 from typer._click import Context as ClickContext
 from typer.core import TyperCommand
+from typer.models import TyperInfo
 
 from gda.binary import resolve_godot_binary
 from gda.errors import (
@@ -243,6 +244,38 @@ def _group_json(
     """
 
 
+def walk_mounted_groups(app: typer.Typer) -> Iterator[TyperInfo]:
+    """Every command group mounted below ``app``, at any depth (#788).
+
+    The ONE walk over the mounted-group tree, so a cross-cutting group behavior is
+    written as a visitor over this rather than as another copy of the recursion. Two
+    visitors today: the shared ``--json`` option (:func:`adopt_group_json`, below) and
+    the refusal class (``gda.hints.adopt``). It walks the REGISTRATION-time tree — the
+    ``TyperInfo`` records ``add_typer`` leaves behind — because that is the only
+    representation that exists before Typer builds the click tree, and so the only one
+    a composition-time adopter can install anything onto. The BUILT click tree is a
+    different walk for a different purpose — reading a finished surface
+    (``gda.surface``).
+
+    **The ordering precondition, stated here once for every visitor:** the walk reports
+    what is mounted AT THE MOMENT IT RUNS, so the composition root (``gda.cli``) mounts
+    the whole tree first and adopts afterwards. A group mounted after an adoption is
+    never visited by it and silently keeps none of what it installs.
+
+    What is yielded is the registration record, not the sub-app: it is the wider handle
+    — the group's ``name`` and ``cls`` as well as its ``typer_instance`` — and one
+    visitor writes to the record itself. Typer types that instance as optional, so the
+    RECURSION skips a group without one: it carries no groups to descend into, and
+    Typer refuses to build such a group into a command at all. A visitor that needs the
+    instance says so itself; the walk does not decide that for it.
+    """
+    for group in app.registered_groups:
+        yield group
+        instance = group.typer_instance
+        if instance is not None:
+            yield from walk_mounted_groups(instance)
+
+
 def adopt_group_json(app: typer.Typer) -> None:
     """Give every group mounted below ``app`` the shared ``--json`` option (#683).
 
@@ -252,16 +285,20 @@ def adopt_group_json(app: typer.Typer) -> None:
     a line an agent composes naturally. Applied once from the composition root,
     AFTER every group has mounted itself, for the reason ``gda.hints.adopt`` is: it
     is one property of the WHOLE surface, so a group added later inherits the option
-    by being mounted rather than by remembering to declare it. The walk RECURSES for
-    the same reason that one does — a sub-group of a group would otherwise be missed
-    silently.
+    by being mounted rather than by remembering to declare it. Reaching a sub-group of
+    a group — which would otherwise be missed silently — is the shared walk's job
+    (:func:`walk_mounted_groups`), including the ordering precondition it states.
 
     Installing the option means installing the callback that carries it, so a group
     that declares a callback of its own is refused rather than silently replaced:
-    such a group must declare the shared option on that callback itself.
+    such a group must declare the shared option on that callback itself. That refusal
+    stays a property of THIS visitor, not of the walk it rides: it guards the one slot
+    this adoption writes, and the other visitor overwrites no such slot.
     """
-    for group in app.registered_groups:
+    for group in walk_mounted_groups(app):
         instance = group.typer_instance
+        # A group registered without a sub-app has no callback to carry the option;
+        # the walk's own contract leaves that reading to each visitor.
         if instance is None:
             continue
         if instance.registered_callback is not None:
@@ -271,7 +308,6 @@ def adopt_group_json(app: typer.Typer) -> None:
                 "gda.headless.adopt_group_json replace it."
             )
         instance.callback()(_group_json)
-        adopt_group_json(instance)
 
 
 def godot_option() -> Optional[str]:

--- a/src/gda/hints.py
+++ b/src/gda/hints.py
@@ -58,7 +58,12 @@ from typer._click.exceptions import NoSuchOption
 from typer._click.globals import get_current_context
 
 from gda.errors import Failure, make_failure
-from gda.headless import emit_failure, json_in_effect, remember_argv
+from gda.headless import (
+    emit_failure,
+    json_in_effect,
+    remember_argv,
+    walk_mounted_groups,
+)
 
 # The two registered codes this module reports (ADR-0002, the `usage` category).
 UNKNOWN_COMMAND = "unknown_command"
@@ -372,17 +377,25 @@ def adopt(app: typer.Typer) -> None:
     Applied once, in the composition root, AFTER every group has mounted itself — so a
     group module declares no dispatch behaviour and a group added later inherits the
     refusal by being mounted, which is the registration ADR-0040 already relies on.
-    The walk RECURSES rather than reading only the root's own groups: gda's tree is two
-    levels deep today, and a sub-group mounted on a sub-app would otherwise escape the
-    interception silently. A test walks the live tree, recursively, to pin it.
+    Reaching every group, a sub-group of a group included, is the shared walk's job
+    (``gda.headless.walk_mounted_groups``), which also states that ordering
+    requirement once for both of its visitors. A test walks the live tree,
+    recursively, to pin the outcome here.
+
+    The class is written onto the REGISTRATION record rather than onto the sub-app,
+    which is why this visitor reads no ``typer_instance``: a group registered without
+    one is never built into a command by Typer, so it is neither reached nor missed.
     """
     app.info.cls = GdaGroup
-    _adopt_groups(app)
-
-
-def _adopt_groups(app: typer.Typer) -> None:
-    """Set the class on every group of ``app``, and on their groups in turn."""
-    for group in app.registered_groups:
+    # No counterpart here to the callback refusal the other visitor raises, for two
+    # reasons. It replaces nothing a gda group declares: Typer leaves a group's `cls`
+    # a default placeholder unless `add_typer` was given one, and none is — while the
+    # option adoption would drop a real callback a group had written. And the class is
+    # exactly what gda IMPOSES on the whole surface: a group opting out of it would
+    # lose the structured refusal silently, so refusing to overwrite would protect the
+    # failure this adoption exists to prevent. Nor could such a guard be hoisted into
+    # the shared walk to cover both: `adopt_group_json` runs FIRST (`gda.cli`) and
+    # gives every group a callback, so a callback check applied to this walk too would
+    # fire on the entire tree.
+    for group in walk_mounted_groups(app):
         group.cls = GdaGroup
-        if group.typer_instance is not None:
-            _adopt_groups(group.typer_instance)

--- a/tests/test_json_flag_acceptance.py
+++ b/tests/test_json_flag_acceptance.py
@@ -276,6 +276,38 @@ def test_the_walker_refuses_to_replace_a_groups_own_callback():
         adopt_group_json(root)
 
 
+def test_the_json_adoption_reaches_a_nested_sub_group():
+    # The negative sentinel for the walk itself: a group mounted on a GROUP — not on
+    # the root — is the shape a flat adoption would miss. The live tree is two levels
+    # deep, so every group-`--json` test above exercises a FIRST-level group and the
+    # walk's recursion rode along unproven: deleting it passed the whole suite (#788).
+    # So the recursion is proven on a tree built here, rather than left until someone
+    # mounts a sub-group and finds the flag dead under it. The twin on the refusal side
+    # is tests/test_unknown_invocation.py::test_the_adoption_reaches_a_nested_sub_group.
+    inner = typer.Typer()
+
+    @inner.command("leaf")
+    def _leaf() -> None:
+        """A leaf."""
+
+    middle = typer.Typer()
+    middle.add_typer(inner, name="inner")
+    root = typer.Typer()
+    root.add_typer(middle, name="middle")
+
+    adopt_group_json(root)
+
+    # The acceptance the first level already has, one level down: the flag parses
+    # between the nested group and the command it runs.
+    accepted = CliRunner().invoke(root, ["middle", "inner", "--json", "leaf"])
+
+    assert accepted.exit_code == 0, accepted.stdout + accepted.stderr
+    rendered = CliRunner().invoke(root, ["middle", "inner", "--help"])
+
+    assert rendered.exit_code == 0, rendered.stdout
+    assert "--json" in plain_text(rendered.stdout)
+
+
 # --- the shipped guidance states the same contract ----------------------------
 
 


### PR DESCRIPTION
## What

Two commits, in the order the issue puts them.

**1. The nested-tree proof (`test`).** `adopt_group_json` recurses into every mounted
sub-group, but nothing proved it: the live tree is two levels deep and every
group-`--json` test exercises a FIRST-level group, so deleting the recursive call
passed the whole suite. The new
`test_the_json_adoption_reaches_a_nested_sub_group` builds the synthetic
three-level tree its twin on the refusal side already has
(`test_the_adoption_reaches_a_nested_sub_group`) and asserts the acceptance
itself: `--json` parses between the nested group and the command it runs, and the
nested group's help advertises it.

**2. One walk (`refactor`).** `gda.headless.walk_mounted_groups` is now the single
generator over every mounted group at any depth; both adopters are visitors over
it. The walk owns the tree-shape knowledge — the `TyperInfo` registration
representation, the recursion, the skip-on-None descent, and the composition
root's mount-then-adopt ordering requirement, stated once for every visitor. A
third cross-cutting group behavior becomes one more visitor, not a seventh walker.

## Where the primitive lives, and why

`gda.headless`. `hints` already imports that module, so routing through it adds no
import edge and risks no cycle; and `headless` already owns the cross-cutting
CLI-surface wiring the whole tree shares — the shared option factories, the
ancestor-`--json` contract, and one of the two adopters. A module of its own would
have been a third file for four lines of recursion.

## The guard asymmetry, resolved

The callback refusal stays a property of the `--json` VISITOR, not of the walk it
rides: it guards the one slot that adoption writes. Applying it uniformly is not
merely undesirable, it is impossible — `adopt_group_json` runs FIRST in the
composition root and gives every group a callback, so the same check on the hints
walk fires on the entire tree. Verified by experiment: hoisting the check into the
walk makes `import gda.cli` die at `hints.adopt` on the first group (`scene`). The
hints side's reasoned absence of an equivalent `cls` guard is written where the
walk is consumed: the class is what gda *imposes* on the whole surface (a group
opting out would silently lose the structured refusal), and it replaces no
declaration — Typer leaves `cls` a default placeholder unless `add_typer` was
given one, and no gda group is.

## Scope

The LIVE-tree walkers (the surface walker and the three test copies) are untouched,
per the issue. This is internal wiring only.

## Evidence

- **Red-proof, the non-negotiable half (measured on the unchanged walk, commit 1):**
  deleting `adopt_group_json`'s recursive call → `1 failed, 2250 passed`, the one
  failure being the new test.
- **Red-proof, after the refactor:** deleting the now-shared `yield from` →
  `2 failed, 2249 passed`, exactly the two nested-tree tests and nothing else.
- **Public surface byte-identical:** the root `--help`, every group's `--help`,
  every leaf's `--schema` and the whole-surface `gda schema --json` manifest,
  captured before and after — same 1362095 bytes, md5
  `4c6963138a5b6f8821de9ddd9e417159`. The group `--json` acceptance suite and the
  near-miss suite are unmodified.
- **Gates:** `pytest -m "not e2e"` → 2251 passed; `ruff check .`, `ruff format
  --check .`, `pyright` (0 errors) all green.
- **No engine run:** this is CLI-layer wiring; nothing here spawns Godot, and no
  e2e tier is implicated.

Closes #788
