### PR TITLE
fix(gda): the emission seam's stderr rule reaches the preflight recipe (#803)

### DIFF
--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -212,6 +212,45 @@ the standard build), and they never determine the outcome or a stable code.
 >   meant. This widens no cross-language contract: neither GDScript surface emits or
 >   reads `hint`, and `OperationErrorEnvelope` stays `extra="forbid"`.
 
+> **Outcome (2026-09-02, #685 / #798 / #803) — the HUMAN failure channel, adjudicated.**
+> Everything above specifies the envelope; until #685 that was the whole of what gda
+> emitted, because a caller who passed no `--json` got the serialized envelope anyway.
+> #685 gave the same outcome a second rendering, and the #798 round-1 review flagged
+> that this made the human channel a public output surface with no ADR behind it. This
+> note is the record. It also gives `CONTEXT.md`'s *Error envelope* entry — "Two
+> renderings of ONE outcome, at one exit code, from one renderer" — its ADR backing,
+> by reference rather than by restatement.
+>
+> - **Every gda-classified failure renders for a human on `stdout`, through the one
+>   renderer** (`gda.render.render_failure`, reached only via `gda.headless.emit_failure`),
+>   the `usage` refusals (`unknown_command` / `unknown_option`) included. Routing those
+>   there is what made the one-renderer invariant TRUE rather than approximate, and what
+>   made the `hint:` line reachable at all — it is set nowhere else, so before #798 a
+>   human could never read it.
+> - **The recorded exception is click's own parse errors** (a missing argument, an
+>   invalid value), which stay click-formatted on `stderr`: gda never classified them,
+>   so it has no envelope to render. The same holds where gda recognizes a mistake but
+>   has no correction to add and no `--json` was asked for — it declines to answer and
+>   the parser's message stands. That is gda staying silent, not a second gda layout.
+> - **`--json` is untouched.** The envelope goes to `stdout` as it always did, byte for
+>   byte; the flag chooses the rendering, never the stream.
+> - **Reversal was considered and declined**, twice over. Sending the `usage` refusals
+>   back to `stderr` resurrects the defect #798 closed — two layouts for one category,
+>   and `hint` as a dead branch. Moving ALL human rendering to `stderr` would buy
+>   convention compliance at the cost of a cross-channel asymmetry with `--json`, plus a
+>   documentation and test resync, with no consumer evidence asking for it.
+>
+> One rule follows from the stream choice, and has ONE home
+> (`gda.headless.emit_failure`): a failed CHILD RUN's raw stderr is forwarded to gda's
+> own stderr, EXCEPT when the human channel is about to print those very bytes as
+> `diagnostics` — byte identity decides, so a curated or capped `diagnostics` keeps its
+> tee, and under `--json` the tee is unconditional. Producers attach the stream to the
+> `Failure` and never tee for themselves; #803 brought the last one that did — `scene
+> preflight`, which reaches the launch primitive directly instead of through the shared
+> pipeline — under the rule. Its own recorded exception is `gda script run`, which tees
+> nothing because its success result IS the promoted `Raw run` (ADR-0031): there the
+> child's streams are the operation's published output, not a diagnostic copy of it.
+
 ## `GdaError.code` registry
 
 `GdaError.code` values are a public ABI for agents. Their authoritative source is

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -212,47 +212,51 @@ the standard build), and they never determine the outcome or a stable code.
 >   meant. This widens no cross-language contract: neither GDScript surface emits or
 >   reads `hint`, and `OperationErrorEnvelope` stays `extra="forbid"`.
 
-> **Outcome (2026-09-02, #685 / #798 / #803) — the HUMAN failure channel, adjudicated.**
+> **Outcome (2026-09-02, #685 / #798 / #803) — the human failure channel.**
 > Everything above specifies the envelope; until #685 that was the whole of what gda
 > emitted, because a caller who passed no `--json` got the serialized envelope anyway.
-> #685 gave the same outcome a second rendering, and the #798 round-1 review flagged
-> that this made the human channel a public output surface with no ADR behind it. This
-> note is the record. It also gives `CONTEXT.md`'s *Error envelope* entry — "Two
+> #685 gave the same outcome a second rendering, and the #798 round-1 review noted that
+> this made the human channel a public output surface with no ADR behind it. This note
+> is the record, and it is the one authority for the channel and child-stderr rules
+> below: the implementation sites state only their local behavior and reference this
+> note (#806 review). It also gives `CONTEXT.md`'s *Error envelope* entry — "Two
 > renderings of ONE outcome, at one exit code, from one renderer" — its ADR backing,
 > by reference rather than by restatement.
 >
-> - **Every gda-classified failure renders for a human on `stdout`, through the one
->   renderer** (`gda.render.render_failure`, reached only via `gda.headless.emit_failure`),
->   the `usage` refusals (`unknown_command` / `unknown_option`) included. Routing those
->   there is what made the one-renderer invariant TRUE rather than approximate, and what
->   made the `hint:` line reachable at all — it is set nowhere else, so before #798 a
->   human could never read it.
-> - **The recorded exception is click's own parse errors** (a missing argument, an
->   invalid value), which stay click-formatted on `stderr`: gda never classified them,
->   so it has no envelope to render. The same holds where gda recognizes a mistake but
->   has no correction to add and no `--json` was asked for — it declines to answer and
->   the parser's message stands. That is gda staying silent, not a second gda layout.
-> - **`--json` is untouched.** The envelope goes to `stdout` as it always did, byte for
->   byte; the flag chooses the rendering, never the stream.
-> - **Reversal was considered and declined**, twice over. Sending the `usage` refusals
->   back to `stderr` resurrects the defect #798 closed — two layouts for one category,
->   and `hint` as a dead branch. Moving ALL human rendering to `stderr` would buy
->   convention compliance at the cost of a cross-channel asymmetry with `--json`, plus a
+> - Every gda-classified failure renders for a human on `stdout`, through the one
+>   renderer (`gda.render.render_failure`, reached only via `gda.headless.emit_failure`).
+>   This includes the `usage` refusals (`unknown_command` / `unknown_option`). Routing
+>   them through the renderer makes the one-renderer statement exact and makes the
+>   `hint:` line reachable: it is set nowhere else, so before #798 a human could not
+>   read it.
+> - The recorded exception is click's own parse errors (a missing argument, an invalid
+>   value), which stay click-formatted on `stderr`: gda did not classify them, so it has
+>   no envelope to render. The same holds where gda recognizes a mistake but has no
+>   correction to add and no `--json` was asked for: gda declines to answer and the
+>   parser's message stands.
+> - `--json` is unchanged. The envelope goes to `stdout`, byte for byte; the flag
+>   chooses the rendering, never the stream.
+> - Two reversals were considered and declined. Sending the `usage` refusals back to
+>   `stderr` reintroduces the defect #798 closed (two layouts for one category, `hint`
+>   as a dead branch). Moving all human rendering to `stderr` buys convention
+>   compliance at the cost of a cross-channel asymmetry with `--json` plus a
 >   documentation and test resync, with no consumer evidence asking for it.
 >
-> One rule follows from the stream choice, and has ONE home
-> (`gda.headless.emit_failure`): a failed CHILD RUN's raw stderr is forwarded to gda's
-> own stderr, EXCEPT when the human channel is about to print those very bytes as
-> `diagnostics` — byte identity decides, so a curated or capped `diagnostics` keeps its
-> tee, and under `--json` the tee is unconditional. On a FAILURE producers attach the
-> stream to the `Failure` and never tee it for themselves; #803 brought the last one
-> that did — `scene preflight`, which reaches the launch primitive directly instead of
-> through the shared pipeline — under the rule. A SUCCESS is the other half and stays
-> with the producer: it carries no `diagnostics` for a tee to duplicate, so each
-> forwards the stream itself, at once, that copy being the reader's only one. The
-> rule's own recorded exception is `gda script run`, which tees nothing because its
-> success result IS the promoted `Raw run` (ADR-0031): there the child's streams are
-> the operation's published output, not a diagnostic copy of it.
+> The stream choice implies one child-stderr rule, recorded here:
+>
+> - On a failure, the producer that classified a child run attaches the raw stderr to
+>   the `Failure` (`child_stderr`) and does not print it. `emit_failure` forwards it to
+>   gda's own stderr, except when the human channel prints the same bytes as
+>   `diagnostics`; byte identity decides, and under `--json` the forward is
+>   unconditional.
+> - On a success, the producer forwards the stream immediately: a success carries no
+>   `diagnostics` block to duplicate, so that copy is the reader's only one.
+> - Producers today: `HeadlessCommand.execute` (the sentinel and live pipelines) and
+>   the `scene preflight` recipe, the last private tee, brought under the rule by #803.
+>   A launch-backed channel gda adds joins them by attaching rather than printing.
+> - Exception: `gda script run` neither attaches nor forwards. Its success result is
+>   the promoted `Raw run` (ADR-0031) — the child's streams are the published output —
+>   and its failures publish the captures as curated `diagnostics` sections.
 
 ## `GdaError.code` registry
 

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -244,12 +244,15 @@ the standard build), and they never determine the outcome or a stable code.
 > (`gda.headless.emit_failure`): a failed CHILD RUN's raw stderr is forwarded to gda's
 > own stderr, EXCEPT when the human channel is about to print those very bytes as
 > `diagnostics` — byte identity decides, so a curated or capped `diagnostics` keeps its
-> tee, and under `--json` the tee is unconditional. Producers attach the stream to the
-> `Failure` and never tee for themselves; #803 brought the last one that did — `scene
-> preflight`, which reaches the launch primitive directly instead of through the shared
-> pipeline — under the rule. Its own recorded exception is `gda script run`, which tees
-> nothing because its success result IS the promoted `Raw run` (ADR-0031): there the
-> child's streams are the operation's published output, not a diagnostic copy of it.
+> tee, and under `--json` the tee is unconditional. On a FAILURE producers attach the
+> stream to the `Failure` and never tee it for themselves; #803 brought the last one
+> that did — `scene preflight`, which reaches the launch primitive directly instead of
+> through the shared pipeline — under the rule. A SUCCESS is the other half and stays
+> with the producer: it carries no `diagnostics` for a tee to duplicate, so each
+> forwards the stream itself, at once, that copy being the reader's only one. The
+> rule's own recorded exception is `gda script run`, which tees nothing because its
+> success result IS the promoted `Raw run` (ADR-0031): there the child's streams are
+> the operation's published output, not a diagnostic copy of it.
 
 ## `GdaError.code` registry
 

--- a/src/gda/commands/scene.py
+++ b/src/gda/commands/scene.py
@@ -1046,6 +1046,11 @@ def run_scene_preflight_operation(
     - **the op reported a verdict** → the public result, with the script errors gda
       read off stderr (#651's parser, the single home of that reading) and the
       CLI-resolved project added to the engine's answer.
+
+    Those four outcomes are decided by :func:`_preflight_verdict` and returned
+    through the ONE tail below, which is what lets this channel answer to the same
+    stderr rule as every other one (#803): a failure carries the launch's stderr to
+    the emission point, a verdict forwards it here.
     """
     run_launch = make_launch or launch
     try:
@@ -1071,13 +1076,35 @@ def run_scene_preflight_operation(
         timeout=params.timeout,
         timeout_label="Godot scene preflight",
     )
-    # Forward the engine's own stream, exactly as the sentinel channel does
-    # (``HeadlessCommand.execute``): a preflight's stderr is where the booted scene's
-    # verbatim complaints are, and this command must not be the one that swallows
-    # them.
-    if raw.stderr:
+    outcome = _preflight_verdict(raw, params, binary, root)
+    # The engine's own stream, forwarded on exactly ONE channel — the same rule
+    # ``HeadlessCommand.execute`` follows since #798, which this recipe did not
+    # inherit because it does not go through it (#803). A preflight's stderr is
+    # where the booted scene's verbatim complaints are, so it must reach the reader;
+    # but a ``Failure`` classified from this run carries that stream as its
+    # ``diagnostics``, and teeing it HERE would say the same bytes twice, across two
+    # streams, for every op-reported refusal. So a failure carries it to
+    # ``emit_failure``, which alone knows the caller's channel and decides there; a
+    # verdict has no diagnostics block to duplicate, so its tee is immediate and
+    # this is the reader's only copy.
+    if isinstance(outcome, Failure):
+        outcome.child_stderr = raw.stderr
+    elif raw.stderr:
         print(raw.stderr, end="", file=sys.stderr)
+    return outcome
 
+
+def _preflight_verdict(
+    raw: RunResult,
+    params: ScenePreflightParams,
+    binary: Path,
+    root: "Path | None",
+) -> "ScenePreflightResult | Failure":
+    """The four-way bifurcation of a finished preflight launch (#664).
+
+    Split out of :func:`run_scene_preflight_operation` so its four exits funnel
+    through one tail there rather than each repeating the stderr decision (#803).
+    """
     diagnostics = parse_script_errors(raw.stderr)
     if raw.launch_failure is LaunchFailure.TIMEOUT:
         # The evidence the launch already measured, which this verdict used to drop

--- a/src/gda/commands/scene.py
+++ b/src/gda/commands/scene.py
@@ -1077,7 +1077,7 @@ def run_scene_preflight_operation(
         timeout_label="Godot scene preflight",
     )
     outcome = _preflight_verdict(raw, params, binary, root)
-    # The engine's own stream, forwarded on exactly ONE channel — the same rule
+    # The engine's own stream, forwarded once for a human — the same rule
     # ``HeadlessCommand.execute`` follows since #798, which this recipe did not
     # inherit because it does not go through it (#803). A preflight's stderr is
     # where the booted scene's verbatim complaints are, so it must reach the reader;

--- a/src/gda/commands/scene.py
+++ b/src/gda/commands/scene.py
@@ -1048,9 +1048,9 @@ def run_scene_preflight_operation(
       CLI-resolved project added to the engine's answer.
 
     Those four outcomes are decided by :func:`_preflight_verdict` and returned
-    through the ONE tail below, which is what lets this channel answer to the same
-    stderr rule as every other one (#803): a failure carries the launch's stderr to
-    the emission point, a verdict forwards it here.
+    through the one tail below, which is what lets this channel answer to the
+    child-stderr rule of ADR-0002's #803 note: a failure carries the launch's
+    stderr to the emission point, a verdict forwards it here.
     """
     run_launch = make_launch or launch
     try:
@@ -1077,16 +1077,10 @@ def run_scene_preflight_operation(
         timeout_label="Godot scene preflight",
     )
     outcome = _preflight_verdict(raw, params, binary, root)
-    # The engine's own stream, forwarded once for a human — the same rule
-    # ``HeadlessCommand.execute`` follows since #798, which this recipe did not
-    # inherit because it does not go through it (#803). A preflight's stderr is
-    # where the booted scene's verbatim complaints are, so it must reach the reader;
-    # but a ``Failure`` classified from this run carries that stream as its
-    # ``diagnostics``, and teeing it HERE would say the same bytes twice, across two
-    # streams, for every op-reported refusal. So a failure carries it to
-    # ``emit_failure``, which alone knows the caller's channel and decides there; a
-    # verdict has no diagnostics block to duplicate, so its tee is immediate and
-    # this is the reader's only copy.
+    # A failure carries the launch's stderr to the emission seam, which alone knows
+    # the caller's channel; a verdict has no diagnostics block to duplicate, so its
+    # tee is immediate and this is the reader's only copy. The rule these two
+    # branches implement is ADR-0002's #803 outcome note (#806 review).
     if isinstance(outcome, Failure):
         outcome.child_stderr = raw.stderr
     elif raw.stderr:

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -77,13 +77,10 @@ class Failure:
     ``child_stderr`` is the raw stderr of the child run this failure classifies,
     attached by its producer instead of being teed there — whether printing it
     would say the same bytes twice depends on the caller's channel, which only the
-    emission point knows (#798 review). Two producers attach it:
-    :meth:`gda.headless.HeadlessCommand.execute` for the sentinel and live
-    pipelines, and ``scene preflight``'s recipe, which reaches the launch primitive
-    directly (#803). The rule they both answer to, and its one recorded exception,
-    are documented at that emission point (:func:`gda.headless.emit_failure`). It
-    stays ``""`` on every failure no child run produced, and it is not part of the
-    serialized envelope.
+    emission point (:func:`gda.headless.emit_failure`) knows (#798 review). The
+    full rule — producers, the success half, and the exception — is ADR-0002's
+    #803 outcome note. It stays ``""`` on every failure no child run produced, and
+    it is not part of the serialized envelope.
     """
 
     error: GdaError

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -75,10 +75,14 @@ class Failure:
     """A classified failure: the stable error shape plus its process exit code.
 
     ``child_stderr`` is the raw stderr of the child run this failure classifies,
-    attached by :meth:`gda.headless.HeadlessCommand.execute` instead of being teed
-    there — whether printing it would say the same bytes twice depends on the
-    caller's channel, which only the emission point knows (#798 review). It stays
-    ``""`` on every failure no child run produced, and it is not part of the
+    attached by its producer instead of being teed there — whether printing it
+    would say the same bytes twice depends on the caller's channel, which only the
+    emission point knows (#798 review). Two producers attach it:
+    :meth:`gda.headless.HeadlessCommand.execute` for the sentinel and live
+    pipelines, and ``scene preflight``'s recipe, which reaches the launch primitive
+    directly (#803). The rule they both answer to, and its one recorded exception,
+    are documented at that emission point (:func:`gda.headless.emit_failure`). It
+    stays ``""`` on every failure no child run produced, and it is not part of the
     serialized envelope.
     """
 

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -655,15 +655,26 @@ def emit_failure(failure: Failure, *, json_output: bool) -> NoReturn:
     key set, so a record does not read differently depending on which half of the
     contract carried it (:class:`gda.models.FailureEvidence`).
 
-    The child run's stderr (``failure.child_stderr``, attached by
-    :meth:`HeadlessCommand.execute`) is forwarded to this process's stderr here,
-    where the channel is known — EXCEPT when the human channel is about to print
-    the very same bytes as ``diagnostics``, which would say one stream twice
-    across two streams (#798 review). Byte identity decides, not the error code:
-    a curated or capped ``diagnostics`` (the labeled ``--strict`` sections, a
-    timeout's tail-capped captures) differs from the raw stream, so its tee — the
-    only copy that is complete — survives. Under ``--json`` the tee is
-    unconditional, keeping that channel's bytes exactly as they were.
+    The child run's stderr (``failure.child_stderr``) is forwarded to this
+    process's stderr here, where the channel is known — EXCEPT when the human
+    channel is about to print the very same bytes as ``diagnostics``, which would
+    say one stream twice across two streams (#798 review). Byte identity decides,
+    not the error code: a curated or capped ``diagnostics`` (the labeled
+    ``--strict`` sections, a timeout's tail-capped captures) differs from the raw
+    stream, so its tee — the only copy that is complete — survives. Under
+    ``--json`` the tee is unconditional, keeping that channel's bytes exactly as
+    they were.
+
+    This is the ONE home of gda's child-stderr policy, and the whole of it is
+    learnable here. Two producers attach the field, and neither tees for itself:
+    :meth:`HeadlessCommand.execute` for the sentinel and live pipelines, and
+    ``scene preflight``'s recipe, which calls the launch primitive directly and so
+    had a private tee of its own until #803. A launch-backed channel gda adds
+    joins them by attaching rather than printing. The recorded EXCEPTION is
+    ``gda script run``, which tees nothing and attaches nothing: its success result
+    IS the promoted ``Raw run`` (ADR-0031), so the child's streams are the
+    operation's own published output rather than a diagnostic copy of it, and its
+    failures publish the captures as curated ``diagnostics`` sections instead.
     """
     if failure.child_stderr and (
         json_output or failure.error.diagnostics != failure.child_stderr

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -666,11 +666,15 @@ def emit_failure(failure: Failure, *, json_output: bool) -> NoReturn:
     they were.
 
     This is the ONE home of gda's child-stderr policy, and the whole of it is
-    learnable here. Two producers attach the field, and neither tees for itself:
+    learnable here. The rule above is the FAILURE half: two producers attach the
+    field, and neither tees a failure's stream for itself —
     :meth:`HeadlessCommand.execute` for the sentinel and live pipelines, and
     ``scene preflight``'s recipe, which calls the launch primitive directly and so
-    had a private tee of its own until #803. A launch-backed channel gda adds
-    joins them by attaching rather than printing. The recorded EXCEPTION is
+    had a private tee of its own until #803. A launch-backed channel gda adds joins
+    them by attaching rather than printing. On a SUCCESS both still tee at once, at
+    the producer, and must: a success carries no ``diagnostics`` block for the tee
+    to duplicate, so that copy is the reader's only one and never reaches this seam
+    (both are pinned — dropping either turns a test red). The recorded EXCEPTION is
     ``gda script run``, which tees nothing and attaches nothing: its success result
     IS the promoted ``Raw run`` (ADR-0031), so the child's streams are the
     operation's own published output rather than a diagnostic copy of it, and its

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -656,7 +656,7 @@ def emit_failure(failure: Failure, *, json_output: bool) -> NoReturn:
     contract carried it (:class:`gda.models.FailureEvidence`).
 
     The child run's stderr (``failure.child_stderr``) is forwarded to this
-    process's stderr here, where the channel is known — EXCEPT when the human
+    process's stderr here, where the channel is known — except when the human
     channel is about to print the very same bytes as ``diagnostics``, which would
     say one stream twice across two streams (#798 review). Byte identity decides,
     not the error code: a curated or capped ``diagnostics`` (the labeled
@@ -665,20 +665,10 @@ def emit_failure(failure: Failure, *, json_output: bool) -> NoReturn:
     ``--json`` the tee is unconditional, keeping that channel's bytes exactly as
     they were.
 
-    This is the ONE home of gda's child-stderr policy, and the whole of it is
-    learnable here. The rule above is the FAILURE half: two producers attach the
-    field, and neither tees a failure's stream for itself —
-    :meth:`HeadlessCommand.execute` for the sentinel and live pipelines, and
-    ``scene preflight``'s recipe, which calls the launch primitive directly and so
-    had a private tee of its own until #803. A launch-backed channel gda adds joins
-    them by attaching rather than printing. On a SUCCESS both still tee at once, at
-    the producer, and must: a success carries no ``diagnostics`` block for the tee
-    to duplicate, so that copy is the reader's only one and never reaches this seam
-    (both are pinned — dropping either turns a test red). The recorded EXCEPTION is
-    ``gda script run``, which tees nothing and attaches nothing: its success result
-    IS the promoted ``Raw run`` (ADR-0031), so the child's streams are the
-    operation's own published output rather than a diagnostic copy of it, and its
-    failures publish the captures as curated ``diagnostics`` sections instead.
+    That is this function's whole part in the child-stderr rule. The rule itself —
+    the success half, the producer roster, and the ``gda script run`` exception —
+    is recorded once, in ADR-0002's #803 outcome note; the producers state their
+    own halves locally and reference it (#806 review).
     """
     if failure.child_stderr and (
         json_output or failure.error.diagnostics != failure.child_stderr

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -81,14 +81,10 @@ def render_failure(error: GdaError) -> str:
     the dump readable — and suppressing it per code is exactly the per-command layout
     this renderer exists to prevent.
 
-    A SECOND duplication — the child-stderr tee repeating the classifiers whose
-    ``diagnostics`` IS that stream — is prevented at the emission point rather than
-    here (#798 review): :meth:`gda.headless.HeadlessCommand.execute` attaches the
-    child's stderr to the ``Failure`` instead of printing it, and
-    :func:`gda.headless.emit_failure` forwards it unless this human channel is about
-    to print the identical bytes as ``diagnostics``. Byte identity decides, so a
-    curated or tail-capped ``diagnostics`` keeps its tee — the only complete copy —
-    and ``--json``'s streams stay exactly as they were.
+    A SECOND duplication — a forwarded child stderr repeating the ``diagnostics``
+    this renderer prints — is prevented at the emission point, not here: this
+    function only renders what the envelope carries. The routing and suppression
+    rule lives in ADR-0002's #803 outcome note (#806 review).
     """
     lines = [f"error: {error.code} ({error.category.value})", error.message]
     if error.probe is not None:

--- a/tests/test_e2e_scene_preflight.py
+++ b/tests/test_e2e_scene_preflight.py
@@ -205,6 +205,20 @@ def test_a_missing_scene_is_refused_not_reported_as_a_verdict(godot_project):
     assert preflighted.returncode == 4, preflighted.stdout + preflighted.stderr
     assert json.loads(preflighted.stdout)["error"]["code"] == "path_not_found"
 
+    # The same refusal for a human says the engine's bytes ONCE (#803, #806 review
+    # P3-3). What triggers the suppression is byte identity between `diagnostics`
+    # and the raw stream, and that identity is an ENGINE fact: the unit red proof
+    # authors both halves at the injected launch seam, so it cannot pin it. Equality
+    # rather than absence-of-a-substring, and it holds however talkative the engine
+    # is — extra stderr lands in `diagnostics` too, so the whole stream is still
+    # suppressed. Anything left on stderr here is gda saying it twice again.
+    human = gda("scene", "preflight", "res://nosuch.tscn")
+
+    assert human.returncode == 4, human.stdout + human.stderr
+    assert human.stdout.startswith("error: path_not_found (operation)\n")
+    assert "gda: running operation: scene-preflight" in human.stdout
+    assert human.stderr == ""
+
 
 # Hands off in _ready — a splash/bootstrap shape. The node is gone before the first
 # observed frame, so a verdict SAMPLED there would call it not_ready.

--- a/tests/test_human_failure_output.py
+++ b/tests/test_human_failure_output.py
@@ -611,27 +611,46 @@ def test_a_preflight_refusal_reaches_a_human_once_not_twice(monkeypatch, tmp_pat
     assert both.count("ERROR: scene file not found: res://nope.tscn") == 1
 
 
-def test_the_same_preflight_refusal_under_json_keeps_its_stderr_tee(
-    monkeypatch, tmp_path
+@pytest.mark.parametrize(
+    ("run", "code"),
+    [
+        pytest.param(
+            RunResult(
+                stdout=error_sentinel(
+                    "path_not_found", "scene file not found: res://nope.tscn"
+                ),
+                stderr=_PREFLIGHT_STDERR,
+                exit_code=1,
+            ),
+            "path_not_found",
+            id="the-classified-refusal",
+        ),
+        pytest.param(
+            RunResult(stdout="", stderr=_PREFLIGHT_STDERR, exit_code=0),
+            "operation_failed",
+            id="the-run-the-project-ended",
+        ),
+    ],
+)
+def test_either_preflight_failure_under_json_keeps_its_stderr_tee(
+    monkeypatch, tmp_path, run, code
 ):
     # The scope boundary, identical to the sentinel channel's: `--json` is byte-for-
     # byte what it was — the envelope alone on stdout, the child's stderr forwarded
     # in full on stderr.
-    _patch_preflight_launch(
-        monkeypatch,
-        RunResult(
-            stdout=error_sentinel(
-                "path_not_found", "scene file not found: res://nope.tscn"
-            ),
-            stderr=_PREFLIGHT_STDERR,
-            exit_code=1,
-        ),
-    )
+    #
+    # BOTH failure exits, because only this channel can see the attach (#806 review
+    # P3-2). In human mode a failure's `diagnostics` IS these bytes, so the seam
+    # suppresses the tee and an attach that never happened looks exactly like one
+    # that was suppressed — the human tests below cannot tell the two apart. Under
+    # `--json` the attach is the only thing that puts the stream on stderr, so
+    # dropping it on either exit is visible here and nowhere else.
+    _patch_preflight_launch(monkeypatch, run)
 
     result = _preflight(tmp_path, "--json")
 
     assert result.exit_code == EXIT_OPERATION, result.stdout + result.stderr
-    assert json.loads(result.stdout)["error"]["code"] == "path_not_found"
+    assert json.loads(result.stdout)["error"]["code"] == code
     assert result.stderr == _PREFLIGHT_STDERR
 
 

--- a/tests/test_human_failure_output.py
+++ b/tests/test_human_failure_output.py
@@ -40,7 +40,7 @@ from gda.models import (
 from gda.render import render_failure
 from gda.runner import LaunchFailure, RunResult, TimeoutBound
 from gda.script_errors import ScriptError, ScriptErrorKind
-from tests.support import inject_runner
+from tests.support import error_sentinel, inject_runner, sentinel
 
 
 def _error(**overrides) -> GdaError:
@@ -543,3 +543,152 @@ def test_an_invalid_params_json_object_is_refused_in_lines(tmp_path):
     assert result.exit_code == EXIT_OPERATION, result.stdout
     assert result.stdout.splitlines()[0] == "error: invalid_params (operation)"
     assert "path: Field required" in result.stdout.splitlines()[1]
+
+
+# --- the launch-backed recipe channel -------------------------------------------
+#
+# `scene preflight` does not answer through `HeadlessCommand.execute` — it calls the
+# launch primitive itself, because it bifurcates on the launch's own outcome (#664).
+# It therefore did not inherit #798's rule and kept a private, unconditional tee at
+# the top of its recipe, so every op-reported refusal whose `diagnostics` IS the raw
+# stderr said those bytes twice, across two streams. What is pinned here is the rule
+# reaching this channel too — and, on the same four exit paths, the success-shaped
+# verdicts still forwarding the engine's stream, which is the only copy they have.
+
+_PREFLIGHT_STDERR = (
+    "gda: running operation: scene-preflight\n"
+    "ERROR: scene file not found: res://nope.tscn\n"
+)
+
+
+def _patch_preflight_launch(monkeypatch, result: RunResult) -> None:
+    """Swap the recipe's own launch seam (it does not go through the runner)."""
+
+    def fake_launch(binary, args, *, cwd, timeout, timeout_label="Godot", watch=None):
+        return result
+
+    monkeypatch.setattr("gda.commands.scene.launch", fake_launch)
+
+
+def _preflight(tmp_path, *extra: str):
+    return CliRunner().invoke(
+        app,
+        [
+            "scene",
+            "preflight",
+            "res://nope.tscn",
+            "--project",
+            str(_project(tmp_path)),
+            *extra,
+        ],
+    )
+
+
+def test_a_preflight_refusal_reaches_a_human_once_not_twice(monkeypatch, tmp_path):
+    # The red proof (#803): `path_not_found` is the reproduced case — the op reports
+    # a structured refusal, `classify_run` carries the raw stderr into `diagnostics`,
+    # and the human renderer lays those bytes out on stdout. The recipe's own tee
+    # said them again on stderr. Asserted per stream, not on a merged capture, since
+    # the defect IS the split across the two.
+    _patch_preflight_launch(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel(
+                "path_not_found", "scene file not found: res://nope.tscn"
+            ),
+            stderr=_PREFLIGHT_STDERR,
+            exit_code=1,
+        ),
+    )
+
+    result = _preflight(tmp_path)
+
+    assert result.exit_code == EXIT_OPERATION, result.stdout + result.stderr
+    assert result.stdout.startswith("error: path_not_found (operation)\n")
+    assert "ERROR: scene file not found: res://nope.tscn" in result.stdout
+    assert _PREFLIGHT_STDERR not in result.stderr
+    both = result.stdout + result.stderr
+    assert both.count("ERROR: scene file not found: res://nope.tscn") == 1
+
+
+def test_the_same_preflight_refusal_under_json_keeps_its_stderr_tee(
+    monkeypatch, tmp_path
+):
+    # The scope boundary, identical to the sentinel channel's: `--json` is byte-for-
+    # byte what it was — the envelope alone on stdout, the child's stderr forwarded
+    # in full on stderr.
+    _patch_preflight_launch(
+        monkeypatch,
+        RunResult(
+            stdout=error_sentinel(
+                "path_not_found", "scene file not found: res://nope.tscn"
+            ),
+            stderr=_PREFLIGHT_STDERR,
+            exit_code=1,
+        ),
+    )
+
+    result = _preflight(tmp_path, "--json")
+
+    assert result.exit_code == EXIT_OPERATION, result.stdout + result.stderr
+    assert json.loads(result.stdout)["error"]["code"] == "path_not_found"
+    assert result.stderr == _PREFLIGHT_STDERR
+
+
+def test_a_preflight_run_the_project_ended_says_its_stderr_once_too(
+    monkeypatch, tmp_path
+):
+    # The recipe's SECOND failure exit (`_ended_before_the_verdict`): a clean exit
+    # with no sentinel is the project's own `quit()`, and its `Failure` carries the
+    # same raw stderr as `diagnostics`. Funnelling the returns is what makes this
+    # path obey the rule as well as the classifier's.
+    _patch_preflight_launch(
+        monkeypatch,
+        RunResult(stdout="", stderr=_PREFLIGHT_STDERR, exit_code=0),
+    )
+
+    result = _preflight(tmp_path)
+
+    assert result.exit_code == EXIT_OPERATION, result.stdout + result.stderr
+    assert result.stdout.startswith("error: operation_failed (operation)\n")
+    assert _PREFLIGHT_STDERR not in result.stderr
+    both = result.stdout + result.stderr
+    assert both.count("ERROR: scene file not found: res://nope.tscn") == 1
+
+
+@pytest.mark.parametrize(
+    "run",
+    [
+        pytest.param(
+            RunResult(
+                stdout=sentinel({"path": "res://nope.tscn", "status": "ready"}),
+                stderr=_PREFLIGHT_STDERR,
+                exit_code=0,
+            ),
+            id="the-verdict",
+        ),
+        pytest.param(
+            RunResult(
+                stdout="",
+                stderr=_PREFLIGHT_STDERR,
+                exit_code=124,
+                launch_failure=LaunchFailure.TIMEOUT,
+                elapsed_seconds=8.1,
+                timeout_bound=TimeoutBound("Godot scene preflight", 8.0),
+            ),
+            id="the-timeout-verdict",
+        ),
+    ],
+)
+def test_a_preflight_verdict_still_forwards_the_engines_stderr(
+    monkeypatch, tmp_path, run
+):
+    # The other two exits are SUCCESS-shaped, and a success has no `diagnostics`
+    # block to duplicate: the tee is the reader's only copy of what the engine
+    # printed, so removing the recipe's unconditional tee must not remove theirs.
+    _patch_preflight_launch(monkeypatch, run)
+
+    result = _preflight(tmp_path)
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert result.stderr == _PREFLIGHT_STDERR


### PR DESCRIPTION
## What

`gda scene preflight` is the one launch-backed recipe that did not answer to the
child-stderr rule #798 put at the emission seam. It calls the launch primitive
directly rather than going through `HeadlessCommand.execute` — because it bifurcates
on the launch's own outcome (#664) — and so kept a private, unconditional tee at the
top of its recipe. Every op-reported refusal whose `diagnostics` IS the raw stderr
therefore said those bytes twice, across two streams.

The recipe's four post-launch exits now funnel through ONE tail in
`run_scene_preflight_operation`: a `Failure` carries the run's stderr as
`child_stderr` to `emit_failure`, which alone knows the caller's channel; a
success-shaped verdict (the final result, the timeout verdict) still tees
immediately, since it has no `diagnostics` block to duplicate and the tee is the
reader's only copy. The bifurcation itself moves into `_preflight_verdict` so the
stderr decision is made once rather than repeated at each of the four returns — the
trap the issue names.

`emit_failure`'s docstring is now the one home of the whole policy: both producers
that attach rather than tee, and the recorded exception — `gda script run`, which
tees nothing because its success result IS the promoted `Raw run` (ADR-0031), so the
child's streams are the operation's published output rather than a diagnostic copy.
The stale `exactly as HeadlessCommand.execute does` comment, wrong since #798, is
corrected to the emission-seam rule.

## Red proof (before the fix)

`tests/test_human_failure_output.py`, streams asserted separately — the defect IS
the split across the two, so a merged capture cannot see it:

```
$ uv run pytest tests/test_human_failure_output.py -q -k preflight

