### PR TITLE
fix(gda): one reader for scene text, correcting four substring-read misattributions (#775)

### DIFF
--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -1160,12 +1160,34 @@ func _scene_ext_resource_nodes_by_path(text: String, base_dir: String) -> Dictio
 	return by_path
 
 
+# Whether one trimmed line OPENS the section named `tag_name` — the SINGLE owner
+# of section recognition for every reader of scene text (#720 recheck ×2, #775).
+#
+# The section NAME must be exactly `tag_name`: after the tag comes the closing
+# bracket or the whitespace before attributes, or a longer name passes a bare
+# prefix test. That is not hypothetical — `[gd_scenery]` reads as a scene header
+# and `[ext_resource_group …]` reads as a declaration, while the ENGINE refuses
+# both outright ("Unknown tag 'ext_resource_group' in file",
+# resource_format_text.cpp, measured on 4.6.3). Three askers used to spell the
+# rule three different ways — closed, bare prefix, and space-only — so the rule
+# is stated here once instead of respelled per section.
+#
+# `]`, " " and "\t" are the accepting characters because that is where the
+# engine's own tokenizer ends the tag name — VariantParser reads it as an
+# identifier, so any non-identifier character closes it.
+func _is_section_header_line(stripped: String, tag_name: String) -> bool:
+	var tag := "[" + tag_name
+	if not stripped.begins_with(tag) or stripped.length() <= tag.length():
+		return false
+	var next := stripped[tag.length()]
+	return next == "]" or next == " " or next == "\t"
+
+
 # Whether the text OPENS with a complete, CLOSED `[gd_scene …]` section header
 # (#720 recheck ×2). Two requirements, each defeating a real bypass:
 #
-# - the section NAME must be exactly "gd_scene" — after the tag comes the
-#   closing bracket or the whitespace before attributes, or "[gd_scenery]"
-#   would pass a bare prefix test;
+# - the section NAME must be exactly "gd_scene" (_is_section_header_line, the one
+#   owner of that rule), or "[gd_scenery]" would pass a bare prefix test;
 # - the header LINE must close with "]" — an unclosed "[gd_scene load_steps=2"
 #   is not a header, and the load cannot be relied on to catch it: when the
 #   dependency walk finds problems the load is deliberately skipped, so
@@ -1176,18 +1198,12 @@ func _scene_ext_resource_nodes_by_path(text: String, base_dir: String) -> Dictio
 # and the load has the final word only on that admitted case.
 func _has_scene_header(text: String) -> bool:
 	var stripped := text.lstrip(" \t\r\n" + String.chr(0xFEFF))
-	const TAG := "[gd_scene"
-	if not stripped.begins_with(TAG):
-		return false
 	var line_end := stripped.find("\n")
 	var line := stripped if line_end == -1 else stripped.substr(0, line_end)
 	line = line.strip_edges()
-	# The shortest admitted header is "[gd_scene]", so a line that closes always
-	# has a character after the tag.
-	if not line.ends_with("]") or line.length() <= TAG.length():
+	if not line.ends_with("]"):
 		return false
-	var next := line[TAG.length()]
-	return next == "]" or next == " " or next == "\t"
+	return _is_section_header_line(line, "gd_scene")
 
 
 # Whether a load produced a scene with a root — the two conditions _load_scene
@@ -4399,19 +4415,12 @@ func _outgoing_references_of(path: String) -> Array:
 
 
 # The res:// paths an [ext_resource ... path="res://..."] line names in a
-# .tscn/.tres file — the file's external dependencies. Read through the ONE
-# scene-text reader (_raw_ext_resource_entries_from_text, #775): which lines are
-# declarations, and how an attribute is pulled out of one, are decided there and
-# nowhere else, so this harvest cannot drift from the rest. What stays here is
-# the part that is its own — the graph identity of each harvested path.
+# .tscn/.tres file — the file's external dependencies, in line order.
 #
-# Returns res:// paths in line order, each under the ONE graph identity (#774) so
-# a file is one graph node however the line spells it: _resolve_ref_path anchors
-# a relative declaration to the DECLARING file's directory before it
-# canonicalizes, because the engine resolves it that way —
-# `path="../shared/leaf.tscn"` in res://scenes/main.tscn loads
-# res://shared/leaf.tscn (measured on 4.6.3). Canonicalizing without anchoring
-# left the relative spelling as its own graph node.
+# Two owners do the work and neither rule lives here: which lines are
+# declarations and how an attribute is pulled out of one belong to the scene-text
+# reader (_raw_ext_resource_entries_from_text, #775), and folding each harvested
+# path to its one graph identity belongs to _resolve_ref_path (#774).
 func _ext_resource_paths(path: String) -> Array[String]:
 	var out: Array[String] = []
 	var text := FileAccess.get_file_as_string(path)
@@ -4443,13 +4452,14 @@ func _script_outgoing_references(path: String) -> Array:
 # The ONE CANONICAL IDENTITY of a declared reference: the path every consumer
 # keys a referenced file by, whichever kind of declaration named it — an
 # [ext_resource] line, or a preload/load/extends argument. #774 left the two as
-# byte-identical twins under two names; #775 merged them, so the rule has one
-# place to be read and one place to be corrected.
+# twins under two names, identical but for a parameter name; #775 merged them, so
+# the rule has one place to be read and one place to be corrected.
 #
 # A relative address is joined onto the DECLARING file's base directory first,
-# because that is how the engine resolves it: "../shared/util.gd" in res://a/b.gd
-# loads res://shared/util.gd, and `path="../shared/leaf.tscn"` in
-# res://scenes/main.tscn loads res://shared/leaf.tscn (both measured on 4.6.3).
+# because that is how the engine resolves it — `preload("../shared/util.gd")` in
+# res://a/b.gd loads res://shared/util.gd, and an [ext_resource] line spelling the
+# same way resolves the same way (measured on 4.6.3; the graph-identity note in
+# the static-analysis section carries that measurement).
 # An ALREADY-prefixed address is canonicalized too, and that half is the #774
 # fix: it used to be returned verbatim, so preload("res://sub/../util.gd") and
 # preload("res://util.gd") — and `res://leaf.tscn` and `res://./leaf.tscn` — were
@@ -4679,9 +4689,9 @@ func _is_text_extension(ext: String) -> bool:
 # substring match reads an [ext_resource] line's uid as its id. The trap is open
 # on every attribute a longer name can end with — a `…_path="…"` attribute ahead
 # of the real `path="…"` hands back the wrong reference — so the rule is applied
-# ONCE, here, for every reader of scene text (#775) rather than relearned per
-# scan. A match is accepted only where the name starts a token: at the line
-# start, after whitespace, or right after the section-opening `[`.
+# ONCE, here, for every header attribute gda reads (#775) rather than relearned
+# per scan. A match is accepted only where the name starts a token: at the line
+# start, after a space or a tab, or right after a `[`.
 func _quoted_named_attr(line: String, attr_name: String) -> String:
 	var needle := attr_name + "="
 	var from := 0
@@ -5425,7 +5435,7 @@ func _scene_attached_external_scripts(scene_path: String) -> Dictionary:
 	var text := FileAccess.get_file_as_string(scene_path)
 	if text.is_empty():
 		return {}
-	var script_resources := _scene_script_ext_resources(text)
+	var script_resources := _scene_script_ext_resources(text, scene_path.get_base_dir())
 	var attached := {}
 	var current_node_path := ""
 	for line in text.split("\n"):
@@ -5435,7 +5445,13 @@ func _scene_attached_external_scripts(scene_path: String) -> Dictionary:
 			continue
 		if current_node_path.is_empty():
 			continue
-		if not stripped.begins_with("script") or stripped.find("ExtResource(") == -1:
+		if stripped.find("ExtResource(") == -1:
+			continue
+		# The assigned property must BE `script`, not merely start with it: a
+		# `script_owner = ExtResource("…")` property read as a script binding made
+		# a mutating op refuse over a script no node actually carries (#775).
+		var assign := stripped.find("=")
+		if assign == -1 or stripped.substr(0, assign).strip_edges() != "script":
 			continue
 		var resource_id := _first_quoted_after(stripped, stripped.find("ExtResource("))
 		if script_resources.has(resource_id):
@@ -5444,34 +5460,33 @@ func _scene_attached_external_scripts(scene_path: String) -> Dictionary:
 
 
 # The scene's Script-typed [ext_resource] declarations as {id -> res:// path},
-# read through the ONE scene-text reader (#775).
+# read through the ONE scene-text reader and folded through the ONE identity
+# owner (#775).
 #
-# The value carries the same canonical identity every other reader here
-# publishes, so a path harvested from scene text compares equal to the
-# resource_path the ENGINE reports for the same file whichever way the
-# declaration spelled it — _validate_scene_script_preload_dependencies makes
-# exactly that comparison. A relative declaration is left out: this reader is
-# handed text with no declaring directory to anchor against, and Godot writes a
-# script reference absolute.
-func _scene_script_ext_resources(text: String) -> Dictionary:
+# The value therefore compares equal to the resource_path the ENGINE reports for
+# the same file however the declaration spelled it — relative or aliased —
+# which is exactly the comparison _validate_scene_script_preload_dependencies
+# makes. A declaration that resolves outside res:// (a uid:// reference) is left
+# out: it names no path the engine would report back.
+func _scene_script_ext_resources(text: String, base_dir: String) -> Dictionary:
 	var resources := {}
 	for entry in _raw_ext_resource_entries_from_text(text):
 		if String(entry["type"]) != "Script":
 			continue
 		var resource_id := String(entry["id"])
-		var ref_path := String(entry["path"])
+		var ref_path := _resolve_ref_path(String(entry["path"]), base_dir)
 		if not resource_id.is_empty() and ref_path.begins_with("res://"):
-			resources[resource_id] = _canonical_resource_path(ref_path)
+			resources[resource_id] = ref_path
 	return resources
 
 
-# Whether one trimmed line OPENS a node block — the single owner of `[node …]`
-# recognition (#775). Three scans ask it: the node-to-ext_resource attribution,
-# the attached-script binding read, and the instance-path recovery. Each used to
-# spell the prefix for itself, which is one place per scan for the next header
-# rule to be learned in only two of three.
+# Whether one trimmed line OPENS a node block (#775). Three scans ask it: the
+# node-to-ext_resource attribution, the attached-script binding read, and the
+# instance-path recovery — each used to spell `[node ` for itself, so a header
+# rule learned in one was learned in none of the others. Section recognition
+# itself is _is_section_header_line's.
 func _is_node_header_line(stripped: String) -> bool:
-	return stripped.begins_with("[node ")
+	return _is_section_header_line(stripped, "node")
 
 
 # The root-relative NodePath a [node …] header declares, or "" when the header
@@ -5875,9 +5890,13 @@ func _scene_instance_paths_by_node_path(path: String) -> Dictionary:
 	var instance_paths := {}
 	for line in text.split("\n"):
 		var stripped := line.strip_edges()
-		if not _is_node_header_line(stripped) or stripped.find("instance=ExtResource(") == -1:
+		if not _is_node_header_line(stripped):
 			continue
-		var id := _first_quoted_after(stripped, stripped.find("instance=ExtResource("))
+		# `instance` is a header ATTRIBUTE, so it is read by NAME like every other
+		# one (#775): a substring scan for `instance=ExtResource(` answered a decoy
+		# `fallback_instance=ExtResource("…")` ahead of it, and `scene get` then
+		# reported the wrong instanced scene for the node.
+		var id := _quoted_named_attr(stripped, "instance")
 		if id.is_empty() or not ext_resources_by_id.has(id):
 			continue
 		var node_path := _scene_node_path_from_header(stripped)
@@ -6535,21 +6554,23 @@ func _restore_existing_ext_resource_ids(
 	return _replace_ext_resource_ids(saved_text, id_remap)
 
 
-# Whether one trimmed line DECLARES an external resource — the single owner of
-# `[ext_resource…]` recognition (#775). The entries reader below and the save-side
-# id substitution are its two askers; the substitution rewrites lines in place and
-# so cannot go through the reader, but it must agree with it on WHICH lines it may
-# touch.
+# Whether one trimmed line DECLARES an external resource (#775). The entries
+# reader below and the save-side id substitution are its two askers; the
+# substitution rewrites lines in place and so cannot go through the reader, but it
+# must agree with it on WHICH lines it may touch. Section recognition itself is
+# _is_section_header_line's, not respelled here.
 func _is_ext_resource_line(stripped: String) -> bool:
-	return stripped.begins_with("[ext_resource")
+	return _is_section_header_line(stripped, "ext_resource")
 
 
 # Every [ext_resource] declaration in one scene/resource text, as written — the
 # ONE reader of scene text (#775). Four more scans over these same lines lived
 # beside this one, and three of them still pulled the path out with a SUBSTRING
-# match — the trap this reader had already been fixed for on `uid=`/`id=`, never
-# propagated. Adapting them onto this reader ends the class: there is no shallow
-# scan left for the next attribute or alias bug to hide in.
+# match: this reader was BORN whole-name (#394 landed it together with
+# _quoted_named_attr), and the older scans it grew up beside never learned the
+# rule. Adapting them onto this reader ends the class for [ext_resource]
+# attributes; the ExtResource("…") CALL-SITE scan over property values
+# (_ext_resource_ids_in_line) is a separate read and is still a substring match.
 #
 # The entry is the line's own content, unresolved: `path` is the spelling the
 # declaration used, and anchoring it to a base directory is the caller's step
@@ -6582,8 +6603,11 @@ func _raw_ext_resource_entries_from_text(text: String) -> Array:
 
 # The ID-KEYED view of the same declarations, each resolved to its canonical
 # graph identity against the declaring file's directory. A declaration with no
-# `id` is left out: nothing here can reach it, because an ExtResource("…") names
-# a reference by id and every consumer of this view keys by one.
+# `id` is left out because the ENGINE refuses the whole file over it — "Parse
+# Error: Missing 'id' in external resource tag" (resource_format_text.cpp,
+# measured on 4.6.3), and `scene validate` answers not_a_scene. That is what
+# separates an id-less line from an unknown ATTRIBUTE, which Godot accepts and
+# this reader therefore must read correctly.
 func _ext_resource_entries_from_text(text: String, base_dir: String) -> Array:
 	var entries: Array = []
 	for entry in _raw_ext_resource_entries_from_text(text):

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -860,7 +860,7 @@ func _new_scene_walk(root_path: String, problems: Array) -> Dictionary:
 #   ONCE PER FILE, not once per referencing site: a broken child instanced at five
 #   places is one broken file, which is the same rule the dependency walk already
 #   applies to a path declared twice. Every key is the canonical path
-#   (_normalize_ext_resource_path), so an alias spelling is the same file.
+#   (_resolve_ref_path), so an alias spelling is the same file.
 #
 # - DEPTH is bounded SEPARATELY, because terminating is not the same as finishing
 #   in time (#721 review). Stopping was never the problem; COST was. Each level
@@ -1447,7 +1447,7 @@ func _scene_ext_resource_nodes_by_id(text: String) -> Dictionary:
 	for line in text.split("\n"):
 		var stripped := line.strip_edges()
 		if stripped.begins_with("["):
-			node_path = _scene_node_path_from_header(stripped) if stripped.begins_with("[node ") else ""
+			node_path = _scene_node_path_from_header(stripped) if _is_node_header_line(stripped) else ""
 		if node_path.is_empty():
 			continue
 		for id in _ext_resource_ids_in_line(stripped):
@@ -3955,9 +3955,9 @@ func _write_text_file(path: String, source: String, noun: String) -> bool:
 #   res://shared/leaf.tscn (measured on 4.6.3), and `preload("../shared/x.gd")`
 #   in res://scripts/user.gd loads res://shared/x.gd (measured likewise).
 #
-# So every path that enters the graph is folded by the owner that knows its base
-# directory: _normalize_ext_resource_path for an [ext_resource] line,
-# _resolve_ref_path for a preload/load/extends argument. Only two entrants have no
+# So every path that enters the graph is folded by the ONE owner that knows its
+# base directory — _resolve_ref_path, for an [ext_resource] line and for a
+# preload/load/extends argument alike. Only two entrants have no
 # declaring file to anchor to and are absolute by construction — project.godot's
 # main scene and autoloads, and the caller's find-references query — and those go
 # straight to _canonical_resource_path.
@@ -4399,13 +4399,17 @@ func _outgoing_references_of(path: String) -> Array:
 
 
 # The res:// paths an [ext_resource ... path="res://..."] line names in a
-# .tscn/.tres file — the file's external dependencies. Parsed by text: each
-# ext_resource line carries a path="..." attribute (Godot 4 also carries a uid,
-# but always the path too). Returns res:// paths in line order, each under the
-# ONE graph identity (#774) so a file is one graph node however the line spells
-# it: _normalize_ext_resource_path anchors a relative declaration to the
-# DECLARING file's directory before it canonicalizes, because the engine resolves
-# it that way — `path="../shared/leaf.tscn"` in res://scenes/main.tscn loads
+# .tscn/.tres file — the file's external dependencies. Read through the ONE
+# scene-text reader (_raw_ext_resource_entries_from_text, #775): which lines are
+# declarations, and how an attribute is pulled out of one, are decided there and
+# nowhere else, so this harvest cannot drift from the rest. What stays here is
+# the part that is its own — the graph identity of each harvested path.
+#
+# Returns res:// paths in line order, each under the ONE graph identity (#774) so
+# a file is one graph node however the line spells it: _resolve_ref_path anchors
+# a relative declaration to the DECLARING file's directory before it
+# canonicalizes, because the engine resolves it that way —
+# `path="../shared/leaf.tscn"` in res://scenes/main.tscn loads
 # res://shared/leaf.tscn (measured on 4.6.3). Canonicalizing without anchoring
 # left the relative spelling as its own graph node.
 func _ext_resource_paths(path: String) -> Array[String]:
@@ -4414,13 +4418,8 @@ func _ext_resource_paths(path: String) -> Array[String]:
 	if text.is_empty():
 		return out
 	var base_dir := path.get_base_dir()
-	for line in text.split("\n"):
-		var stripped := line.strip_edges()
-		if not stripped.begins_with("[ext_resource"):
-			continue
-		var ref := _quoted_attr(stripped, "path=")
-		if not ref.is_empty():
-			out.append(_normalize_ext_resource_path(ref, base_dir))
+	for entry in _raw_ext_resource_entries_from_text(text):
+		out.append(_resolve_ref_path(String(entry["path"]), base_dir))
 	return out
 
 
@@ -4441,14 +4440,31 @@ func _script_outgoing_references(path: String) -> Array:
 	return out
 
 
-# Resolve a reference-path argument to a canonical res:// path: a relative path is
-# joined onto the referencing file's base directory first, so "../shared/util.gd"
-# from res://a/b.gd becomes res://shared/util.gd. An ALREADY-prefixed argument is
-# canonicalized too and that half is the #774 fix: it used to be returned verbatim,
-# so preload("res://sub/../util.gd") and preload("res://util.gd") were two graph
-# nodes for one file. simplify_path leaves a scheme it does not own alone, so a
-# uid:// reference still passes through unchanged (it round-trips through Godot's
-# UID system, not the path graph).
+# The ONE CANONICAL IDENTITY of a declared reference: the path every consumer
+# keys a referenced file by, whichever kind of declaration named it — an
+# [ext_resource] line, or a preload/load/extends argument. #774 left the two as
+# byte-identical twins under two names; #775 merged them, so the rule has one
+# place to be read and one place to be corrected.
+#
+# A relative address is joined onto the DECLARING file's base directory first,
+# because that is how the engine resolves it: "../shared/util.gd" in res://a/b.gd
+# loads res://shared/util.gd, and `path="../shared/leaf.tscn"` in
+# res://scenes/main.tscn loads res://shared/leaf.tscn (both measured on 4.6.3).
+# An ALREADY-prefixed address is canonicalized too, and that half is the #774
+# fix: it used to be returned verbatim, so preload("res://sub/../util.gd") and
+# preload("res://util.gd") — and `res://leaf.tscn` and `res://./leaf.tscn` — were
+# TWO graph nodes for ONE file. Everything downstream keys on this string: the
+# dependency walk's "a path declared twice is checked once and reported once"
+# rule, the sub-scene walk's own `answered`/`reached_depth`/`chain` sets, and the
+# id-restoring re-save — so a lexical alias defeated all of them at once.
+#
+# simplify_path() is the ENGINE'S own normalization, not gda's invention: Godot
+# reports `res://..\outside.gd` back as `res://../outside.gd` (measured on 4.6.3),
+# and it leaves a scheme it does not own alone — `uid://abc` and `user://x.tscn`
+# pass through unchanged (a uid:// reference round-trips through Godot's UID
+# system, not the path graph). It collapses `.`, `..` and doubled separators
+# without touching the scheme, which is exactly the identity question and nothing
+# more.
 func _resolve_ref_path(ref: String, base_dir: String) -> String:
 	if ref.begins_with("res://") or ref.begins_with("uid://") or ref.begins_with("user://"):
 		return _canonical_resource_path(ref)
@@ -4476,18 +4492,23 @@ func _collect_references_from(path: String, target_paths: Dictionary, target_cla
 		return
 	if ext == "tscn" or ext == "tres":
 		var ext_base_dir := path.get_base_dir()
-		for line in text.split("\n"):
-			var stripped := line.strip_edges()
-			if not stripped.begins_with("[ext_resource"):
-				continue
-			var ref := _quoted_attr(stripped, "path=")
+		# The SAME reader the dependencies harvest uses (#775), so the incoming and
+		# outgoing views of the graph cannot recognize a different set of lines or
+		# read a different attribute out of one.
+		for entry in _raw_ext_resource_entries_from_text(text):
 			# One identity on BOTH sides: target_paths is seeded canonical, and the
 			# declared spelling is folded here through the SAME owner the harvest
-			# side uses (_normalize_ext_resource_path — anchor to the declaring
-			# file's directory, then canonicalize), so an aliased OR relative
-			# declaration matches a canonical query and the reverse (#774).
-			if target_paths.has(_normalize_ext_resource_path(ref, ext_base_dir)):
-				references.append({"path": path, "kind": "ext_resource", "context": stripped})
+			# side uses (_resolve_ref_path — anchor to the declaring file's
+			# directory, then canonicalize), so an aliased OR relative declaration
+			# matches a canonical query and the reverse (#774).
+			if target_paths.has(_resolve_ref_path(String(entry["path"]), ext_base_dir)):
+				# The context is the declaration as WRITTEN, so the agent still sees
+				# the spelling it must edit — only the MATCHING is normalized.
+				references.append({
+					"path": path,
+					"kind": "ext_resource",
+					"context": String(entry["line"]),
+				})
 	elif ext == "gd":
 		var base_dir := path.get_base_dir()
 		for line in text.split("\n"):
@@ -4649,18 +4670,18 @@ func _is_text_extension(ext: String) -> bool:
 	]
 
 
-# The value of a quoted attribute (e.g. path="res://x") in a line, or "" when the
-# attribute is absent. `attr` includes the trailing '=' ("path="). Returns the
-# text between the first pair of double quotes after the attribute.
-func _quoted_attr(line: String, attr: String) -> String:
-	var idx := line.find(attr)
-	if idx == -1:
-		return ""
-	return _first_quoted_after(line, idx + attr.length())
-
-
-# Like _quoted_attr, but matches a full attribute name. This matters for
-# ext_resource id="..." because uid="..." also contains the substring "id=".
+# The value of the quoted attribute `attr_name` in a section-header line —
+# path="res://x" in an [ext_resource] line, name="Root" in a [node] header — or
+# "" when the line carries no such attribute.
+#
+# The name is matched WHOLE, never as a substring, and that rule is the reason
+# this helper exists: `uid="uid://…"` also contains the substring `id=`, so a
+# substring match reads an [ext_resource] line's uid as its id. The trap is open
+# on every attribute a longer name can end with — a `…_path="…"` attribute ahead
+# of the real `path="…"` hands back the wrong reference — so the rule is applied
+# ONCE, here, for every reader of scene text (#775) rather than relearned per
+# scan. A match is accepted only where the name starts a token: at the line
+# start, after whitespace, or right after the section-opening `[`.
 func _quoted_named_attr(line: String, attr_name: String) -> String:
 	var needle := attr_name + "="
 	var from := 0
@@ -5409,7 +5430,7 @@ func _scene_attached_external_scripts(scene_path: String) -> Dictionary:
 	var current_node_path := ""
 	for line in text.split("\n"):
 		var stripped := line.strip_edges()
-		if stripped.begins_with("[node "):
+		if _is_node_header_line(stripped):
 			current_node_path = _scene_node_path_from_header(stripped)
 			continue
 		if current_node_path.is_empty():
@@ -5422,26 +5443,46 @@ func _scene_attached_external_scripts(scene_path: String) -> Dictionary:
 	return attached
 
 
+# The scene's Script-typed [ext_resource] declarations as {id -> res:// path},
+# read through the ONE scene-text reader (#775).
+#
+# The value carries the same canonical identity every other reader here
+# publishes, so a path harvested from scene text compares equal to the
+# resource_path the ENGINE reports for the same file whichever way the
+# declaration spelled it — _validate_scene_script_preload_dependencies makes
+# exactly that comparison. A relative declaration is left out: this reader is
+# handed text with no declaring directory to anchor against, and Godot writes a
+# script reference absolute.
 func _scene_script_ext_resources(text: String) -> Dictionary:
 	var resources := {}
-	for line in text.split("\n"):
-		var stripped := line.strip_edges()
-		if not stripped.begins_with("[ext_resource"):
+	for entry in _raw_ext_resource_entries_from_text(text):
+		if String(entry["type"]) != "Script":
 			continue
-		if _quoted_attr(stripped, "type=") != "Script":
-			continue
-		var resource_id := _quoted_named_attr(stripped, "id")
-		var path := _quoted_attr(stripped, "path=")
-		if not resource_id.is_empty() and path.begins_with("res://"):
-			resources[resource_id] = path
+		var resource_id := String(entry["id"])
+		var ref_path := String(entry["path"])
+		if not resource_id.is_empty() and ref_path.begins_with("res://"):
+			resources[resource_id] = _canonical_resource_path(ref_path)
 	return resources
 
 
+# Whether one trimmed line OPENS a node block — the single owner of `[node …]`
+# recognition (#775). Three scans ask it: the node-to-ext_resource attribution,
+# the attached-script binding read, and the instance-path recovery. Each used to
+# spell the prefix for itself, which is one place per scan for the next header
+# rule to be learned in only two of three.
+func _is_node_header_line(stripped: String) -> bool:
+	return stripped.begins_with("[node ")
+
+
+# The root-relative NodePath a [node …] header declares, or "" when the header
+# names no node. Both attributes are read WHOLE-NAME (_quoted_named_attr), the
+# same rule the [ext_resource] reader applies: a longer attribute ending in
+# `name` or `parent` ahead of the real one would otherwise hand back its value.
 func _scene_node_path_from_header(header: String) -> String:
-	var name := _quoted_attr(header, "name=")
+	var name := _quoted_named_attr(header, "name")
 	if name.is_empty():
 		return ""
-	var parent := _quoted_attr(header, "parent=")
+	var parent := _quoted_named_attr(header, "parent")
 	if parent.is_empty():
 		return "."
 	if parent == ".":
@@ -5834,7 +5875,7 @@ func _scene_instance_paths_by_node_path(path: String) -> Dictionary:
 	var instance_paths := {}
 	for line in text.split("\n"):
 		var stripped := line.strip_edges()
-		if not stripped.begins_with("[node ") or stripped.find("instance=ExtResource(") == -1:
+		if not _is_node_header_line(stripped) or stripped.find("instance=ExtResource(") == -1:
 			continue
 		var id := _first_quoted_after(stripped, stripped.find("instance=ExtResource("))
 		if id.is_empty() or not ext_resources_by_id.has(id):
@@ -6494,64 +6535,74 @@ func _restore_existing_ext_resource_ids(
 	return _replace_ext_resource_ids(saved_text, id_remap)
 
 
+# Whether one trimmed line DECLARES an external resource — the single owner of
+# `[ext_resource…]` recognition (#775). The entries reader below and the save-side
+# id substitution are its two askers; the substitution rewrites lines in place and
+# so cannot go through the reader, but it must agree with it on WHICH lines it may
+# touch.
+func _is_ext_resource_line(stripped: String) -> bool:
+	return stripped.begins_with("[ext_resource")
+
+
+# Every [ext_resource] declaration in one scene/resource text, as written — the
+# ONE reader of scene text (#775). Four more scans over these same lines lived
+# beside this one, and three of them still pulled the path out with a SUBSTRING
+# match — the trap this reader had already been fixed for on `uid=`/`id=`, never
+# propagated. Adapting them onto this reader ends the class: there is no shallow
+# scan left for the next attribute or alias bug to hide in.
+#
+# The entry is the line's own content, unresolved: `path` is the spelling the
+# declaration used, and anchoring it to a base directory is the caller's step
+# (_resolve_ref_path, or the id-keyed view below). A line naming no path declares
+# no reference and is dropped.
 func _raw_ext_resource_entries_from_text(text: String) -> Array:
 	var entries: Array = []
 	for line in text.split("\n"):
 		var stripped := line.strip_edges()
-		if not stripped.begins_with("[ext_resource"):
+		if not _is_ext_resource_line(stripped):
 			continue
 		var ref_path := _quoted_named_attr(stripped, "path")
-		var id := _quoted_named_attr(stripped, "id")
-		if ref_path.is_empty() or id.is_empty():
+		if ref_path.is_empty():
 			continue
 		# `type` is the class the line DECLARES for the reference ("Script",
 		# "Texture2D", …); "" when the line names none. Carried so scene-validate can
 		# report what was expected at a path that did not resolve (#664) — the
 		# id/path consumers ignore it.
-		entries.append({"path": ref_path, "id": id, "type": _quoted_named_attr(stripped, "type")})
+		#
+		# `line` is the declaration as WRITTEN (trimmed): find-references reports it
+		# as the match context, so an agent sees the spelling it has to edit.
+		entries.append({
+			"path": ref_path,
+			"id": _quoted_named_attr(stripped, "id"),
+			"type": _quoted_named_attr(stripped, "type"),
+			"line": stripped,
+		})
 	return entries
 
 
+# The ID-KEYED view of the same declarations, each resolved to its canonical
+# graph identity against the declaring file's directory. A declaration with no
+# `id` is left out: nothing here can reach it, because an ExtResource("…") names
+# a reference by id and every consumer of this view keys by one.
 func _ext_resource_entries_from_text(text: String, base_dir: String) -> Array:
 	var entries: Array = []
 	for entry in _raw_ext_resource_entries_from_text(text):
+		var id := String(entry["id"])
+		if id.is_empty():
+			continue
 		var ref_path := String(entry["path"])
 		entries.append({
 			"path": ref_path,
-			"normalized_path": _normalize_ext_resource_path(ref_path, base_dir),
-			"id": String(entry["id"]),
+			"normalized_path": _resolve_ref_path(ref_path, base_dir),
+			"id": id,
 			"type": String(entry.get("type", "")),
 		})
 	return entries
 
 
-# The one CANONICAL IDENTITY of an [ext_resource] reference: the path every
-# consumer keys a file by (#721 review).
-#
-# A relative reference is resolved against the scene's own directory, as before.
-# An already-absolute one is simplified as well, and that half is the fix: it used
-# to be returned verbatim, so `res://leaf.tscn` and `res://./leaf.tscn` were TWO
-# keys for ONE file. Everything downstream keys on this string — the dependency
-# walk's "a path declared twice is checked once and reported once" rule, the
-# sub-scene walk's own `answered`/`reached_depth`/`chain` sets, and the
-# id-restoring re-save — so a lexical alias defeated all three at once: two
-# identical problems for one broken file, a cycle-closing edge that did not match
-# its ancestor, and a per-file cost bound a hand-written alias could evade.
-#
-# simplify_path() is the ENGINE'S own normalization, not gda's invention: Godot
-# reports `res://..\outside.gd` back as `res://../outside.gd` (measured on 4.6.3),
-# and it leaves a scheme it does not own alone — `uid://abc` and `user://x.tscn`
-# pass through unchanged. It collapses `.`, `..` and doubled separators without
-# touching the scheme, which is exactly the identity question and nothing more.
-func _normalize_ext_resource_path(ref_path: String, base_dir: String) -> String:
-	if ref_path.begins_with("res://") or ref_path.begins_with("uid://") or ref_path.begins_with("user://"):
-		return _canonical_resource_path(ref_path)
-	return _canonical_resource_path(base_dir.path_join(ref_path))
-
-
 # The canonical spelling of one already-absolute path — the identity half of
-# _normalize_ext_resource_path, split out so a caller that has no base directory
-# to resolve against can key by the SAME identity (#721 review round 3).
+# _resolve_ref_path, split out so a caller that has no base directory to resolve
+# against can key by the SAME identity (#721 review round 3).
 #
 # The composed scene walk is that caller: its root arrives from the command line
 # rather than from an [ext_resource] line, and seeding the walk with the caller's
@@ -6617,7 +6668,7 @@ func _replace_ext_resource_id_attr(text: String, old_id: String, new_id: String)
 	var lines := text.split("\n")
 	for index in lines.size():
 		var line := String(lines[index])
-		if line.strip_edges().begins_with("[ext_resource"):
+		if _is_ext_resource_line(line.strip_edges()):
 			lines[index] = line.replace(old_attr, new_attr)
 	return "\n".join(lines)
 

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -3307,3 +3307,106 @@ def test_inline_projection_drops_a_storage_property_named_object_string(
     assert value["honest_field"] == 7
     assert "object_string" not in value
     assert "width" not in value and "digest" not in value
+
+
+# --- the script-binding reader reads attributes and property names whole -------
+#
+# `_scene_attached_external_scripts` is what catches a script Godot could not
+# materialize: the node still exists with no script, so walking the instantiated
+# tree alone cannot see the dependency. It reads the scene as TEXT, and every
+# read it makes is a whole-name one (#775) — the declaration's `type`, the
+# declaration's `path` under the one identity owner, and the assigned property
+# name. Each of the three is pinned below, on the mutating op where getting it
+# wrong is destructive or obstructive.
+
+BROKEN_SCRIPT_GD = """\
+extends Node2D
+
+const Projectile = preload("res://enemy_projectile.tscn")
+"""
+
+
+@pytest.mark.e2e
+def test_node_add_refuses_a_broken_script_behind_a_type_decoy(godot_project):
+    # A decoy attribute ENDING in `type` ahead of the real `type="Script"`. Read
+    # by substring the declaration answers "Resource", the binding is not seen,
+    # and the mutation reports clean success while re-saving a scene that has
+    # LOST its script — measured on the pre-#775 reader.
+    (godot_project / "enemy.gd").write_text(BROKEN_SCRIPT_GD, encoding="utf-8")
+    (godot_project / "main.tscn").write_text(
+        "[gd_scene load_steps=2 format=3]\n\n"
+        '[ext_resource subtype="Resource" type="Script" path="res://enemy.gd"'
+        ' id="1_enemy"]\n\n'
+        '[node name="Main" type="Node2D"]\n'
+        'script = ExtResource("1_enemy")\n',
+        encoding="utf-8",
+    )
+    before = (godot_project / "main.tscn").read_text(encoding="utf-8")
+    gda = _gda_project(godot_project)
+
+    added = gda(
+        "node", "add", "res://main.tscn", "--type", "Marker2D", "--name", "M", "--json"
+    )
+
+    err = _assert_operation_error(added, "missing_dependency")
+    assert "res://enemy_projectile.tscn" in err["message"]
+    assert (godot_project / "main.tscn").read_text(encoding="utf-8") == before
+
+
+@pytest.mark.e2e
+def test_node_add_refuses_a_broken_script_declared_by_a_relative_path(godot_project):
+    # The declaration spells the script relative to the scene's own directory,
+    # which is how the ENGINE resolves it. Folded through the one identity owner
+    # the binding is found; left unresolved it is dropped, and the mutation
+    # re-saves a scene whose script cannot load.
+    (godot_project / "enemy.gd").write_text(BROKEN_SCRIPT_GD, encoding="utf-8")
+    (godot_project / "scenes").mkdir()
+    (godot_project / "scenes" / "main.tscn").write_text(
+        "[gd_scene load_steps=2 format=3]\n\n"
+        '[ext_resource type="Script" path="../enemy.gd" id="1_enemy"]\n\n'
+        '[node name="Main" type="Node2D"]\n'
+        'script = ExtResource("1_enemy")\n',
+        encoding="utf-8",
+    )
+    before = (godot_project / "scenes" / "main.tscn").read_text(encoding="utf-8")
+    gda = _gda_project(godot_project)
+
+    added = gda(
+        "node",
+        "add",
+        "res://scenes/main.tscn",
+        "--type",
+        "Marker2D",
+        "--name",
+        "M",
+        "--json",
+    )
+
+    err = _assert_operation_error(added, "missing_dependency")
+    assert "res://enemy_projectile.tscn" in err["message"]
+    assert (godot_project / "scenes" / "main.tscn").read_text(
+        encoding="utf-8"
+    ) == before
+
+
+@pytest.mark.e2e
+def test_node_add_does_not_read_a_script_prefixed_property_as_a_binding(godot_project):
+    # The mirror case: NO node carries the broken script — a property whose name
+    # merely STARTS with `script` names the declaration. A prefix match read that
+    # as a binding and refused a mutation there was nothing wrong with.
+    (godot_project / "enemy.gd").write_text(BROKEN_SCRIPT_GD, encoding="utf-8")
+    (godot_project / "main.tscn").write_text(
+        "[gd_scene load_steps=2 format=3]\n\n"
+        '[ext_resource type="Script" path="res://enemy.gd" id="1_enemy"]\n\n'
+        '[node name="Main" type="Node2D"]\n'
+        'script_owner = ExtResource("1_enemy")\n',
+        encoding="utf-8",
+    )
+    gda = _gda_project(godot_project)
+
+    added = gda(
+        "node", "add", "res://main.tscn", "--type", "Marker2D", "--name", "M", "--json"
+    )
+
+    assert added.returncode == 0, added.stdout + added.stderr
+    assert json.loads(added.stdout)["name"] == "M"

--- a/tests/test_e2e_project_analysis.py
+++ b/tests/test_e2e_project_analysis.py
@@ -918,3 +918,100 @@ def test_find_unused_resources_never_lists_an_aliased_reference(alias_project):
             _gda(alias_project, "project", "find-references", path, "--json").stdout
         )["references"]
         assert refs == [], f"{path} reported unused but has references {refs}"
+
+
+# --- one reader for scene text (#775) ----------------------------------------
+#
+# An `[ext_resource]` attribute is read by NAME, never by substring. The reader
+# these commands now share learned that rule once, on the pair the engine really
+# writes: `uid="uid://…"` contains the substring `id=`, so a substring match reads
+# a line's uid as its id. The rescans this issue removed never learned it — each
+# pulled the reference out with `find("path=")`, which any longer attribute ending
+# in `path` answers first.
+#
+# No attribute Godot 4.6.3 emits triggers it today, and this fixture does not
+# pretend otherwise: it is hand-written `.tscn` text, which is admissible input
+# (gda parses scenes as text precisely so it can read files it did not author) and
+# the form an agent or a third-party tool can produce. The rule is pinned here so
+# the graph reads keep it however the declaration is spelled.
+
+ONE_READER_PROJECT_GODOT = project_godot(name="gda-one-reader-fixture")
+
+# The decoy attribute ends in `path`, so a substring match hands back
+# res://decoy.png — a dependency on a file the scene does not use, and no
+# dependency on the file it does.
+ONE_READER_MAIN_TSCN = """\
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Texture2D" fallback_path="res://decoy.png" path="res://real.png" id="1_real"]
+
+[node name="Main" type="Sprite2D"]
+texture = ExtResource("1_real")
+"""
+
+
+@pytest.fixture
+def one_reader_project(tmp_path):
+    """A project whose one scene declares a reference behind a decoy attribute."""
+    (tmp_path / "project.godot").write_text(ONE_READER_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(ONE_READER_MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "real.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+    (tmp_path / "decoy.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+    return tmp_path
+
+
+@pytest.mark.e2e
+def test_dependencies_reads_the_named_path_attribute_not_a_substring(
+    one_reader_project,
+):
+    proc = _gda(one_reader_project, "project", "dependencies", "--json")
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    by_source = {
+        row["path"]: row["depends_on"]
+        for row in json.loads(proc.stdout)["dependencies"]
+    }
+
+    assert by_source["res://main.tscn"] == [
+        {"path": "res://real.png", "kind": "ext_resource"}
+    ]
+
+
+@pytest.mark.e2e
+def test_find_references_reads_the_named_path_attribute_not_a_substring(
+    one_reader_project,
+):
+    real = _gda(
+        one_reader_project, "project", "find-references", "res://real.png", "--json"
+    )
+    decoy = _gda(
+        one_reader_project, "project", "find-references", "res://decoy.png", "--json"
+    )
+
+    assert real.returncode == 0, real.stdout + real.stderr
+    assert decoy.returncode == 0, decoy.stdout + decoy.stderr
+    assert [(r["path"], r["kind"]) for r in json.loads(real.stdout)["references"]] == [
+        ("res://main.tscn", "ext_resource")
+    ]
+    # The decoy value is not a reference: nothing loads it.
+    assert json.loads(decoy.stdout)["references"] == []
+    # The context is still the line as written, now that it comes from the shared
+    # reader rather than from the scan's own copy of the line.
+    assert (
+        'path="res://real.png"' in json.loads(real.stdout)["references"][0]["context"]
+    )
+
+
+@pytest.mark.e2e
+def test_find_unused_resources_agrees_with_the_named_path_attribute(
+    one_reader_project,
+):
+    proc = _gda(one_reader_project, "project", "find-unused-resources", "--json")
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    unused = json.loads(proc.stdout)["unused"]
+
+    # The destructive half: real.png is the file the scene loads, so it is not
+    # deletable — and decoy.png, which nothing loads, is.
+    assert "res://real.png" not in unused
+    assert "res://decoy.png" in unused

--- a/tests/test_e2e_project_analysis.py
+++ b/tests/test_e2e_project_analysis.py
@@ -1015,3 +1015,102 @@ def test_find_unused_resources_agrees_with_the_named_path_attribute(
     # deletable — and decoy.png, which nothing loads, is.
     assert "res://real.png" not in unused
     assert "res://decoy.png" in unused
+
+
+# --- section recognition is closed, not a prefix (#775 review) ----------------
+#
+# `[ext_resource` as a bare prefix admits `[ext_resource_group …]`, which the
+# ENGINE refuses outright: loading the scene below reports "Parse Error: Unknown
+# tag 'ext_resource_group' in file" (resource_format_text.cpp, measured on
+# 4.6.3) and `gda scene get` answers not_a_scene. Reading a dependency out of a
+# tag the engine will not accept invents a reference no run can ever make — the
+# same bypass `[gd_scenery]` opens on the scene header, one section deeper. The
+# reader now applies the scene header's own closed-tag rule.
+
+UNKNOWN_TAG_PROJECT_GODOT = project_godot(name="gda-unknown-tag-fixture")
+
+UNKNOWN_TAG_MAIN_TSCN = """\
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Texture2D" path="res://real.png" id="1_real"]
+[ext_resource_group type="Texture2D" path="res://ghost.png" id="9_ghost"]
+
+[node name="Main" type="Sprite2D"]
+texture = ExtResource("1_real")
+"""
+
+
+@pytest.fixture
+def unknown_tag_project(tmp_path):
+    """A project whose one scene carries a tag that only PREFIX-matches a declaration."""
+    (tmp_path / "project.godot").write_text(UNKNOWN_TAG_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(UNKNOWN_TAG_MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "real.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+    (tmp_path / "ghost.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+    return tmp_path
+
+
+@pytest.mark.e2e
+def test_an_unknown_section_tag_is_not_an_ext_resource_declaration(
+    unknown_tag_project,
+):
+    deps = _gda(unknown_tag_project, "project", "dependencies", "--json")
+    ghost = _gda(
+        unknown_tag_project, "project", "find-references", "res://ghost.png", "--json"
+    )
+
+    assert deps.returncode == 0, deps.stdout + deps.stderr
+    assert ghost.returncode == 0, ghost.stdout + ghost.stderr
+    by_source = {
+        row["path"]: row["depends_on"]
+        for row in json.loads(deps.stdout)["dependencies"]
+    }
+    # Only the real declaration is a dependency; the prefix-matching tag is not.
+    assert by_source["res://main.tscn"] == [
+        {"path": "res://real.png", "kind": "ext_resource"}
+    ]
+    assert json.loads(ghost.stdout)["references"] == []
+
+
+# --- a directory-shaped query no longer matches a path-less declaration -------
+#
+# `find-references` never checks that its target exists, so a directory-shaped
+# query is ordinary input. An [ext_resource] line with no `path=` used to fold to
+# its DECLARING file's own directory, which such a query then matched: a fixed
+# false positive, not a theoretical one. The reader drops a declaration that
+# names no path, so the query answers empty.
+
+PATHLESS_DECL_PROJECT_GODOT = project_godot(name="gda-pathless-decl-fixture")
+
+PATHLESS_DECL_MAIN_TSCN = """\
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Texture2D" id="1_nopath"]
+
+[node name="Main" type="Node2D"]
+"""
+
+
+@pytest.fixture
+def pathless_decl_project(tmp_path):
+    """A project whose one scene declares an [ext_resource] with no ``path``."""
+    (tmp_path / "project.godot").write_text(
+        PATHLESS_DECL_PROJECT_GODOT, encoding="utf-8"
+    )
+    (tmp_path / "scenes").mkdir()
+    (tmp_path / "scenes" / "main.tscn").write_text(
+        PATHLESS_DECL_MAIN_TSCN, encoding="utf-8"
+    )
+    return tmp_path
+
+
+@pytest.mark.e2e
+def test_find_references_does_not_match_a_directory_through_a_pathless_declaration(
+    pathless_decl_project,
+):
+    found = _gda(
+        pathless_decl_project, "project", "find-references", "res://scenes", "--json"
+    )
+
+    assert found.returncode == 0, found.stdout + found.stderr
+    assert json.loads(found.stdout)["references"] == []

--- a/tests/test_e2e_scene.py
+++ b/tests/test_e2e_scene.py
@@ -342,6 +342,46 @@ def test_scene_get_marks_instanced_child_and_resolves_its_root_type(godot_projec
     assert hud["instance_status"] == "resolved"
 
 
+# A host whose [node] header carries a decoy attribute ENDING in `instance`
+# ahead of the real one (#775 review). `instance` is a header attribute, so it is
+# read by whole name like `name` and `parent`; a substring scan for
+# `instance=ExtResource(` matched `fallback_instance=` first and reported the
+# wrong instanced scene.
+HOST_WITH_DECOYED_INSTANCE_ATTR_TSCN = """\
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="PackedScene" path="res://scenes/hud.tscn" id="1_hud"]
+[ext_resource type="PackedScene" path="res://scenes/decoy.tscn" id="2_decoy"]
+
+[node name="Main" type="Node2D"]
+
+[node name="Hud" parent="." fallback_instance=ExtResource("2_decoy") instance=ExtResource("1_hud")]
+"""
+
+
+@pytest.mark.e2e
+def test_scene_get_reads_the_instance_attribute_by_whole_name(godot_project):
+    (godot_project / "scenes").mkdir()
+    (godot_project / "scenes" / "hud.tscn").write_text(
+        INSTANCED_HUD_TSCN, encoding="utf-8"
+    )
+    (godot_project / "scenes" / "decoy.tscn").write_text(
+        INSTANCED_HUD_TSCN, encoding="utf-8"
+    )
+    (godot_project / "main.tscn").write_text(
+        HOST_WITH_DECOYED_INSTANCE_ATTR_TSCN, encoding="utf-8"
+    )
+    gda = _gda_project(godot_project)
+
+    got = gda("scene", "get", "res://main.tscn", "--json")
+
+    assert got.returncode == 0, got.stdout + got.stderr
+    hud = json.loads(got.stdout)["root"]["children"][0]
+    # The scene the node really instances, not the decoy attribute's value.
+    assert hud["instance_path"] == "res://scenes/hud.tscn"
+    assert hud["instance_status"] == "resolved"
+
+
 @pytest.mark.e2e
 def test_scene_get_marks_missing_instanced_child_reference(godot_project):
     # issue #400: when the referenced scene is missing, the static read must

--- a/tests/test_e2e_scene_validate.py
+++ b/tests/test_e2e_scene_validate.py
@@ -1484,15 +1484,21 @@ def test_a_deferred_depth_edge_does_not_suppress_a_later_cycle(
 
 
 # A hand-written scene whose [node] header carries a decoy attribute ending in
-# `name` ahead of the real one, and whose [ext_resource] line carries a decoy
-# ending in `type` (#775). Both are read WHOLE-NAME by the one owner of each
-# recognition, so the verdict names the node that really references the missing
-# file, and the class the line really declares. Read by substring, the header
-# attributes answer "Decoy" and the type answers "Resource".
+# `name` AHEAD of the real one (#775). The header is read WHOLE-NAME, so the
+# verdict names the node that really references the missing file; read by
+# substring, `instance_name=` answers first and the verdict says "Decoy".
+#
+# Only the header attributes are decoyed here, because only they were read by
+# substring on this path: `scene validate` already took `path` and `type` from
+# the whole-name entries reader. A decoy ending in `type` was measured on both
+# sides of this change and reported `"Script"` either way — it pinned nothing, so
+# it is not in the fixture. The `type=` substring read that DID exist lived in
+# the script-binding reader, and is pinned where it is observable
+# (test_e2e_node.py::test_node_add_refuses_a_broken_script_behind_a_type_decoy).
 DECOY_ATTR_TSCN = """\
 [gd_scene load_steps=2 format=3]
 
-[ext_resource type="Script" subtype="Resource" path="res://gone.gd" id="1_gone"]
+[ext_resource type="Script" path="res://gone.gd" id="1_gone"]
 
 [node name="Root" type="Node2D"]
 
@@ -1517,8 +1523,9 @@ def test_a_problem_names_the_node_a_whole_name_header_read_finds(godot_project):
             "scene": "res://main.tscn",
             "path": "res://gone.gd",
             "type": "Script",
-            # "Decoy" before the [node] header was read by whole attribute name:
-            # an agent sent to fix the reference would open the wrong node.
+            # The header's real `name=` wins over the `instance_name=` decoy
+            # ahead of it: an agent sent to fix the reference by a substring read
+            # would open a node called "Decoy" that does not exist.
             "nodes": ["Sprite"],
             "message": "the referenced file does not exist",
         }

--- a/tests/test_e2e_scene_validate.py
+++ b/tests/test_e2e_scene_validate.py
@@ -1481,3 +1481,45 @@ def test_a_deferred_depth_edge_does_not_suppress_a_later_cycle(
     assert [
         (p["kind"], p["scene"], p["path"], p["nodes"]) for p in data["problems"]
     ] == [("cyclic_instance", "res://s.tscn", "res://t.tscn", ["Child"])]
+
+
+# A hand-written scene whose [node] header carries a decoy attribute ending in
+# `name` ahead of the real one, and whose [ext_resource] line carries a decoy
+# ending in `type` (#775). Both are read WHOLE-NAME by the one owner of each
+# recognition, so the verdict names the node that really references the missing
+# file, and the class the line really declares. Read by substring, the header
+# attributes answer "Decoy" and the type answers "Resource".
+DECOY_ATTR_TSCN = """\
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" subtype="Resource" path="res://gone.gd" id="1_gone"]
+
+[node name="Root" type="Node2D"]
+
+[node instance_name="Decoy" name="Sprite" type="Sprite2D" parent="."]
+script = ExtResource("1_gone")
+"""
+
+
+@pytest.mark.e2e
+def test_a_problem_names_the_node_a_whole_name_header_read_finds(godot_project):
+    (godot_project / "main.tscn").write_text(DECOY_ATTR_TSCN, encoding="utf-8")
+    gda = _gda_project(godot_project)
+
+    validated = gda("scene", "validate", "res://main.tscn", "--json")
+
+    assert validated.returncode == 0, validated.stdout + validated.stderr
+    data = json.loads(validated.stdout)
+    assert data["valid"] is False
+    assert data["problems"] == [
+        {
+            "kind": "missing_resource",
+            "scene": "res://main.tscn",
+            "path": "res://gone.gd",
+            "type": "Script",
+            # "Decoy" before the [node] header was read by whole attribute name:
+            # an agent sent to fix the reference would open the wrong node.
+            "nodes": ["Sprite"],
+            "message": "the referenced file does not exist",
+        }
+    ]


### PR DESCRIPTION
## What changed

`src/gda/ops/operations.gd` recognized an `[ext_resource]` line in **five** places and a
`[node …]` header in **three**. Three of the rescans still extracted the reference with
`_quoted_attr(line, "path=")` — a SUBSTRING match, the rule this reader was BORN with
(#394 landed `_raw_ext_resource_entries_from_text` and `_quoted_named_attr` together) but
that the older scans beside it never learned. Those rescans are adapted onto the canonical
reader: three loops are deleted outright, and four now call a shared predicate instead of
spelling the prefix for themselves.

| seam | before | after |
|---|---|---|
| section recognition | `[gd_scene` (closed), `[ext_resource` (bare prefix), `[node ` (space only) — three spellings of one rule | one `_is_section_header_line`, asked by all three |
| `[ext_resource]` reads | 5 scans (`_raw_ext_resource_entries_from_text`, `_ext_resource_paths`, `_collect_references_from`, `_scene_script_ext_resources`, `_replace_ext_resource_id_attr`) | one reader `_raw_ext_resource_entries_from_text` + one predicate `_is_ext_resource_line` |
| `[node …]` reads | 3 scans (`:1450`, `:5412`, `:5837`) | one predicate `_is_node_header_line` |
| attribute extraction | `_quoted_attr` (substring) **and** `_quoted_named_attr` (whole name) | `_quoted_named_attr` only; `_quoted_attr` deleted |
| reference identity | `_normalize_ext_resource_path` **and** `_resolve_ref_path` | `_resolve_ref_path` |

The reader splits into two tiers instead of one, so no consumer changes admission rule:
raw entries need only a `path`, and the id-keyed view additionally needs an `id` (what its
six consumers already required). The raw entry now carries the declaration line, so
`find-references` still reports the spelling as written instead of keeping its own copy of
the line.

## Behavior changes

Four reads answered wrongly on input Godot accepts — or answered at all on input Godot
refuses. Each is pinned by an e2e regression.

1. **`[ext_resource_group …]` is no longer a declaration.** A bare `[ext_resource` prefix
   admitted it, and the ENGINE refuses the whole file over it — `Parse Error: Unknown tag
   'ext_resource_group' in file` (`scene/resources/resource_format_text.cpp`, measured on
   4.6.3; `gda scene get` answers `not_a_scene`). gda reported a `project dependencies`
   edge and a `scene validate` problem for a reference no run can make. Section
   recognition now applies `_has_scene_header`'s own closed-tag rule — the `[gd_scenery]`
   bypass (#720 recheck ×2), one section deeper. **Tightening**, disclosed: a tag that only
   prefix-matches is no longer read.
   The same rule slightly WIDENS `[node …]`: `[node]` and a tab after the tag now count,
   because the engine's `VariantParser` ends a tag name at any non-identifier character.
   `[node]` names no node either way, so nothing observable changes there.
2. **`instance` is read by name.** `find("instance=ExtResource(")` matched a decoy
   `fallback_instance=ExtResource("…")` ahead of it, and `scene get` reported the wrong
   instanced scene (`res://decoy.tscn` for a node instancing `res://hero.tscn`).
3. **A `script`-prefixed property is not a script binding.** `begins_with("script")` read
   `script_owner = ExtResource("…")` as a binding, so `node add` refused with
   `missing_dependency` over a script no node carries. The assigned property must now BE
   `script`.
4. **A relative Script declaration resolves.** `_scene_script_ext_resources` folds through
   `_resolve_ref_path` against the scene's own directory, as the engine does. Before, a
   scene declaring `path="../enemy.gd"` lost the binding, and a mutating op re-saved a
   scene whose script cannot load instead of refusing.

The whole-name rule also reaches the `[node …]` header's `name` and `parent`, which were
read by substring.

## The duplicate pair: converged

`_resolve_ref_path` and `_normalize_ext_resource_path` had bodies identical but for a
parameter name (`ref` vs `ref_path`) since #774 (PR #777 deferred the merge here, and the
issue records that deferral). They converge on **`_resolve_ref_path`**, chosen because its
name is not `[ext_resource]`-specific — the merged owner serves an `[ext_resource]` line
and a `preload`/`load`/`extends` argument alike. (The two were TIED at three call sites
each, so the merge moved three calls either way; call-site count decided nothing.) The
richer identity rationale from `_normalize_ext_resource_path`'s comment is merged onto it.

**Cross-language edge:** `_canonical_resource_path` is untouched. Both merged bodies already
called it, so the merge publishes **no spelling decision** — the known GDScript/Python
disagreement on root collapse (`res://a/..` → `res://.` vs `res://`) is unchanged in either
direction. #763 owns the Python side and is still open; nothing here pre-empts it.

## Identity is now structural for scene text

Harvesting **through** the reader returns canonicalized identities by construction: the
id-keyed view already carries `normalized_path`, and all three raw-tier consumers now fold
through the one `_resolve_ref_path`. #774's discipline is no longer a rule each harvest
site has to remember.

## Where the whole-name rule stops

`[ext_resource]`/`[node]` **section recognition** and every **header attribute** read are
whole-name, at one owner each. The `ExtResource("…")` **call-site** scans over property
values are not: `_ext_resource_ids_in_line` (`:1466`) and the save-side
`_replace_ext_resource_ids` still use `find("ExtResource(")`, which `MyExtResource(` also
matches. That is a different read — a GDScript-style call inside a Variant value, not a
header attribute — and it is left as is, named here rather than covered by an absolute
claim. The reader's own comment carries the same boundary.

## Red-proof

Ten e2e regressions, each failing on the commit it pins (`operations.gd` swapped, same
tests).

**Six red on `181da20d`** (the reader consolidation):

```
FAILED test_dependencies_reads_the_named_path_attribute_not_a_substring
FAILED test_find_references_reads_the_named_path_attribute_not_a_substring
FAILED test_find_unused_resources_agrees_with_the_named_path_attribute
FAILED test_find_references_does_not_match_a_directory_through_a_pathless_declaration
FAILED test_a_problem_names_the_node_a_whole_name_header_read_finds
FAILED test_node_add_refuses_a_broken_script_behind_a_type_decoy
```

**Four red on `d03e23df`** (the behavior changes above):

```
FAILED test_an_unknown_section_tag_is_not_an_ext_resource_declaration
FAILED test_scene_get_reads_the_instance_attribute_by_whole_name
FAILED test_node_add_refuses_a_broken_script_declared_by_a_relative_path
FAILED test_node_add_does_not_read_a_script_prefixed_property_as_a_binding
```

The sharpest ones repeat #774's destructive shape. On base, `find-unused-resources`
reported `res://real.png` — the texture the scene actually loads — as deletable, because
`find("path=")` answered with the decoy attribute's value. And with a decoy ending in
`type` ahead of the real `type="Script"`, base's `node add` reported clean success while
re-saving a scene that had LOST its script and its `[ext_resource]` line entirely.

**Honest scope of the fixtures:** no attribute Godot 4.6.3 emits ends in `path`, `name`,
`type` or `instance` ahead of the real one. These are hand-written `.tscn` texts —
admissible input, since gda parses scenes as text precisely to read files it did not
author, and Godot 4.6.3 loads them, silently dropping the unknown attributes. The
`uid=`/`id=` pair proves the defect class is real on input the engine itself writes.
A `subtype=` decoy was measured on both sides and reported `"Script"` either way, so it is
not in any fixture: the `type=` substring read that DID exist lived in the script-binding
reader, and is pinned there.

## Public contracts

Byte-identical, as required by the scope-defining criterion — and structurally so: the
diff touches no Python at all (`git diff --name-only 181da20d -- 'src/gda/**/*.py'` is
empty).

- `gda schema` — `cmp` identical (675 342 bytes)
- `gda --help` plus every group's `--help` — `cmp` identical
- `docs/` and the command catalog — untouched

## Verification

- pytest non-e2e: **2250 passed**
- `ruff check` / `ruff format --check` / `pyright`: clean (0 errors, 0 warnings)
- Targeted real-engine e2e (the reader's consumers), serial:
  - `test_e2e_scene_validate.py` + `test_e2e_project_analysis.py` — **68 passed**
  - `test_e2e_node.py` + `test_e2e_scene.py` — **132 passed** (covers the save-side id
    restore and the script-binding reader)

## Residual risk

- The two-tier admission rule is the one place a behavior delta could hide. It was chosen
  to preserve both sides on well-formed input: the deleted rescans admitted a line with a
  `path` and no `id`, and the raw tier still does; the id-keyed view's six consumers
  required an `id`, and it still filters. A line with **neither** was dropped before and is
  dropped now. Two narrowings are deliberate and disclosed — the path-less declaration
  below, and the unknown-tag tightening above.
- One narrowing removes a REAL false positive, not a theoretical one: `find-references`
  never checks that its target exists, so a directory-shaped query is ordinary input. On
  base, a scene carrying `[ext_resource type="Texture2D" id="1_nopath"]` made
  `find-references res://scenes` report that scene as a reference — the malformed line
  folded to its own directory. Head answers `[]`. Pinned by
  `test_find_references_does_not_match_a_directory_through_a_pathless_declaration`.
- The `ExtResource("…")` call-site scans stay substring matches (named above). No
  reproduced failure; a `MyExtResource(` property value is the shape that would expose it.
- Section recognition now has one owner, but the reader's members are still spread across
  the file with no section markers, and the reference-identity rule that governs five
  commands still has no `CONTEXT.md` entry or ADR. Follow-up, not this PR.

Closes #775
