### PR TITLE
fix(gda): decide the res:// walk's symlink policy by filesystem identity (#760)

### DIFF
--- a/docs/adr/0032-project-local-class-name-resolution-static-fallback.md
+++ b/docs/adr/0032-project-local-class-name-resolution-static-fallback.md
@@ -60,10 +60,13 @@ instantiation (and the Node-vs-Resource base-class check) remains **split per si
 > the boundary is now: a `class_name` declared in a script inside the ROOT engine cache does not
 > resolve, whatever path reaches it (the #760 repro resolved `RootCacheThing` through an alias); a
 > `class_name` under a NESTED `.godot`, or in a vendored checkout reached through a link, still
-> does. A file link at an authored script is indexed under both its paths, so a `class_name` it
-> declares is `ambiguous_class_name` — the same report this ADR already gives a name declared in two
-> files. The full rule and its rationale live with the walk, in `docs/command-catalog.md`'s
-> exclusion passage.
+> resolves — for ENUMERATION and this index. Whether that same file may be NAMED as an operation's
+> target is a different question, owned by ADR-0006's addressing gate rather than by this ADR: the
+> walk decides what the project can address by filesystem identity, the gate decides what a caller
+> may operate on from the caller's own spelling. A file link at an authored script is indexed under
+> both its paths, so a `class_name` it declares is `ambiguous_class_name` — the same report this ADR
+> already gives a name declared in two files. The full rule and its rationale live with the walk, in
+> `docs/command-catalog.md`'s exclusion passage.
 
 **Explicit contract edges:**
 

--- a/docs/adr/0032-project-local-class-name-resolution-static-fallback.md
+++ b/docs/adr/0032-project-local-class-name-resolution-static-fallback.md
@@ -46,10 +46,24 @@ instantiation (and the Node-vs-Resource base-class check) remains **split per si
 > declaration there can make a name `ambiguous_class_name` that was unambiguous before. The trade
 > is accepted deliberately — a nested `.godot` is usually authored content (an addon vendoring a
 > sample tree), and nothing in the path distinguishes it from a vendored sub-project's own engine
-> cache, whose scripts then enter the index too. The comparison being lexical, it does not resolve
-> filesystem targets: an alias that leads to `res://.godot` is walked and the cache's own scripts
-> are indexed through it. Symlink policy for the `res://` walk is undecided and tracked in #760;
-> it is not decided here.
+> cache, whose scripts then enter the index too. The comparison being lexical, it did not resolve
+> filesystem targets: an alias that leads to `res://.godot` was walked and the cache's own scripts
+> were indexed through it. Symlink policy for the `res://` walk was undecided and tracked in #760.
+
+> **Amendment (2026-08-31, #760) — the boundary is the cache's filesystem IDENTITY, not its
+> spelling.** #760 decided the symlink policy the amendment above left open, for the whole `res://`
+> walk and therefore for this index. The walk follows a link as the engine does, but identifies what
+> it reaches with the engine's own `DirAccess.is_equivalent`, so the cache is excluded however it is
+> aliased — a directory link at it, a directory link into one of its subdirectories, or a file link
+> at a file inside it — and a link that leads back up the descent chain is not re-entered, so a
+> symlink cycle no longer floods the index with paths that name one script many times. For this ADR
+> the boundary is now: a `class_name` declared in a script inside the ROOT engine cache does not
+> resolve, whatever path reaches it (the #760 repro resolved `RootCacheThing` through an alias); a
+> `class_name` under a NESTED `.godot`, or in a vendored checkout reached through a link, still
+> does. A file link at an authored script is indexed under both its paths, so a `class_name` it
+> declares is `ambiguous_class_name` — the same report this ADR already gives a name declared in two
+> files. The full rule and its rationale live with the walk, in `docs/command-catalog.md`'s
+> exclusion passage.
 
 **Explicit contract edges:**
 
@@ -103,9 +117,9 @@ gda's existing boundary); its resolution would need a different mechanism and is
 - **Consistency restored** across the three sites: they now agree on `class_name` resolution in a
   never-opened project, rather than `find-references` reporting "no such class" while a repaired
   `resource create` resolves it.
-- **Scan boundary (amended 2026-08-28, #712).** What the scan skips is the root cache **path**, not
-  every directory named `.godot` — see the Decision amendment for the boundary, the accepted
-  nested-cache trade, and the open symlink question.
+- **Scan boundary (amended 2026-08-28 #712, 2026-08-31 #760).** What the scan skips is the root
+  cache **identity**, not every directory named `.godot` and not the path as written — see the
+  Decision amendments for the boundary, the accepted nested-cache trade, and the symlink policy.
 - **Cost.** A never-opened-project miss walks the whole `res://` tree and parses every `.gd`; this is
   acceptable for one-shot ops and is **not** backed by a persistent gda-owned cache — a gda-owned
   cache would re-introduce the very ".godot ownership" complexity the editor-scan option was rejected

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -552,19 +552,16 @@ issue #30) — null when the source declares neither, so the listing names every
 Enumeration needs a project, so projectless it is refused with `project_not_found` (pass
 `--project`); an empty project is a valid, empty listing, not an error. The walk excludes exactly
 one directory — the engine's own cache at `res://.godot`, whose contents are import artefacts no
-agent authored. The test is **lexical**: the child's `res://` PATH is compared against that one
-path. Not the directory NAME, so a nested `.godot` is walked — it is usually authored content, and
+agent authored. The first test is **lexical**: the child's `res://` PATH is compared against that
+one path. Not the directory NAME, so a nested `.godot` is walked — it is usually authored content, and
 excluding it hid real scripts from the listing and let `script validate --all` report a valid
 aggregate for a project holding an invalid script (#663 review). Sometimes it is not authored
 content — a vendored sub-project checked out under `res://` and opened once in an editor keeps an
 engine cache of its own, whose import artefacts then count in `project statistics` and become
 `find-unused-resources` candidates. That cost is accepted deliberately: gda cannot tell the two
-apart from the directory alone, and a false-valid aggregate is the worse failure. And because the
-test is lexical it compares the path as written, so it does **not** resolve filesystem targets: a
-symlink or alias under another path that leads to `res://.godot` is walked, and the cache's contents
-are then enumerated through that path. Symlink policy for the `res://` walk is undecided — #760 owns it, together with the symlink CYCLE the same walk descends until the OS path
-limit stops it. Hidden entries are otherwise enumerated as promised (#54). **This rule governs the
-four `res://` collectors in `operations.gd`** — the `script list` walk, the `scene list` walk, and
+apart from the directory alone, and a false-valid aggregate is the worse failure. Hidden entries are
+otherwise enumerated as promised (#54). **This rule governs the four `res://` collectors in
+`operations.gd`** — the `script list` walk, the `scene list` walk, and
 both static-analysis walks (the extension-filtered one behind `find-references`, `dependencies`,
 `find-unused-resources` and the `class_name` index, and the unfiltered one `project statistics`
 counts with) — so one project cannot answer two ways. It once did: three of the four compared the
@@ -575,6 +572,35 @@ copied per collector, and the copies drifted a second time — on the extension 
 shared traversal plus the acceptance test it passes. What they share is the traversal and the
 exclusion rule, **not** a file universe; the two static-analysis walks below still range over
 different files.
+
+The lexical test is the walk's first question, not its only one, because a link renames what it
+points at (#760). Comparing the path as written let an alias re-admit exactly what the rule
+excludes — `res://nested/.godot` pointing at the root cache made the cache's own scripts and scenes
+visible under a second name — and let a cycle (`sub/loop` -> `sub`) be descended until the OS
+refused another symlink hop, spelling one `.gd` 33 ways with a deepest path 174 characters long.
+The walk therefore **follows a link, as the engine does** — `DirAccess` stats a link entry so a
+linked directory lists as a directory, `ResourceLoader` loads through an alias, and gda's own
+addressing gate already counts a symlinked-in file as part of the project's `res://` namespace
+(ADR-0006) — but it **identifies what it reaches by filesystem identity**, through the engine's own
+`DirAccess.is_equivalent` (`st_dev`/`st_ino` on Unix, the volume+file id on Windows), rather than by
+the spelling that reached it. Two rules follow:
+
+- the **engine cache is excluded by identity**, so no alias re-admits it: not a directory link AT
+  `res://.godot`, not one INTO a subdirectory of it, and not a FILE link at a file inside it. That
+  last shape is a second touch point — it reaches the acceptance test without passing the descent
+  decision — so both branches of the walk ask the same owner;
+- a linked directory **already on the current descent chain is not re-entered**, so a cycle ends by
+  rule once every real directory has been walked, and the listing is a decided, bounded answer
+  rather than the leftovers of an OS limit.
+
+Both rules are about **where** a link leads, not about links: a vendored checkout that physically
+lives outside `res://` and is reached through a directory link inside it is walked and enumerated
+exactly as an ordinary directory, and its scripts' `class_name`s resolve. One consequence is kept
+deliberately — a FILE link at authored content is enumerated under **both** paths, since both are
+real `res://` addresses the engine loads; when the linked script declares a `class_name`, those two
+paths make it `ambiguous_class_name` (ADR-0032), the same report gda gives any project that declares
+one name twice.
+
 `gda script delete`
 removes a script file and reports the removed script's `class_name`/`extends` (parsed before
 deletion), so the result names the content, not just the path. Delete honors the same addressing

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -580,26 +580,49 @@ visible under a second name — and let a cycle (`sub/loop` -> `sub`) be descend
 refused another symlink hop, spelling one `.gd` 33 ways with a deepest path 174 characters long.
 The walk therefore **follows a link, as the engine does** — `DirAccess` stats a link entry so a
 linked directory lists as a directory, `ResourceLoader` loads through an alias, and gda's own
-addressing gate already counts a symlinked-in file as part of the project's `res://` namespace
-(ADR-0006) — but it **identifies what it reaches by filesystem identity**, through the engine's own
+containment gate already counts a symlinked-in file as part of the project's `res://` namespace
+(the containment rule under `script validate` below, implemented in `src/gda/project.py`) — but it
+**identifies what it reaches by filesystem identity**, through the engine's own
 `DirAccess.is_equivalent` (`st_dev`/`st_ino` on Unix, the volume+file id on Windows), rather than by
 the spelling that reached it. Two rules follow:
 
-- the **engine cache is excluded by identity**, so no alias re-admits it: not a directory link AT
-  `res://.godot`, not one INTO a subdirectory of it, and not a FILE link at a file inside it. That
-  last shape is a second touch point — it reaches the acceptance test without passing the descent
-  decision — so both branches of the walk ask the same owner;
-- a linked directory **already on the current descent chain is not re-entered**, so a cycle ends by
-  rule once every real directory has been walked, and the listing is a decided, bounded answer
-  rather than the leftovers of an OS limit.
+- the **engine cache is excluded by identity**, so no symlink alias re-admits it: not a directory
+  link AT `res://.godot`, not one INTO a subdirectory of it, not a FILE link at a file inside it,
+  and not any of those three reached under a second spelling — a parent directory that is itself a
+  link. That last shape is why the walk resolves **every component** of a path rather than only its
+  last one: a link's target is read against the directory the kernel reads it from, never against
+  the spelling the walk arrived by. The file link is a second touch point — it reaches the
+  acceptance test without passing the descent decision — so both branches of the walk ask the same
+  owner. A **hard** link is outside the rule by construction, not by oversight: the filesystem does
+  not report one as a link, so a hard link at a file inside the cache is enumerated like any other
+  file. The guarantee is about symlink aliases;
+- a linked directory **already on the current descent chain is not re-entered**, so a cycle
+  terminates by rule instead of at the OS symlink limit. What the listing enumerates is distinct
+  `res://` **paths**, not distinct directories: a directory reachable through several link paths is
+  reported under each of them, and mutually linked directories multiply the spellings quickly. The
+  answer is a decided, finite one rather than the leftovers of an OS limit — that is the guarantee,
+  and it is not "each real directory exactly once".
+
+A refused descent is reported by **omission**: the cycle's paths are simply absent, and no result
+field names the link the walk declined to follow. Adding one was considered and declined — it would
+widen all four collectors' result contracts for a diagnostic the listing already carries, and none
+of the four has a place for a per-path note.
 
 Both rules are about **where** a link leads, not about links: a vendored checkout that physically
 lives outside `res://` and is reached through a directory link inside it is walked and enumerated
-exactly as an ordinary directory, and its scripts' `class_name`s resolve. One consequence is kept
-deliberately — a FILE link at authored content is enumerated under **both** paths, since both are
-real `res://` addresses the engine loads; when the linked script declares a `class_name`, those two
-paths make it `ambiguous_class_name` (ADR-0032), the same report gda gives any project that declares
-one name twice.
+exactly as an ordinary directory, and its scripts' `class_name`s resolve — including a checkout that
+carries an engine cache of its own, which is that checkout's cache and not this project's. One
+consequence is kept deliberately — a FILE link at authored content is enumerated under **both**
+paths, since both are real `res://` addresses the engine loads; when the linked script declares a
+`class_name`, those two paths make it `ambiguous_class_name` (ADR-0032), the same report gda gives
+any project that declares one name twice.
+
+**Enumeration is not targeting.** Being reached by this walk says what the project can address; it
+does not say gda will operate on the path once it is NAMED as an operation's target. That is the
+separate question the containment rule under `script validate` below answers, and the two read
+differently on purpose — this walk decides by filesystem identity, containment reads the caller's
+own spelling. So a linked-in sub-project can be enumerated, counted and indexed here while whether
+it may be named as a target is settled there.
 
 `gda script delete`
 removes a script file and reports the removed script's `class_name`/`extends` (parsed before

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -553,38 +553,37 @@ Enumeration needs a project, so projectless it is refused with `project_not_foun
 `--project`); an empty project is a valid, empty listing, not an error. The walk excludes exactly
 one directory — the engine's own cache at `res://.godot`, whose contents are import artefacts no
 agent authored. The first test is **lexical**: the child's `res://` PATH is compared against that
-one path. Not the directory NAME, so a nested `.godot` is walked — it is usually authored content, and
-excluding it hid real scripts from the listing and let `script validate --all` report a valid
+one path. Not the directory NAME, so a nested `.godot` is walked — it is usually authored content,
+and excluding it hid real scripts from the listing and let `script validate --all` report a valid
 aggregate for a project holding an invalid script (#663 review). Sometimes it is not authored
 content — a vendored sub-project checked out under `res://` and opened once in an editor keeps an
 engine cache of its own, whose import artefacts then count in `project statistics` and become
 `find-unused-resources` candidates. That cost is accepted deliberately: gda cannot tell the two
-apart from the directory alone, and a false-valid aggregate is the worse failure. Hidden entries are
-otherwise enumerated as promised (#54). **This rule governs the four `res://` collectors in
-`operations.gd`** — the `script list` walk, the `scene list` walk, and
-both static-analysis walks (the extension-filtered one behind `find-references`, `dependencies`,
-`find-unused-resources` and the `class_name` index, and the unfiltered one `project statistics`
-counts with) — so one project cannot answer two ways. It once did: three of the four compared the
-directory NAME, so `script list` reported a script `project statistics` counted as zero (#712).
-Since #764 the four also share ONE traversal. The scaffolding around the exclusion rule had been
-copied per collector, and the copies drifted a second time — on the extension test, where the
-`scene list` walk alone compared case-sensitively — so each collector is now a single line: the
-shared traversal plus the acceptance test it passes. What they share is the traversal and the
-exclusion rule, **not** a file universe; the two static-analysis walks below still range over
-different files.
+apart from the directory alone, and a false-valid aggregate is the worse failure. Hidden entries
+are otherwise enumerated as promised (#54). **This rule governs the four `res://` collectors in
+`operations.gd`** — the `script list` walk, the `scene list` walk, and both static-analysis walks
+(the extension-filtered one behind `find-references`, `dependencies`, `find-unused-resources` and
+the `class_name` index, and the unfiltered one `project statistics` counts with) — so one project
+cannot answer two ways. It once did: three of the four compared the directory NAME, so `script
+list` reported a script `project statistics` counted as zero (#712). Since #764 the four also
+share ONE traversal. The scaffolding around the exclusion rule had been copied per collector, and
+the copies drifted a second time — on the extension test, where the `scene list` walk alone
+compared case-sensitively — so each collector is now a single line: the shared traversal plus the
+acceptance test it passes. What they share is the traversal and the exclusion rule, **not** a file
+universe; the two static-analysis walks below still range over different files.
 
 The lexical test is the walk's first question, not its only one, because a link renames what it
 points at (#760). Comparing the path as written let an alias re-admit exactly what the rule
-excludes — `res://nested/.godot` pointing at the root cache made the cache's own scripts and scenes
-visible under a second name — and let a cycle (`sub/loop` -> `sub`) be descended until the OS
-refused another symlink hop, spelling one `.gd` 33 ways with a deepest path 174 characters long.
-The walk therefore **follows a link, as the engine does** — `DirAccess` stats a link entry so a
-linked directory lists as a directory, `ResourceLoader` loads through an alias, and gda's own
+excludes — `res://nested/.godot` pointing at the root cache made the cache's own scripts and
+scenes visible under a second name — and let a cycle (`sub/loop` -> `sub`) be descended until the
+OS refused another symlink hop, spelling one `.gd` 33 ways with a deepest path 174 characters
+long. The walk therefore **follows a link, as the engine does** — `DirAccess` stats a link entry
+so a linked directory lists as a directory, `ResourceLoader` loads through an alias, and gda's own
 containment gate already counts a symlinked-in file as part of the project's `res://` namespace
 (the containment rule under `script validate` below, implemented in `src/gda/project.py`) — but it
 **identifies what it reaches by filesystem identity**, through the engine's own
-`DirAccess.is_equivalent` (`st_dev`/`st_ino` on Unix, the volume+file id on Windows), rather than by
-the spelling that reached it. Two rules follow:
+`DirAccess.is_equivalent` (`st_dev`/`st_ino` on Unix, the volume+file id on Windows), rather than
+by the spelling that reached it. Two rules follow:
 
 - the **engine cache is excluded by identity**, so no symlink alias re-admits it: not a directory
   link AT `res://.godot`, not one INTO a subdirectory of it, not a FILE link at a file inside it,
@@ -600,21 +599,23 @@ the spelling that reached it. Two rules follow:
   terminates by rule instead of at the OS symlink limit. What the listing enumerates is distinct
   `res://` **paths**, not distinct directories: a directory reachable through several link paths is
   reported under each of them, and mutually linked directories multiply the spellings quickly. The
-  answer is a decided, finite one rather than the leftovers of an OS limit — that is the guarantee,
-  and it is not "each real directory exactly once".
+  answer is a decided, finite one rather than the leftovers of an OS limit — that is the
+  guarantee, and it is not "each real directory exactly once".
 
 A refused descent is reported by **omission**: the cycle's paths are simply absent, and no result
-field names the link the walk declined to follow. Adding one was considered and declined — it would
-widen all four collectors' result contracts for a diagnostic the listing already carries, and none
-of the four has a place for a per-path note.
+field names the link the walk declined to follow. Adding one was considered and declined — it
+would widen all four collectors' result contracts for a diagnostic the listing already carries,
+and none of the four has a place for a per-path note.
 
 Both rules are about **where** a link leads, not about links: a vendored checkout that physically
 lives outside `res://` and is reached through a directory link inside it is walked and enumerated
-exactly as an ordinary directory, and its scripts' `class_name`s resolve — including a checkout that
-carries an engine cache of its own, which is that checkout's cache and not this project's. One
-consequence is kept deliberately — a FILE link at authored content is enumerated under **both**
-paths, since both are real `res://` addresses the engine loads; when the linked script declares a
-`class_name`, those two paths make it `ambiguous_class_name` (ADR-0032), the same report gda gives
+exactly as an ordinary directory, and its scripts' `class_name`s resolve — including a checkout
+that carries an engine cache of its own, which is that checkout's cache and not this project's.
+One consequence is kept deliberately — content reachable under two `res://` paths is enumerated
+under **both**, since both are real addresses the engine loads. That holds for a FILE link at an
+authored script and equally for a DIRECTORY link at authored content already reachable in-tree,
+which enumerates everything below it a second time; when a script so reached declares a
+`class_name`, the two paths make it `ambiguous_class_name` (ADR-0032), the same report gda gives
 any project that declares one name twice.
 
 **Enumeration is not targeting.** Being reached by this walk says what the project can address; it

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -165,11 +165,22 @@ const SCENE_STARTUP_NOT_READY := "not_ready"
 const ENGINE_CACHE_DIR := "res://.godot"
 
 # How far a res:// walk follows symlinks when it asks whether an entry is the
-# engine cache (#760): the links resolved in one chain, and the ancestors probed
-# above a resolved target. One bound serves both, and 32 is the ceiling the OS
-# itself puts on symlink resolution (MAXSYMLINKS on macOS and Linux) — a chain gda
-# gives up on is one the kernel would refuse to open anyway, so the bound cannot
-# hide a path the walk could otherwise have reached.
+# engine cache (#760): the links followed in one chain, and the passes the
+# component-by-component resolution takes to reach its fixed point. Both count
+# SYMLINK TRAVERSALS — a pass that changes the path resolved at least one more
+# link — which is the quantity the OS itself bounds, so a chain gda gives up on
+# is one the kernel would refuse to open anyway and the bound cannot hide a path
+# the walk could otherwise have reached. The value is the LOWER of the two
+# ceilings gda targets: MAXSYMLINKS is 32 on macOS (MacOSX.sdk/usr/include/
+# sys/param.h:197) and 40 on Linux (include/linux/namei.h), so a 33-to-40-link
+# chain is resolvable on Linux and gda stops short of it — accepted, because
+# such a chain is not a shape an honest project produces.
+#
+# The ancestor climb in _is_in_engine_cache is deliberately NOT bounded by this
+# constant: it counts path COMPONENTS, a quantity no kernel limits, and running
+# out of steps there returned false, which ADMITTED cache content — the opposite
+# direction from the failure MAXSYMLINKS reasons about, and a leak at 32 levels
+# below the cache (#795 review). It terminates on its own at the root instead.
 const SYMLINK_PROBE_MAX_STEPS := 32
 
 # The project-info settings (issue #111), read with a default so a project that
@@ -4283,12 +4294,17 @@ func _ambiguous_class_name_message(class_token: String, paths: Array) -> String:
 # identifies what it reached by FILESYSTEM IDENTITY, not by the spelling that
 # reached it. Two rules follow, and only a link pays for them:
 #
-#   - the engine cache is excluded by identity, so no alias re-admits it
-#     (_is_in_engine_cache);
+#   - the engine cache is excluded by identity, so no SYMLINK alias re-admits it
+#     (_is_in_engine_cache — which also states why a hard link is outside the
+#     rule);
 #   - a linked directory already on this descent CHAIN is not re-entered, so a
-#     cycle ends by rule after each real directory has been walked once, instead
-#     of running to the OS symlink limit — `sub/loop -> sub` once emitted 33
-#     spellings of one file, the deepest 174 characters long.
+#     cycle terminates by rule instead of running to the OS symlink limit —
+#     `sub/loop -> sub` once emitted 33 spellings of one file, the deepest 174
+#     characters long. The chain is per-BRANCH, so what the walk enumerates is
+#     distinct res:// PATHS: a directory reachable through several link paths is
+#     reported under each, and mutually linked directories multiply the spellings
+#     quickly. The answer is decided and finite — that is the guarantee — not
+#     "each real directory exactly once" (#795 review).
 #
 # A link to ordinary authored content — a vendored checkout reached through one —
 # is neither the cache nor an ancestor, so it is followed and enumerated exactly
@@ -4333,54 +4349,125 @@ func _should_collect(dir: DirAccess, child: String) -> bool:
 # The identity test is the ENGINE's own: DirAccess.is_equivalent compares
 # (st_dev, st_ino) on Unix and (VolumeSerialNumber, FileId) on Windows, both
 # stat-resolved, and falls back to string equality when a path cannot be stat'd
-# (DirAccess::is_equivalent, core/io/dir_access.cpp:636-638, overridden in
+# (DirAccess::is_equivalent, core/io/dir_access.cpp:630-632, overridden in
 # DirAccessUnix::is_equivalent, drivers/unix/dir_access_unix.cpp:713-729, and
-# DirAccessWindows::is_equivalent, drivers/windows/dir_access_windows.cpp:442-462;
-# line numbers from a 4.6-stable+ checkout). gda does not answer "are these
-# the same directory" itself, and the fallback degrades to exactly the lexical
-# rule this predicate replaced — a project with no `res://.godot` at all keeps
+# DirAccessWindows::is_equivalent, drivers/windows/dir_access_windows.cpp:411-431;
+# line numbers from the 4.6.3-stable tag). gda does not answer "are these the
+# same directory" itself, and the fallback degrades to exactly the lexical rule
+# this predicate replaced — a project with no `res://.godot` at all keeps
 # answering as it did.
 #
-# The link target is resolved by hand because DirAccess cannot do it for us:
+# The path is resolved by hand first because DirAccess cannot do it for us:
 # DirAccessUnix::fix_path simplifies a path LEXICALLY before every syscall
 # (drivers/unix/dir_access_unix.cpp:55-57), so a `..` appended to a link never
 # reaches the kernel and cannot be used to walk up out of an alias (measured on
 # 4.6.3: is_equivalent("res://nested/.godot/..", "res://") answers false through an
-# alias of the root cache). DirAccessUnix::read_link gives the raw target, relative
-# to the link's own directory (drivers/unix/dir_access_unix.cpp:481-499).
+# alias of the root cache).
 #
-# Ancestors are probed so a link INTO the cache — `res://nested/imported ->
-# res://.godot/imported` — is excluded too, not only a link AT it. Each probe is
-# stat-resolved, so an ancestor that is itself an alias of the cache still
-# answers true. A deliberately nested chain of links could still spell a path
-# whose ancestors resolve elsewhere; that is a Trusted project (ADR-0009)
-# question, not one this predicate defends against — the rule exists so an honest
-# project's aliases report honestly.
+# ANCESTORS of the resolved path are probed, so a link INTO the cache —
+# `res://nested/imported -> res://.godot/imported` — is excluded too, not only a
+# link AT it. That climb is why _fully_resolved_path has to resolve EVERY
+# component and not just the last one: with `link1 -> sub/deep` and
+# `sub/deep/c -> ../../.godot`, reading the target against the spelling
+# `res://link1` instead of against the real `res://sub/deep` made the ancestors
+# of `res://link1/c` a directory the kernel never visits, and answered that the
+# cache was not reached — the same wrong answer in both directions, admitting the
+# root cache under one spelling and hiding a vendored checkout's own nested cache
+# under another (#795 review). The climb carries no step bound of its own: it
+# counts path COMPONENTS, which no kernel limits, and get_base_dir() shortens the
+# path every step until the root is its own parent.
+#
+# What survives is a link gda cannot read — a target read_link refuses, or a
+# chain longer than the OS resolves — which stops at the furthest path it did
+# resolve, so an unresolvable alias is reported rather than hidden. Hard links
+# are outside the rule by construction: the filesystem does not call them links,
+# so is_link never reports one and this predicate is never asked. The guarantee
+# is therefore about SYMLINK aliases.
 func _is_in_engine_cache(dir: DirAccess, path: String) -> bool:
-	var probe := _resolved_link_path(dir, path)
-	for _step in range(SYMLINK_PROBE_MAX_STEPS):
-		if dir.is_equivalent(probe, ENGINE_CACHE_DIR):
-			return true
+	var probe := _fully_resolved_path(dir, path)
+	while not dir.is_equivalent(probe, ENGINE_CACHE_DIR):
 		var parent := probe.get_base_dir()
 		if parent.is_empty() or parent == probe:
 			return false
 		probe = parent
-	return false
+	return true
 
 
-# The path a link finally names, following a chain of links up to the OS's own
-# ceiling (#760). A relative target is joined onto the directory holding the
-# link, which is how the kernel reads it; an absolute one is taken as it is.
-# Returns `path` unchanged when it is not a link, when the target cannot be read,
-# and when the chain outruns the bound — a path gda could not resolve is one it
-# reports rather than hides.
+# The path `path` really names, resolved the way the KERNEL resolves one: every
+# component read against the components already resolved before it, not against
+# the spelling that reached it (#795 review).
+#
+# One pass rebuilds the path component by component (_resolve_path_segments); a
+# component whose target itself names a link is resolved by the NEXT pass, and
+# the passes stop as soon as one changes nothing. A pass that does change the
+# path resolved at least one more link, so SYMLINK_PROBE_MAX_STEPS bounds the
+# passes for the same reason it bounds the hops inside one chain.
+func _fully_resolved_path(dir: DirAccess, path: String) -> String:
+	var resolved := path
+	for _pass in range(SYMLINK_PROBE_MAX_STEPS):
+		var next_path := _resolve_path_segments(dir, resolved)
+		if next_path == resolved:
+			break
+		resolved = next_path
+	return resolved
+
+
+# One left-to-right pass of the component resolution above: split `path` into its
+# root and its components, then rebuild it, resolving each component against the
+# prefix already rebuilt.
+#
+# The split climbs with get_base_dir()/get_file() rather than looking for a `/`,
+# so it makes no assumption about the root it is given — `res://`, a Unix `/`, or
+# a Windows drive all end the climb by being their own base directory, and a
+# read_link target that leaves the project (an absolute path outside `res://`) is
+# rebuilt on its own root.
+#
+# `..` pops the rebuilt prefix instead of being appended, which is the kernel's
+# reading and is safe here for the reason the lexical shortcut is not: the prefix
+# it pops is already resolved, so its parent is the real one. That is also what
+# keeps the result canonical enough for the ancestor climb above.
+func _resolve_path_segments(dir: DirAccess, path: String) -> String:
+	var segments: Array[String] = []
+	var root := path
+	while true:
+		var base := root.get_base_dir()
+		if base == root:
+			break
+		segments.push_front(root.get_file())
+		root = base
+	var resolved := root
+	for segment in segments:
+		if segment.is_empty() or segment == ".":
+			continue
+		if segment == "..":
+			resolved = resolved.get_base_dir()
+			continue
+		resolved = _resolved_link_path(dir, resolved.path_join(segment))
+	return resolved
+
+
+# The path ONE component finally names, following a chain of links up to the OS's
+# own ceiling (#760). A relative target is joined onto the directory holding the
+# link — correct for the first hop, whose base the caller has already resolved,
+# and repaired for any later one by the next pass of _fully_resolved_path. An
+# absolute target is taken as it is.
+#
+# Returns the FURTHEST path it resolved: `path` itself when that is not a link,
+# and otherwise the last target it read before the target became unreadable, the
+# chain outran the bound, or a target named the path it came from. That last case
+# is what a failed DirAccessWindows::read_link looks like — it returns the fixed
+# input path, never the empty string, and otherwise returns an already-resolved
+# absolute path from GetFinalPathNameByHandleW (drivers/windows/
+# dir_access_windows.cpp:444-462) — so on Windows an unopenable reparse point
+# stops after one probe instead of spinning out the bound, and the relative join
+# below is dead code by that platform's contract rather than by accident.
 func _resolved_link_path(dir: DirAccess, path: String) -> String:
 	var current := path
 	for _step in range(SYMLINK_PROBE_MAX_STEPS):
 		if not dir.is_link(current):
 			return current
 		var target := dir.read_link(current)
-		if target.is_empty():
+		if target.is_empty() or target == current:
 			return current
 		current = target if target.is_absolute_path() else current.get_base_dir().path_join(target)
 	return current

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -161,8 +161,16 @@ const SCENE_STARTUP_NOT_READY := "not_ready"
 
 # The ONE directory a res:// walk excludes: the engine's own import/cache tree at
 # the project root. The VALUE only — the decision that uses it lives in exactly one
-# place, _should_descend, which every walk calls.
+# place, _is_in_engine_cache, which _should_descend and _should_collect both ask.
 const ENGINE_CACHE_DIR := "res://.godot"
+
+# How far a res:// walk follows symlinks when it asks whether an entry is the
+# engine cache (#760): the links resolved in one chain, and the ancestors probed
+# above a resolved target. One bound serves both, and 32 is the ceiling the OS
+# itself puts on symlink resolution (MAXSYMLINKS on macOS and Linux) — a chain gda
+# gives up on is one the kernel would refuse to open anyway, so the bound cannot
+# hide a path the walk could otherwise have reached.
+const SYMLINK_PROBE_MAX_STEPS := 32
 
 # The project-info settings (issue #111), read with a default so a project that
 # never wrote them still reports a sensible value rather than failing: a new
@@ -4251,11 +4259,11 @@ func _ambiguous_class_name_message(class_token: String, paths: Array) -> String:
 
 
 # Whether a res:// walk descends into this child DIRECTORY. The ONE owner of the
-# exclusion decision: every walk over the project tree (scripts, scenes, graph
+# descent decision: every walk over the project tree (scripts, scenes, graph
 # resources, all files) asks this and nothing else, so the rule cannot drift
 # between them and a new walk inherits it by calling this.
 #
-# The comparison is the full path, never the directory NAME, because a `.godot`
+# The first test is the full path, never the directory NAME, because a `.godot`
 # deeper in the tree is not this project's engine cache. It is usually authored
 # content (an addon vendoring a sample project, a fixture tree), and excluding it
 # hid real scripts from `script list` and let `script validate --all` report a
@@ -4268,13 +4276,114 @@ func _ambiguous_class_name_message(class_token: String, paths: Array) -> String:
 # ways: `script list` reported a script `project statistics` counted as zero
 # (#712). One decision, one site — that is what keeps them in agreement.
 #
-# The test is LEXICAL and stays that way here: it does not resolve filesystem
-# targets, so an alias that leads to the root cache is descended into, and a
-# symlink cycle is descended until the OS path limit stops it. Symlink policy for
-# the res:// walk is undecided and tracked in #760 — do not decide half of it
-# in this predicate.
-func _should_descend(child: String) -> bool:
-	return child != ENGINE_CACHE_DIR
+# SYMLINK POLICY (#760). The walk FOLLOWS a link, as the engine does —
+# DirAccessUnix::get_next stat()s a DT_LNK entry on purpose, so a linked directory
+# reports current_is_dir() (drivers/unix/dir_access_unix.cpp:148-183), and
+# ResourceLoader loads through an alias (both measured on 4.6.3) — but it
+# identifies what it reached by FILESYSTEM IDENTITY, not by the spelling that
+# reached it. Two rules follow, and only a link pays for them:
+#
+#   - the engine cache is excluded by identity, so no alias re-admits it
+#     (_is_in_engine_cache);
+#   - a linked directory already on this descent CHAIN is not re-entered, so a
+#     cycle ends by rule after each real directory has been walked once, instead
+#     of running to the OS symlink limit — `sub/loop -> sub` once emitted 33
+#     spellings of one file, the deepest 174 characters long.
+#
+# A link to ordinary authored content — a vendored checkout reached through one —
+# is neither the cache nor an ancestor, so it is followed and enumerated exactly
+# as before. That is the point of deciding by identity rather than by refusing
+# links: the two defects are about WHERE a link leads, not about links.
+func _should_descend(dir: DirAccess, child: String, chain: Array[String]) -> bool:
+	if child == ENGINE_CACHE_DIR:
+		return false
+	if not dir.is_link(child):
+		# Not a link: its real parent is the directory being listed, which the
+		# walk already cleared, and it cannot be an ancestor of itself. So the
+		# lexical test above is the whole decision — an ordinary project pays one
+		# lstat per entry and nothing else.
+		return true
+	if _is_in_engine_cache(dir, child):
+		return false
+	for ancestor in chain:
+		if dir.is_equivalent(child, ancestor):
+			return false
+	return true
+
+
+# Whether a res:// walk COLLECTS this child FILE, once the collector's own
+# acceptance test has said yes. The file-side half of the symlink policy above
+# (#760): _should_descend gates DIRECTORY descent only, so a file link INTO the
+# cache — `res://alias.gd -> res://.godot/root_cache.gd` — reaches the accept
+# branch without ever passing it, and re-admits by itself the content the descent
+# rule keeps out. The two halves ask the same question of the same owner.
+#
+# A link to ordinary content is collected, deliberately: it is a real res:// path
+# the engine loads (measured on 4.6.3), so hiding it would hide authored content
+# the game can address. That also means the same file can be listed under two
+# paths when one is an alias of the other — both are true answers to "what can
+# this project load", and neither is the fabricated path a cycle produced.
+func _should_collect(dir: DirAccess, child: String) -> bool:
+	return not dir.is_link(child) or not _is_in_engine_cache(dir, child)
+
+
+# Whether `path` IS the engine cache or lives inside it, however it is spelled —
+# the ONE owner of the exclusion decision both walk-side predicates ask (#760).
+#
+# The identity test is the ENGINE's own: DirAccess.is_equivalent compares
+# (st_dev, st_ino) on Unix and (VolumeSerialNumber, FileId) on Windows, both
+# stat-resolved, and falls back to string equality when a path cannot be stat'd
+# (DirAccess::is_equivalent, core/io/dir_access.cpp:636-638, overridden in
+# DirAccessUnix::is_equivalent, drivers/unix/dir_access_unix.cpp:713-729, and
+# DirAccessWindows::is_equivalent, drivers/windows/dir_access_windows.cpp:442-462;
+# line numbers from a 4.6-stable+ checkout). gda does not answer "are these
+# the same directory" itself, and the fallback degrades to exactly the lexical
+# rule this predicate replaced — a project with no `res://.godot` at all keeps
+# answering as it did.
+#
+# The link target is resolved by hand because DirAccess cannot do it for us:
+# DirAccessUnix::fix_path simplifies a path LEXICALLY before every syscall
+# (drivers/unix/dir_access_unix.cpp:55-57), so a `..` appended to a link never
+# reaches the kernel and cannot be used to walk up out of an alias (measured on
+# 4.6.3: is_equivalent("res://nested/.godot/..", "res://") answers false through an
+# alias of the root cache). DirAccessUnix::read_link gives the raw target, relative
+# to the link's own directory (drivers/unix/dir_access_unix.cpp:481-499).
+#
+# Ancestors are probed so a link INTO the cache — `res://nested/imported ->
+# res://.godot/imported` — is excluded too, not only a link AT it. Each probe is
+# stat-resolved, so an ancestor that is itself an alias of the cache still
+# answers true. A deliberately nested chain of links could still spell a path
+# whose ancestors resolve elsewhere; that is a Trusted project (ADR-0009)
+# question, not one this predicate defends against — the rule exists so an honest
+# project's aliases report honestly.
+func _is_in_engine_cache(dir: DirAccess, path: String) -> bool:
+	var probe := _resolved_link_path(dir, path)
+	for _step in range(SYMLINK_PROBE_MAX_STEPS):
+		if dir.is_equivalent(probe, ENGINE_CACHE_DIR):
+			return true
+		var parent := probe.get_base_dir()
+		if parent.is_empty() or parent == probe:
+			return false
+		probe = parent
+	return false
+
+
+# The path a link finally names, following a chain of links up to the OS's own
+# ceiling (#760). A relative target is joined onto the directory holding the
+# link, which is how the kernel reads it; an absolute one is taken as it is.
+# Returns `path` unchanged when it is not a link, when the target cannot be read,
+# and when the chain outruns the bound — a path gda could not resolve is one it
+# reports rather than hides.
+func _resolved_link_path(dir: DirAccess, path: String) -> String:
+	var current := path
+	for _step in range(SYMLINK_PROBE_MAX_STEPS):
+		if not dir.is_link(current):
+			return current
+		var target := dir.read_link(current)
+		if target.is_empty():
+			return current
+		current = target if target.is_absolute_path() else current.get_base_dir().path_join(target)
+	return current
 
 
 # The ONE res:// traversal (#764). Open the directory, enumerate hidden entries,
@@ -4302,19 +4411,27 @@ func _should_descend(child: String) -> bool:
 # the extension anyway — String.get_extension() stops at the last '/', so a file
 # with no extension under a dotted directory (res://a.b/README) answers "" either
 # way — but only the full path can carry a test that looks at the directory too.
-func _collect_paths(dir_path: String, accept: Callable, out: Array[String]) -> void:
+#
+# `chain` is the descent chain: the directories above `dir_path`, which the walk
+# carries so the symlink policy can tell a link that leads back UP the chain from
+# one that leads to new content (#760). A caller never passes it — a walk starts
+# at the root with an empty chain — and the recursion extends it by one, in a NEW
+# array, so a branch cannot see a sibling branch's ancestors.
+func _collect_paths(dir_path: String, accept: Callable, out: Array[String], chain: Array[String] = []) -> void:
 	var dir := DirAccess.open(dir_path)
 	if dir == null:
 		return
+	var descended: Array[String] = chain.duplicate()
+	descended.append(dir_path)
 	dir.include_hidden = true
 	dir.list_dir_begin()
 	var entry := dir.get_next()
 	while not entry.is_empty():
 		var child := dir_path.path_join(entry)
 		if dir.current_is_dir():
-			if _should_descend(child):
-				_collect_paths(child, accept, out)
-		elif accept.call(child):
+			if _should_descend(dir, child, descended):
+				_collect_paths(child, accept, out, descended)
+		elif accept.call(child) and _should_collect(dir, child):
 			out.append(child)
 		entry = dir.get_next()
 	dir.list_dir_end()

--- a/tests/test_e2e_project_walk.py
+++ b/tests/test_e2e_project_walk.py
@@ -160,8 +160,16 @@ def test_the_two_file_universes_survive_the_shared_traversal(walk_project):
 # Two files planted INSIDE the engine cache — content no agent authored, which
 # every collector must keep out however it is spelled. `class_name` is what makes
 # the aliasing visible in the resolver too: it is the exact repro from #760.
+#
+# They extend **Node** so the index assertion can FAIL. Both once extended
+# RefCounted, which made `node add --type RootCacheThing` answer
+# `invalid_node_type` whether or not the alias leaked — the leak reported "is not
+# a Node-derived script: res://<alias>", the clean walk "no .gd script declares
+# class_name" — so the guard for the fifth consumer of the walk asserted a code
+# that no regression could change (#795 review). Node-derived, a leak makes the
+# same call SUCCEED, which is an outcome no wording can blur.
 ROOT_CACHE_GD = """\
-extends RefCounted
+extends Node
 class_name RootCacheThing
 """
 
@@ -172,14 +180,15 @@ ROOT_CACHE_TSCN = """\
 """
 
 CACHED_IMPORT_GD = """\
-extends RefCounted
+extends Node
 class_name CachedImport
 """
 
 # The authored content a link legitimately points at: a checkout that physically
 # lives OUTSIDE res:// and is reached through a directory link inside it. This is
-# the workflow the policy must not break — the ADR-0006 addressing gate already
-# treats such a file as inside the project because the engine walks the link.
+# the workflow the policy must not break — gda's own containment gate
+# (``src/gda/project.py``) already treats such a file as inside the project
+# because the engine walks the link.
 VENDORED_GD = """\
 extends Node
 class_name VendoredThing
@@ -240,6 +249,38 @@ def symlink_project(tmp_path):
     return project
 
 
+def _assert_class_name_unresolvable(project, *classes: str) -> None:
+    """Every named ``class_name`` must be unknown to the index (ADR-0032).
+
+    The index is the fifth consumer of the same walk, and the only one that
+    reports through another command. The planted cache scripts are Node-derived,
+    so a walk that admits one makes ``node add --type <class>`` **succeed** —
+    the assertion below then fails on the missing ``error`` key, not on wording.
+    The message half is asserted too, because it is the half that distinguishes
+    "no script declares this" from every other ``invalid_node_type``.
+    """
+    _result(project, "scene", "create", "res://host.tscn", "--root-type", "Node")
+    for name in classes:
+        proc = _gda(
+            project,
+            "node",
+            "add",
+            "res://host.tscn",
+            "--parent",
+            ".",
+            "--name",
+            "X",
+            "--type",
+            name,
+            "--json",
+        )
+        payload = json.loads(proc.stdout)
+        assert "error" in payload, f"{name} resolved through an alias: {payload}"
+        error = payload["error"]
+        assert error["code"] == "invalid_node_type", error
+        assert f"no .gd script declares class_name {name}" in error["message"], error
+
+
 def _walked_paths(project) -> set[str]:
     """Every path the four collectors reach, as one set.
 
@@ -284,28 +325,7 @@ def test_an_alias_cannot_re_admit_the_engine_cache(symlink_project):
 
     # And the class_name index, the fifth consumer of the same walk (ADR-0032):
     # both cache-declared classes were resolvable through their aliases before.
-    scene = symlink_project / "host.tscn"
-    _result(
-        symlink_project, "scene", "create", "res://host.tscn", "--root-type", "Node"
-    )
-    assert scene.exists()
-    for cache_class in ("RootCacheThing", "CachedImport"):
-        proc = _gda(
-            symlink_project,
-            "node",
-            "add",
-            "res://host.tscn",
-            "--parent",
-            ".",
-            "--name",
-            "X",
-            "--type",
-            cache_class,
-            "--json",
-        )
-        error = json.loads(proc.stdout)["error"]
-        assert error["code"] == "invalid_node_type", error
-        assert cache_class in error["message"]
+    _assert_class_name_unresolvable(symlink_project, "RootCacheThing", "CachedImport")
 
 
 @pytest.mark.e2e
@@ -332,9 +352,11 @@ def test_a_link_to_authored_content_is_still_walked(symlink_project):
     # AC1 (#760): the policy decides by WHERE a link leads, not by refusing
     # links. A vendored checkout that physically lives outside res:// and is
     # reached through a directory link is ordinary authored content — the engine
-    # loads through the link and the ADR-0006 addressing gate already calls such
-    # a file inside the project — so the walk enumerates it, and its `class_name`
-    # resolves at the instantiating call sites.
+    # loads through the link and gda's own containment gate already calls such a
+    # file inside the project — so the walk enumerates it, and its `class_name`
+    # resolves at the instantiating call sites. Enumerating it is not the same as
+    # letting it be NAMED as a target: that is the containment gate's question,
+    # not this walk's.
     walked = _walked_paths(symlink_project)
 
     assert "res://vendored/vendored.gd" in walked, walked
@@ -356,3 +378,169 @@ def test_a_link_to_authored_content_is_still_walked(symlink_project):
         "VendoredThing",
     )
     assert added["script_class"] == "VendoredThing", added
+
+
+# --- the SPELLING that reaches a link is not the directory it lives in --------
+#
+# The fixture above builds every link with an ABSOLUTE target and never nests one
+# link inside another, so it could not see the defect the first fix shipped with:
+# a RELATIVE target was joined onto the link's res:// spelling instead of onto the
+# directory the kernel reads it from, which is a different directory as soon as
+# the link's own parent is a link (#795 review). The two fixtures below carry the
+# missing shapes, one per direction of the same error.
+
+# A cache script under the VENDORED checkout's own `.godot`, not the project's.
+# #712 decided a nested cache is walked — it is usually authored content — so
+# this file must stay VISIBLE. It is the direction in which mistaking a spelling
+# for a real directory hides authored content instead of leaking cache content.
+VENDORED_SAMPLE_GD = """\
+extends Node
+class_name VendoredSample
+"""
+
+# How far below the engine cache the deep alias points. The ancestor climb used
+# to give up after SYMLINK_PROBE_MAX_STEPS components and answer "not the cache",
+# so an alias exactly this deep was admitted while one level shallower was not.
+CACHE_DEPTH_PAST_THE_OLD_STEP_BOUND = 32
+
+
+@pytest.fixture
+def aliased_spelling_project(tmp_path):
+    """One real directory reached under two ``res://`` spellings (#795 review).
+
+    ``sub/deep`` holds three ordinary RELATIVE links into the engine cache, and
+    ``link1`` is a second spelling of ``sub/deep`` itself, so ``res://link1/c``
+    and ``res://sub/deep/c`` are the same directory entry. ``L2`` adds a link
+    THROUGH a link, the shape that survives resolving only one more component.
+    """
+    project = tmp_path / "game"
+    project.mkdir()
+    (project / "project.godot").write_text(
+        project_godot(name="gda-alias-spelling-fixture"), encoding="utf-8"
+    )
+
+    cache = project / ".godot"
+    (cache / "imported").mkdir(parents=True)
+    (cache / "root_cache.gd").write_text(ROOT_CACHE_GD, encoding="utf-8")
+    (cache / "root_cache.tscn").write_text(ROOT_CACHE_TSCN, encoding="utf-8")
+    (cache / "imported" / "cached.gd").write_text(CACHED_IMPORT_GD, encoding="utf-8")
+
+    (project / "real.gd").write_text(LEAF_GD, encoding="utf-8")
+    deep = project / "sub" / "deep"
+    deep.mkdir(parents=True)
+    (deep / "deep_leaf.gd").write_text(LEAF_GD, encoding="utf-8")
+    # Relative targets, as a checked-in repo writes them: a directory link AT the
+    # cache, one INTO a subdirectory of it, and a FILE link at a file inside it.
+    (deep / "c").symlink_to("../../.godot", target_is_directory=True)
+    (deep / "ci").symlink_to("../../.godot/imported", target_is_directory=True)
+    (deep / "f_alias.gd").symlink_to("../../.godot/root_cache.gd")
+    (project / "link1").symlink_to("sub/deep", target_is_directory=True)
+    (project / "L2").symlink_to("link1/c", target_is_directory=True)
+    return project
+
+
+@pytest.fixture
+def vendored_cache_project(tmp_path):
+    """A vendored checkout outside ``res://`` carrying a cache of its OWN."""
+    project = tmp_path / "game"
+    project.mkdir()
+    (project / "project.godot").write_text(
+        project_godot(name="gda-vendored-cache-fixture"), encoding="utf-8"
+    )
+    cache = project / ".godot"
+    cache.mkdir()
+    (cache / "root_cache.gd").write_text(ROOT_CACHE_GD, encoding="utf-8")
+    (project / "real.gd").write_text(LEAF_GD, encoding="utf-8")
+
+    checkout = tmp_path / "checkout"
+    (checkout / ".godot").mkdir(parents=True)
+    (checkout / ".godot" / "vendored_sample.gd").write_text(
+        VENDORED_SAMPLE_GD, encoding="utf-8"
+    )
+    (checkout / "v").mkdir()
+    (checkout / "v" / "x").symlink_to("../.godot", target_is_directory=True)
+    (project / "vendored").symlink_to(checkout / "v", target_is_directory=True)
+    return project
+
+
+@pytest.mark.e2e
+def test_the_cache_stays_excluded_under_a_second_spelling_of_its_parent(
+    aliased_spelling_project,
+):
+    # AC2 (#760), the case the absolute-target fixture cannot build: the walk
+    # reads `sub/deep/c -> ../../.godot` against the directory the KERNEL reads
+    # it from, so `res://link1/c` — the same entry under a second spelling — is
+    # the cache too. Joining the target onto the spelling `res://link1` instead
+    # answered `res://link1/../../.godot`, which is not the cache, and every
+    # collector then enumerated the cache's contents under that name.
+    walked = _walked_paths(aliased_spelling_project)
+
+    leaked = {p for p in walked if p.startswith(("res://link1/c/", "res://L2/"))}
+    leaked |= {"res://link1/ci/cached.gd", "res://link1/f_alias.gd"} & walked
+    leaked |= {p for p in walked if p.startswith("res://sub/deep/c")}
+    leaked |= {"res://sub/deep/ci/cached.gd", "res://sub/deep/f_alias.gd"} & walked
+    assert not leaked, leaked
+
+    # The authored file in that same directory is still reported under BOTH of
+    # its real spellings — the rule excludes the cache, it does not refuse the
+    # link that renamed the directory.
+    assert {
+        "res://real.gd",
+        "res://sub/deep/deep_leaf.gd",
+        "res://link1/deep_leaf.gd",
+    } <= walked, walked
+
+    stats = _result(aliased_spelling_project, "project", "statistics")
+    assert stats["script_count"] == 3, stats
+    assert stats["scene_count"] == 0, stats
+
+    _assert_class_name_unresolvable(
+        aliased_spelling_project, "RootCacheThing", "CachedImport"
+    )
+
+
+@pytest.mark.e2e
+def test_a_vendored_checkouts_own_cache_is_not_taken_for_the_projects(
+    vendored_cache_project,
+):
+    # The same error in the other direction, and a regression the first fix
+    # introduced: `vendored/x -> ../.godot` is the CHECKOUT's cache, but joining
+    # that target onto the res:// spelling `res://vendored` produced
+    # `res://.godot`, which is_equivalent then confirmed against the project's own
+    # cache — so a nested cache #712 decided to walk was silently hidden.
+    scripts = {
+        s["path"] for s in _result(vendored_cache_project, "script", "list")["scripts"]
+    }
+
+    assert "res://vendored/x/vendored_sample.gd" in scripts, scripts
+    # The project's OWN cache is still excluded, under its own name and through
+    # the link — the fix widens nothing.
+    assert not {p for p in scripts if "root_cache" in p}, scripts
+    assert scripts == {"res://real.gd", "res://vendored/x/vendored_sample.gd"}
+
+
+@pytest.mark.e2e
+def test_a_cache_alias_is_excluded_however_deep_below_the_cache_it_points(tmp_path):
+    # The exclusion asks whether any ANCESTOR of the resolved path is the cache.
+    # That climb once ran on a step budget borrowed from the symlink bound, and
+    # exhausting it returned "not the cache" — so an alias exactly
+    # SYMLINK_PROBE_MAX_STEPS levels below `res://.godot` was admitted while a
+    # shallower one was excluded (#795 review). Path depth is not a symlink
+    # count; the climb now ends at the root instead.
+    project = tmp_path / "game"
+    project.mkdir()
+    (project / "project.godot").write_text(
+        project_godot(name="gda-deep-cache-fixture"), encoding="utf-8"
+    )
+    (project / "real.gd").write_text(LEAF_GD, encoding="utf-8")
+
+    deep = project / ".godot"
+    for level in range(CACHE_DEPTH_PAST_THE_OLD_STEP_BOUND):
+        deep = deep / f"d{level}"
+    deep.mkdir(parents=True)
+    (deep / "deep_cache.gd").write_text(ROOT_CACHE_GD, encoding="utf-8")
+    (project / "alias_deep").symlink_to(deep, target_is_directory=True)
+
+    scripts = {s["path"] for s in _result(project, "script", "list")["scripts"]}
+    assert scripts == {"res://real.gd"}, scripts
+    _assert_class_name_unresolvable(project, "RootCacheThing")

--- a/tests/test_e2e_project_walk.py
+++ b/tests/test_e2e_project_walk.py
@@ -1,8 +1,8 @@
-"""S1 (e2e): the shared ``res://`` walk's two behavioural contracts (#764).
+"""S1 (e2e): the shared ``res://`` walk's behavioural contracts (#764, #760).
 
 The four project-wide collectors in ``operations.gd`` run ONE traversal. These
-tests pin the two things that consolidation had to decide or preserve, against a
-real engine:
+tests pin, against a real engine, the two things that consolidation had to decide
+or preserve:
 
 * **The acceptance test is case-insensitive.** The scene walk used to compare the
   extension as written while the script walk lowercased it, so a ``Level.TSCN``
@@ -14,6 +14,11 @@ real engine:
   universe: ``project statistics`` must keep counting the ``.import`` sidecars and
   ``project.godot`` that the extension-filtered walk behind ``dependencies`` /
   ``find-unused-resources`` excludes.
+
+…and the walk's **symlink policy** (#760), which that consolidation deliberately
+left undecided: the walk follows a link as the engine does, but identifies what it
+reaches by filesystem identity, so an alias cannot re-admit the engine cache and a
+cycle cannot spell one file 33 ways.
 """
 
 import json
@@ -142,3 +147,212 @@ def test_the_two_file_universes_survive_the_shared_traversal(walk_project):
     # ...while the leaf asset sitting right next to the sidecar still is one, so
     # the exclusion is the acceptance test's, not an emptied walk.
     assert "res://icon.png" in unused
+
+
+# --- the symlink policy (#760) ---------------------------------------------
+#
+# The walk had none: it compared paths lexically and descended into whatever the
+# listing called a directory, so an alias re-admitted the engine cache the walk
+# excludes and a cycle ran to the OS symlink limit. The fixture below carries all
+# four shapes at once, because the policy is one decision and the collectors must
+# answer it the same way.
+
+# Two files planted INSIDE the engine cache — content no agent authored, which
+# every collector must keep out however it is spelled. `class_name` is what makes
+# the aliasing visible in the resolver too: it is the exact repro from #760.
+ROOT_CACHE_GD = """\
+extends RefCounted
+class_name RootCacheThing
+"""
+
+ROOT_CACHE_TSCN = """\
+[gd_scene format=3]
+
+[node name="RootCache" type="Node2D"]
+"""
+
+CACHED_IMPORT_GD = """\
+extends RefCounted
+class_name CachedImport
+"""
+
+# The authored content a link legitimately points at: a checkout that physically
+# lives OUTSIDE res:// and is reached through a directory link inside it. This is
+# the workflow the policy must not break — the ADR-0006 addressing gate already
+# treats such a file as inside the project because the engine walks the link.
+VENDORED_GD = """\
+extends Node
+class_name VendoredThing
+"""
+
+VENDORED_TSCN = """\
+[gd_scene format=3]
+
+[node name="Vendored" type="Node3D"]
+"""
+
+LEAF_GD = """\
+extends Node
+"""
+
+
+@pytest.fixture
+def symlink_project(tmp_path):
+    """A project carrying every symlink shape the policy decides (#760).
+
+    * ``nested/.godot`` -> the root cache: a directory alias AT the cache;
+    * ``nested/imported_alias`` -> ``.godot/imported``: an alias INTO the cache;
+    * ``alias_cache.gd`` / ``alias_cache.tscn``: FILE aliases at cache files,
+      which reach the acceptance test without passing the descent predicate;
+    * ``sub/loop`` -> ``sub``: a cycle;
+    * ``vendored`` -> a checkout outside the project: the legitimate workflow.
+    """
+    project = tmp_path / "game"
+    project.mkdir()
+    (project / "project.godot").write_text(
+        project_godot(name="gda-symlink-fixture"), encoding="utf-8"
+    )
+
+    cache = project / ".godot"
+    (cache / "imported").mkdir(parents=True)
+    (cache / "root_cache.gd").write_text(ROOT_CACHE_GD, encoding="utf-8")
+    (cache / "root_cache.tscn").write_text(ROOT_CACHE_TSCN, encoding="utf-8")
+    (cache / "imported" / "cached.gd").write_text(CACHED_IMPORT_GD, encoding="utf-8")
+
+    (project / "nested").mkdir()
+    (project / "nested" / ".godot").symlink_to(cache, target_is_directory=True)
+    (project / "nested" / "imported_alias").symlink_to(
+        cache / "imported", target_is_directory=True
+    )
+    (project / "alias_cache.gd").symlink_to(cache / "root_cache.gd")
+    (project / "alias_cache.tscn").symlink_to(cache / "root_cache.tscn")
+
+    (project / "sub").mkdir()
+    (project / "sub" / "leaf.gd").write_text(LEAF_GD, encoding="utf-8")
+    (project / "sub" / "loop").symlink_to(project / "sub", target_is_directory=True)
+
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    (checkout / "vendored.gd").write_text(VENDORED_GD, encoding="utf-8")
+    (checkout / "vendored.tscn").write_text(VENDORED_TSCN, encoding="utf-8")
+    (project / "vendored").symlink_to(checkout, target_is_directory=True)
+
+    return project
+
+
+def _walked_paths(project) -> set[str]:
+    """Every path the four collectors reach, as one set.
+
+    The policy is one decision, so the assertions are made against the union: a
+    path admitted by any collector is a path the walk admitted.
+    """
+    scripts = {s["path"] for s in _result(project, "script", "list")["scripts"]}
+    scenes = {s["path"] for s in _result(project, "scene", "list")["scenes"]}
+    sources = {
+        d["path"] for d in _result(project, "project", "dependencies")["dependencies"]
+    }
+    unused = set(_result(project, "project", "find-unused-resources")["unused"])
+    return scripts | scenes | sources | unused
+
+
+@pytest.mark.e2e
+def test_an_alias_cannot_re_admit_the_engine_cache(symlink_project):
+    # AC2 (#760): the excluded cache stays excluded however it is spelled — as a
+    # directory alias AT it, as a directory alias INTO one of its subdirectories,
+    # and as a FILE alias at a file inside it. The last one is the shape that
+    # never reaches the descent predicate at all.
+    walked = _walked_paths(symlink_project)
+
+    # Every spelling that reaches cache content, listed by shape so a leak names
+    # which half of the policy let it through. None of these paths contains the
+    # excluded directory's own name, which is the whole difficulty: an alias
+    # renames it.
+    aliased = {
+        "res://nested/.godot/root_cache.gd",  # directory alias AT the cache
+        "res://nested/.godot/root_cache.tscn",
+        "res://nested/imported_alias/cached.gd",  # directory alias INTO it
+        "res://alias_cache.gd",  # file alias at a file inside it
+        "res://alias_cache.tscn",
+    }
+    assert not (walked & aliased), walked & aliased
+
+    # `project statistics` counts over the unfiltered universe, so it is the
+    # collector that would show the cache re-entering as a raw count.
+    stats = _result(symlink_project, "project", "statistics")
+    assert stats["script_count"] == 2, stats  # sub/leaf.gd and vendored/vendored.gd
+    assert stats["scene_count"] == 1, stats  # vendored/vendored.tscn — nothing aliased
+
+    # And the class_name index, the fifth consumer of the same walk (ADR-0032):
+    # both cache-declared classes were resolvable through their aliases before.
+    scene = symlink_project / "host.tscn"
+    _result(
+        symlink_project, "scene", "create", "res://host.tscn", "--root-type", "Node"
+    )
+    assert scene.exists()
+    for cache_class in ("RootCacheThing", "CachedImport"):
+        proc = _gda(
+            symlink_project,
+            "node",
+            "add",
+            "res://host.tscn",
+            "--parent",
+            ".",
+            "--name",
+            "X",
+            "--type",
+            cache_class,
+            "--json",
+        )
+        error = json.loads(proc.stdout)["error"]
+        assert error["code"] == "invalid_node_type", error
+        assert cache_class in error["message"]
+
+
+@pytest.mark.e2e
+def test_a_symlink_cycle_terminates_without_fabricated_paths(symlink_project):
+    # AC3 (#760): `sub/loop -> sub` used to be descended until the OS refused
+    # another symlink hop, and every entry past the first named a file that had
+    # already been reported under a shorter path — 33 spellings of one `.gd`, the
+    # deepest 174 characters long. The link is now not followed, because it leads
+    # back to a directory already on the descent chain, so the real file is
+    # reported once and no path is invented.
+    walked = _walked_paths(symlink_project)
+
+    assert "res://sub/leaf.gd" in walked
+    assert not {p for p in walked if "/loop/" in p}, walked
+
+    # The termination is a rule, not a truncation: the counting collector agrees
+    # with the listing rather than reporting the OS limit's leftovers.
+    scripts = [s["path"] for s in _result(symlink_project, "script", "list")["scripts"]]
+    assert scripts.count("res://sub/leaf.gd") == 1, scripts
+
+
+@pytest.mark.e2e
+def test_a_link_to_authored_content_is_still_walked(symlink_project):
+    # AC1 (#760): the policy decides by WHERE a link leads, not by refusing
+    # links. A vendored checkout that physically lives outside res:// and is
+    # reached through a directory link is ordinary authored content — the engine
+    # loads through the link and the ADR-0006 addressing gate already calls such
+    # a file inside the project — so the walk enumerates it, and its `class_name`
+    # resolves at the instantiating call sites.
+    walked = _walked_paths(symlink_project)
+
+    assert "res://vendored/vendored.gd" in walked, walked
+    assert "res://vendored/vendored.tscn" in walked, walked
+
+    _result(
+        symlink_project, "scene", "create", "res://host.tscn", "--root-type", "Node"
+    )
+    added = _result(
+        symlink_project,
+        "node",
+        "add",
+        "res://host.tscn",
+        "--parent",
+        ".",
+        "--name",
+        "Vendored",
+        "--type",
+        "VendoredThing",
+    )
+    assert added["script_class"] == "VendoredThing", added

--- a/tests/test_project_walk.py
+++ b/tests/test_project_walk.py
@@ -132,3 +132,74 @@ def test_the_static_analysis_note_names_only_helpers_that_exist():
         "_collect_all_file_paths",
         TRAVERSAL,
     } <= mentioned
+
+
+# The two branches of that traversal, and the predicate each must ask (#760).
+DESCEND_PREDICATE = "_should_descend"
+COLLECT_PREDICATE = "_should_collect"
+
+# The single owner of the engine-cache exclusion both predicates route through,
+# and the constant only it and the descent predicate's lexical fast path may name.
+CACHE_OWNER = "_is_in_engine_cache"
+CACHE_CONSTANT = "ENGINE_CACHE_DIR"
+
+
+def _enclosing_function(source: str, line_index: int) -> str | None:
+    """The name of the top-level ``func`` whose body holds ``line_index``."""
+    lines = source.splitlines()
+    for i in range(line_index, -1, -1):
+        line = lines[i]
+        if line.startswith("func "):
+            return line[len("func ") :].split("(")[0]
+        if line and not line.startswith(("\t", " ", "#")):
+            return None  # a top-level statement that is not a func: outside one
+    return None
+
+
+def test_the_symlink_policy_is_asked_on_both_branches_of_the_traversal():
+    # AC2 (#760): the aliasing rule has TWO touch points. `_should_descend` gates
+    # DIRECTORY descent only, so a symlinked FILE — `res://alias.gd` pointing at a
+    # file inside the engine cache — reaches the acceptance test without ever
+    # passing it, and re-admits by itself the content the descent rule keeps out.
+    # The traversal must therefore ask both, and this is the guard against a later
+    # change fixing only the half that is easy to see.
+    source = _source()
+    traversal = "\n".join(_function_body(source, TRAVERSAL))
+
+    for predicate in (DESCEND_PREDICATE, COLLECT_PREDICATE):
+        assert f"{predicate}(" in traversal, (
+            f"{TRAVERSAL} must ask {predicate}; the symlink policy covers both the "
+            f"directory branch and the file branch"
+        )
+        assert f"func {predicate}(" in source, f"{predicate} is asked but not defined"
+
+
+def test_the_engine_cache_exclusion_has_one_owner():
+    # The exclusion is one decision (#712) and stays one now that answering it
+    # means resolving filesystem identity (#760): both walk-side predicates route
+    # the question to `_is_in_engine_cache`, and nothing else compares against the
+    # cache path. A second comparison site is how the four collectors drifted the
+    # first time.
+    source = _source()
+
+    for predicate in (DESCEND_PREDICATE, COLLECT_PREDICATE):
+        body = "\n".join(_function_body(source, predicate))
+        assert f"{CACHE_OWNER}(" in body, (
+            f"{predicate} must ask {CACHE_OWNER} rather than test the cache itself"
+        )
+
+    users = set()
+    for index, line in enumerate(source.splitlines()):
+        stripped = line.strip()
+        if stripped.startswith("#") or CACHE_CONSTANT not in stripped:
+            continue
+        if stripped.startswith(f"const {CACHE_CONSTANT}"):
+            continue  # the value's own declaration
+        enclosing = _enclosing_function(source, index)
+        assert enclosing is not None, f"{CACHE_CONSTANT} used outside any function"
+        users.add(enclosing)
+
+    assert users == {DESCEND_PREDICATE, CACHE_OWNER}, (
+        f"{CACHE_CONSTANT} must be compared only in {DESCEND_PREDICATE}'s lexical "
+        f"fast path and in {CACHE_OWNER}; found it in {sorted(users)}"
+    )


### PR DESCRIPTION
Closes #760

## The decision

The `res://` walk had no symlink policy: it compared paths lexically and descended into whatever
the directory listing called a directory. Two defects followed — an alias re-admitted the engine
cache the walk excludes, and a cycle was descended until the OS refused another symlink hop.

**The walk now FOLLOWS a link, as the engine does, but identifies what it reaches by FILESYSTEM
IDENTITY rather than by the spelling that reached it.** Two rules follow, and only a link pays for
them:

1. **Aliasing rule — the engine cache is excluded by identity.** No symlink alias re-admits it: not
   a directory link AT `res://.godot`, not a directory link INTO one of its subdirectories, not a
   FILE link at a file inside it, and not any of those three reached under a **second spelling** of
   a parent directory that is itself a link. `DirAccess.is_equivalent` — the engine's own
   `(st_dev, st_ino)` / `(volume, file id)` test — answers the identity question, and the path it
   is asked about is resolved **component by component**, each read against the components already
   resolved before it. `_is_in_engine_cache` is its single owner; both walk-side predicates route
   the question to it. A **hard** link is outside the rule by construction — the filesystem does
   not report one as a link — which the catalog and the code now state rather than implying "no
   alias".
2. **Cycle termination — a linked directory already on the current descent CHAIN is not
   re-entered.** `_collect_paths` carries the chain of ancestors (a new array per branch, so a
   branch cannot see a sibling's), and the cycle terminates *by rule* instead of running out at the
   OS symlink limit. The chain being per-branch, what the listing enumerates is distinct `res://`
   **paths**: a directory reachable through several link paths is reported under each. The answer is
   decided and finite — that is the guarantee — not "each real directory exactly once".

**A link to ordinary authored content is untouched by both.** A vendored checkout that physically
lives outside `res://` and is reached through a directory link inside it is walked and enumerated
as an ordinary directory, and its `class_name`s resolve at the instantiating call sites —
including a checkout that carries an engine cache of its **own**, which is that checkout's cache
and not this project's. The policy decides **where a link leads**, not whether links are allowed
(AC1's "do not break a real workflow silently").

**Enumeration is not targeting.** Being reached by this walk says what the project can *address*;
whether gda will operate on a path once it is NAMED as a target is the separate question the
containment gate answers, from the caller's own spelling. The catalog passage and ADR-0032's
amendment both say so, so the two rules read as layers rather than as opposite answers.

One consequence is kept deliberately: a FILE link at authored content is enumerated under **both**
paths, since both are real `res://` addresses the engine loads. When the linked script declares a
`class_name`, those two paths make it `ambiguous_class_name` — the same report gda already gives
any project that declares one name twice.

### Two touch points, not one

The aliasing rule lands in **two** places, per the issue's 2026-08-31 landing-site correction:
`_should_descend` gates DIRECTORY descent only, so a FILE link into the cache
(`res://alias_cache.gd` → `res://.godot/root_cache.gd`) reaches the acceptance branch without ever
passing it. The traversal therefore asks a file-side predicate too (`_should_collect`). Red-proof 3
below isolates exactly that half.

### What the review round changed (`2bd3160` → `79ac13d`)

The first commit's `_resolved_link_path` joined a **relative** link target onto the link's `res://`
spelling instead of onto the directory the kernel reads it from. Those differ as soon as the link's
own parent is a link, so the policy still decided by spelling — in **both** directions:

- `sub/deep/c -> ../../.godot` plus `link1 -> sub/deep`: `res://sub/deep/c/...` excluded,
  `res://link1/c/...` **admitted** — the same directory entry, two answers. All four collectors,
  `project statistics` and the `class_name` index leaked the root cache under the second spelling;
- `vendored/x -> ../.godot` inside a checkout outside `res://`: the lexical join produced
  `res://.godot`, so the CHECKOUT's own nested cache was taken for the project's and silently
  **hidden** — a regression against base `181da20d`, and exactly the workflow #712 decided to walk.

The path is now resolved as the kernel resolves one — component by component, the pass repeated
until it changes nothing so a target that itself names a link is resolved too. Resolving only one
more component does not suffice: a link through a link (`L2 -> link1/c`) survives it.

A **second, independent** leak is closed by a deletion: `_is_in_engine_cache`'s ancestor climb had
borrowed `SYMLINK_PROBE_MAX_STEPS` as a PATH-DEPTH bound, and exhausting it returned `false`, which
**admitted** cache content — an alias 32 levels below the cache leaked while 31 did not. Path depth
is not a symlink count; the climb now ends at the root.

## Engine evidence (measured on Godot 4.6.3.stable, source read at the `4.6.3-stable` tag)

- **Links are followed by the engine, so the walk must decide where they lead rather than whether
  to allow them.** `DirAccessUnix::get_next` `stat()`s a `DT_LNK` entry on purpose, so a linked
  directory reports `current_is_dir()` (`drivers/unix/dir_access_unix.cpp:148-183`), and
  `ResourceLoader` loads through an alias.
- **`DirAccess.is_equivalent` is the engine's own identity test** and is bound to script
  (`core/io/dir_access.cpp:681`). `DirAccessUnix::is_equivalent` compares `(st_dev, st_ino)`
  (`drivers/unix/dir_access_unix.cpp:713-729`); `DirAccessWindows::is_equivalent` compares
  `(VolumeSerialNumber, FileId)` (`drivers/windows/dir_access_windows.cpp:411-431`); both fall back
  to `DirAccess::is_equivalent`'s **string equality** when a path cannot be `stat`'d
  (`core/io/dir_access.cpp:630-632`). That fallback is why a project with no `res://.godot` at all
  keeps answering exactly as it did.
- **The path is resolved by hand because `DirAccess` cannot do it for us.**
  `DirAccessUnix::fix_path` simplifies a path LEXICALLY before every syscall
  (`drivers/unix/dir_access_unix.cpp:55-57`), so a `..` appended to a link never reaches the kernel
  and cannot walk up out of an alias — measured: `is_equivalent("res://nested/.godot/..", "res://")`
  answers `false` through an alias of the root cache. `DirAccessUnix::read_link` gives the raw
  target relative to the link's own directory (`drivers/unix/dir_access_unix.cpp:481-499`).
- **`DirAccessWindows::read_link` has a different contract**
  (`drivers/windows/dir_access_windows.cpp:444-462`): it returns an already-resolved absolute path
  from `GetFinalPathNameByHandleW`, and on failure returns the fixed input path, **never** the
  empty string. The resolver therefore also stops when a target names the path it came from, so an
  unopenable reparse point costs one probe instead of the whole bound.
- The probe bound is `32`, the **lower** of the two ceilings gda targets: `MAXSYMLINKS` is 32 on
  macOS (`MacOSX.sdk/usr/include/sys/param.h:197`) and **40** on Linux (`include/linux/namei.h`).
  It bounds symlink traversals only — the link hops in one chain and the resolution passes, each of
  which resolves at least one more link. It does **not** bound the ancestor climb, which counts
  path components.

## Tests

`tests/test_e2e_project_walk.py` carries the original fixture (directory alias AT the cache,
directory alias INTO it, two FILE aliases at cache files, a cycle, and the legitimate vendored
checkout) and gains two more, built with **relative** link targets and links nested inside linked
directories — the shapes no existing test exercised, which is why the first commit's defect was
invisible to a green suite:

- `aliased_spelling_project` — one real directory under two `res://` spellings (`link1 -> sub/deep`),
  three relative links into the cache inside it, and `L2 -> link1/c`, a link through a link;
- `vendored_cache_project` — a checkout outside `res://` carrying its own `.godot`, reached through
  `vendored -> <outside>/v` with `v/x -> ../.godot`;
- a deep-alias case pinning the ancestor climb past the old step bound.

The planted cache scripts now `extends Node` so the `class_name`-index assertion can **fail**:
extending `RefCounted`, a leak and a clean walk both answered `invalid_node_type` with the class in
the message, so that guard asserted an outcome no regression could change. Node-derived, a leak
makes `node add --type RootCacheThing` **succeed**. `tests/test_project_walk.py` keeps the two
source-level guards: the traversal must ask both predicates, and `ENGINE_CACHE_DIR` may be compared
only in the descent predicate's lexical fast path and in `_is_in_engine_cache`.

## Verification

All run locally against Godot `4.6.3.stable.official.7d41c59c4`, on head `79ac13d0`.

| Gate | Result |
| --- | --- |
| `uv run pytest -m "not e2e" -q` | 2252 passed, 598 deselected |
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 481 files already formatted |
| `uv run pyright` | 0 errors, 0 warnings |
| e2e: `test_project_walk.py` + `test_e2e_project_walk.py` | 12 passed |
| e2e: `classname_resolution`, `project`, `project_analysis` | 60 passed |
| e2e: `script`, `scene` | 91 passed |

**Cost unchanged.** `project statistics` over `examples/platformer/panda-adventure`, 3 runs each:
base `181da20d` 0.61 / 0.61 / 0.64 s, head `79ac13d0` 0.61 / 0.62 / 0.64 s, identical counts. The
component resolution runs only for entries that ARE links, of which an ordinary project has none.

### Red-proofs

Each reverts one hunk of `operations.gd` and reruns the real-engine tests.

1. **Aliasing rule reverted** (drop the `_is_in_engine_cache` guard in `_should_descend`, and
   `_should_collect` → `return true`) → `test_an_alias_cannot_re_admit_the_engine_cache` FAILS,
   leaking all five aliased spellings.
2. **Cycle rule reverted** (drop the ancestor-chain loop) →
   `test_a_symlink_cycle_terminates_without_fabricated_paths` FAILS with `res://sub/loop/leaf.gd`,
   `res://sub/loop/loop/leaf.gd`, … — the fabricated paths the issue reported.
3. **File-side touch point reverted only** (`_should_collect` → `return true`) →
   `test_an_alias_cannot_re_admit_the_engine_cache` FAILS with **exactly**
   `{res://alias_cache.gd, res://alias_cache.tscn}` while the directory aliases stay excluded, and
   the source-level guard `test_the_engine_cache_exclusion_has_one_owner` FAILS.
4. **Component resolution reverted** (`_fully_resolved_path` → `_resolved_link_path`) → both new
   tests FAIL, in opposite directions: the leak test on
   `{res://L2/*, res://link1/c/*, res://link1/ci/cached.gd, res://link1/f_alias.gd}`, and the
   vendored-cache test on `res://vendored/x/vendored_sample.gd` being absent.
5. **Ancestor climb re-bounded** (`while` → `for _step in range(SYMLINK_PROBE_MAX_STEPS)`) →
   `test_a_cache_alias_is_excluded_however_deep_below_the_cache_it_points` FAILS with
   `res://alias_deep/deep_cache.gd`.
6. **The `class_name` assertion is falsifiable.** Under red-proof 3, `node add --type
   RootCacheThing` returns `{"script_class": "RootCacheThing", …}` — no `error` key — and the
   assertion fails. With the previous `extends RefCounted` fixture the same leak returned
   `invalid_node_type: registered class_name RootCacheThing is not a Node-derived script:
   res://alias_cache.gd`, which the old assertion **accepted**.

## Docs synced (AC5, AC6)

`docs/command-catalog.md`'s exclusion passage holds the full rule and its rationale;
`_should_descend`'s comment and ADR-0032's amendment point at it. The catalog additionally records
the AC3 disposition that previously lived only here: a refused descent is reported by **omission**,
and a result field naming the skipped link was considered and declined because it would widen all
four collectors' result contracts for a diagnostic the listing already carries.

## Residual risk

- **A link gda cannot read.** A `read_link` the process is not permitted to make, or a chain longer
  than the OS resolves, stops at the furthest path resolved — so an unresolvable alias is reported
  rather than hidden. On Linux a 33-to-40-link chain is kernel-resolvable and gda stops short of it;
  accepted, since such a chain is not a shape an honest project produces.
- **Hard links.** A hard link at a file inside the cache is enumerated, because the filesystem does
  not report one as a link. Stated as scope in the catalog and in `_is_in_engine_cache`, not left
  implied by "no alias".
- Windows `is_equivalent` and `read_link` are exercised only through the engine's own
  implementations; the e2e fixtures are POSIX symlinks and CI is macOS/Linux. The Windows contract
  difference is documented at the resolver rather than assumed away.
- **Known, not addressed in this PR** (raised by the review, no behaviour impact today): the
  `_should_descend` fast path compares `ENGINE_CACHE_DIR` outside `_is_in_engine_cache`, so the
  "one owner" claim holds for links but not for the ordinary non-link case; three co-located notes
  still describe the exclusion as one directory-side rule; the source-level guard keys on the
  constant's NAME rather than the cache literal; and `project statistics`'s fourth-collector
  evidence rests on `script_count`/`scene_count` rather than `total_files`.