>       assert _PREFLIGHT_STDERR not in result.stderr
E       AssertionError: assert 'gda: runnin.../nope.tscn\n' not in 'gda: runnin.../nope.tscn\n'
E         'gda: running opera...: res://nope.tscn\n' is contained here:
E           gda: running operation: scene-preflight
E           ERROR: scene file not found: res://nope.tscn
tests/test_human_failure_output.py:609: AssertionError

FAILED ...::test_a_preflight_refusal_reaches_a_human_once_not_twice
FAILED ...::test_a_preflight_run_the_project_ended_says_its_stderr_once_too
2 failed, 3 passed, 30 deselected
```

The three that passed are the guards: `--json` keeps its unconditional tee, and both
success-shaped verdicts keep forwarding. After the fix, 5 passed.

## Real-engine before / after

Godot 4.6 on macOS, throwaway project, per-run `--user-data-root` under a fresh
`/tmp` dir.

```
$ gda scene preflight res://nope.tscn --project <proj>          # BEFORE
--- stdout ---
error: path_not_found (operation)
scene file does not exist: res://nope.tscn

gda: running operation: scene-preflight
--- stderr ---
gda: running operation: scene-preflight        <-- the duplicate
```

```
$ gda scene preflight res://nope.tscn --project <proj>          # AFTER
--- stdout ---   (byte-identical to before)
error: path_not_found (operation)
scene file does not exist: res://nope.tscn

gda: running operation: scene-preflight
--- stderr ---
(empty: 0 bytes)
```

Success path, same engine, a real `res://main.tscn`: stdout `ready res://main.tscn`,
stderr still carries `gda: running operation: scene-preflight` — the forwarding is
preserved, and pinned by a parametrized test over both success-shaped exits.

## `--json` byte-identity

Same failing invocation under `--json`, captured before and after against the real
engine and compared with `cmp`:

```
=== JSON byte-identity: stdout ===  IDENTICAL
=== JSON byte-identity: stderr ===  IDENTICAL
```

The envelope alone on stdout, the child's stderr forwarded in full on stderr —
exactly as before.

## ADR-0002 outcome note

`docs/adr/0002` gains `> **Outcome (2026-09-02, #685 / #798 / #803)**`, recording
the adjudicated human failure channel that #798's round-1 review flagged as a public
output surface with no ADR behind it:

- every gda-classified failure renders for a human on **stdout** through the one
  renderer, the `usage` refusals (`unknown_command` / `unknown_option`) included —
  routing them there is what made the one-renderer invariant true and the `hint:`
  line reachable at all;
- the recorded exception is **click's own parse errors** (missing argument, invalid
  value), which stay click-formatted on stderr — gda never classified them, so it
  has no envelope to render; likewise where gda has no correction and no `--json`
  was asked, it declines to answer and the parser's message stands;
- **`--json` is untouched** — the envelope goes to stdout byte for byte;
- **reversal considered and declined**: sending usage back to stderr resurrects the
  two-layout / dead-`hint` defect, and moving all human rendering to stderr buys
  convention compliance at the cost of a cross-channel asymmetry with `--json` plus
  a doc/test resync, with no consumer evidence demanding it.

It closes with the child-stderr rule this PR extends, and names its ADR-0031
exception. `CONTEXT.md` gets its renderer sentence's ADR backing by reference, not by
edit (that file belongs to #805 this wave).

## Surface diff

**None.** Measured, not asserted: `gda schema` and the concatenated `--help` of the
root, all nine groups and `scene preflight` were captured on this branch and on the
base (`git stash` of `src/`), then compared with `cmp` — `IDENTICAL` both times. The
change is output-channel behaviour only; the catalog and SKILL are untouched.

## Gates

- `uv run pytest tests/ -q -m "not e2e"` → **2395 passed**
- `uv run pytest tests/test_e2e_scene_preflight.py -m e2e` → **14 passed** (real engine)
- `uv run ruff check .` / `ruff format --check .` → clean
- `uv run pyright` → 0 errors, 0 warnings

Closes #803

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjjKc1dRim7zkAYp3rUDnL
