### PR TITLE
refactor(gda): one containment gate on gda.project, three call sites folded (#802)

### DIFF
--- a/src/gda/commands/resource.py
+++ b/src/gda/commands/resource.py
@@ -28,8 +28,9 @@ from pydantic import BaseModel, Field, model_validator
 from gda.binary import resolve_godot_binary
 from gda.dispatch import dispatch_domain, dispatch_recipe, params_or_bad_parameter
 from gda.errors import (
-    Failure,
     classify_launch_or_crash,
+    containment_refusal,
+    Failure,
     make_failure,
 )
 from gda.execution import ExecutionKind
@@ -50,7 +51,6 @@ from gda.models import (
 from gda.project import (
     RES_PREFIX,
     canonical_res_path,
-    containment_refusal,
     is_engine_virtual_path,
     project_absolute,
     project_anchored,

--- a/src/gda/commands/resource.py
+++ b/src/gda/commands/resource.py
@@ -31,8 +31,6 @@ from gda.errors import (
     Failure,
     classify_launch_or_crash,
     make_failure,
-    target_outside_project_failure,
-    target_owned_by_another_project_failure,
 )
 from gda.execution import ExecutionKind
 from gda.headless import (
@@ -52,12 +50,10 @@ from gda.models import (
 from gda.project import (
     RES_PREFIX,
     canonical_res_path,
+    containment_refusal,
     is_engine_virtual_path,
-    owner_relative_target,
-    owning_project,
-    path_outside_project,
+    project_absolute,
     project_anchored,
-    target_location,
 )
 from gda.render import render_property_lines, render_set_echo
 from gda.runner import launch
@@ -834,28 +830,17 @@ def _asset_res_path(project: Path, raw: str) -> "str | Failure":
         )
     # One coordinate system for BOTH sides before any comparison: a relative
     # --project must not meet an absolute candidate (#738 re-review 2 — the
-    # mixed comparison raised a bare ValueError on the lexical fallback).
-    project_abs = project.expanduser()
-    if not project_abs.is_absolute():
-        project_abs = Path.cwd() / project_abs
-    # The checks read the project as SPELLED (the double reading is theirs to make);
-    # the refusals report it RESOLVED, which is what `FailureEvidence.project_root`
-    # publishes ("in its resolved form — the same value a successful result
-    # reports") and what the two sibling gates already did. Reporting `project_abs`
-    # itself made this one command answer `/tmp/...` where `script validate`
-    # answered `/private/tmp/...` for the same call (#799 review).
-    root = project_abs.resolve()
-    owner = owning_project(raw, project_abs)
-    if owner is not None:
-        return target_owned_by_another_project_failure(
-            target_location(raw, project_abs),
-            owner.resolve(),
-            root,
-            owner_relative_target(raw, project_abs, owner),
-        )
-    outside = path_outside_project(raw, project_abs)
-    if outside is not None:
-        return target_outside_project_failure(outside, root)
+    # mixed comparison raised a bare ValueError on the lexical fallback). The
+    # gate below normalizes the same way; this local is for the res:// MAPPING
+    # further down, which needs the same absolute root.
+    project_abs = project_absolute(project)
+    # ONE call for ownership-then-containment and both refusal envelopes (#802).
+    # What used to stand here — the two probes, their order, the four coordinates
+    # and the resolved root each refusal reports — now lives on ADR-0006's path
+    # authority, so this gate keeps only what is genuinely about ASSETS.
+    refusal = containment_refusal(raw, project)
+    if refusal is not None:
+        return refusal
     if raw.startswith(RES_PREFIX):
         # Already in the engine's namespace: canonicalize the spelling and stop.
         # Reading it lexically is what the engine does too — a symlink inside the

--- a/src/gda/commands/resource.py
+++ b/src/gda/commands/resource.py
@@ -830,9 +830,11 @@ def _asset_res_path(project: Path, raw: str) -> "str | Failure":
         )
     # One coordinate system for BOTH sides before any comparison: a relative
     # --project must not meet an absolute candidate (#738 re-review 2 — the
-    # mixed comparison raised a bare ValueError on the lexical fallback). The
-    # gate below normalizes the same way; this local is for the res:// MAPPING
-    # further down, which needs the same absolute root.
+    # mixed comparison raised a bare ValueError on the lexical fallback). This
+    # local is for the res:// MAPPING further down, which needs the same absolute
+    # root the gate below reads. Not a two-places-must-agree coupling: there is one
+    # normalization RULE — `project_absolute` — and both sites call it, so the only
+    # cost of asking twice is a second `Path.cwd()` (#807 review).
     project_abs = project_absolute(project)
     # ONE call for ownership-then-containment and both refusal envelopes (#802).
     # What used to stand here — the two probes, their order, the four coordinates

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -64,6 +64,7 @@ from gda.project import (
     RES_PREFIX,
     canonical_res_path,
     containment_refusal,
+    project_absolute,
     res_escape_remainder,
 )
 from gda.runner import LaunchFailure, LaunchFn, RunResult, launch
@@ -2180,7 +2181,11 @@ def _script_validate_recipe(
     built once by the caller, identical on the argv and ``--params-json`` paths
     (ADR-0015).
     """
-    root = None if project is None else project.expanduser().resolve()
+    # The SUCCESS path's root, normalized the way the refusal path's is (#807
+    # review): both sides of one verdict must reach the project by one reading, and
+    # the same call answering two spellings of one root is what #799 was.
+    # `project_absolute` differs only in staying total on an unresolvable `~user`.
+    root = None if project is None else project_absolute(project).resolve()
     for path in params.paths:
         # ONE call for both halves and their ordering (#802): the gate on ADR-0006's
         # path authority owns them, so this recipe states only WHICH targets it is

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -31,9 +31,10 @@ from gda import dispatch
 from gda.binary import resolve_godot_binary
 from gda.dispatch import dispatch_domain, dispatch_recipe, params_or_bad_parameter
 from gda.errors import (
-    Failure,
     classify_launch_or_crash,
     classify_run,
+    containment_refusal,
+    Failure,
     make_failure,
     script_did_not_run_failure,
     script_escapes_project_failure,
@@ -63,7 +64,6 @@ from gda.models import (
 from gda.project import (
     RES_PREFIX,
     canonical_res_path,
-    containment_refusal,
     project_absolute,
     res_escape_remainder,
 )
@@ -2147,7 +2147,7 @@ def _script_validate_recipe(
 
     The refusal has TWO halves since ADR-0006's 2026-08-31 amendment (#697), and
     the second is why a *projectless* call is now checked too. Both are asked by
-    ONE call to :func:`~gda.project.containment_refusal` (#802), which owns their
+    ONE call to :func:`~gda.errors.containment_refusal` (#802), which owns their
     ordering and builds whichever envelope fires; this recipe only chooses the
     targets. Containment (:func:`~gda.project.path_outside_project`) asks whether
     the target is in the resolved project's tree, which only a resolved project

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -2147,9 +2147,9 @@ def _script_validate_recipe(
 
     The refusal has TWO halves since ADR-0006's 2026-08-31 amendment (#697), and
     the second is why a *projectless* call is now checked too. Both are asked by
-    ONE call to :func:`~gda.errors.containment_refusal` (#802), which owns their
-    ordering and builds whichever envelope fires; this recipe only chooses the
-    targets. Containment (:func:`~gda.project.path_outside_project`) asks whether
+    ONE call to :func:`~gda.errors.containment_refusal` (#802), which maps the
+    ordered decision :func:`~gda.project.containment_violation` makes to whichever
+    envelope fires; this recipe only chooses the targets. Containment (:func:`~gda.project.path_outside_project`) asks whether
     the target is in the resolved project's tree, which only a resolved project
     can fail. Ownership (:func:`~gda.project.owning_project`) asks whether that
     project is really the target's OWNER — a ``project.godot`` nearer to the

--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -42,8 +42,6 @@ from gda.errors import (
     script_run_aborted_failure,
     script_run_project_not_found_failure,
     script_run_timeout_failure,
-    target_outside_project_failure,
-    target_owned_by_another_project_failure,
     termination_phase,
     unresolvable_binary_failure,
 )
@@ -65,11 +63,8 @@ from gda.models import (
 from gda.project import (
     RES_PREFIX,
     canonical_res_path,
-    owner_relative_target,
-    owning_project,
-    path_outside_project,
+    containment_refusal,
     res_escape_remainder,
-    target_location,
 )
 from gda.runner import LaunchFailure, LaunchFn, RunResult, launch
 from gda.script_errors import (
@@ -1564,16 +1559,19 @@ def run_script_run_operation(
     # address gate above is lexical, so it cannot see a `project.godot` nested
     # between the resolved root and the script. Running against the outer root
     # would resolve the script's own `res://` references against a root that is
-    # not its own — GDA-DF-035 in the executing form. One rule, two commands: the
-    # same probe `script validate` applies, reported under the same code.
-    owner = owning_project(script, project)
-    if owner is not None:
-        return target_owned_by_another_project_failure(
-            target_location(script, project),
-            owner.resolve(),
-            project.expanduser().resolve(),
-            owner_relative_target(script, project, owner),
-        )
+    # not its own — GDA-DF-035 in the executing form. One rule, three commands:
+    # the same shared gate `script validate` and `resource import` apply, reported
+    # under the same code.
+    #
+    # This site asked ownership ALONE until #802, because the address gate above
+    # has already decided containment for it — every escaping spelling is refused
+    # there, and a non-escaping res:// address is inside the root by construction.
+    # It now calls the whole gate anyway: the containment half is inert here (the
+    # consistency table proves it spelling by spelling rather than assuming it),
+    # and one call site cannot drift from the other two.
+    refusal = containment_refusal(script, project)
+    if refusal is not None:
+        return refusal
 
     try:
         binary = resolve_godot_binary(godot)
@@ -2147,18 +2145,21 @@ def _script_validate_recipe(
     own entry.
 
     The refusal has TWO halves since ADR-0006's 2026-08-31 amendment (#697), and
-    the second is why a *projectless* call is now checked too. Containment
-    (:func:`~gda.project.path_outside_project`) asks whether the target is in the
-    resolved project's tree, which only a resolved project can fail. Ownership
-    (:func:`~gda.project.owning_project`) asks whether that project is really the
-    target's OWNER — a ``project.godot`` nearer to the target claims it — and that
-    is the half GDA-DF-035 exposed in both its readings: an ancestor that is a
-    project, with the target in a nested one; and a projectless run of a file that
-    does have an owner. Both compiled the target against a root that was not its
-    own and produced the same cascade of false ``res://`` errors. gda refuses and
-    names the owner instead of adopting it: deriving the root from the target is
-    what ADR-0006 rejected and the amendment keeps rejected, so ``--project``
-    naming the owner stays the way to say what you mean. A standalone script with
+    the second is why a *projectless* call is now checked too. Both are asked by
+    ONE call to :func:`~gda.project.containment_refusal` (#802), which owns their
+    ordering and builds whichever envelope fires; this recipe only chooses the
+    targets. Containment (:func:`~gda.project.path_outside_project`) asks whether
+    the target is in the resolved project's tree, which only a resolved project
+    can fail. Ownership (:func:`~gda.project.owning_project`) asks whether that
+    project is really the target's OWNER — a ``project.godot`` nearer to the
+    target claims it — and that is the half GDA-DF-035 exposed in both its
+    readings: an ancestor that is a project, with the target in a nested one; and
+    a projectless run of a file that does have an owner. Both compiled the target
+    against a root that was not its own and produced the same cascade of false
+    ``res://`` errors. gda refuses and names the owner instead of adopting it:
+    deriving the root from the target is what ADR-0006 rejected and the amendment
+    keeps rejected, so ``--project`` naming the owner stays the way to say what
+    you mean. A standalone script with
     no owner is still validated projectless by filesystem path, exactly as before.
 
     ``--all`` has nothing to check: the engine enumerates the resolved project's
@@ -2181,22 +2182,12 @@ def _script_validate_recipe(
     """
     root = None if project is None else project.expanduser().resolve()
     for path in params.paths:
-        # Ownership first: it is the more specific diagnosis, and it is the only
-        # one a projectless call can make. Containment then needs a root to be
-        # outside OF — `root` is set exactly when `project` is, and both are named
-        # so the narrowing stays local to the branch that uses them.
-        owner = owning_project(path, project)
-        if owner is not None:
-            return target_owned_by_another_project_failure(
-                target_location(path, project),
-                owner.resolve(),
-                root,
-                owner_relative_target(path, project, owner),
-            )
-        if project is not None and root is not None:
-            outside = path_outside_project(path, project)
-            if outside is not None:
-                return target_outside_project_failure(outside, root)
+        # ONE call for both halves and their ordering (#802): the gate on ADR-0006's
+        # path authority owns them, so this recipe states only WHICH targets it is
+        # asking about — the batch, in requested order, first offender wins.
+        refusal = containment_refusal(path, project)
+        if refusal is not None:
+            return refusal
     # The runner seam is read off the module at call time — never imported by
     # name — so a test monkeypatch on ``gda.dispatch.make_runner`` still binds.
     # Naming the HEADLESS factory directly is correct only while this command is

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -61,6 +61,7 @@ from gda.models import (
     TerminationPhase,
 )
 from gda.parser import parse_result
+from gda.project import ForeignOwnerViolation, containment_violation
 from gda.runner import DEFAULT_TIMEOUT_LABEL, LaunchFailure, RunResult
 from gda.script_errors import ScriptError, script_error_line
 
@@ -885,6 +886,38 @@ def target_owned_by_another_project_failure(
             owning_project=str(owner),
         ),
     )
+
+
+def containment_refusal(target: str, project: Path | None) -> Failure | None:
+    """The refusal when ``target`` does not belong to ``project`` — or ``None`` (#802).
+
+    THE gate the three path-taking commands call — ``script validate`` per batch
+    entry, ``script run`` for its entry script, ``resource import`` per asset. The
+    DECISION is not made here: :func:`gda.project.containment_violation` owns the
+    ordering (ownership first), the normalization, and the four coordinates; this
+    function maps each half of its answer to the envelope the taxonomy owns. The
+    split follows ADR-0040 §5 — the taxonomy reaches DOWN to the path authority,
+    never the reverse; the composition briefly lived whole on ``gda.project`` and
+    needed a deferred import of this module to hide the inverted edge (#807
+    review).
+
+    One builder of the same code stays outside the gate, deliberately:
+    :func:`script_escapes_project_failure`, ``script run``'s pre-resolution address
+    gate (ADR-0031). It decides on the spelling alone, before there is a project to
+    be outside OF, so it holds none of the four coordinates a refusal from here
+    reports; the argument for keeping it apart is at that builder.
+    """
+    violation = containment_violation(target, project)
+    if violation is None:
+        return None
+    if isinstance(violation, ForeignOwnerViolation):
+        return target_owned_by_another_project_failure(
+            violation.location,
+            violation.owner,
+            violation.root,
+            violation.owner_relative,
+        )
+    return target_outside_project_failure(violation.outside, violation.root)
 
 
 def script_escapes_project_failure(script: str) -> Failure:

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -797,11 +797,13 @@ def target_outside_project_failure(location: Path, project: Path) -> Failure:
     gda therefore refuses *before* the target is parsed and reports the mismatch
     itself, naming both sides so the reader can see which one is wrong.
 
-    The three commands that hold a resolved project when they ask the containment
-    question share this builder through the gate (:func:`containment_refusal`,
-    #802) — ``script validate``, ``script run``, and ``resource import`` — so one
+    Two commands can reach this builder through the gate
+    (:func:`containment_refusal`, #802) — ``script validate`` and ``resource
+    import``, the ones whose target may still be a filesystem spelling — so one
     condition reports one code, one message and one pair of typed coordinates
-    (#763). The message says what is true of BOTH: a
+    (#763). ``script run`` calls the same gate, but only its ownership half is
+    reachable there: an address its own gate accepted is canonical ``res://``,
+    which is never outside the root (#807 round 4). The message says what is true of BOTH: a
     target gda addresses through the project's ``res://`` namespace has no place
     in that namespace. Why that matters differs per command — a compile resolves
     the target's own dependencies, an import writes into the project's cache — and

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -797,10 +797,11 @@ def target_outside_project_failure(location: Path, project: Path) -> Failure:
     gda therefore refuses *before* the target is parsed and reports the mismatch
     itself, naming both sides so the reader can see which one is wrong.
 
-    The two commands that hold a resolved project when they ask the containment
-    question share this builder — ``script validate``'s recipe and ``resource
-    import``'s asset gate — so one condition reports one code, one message and one
-    pair of typed coordinates (#763). The message says what is true of BOTH: a
+    The three commands that hold a resolved project when they ask the containment
+    question share this builder through the gate (:func:`containment_refusal`,
+    #802) — ``script validate``, ``script run``, and ``resource import`` — so one
+    condition reports one code, one message and one pair of typed coordinates
+    (#763). The message says what is true of BOTH: a
     target gda addresses through the project's ``res://`` namespace has no place
     in that namespace. Why that matters differs per command — a compile resolves
     the target's own dependencies, an import writes into the project's cache — and

--- a/src/gda/project.py
+++ b/src/gda/project.py
@@ -509,9 +509,9 @@ def project_absolute(project: Path) -> Path:
     ``~user`` stays literal rather than raising out of a containment check.
 
     Written for ``resource import``'s asset gate and adopted by
-    :func:`containment_refusal` as the gate's own normalization (#802); the asset
-    gate still calls it directly because it also maps an accepted path back onto
-    ``res://`` afterwards, which needs the same absolute root.
+    :func:`containment_violation` as the decision's own normalization (#802); the
+    asset gate still calls it directly because it also maps an accepted path back
+    onto ``res://`` afterwards, which needs the same absolute root.
     """
     absolute = _expand_user(project)
     if not absolute.is_absolute():

--- a/src/gda/project.py
+++ b/src/gda/project.py
@@ -27,12 +27,26 @@ on, :func:`canonical_res_path` and :func:`res_escape_remainder`, live here too:
 they are pure lexical address rules, so they belong beside
 :data:`ENGINE_VIRTUAL_PREFIXES` and :func:`_lexical_abs` rather than in the
 stderr parser that first needed one (:mod:`gda.script_errors`, now a consumer).
+
+Since #802 the authority owns the **gate** as well as the primitives:
+:func:`containment_refusal` is the whole ordered composition — normalize the
+project, ask ownership, ask containment, build whichever refusal fired — so a
+command module states only WHICH target it is asking about. Before it, three call
+sites wrote that orchestration by hand and the ordering rule, the argument shapes
+and the ``.resolve()`` discipline were interface cost each of them paid.
 """
 
 import os
 import posixpath
 from collections.abc import Mapping
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    # `gda.errors` imports `gda.models`, which imports THIS module, so the two
+    # refusal builders `containment_refusal` needs can only be imported inside
+    # it (see the note there). The name is still needed at type-check time.
+    from gda.errors import Failure
 
 GDA_PROJECT_ENV = "GDA_PROJECT"
 
@@ -477,6 +491,107 @@ def owning_project(path: str, project: Path | None) -> Path | None:
             return None
         if (directory / PROJECT_MARKER).exists():
             return directory
+    return None
+
+
+def project_absolute(project: Path) -> Path:
+    """``project`` as an absolute directory, still spelled the caller's way (#738).
+
+    ONE coordinate system for both sides of every containment comparison. A
+    project may arrive relative — ``--project game`` is resolved to a directory,
+    not to an absolute one (:func:`resolve_project_dir`) — and a relative root met
+    an absolute candidate on :func:`path_outside_project`'s lexical fallback,
+    where ``relative_to`` raised a bare ``ValueError`` instead of answering.
+    Anchoring at the cwd is the right anchor because that is where a relative
+    ``--project`` was typed.
+
+    Symlinks are deliberately NOT followed: the two readings
+    :func:`path_outside_project` and :func:`owning_project` make are theirs to
+    make, and pre-resolving here would take the lexical one away from them. ``~``
+    is expanded the module's total way (:func:`_expand_user`), so an unresolvable
+    ``~user`` stays literal rather than raising out of a containment check.
+
+    Written for ``resource import``'s asset gate and adopted by
+    :func:`containment_refusal` as the gate's own normalization (#802); the asset
+    gate still calls it directly because it also maps an accepted path back onto
+    ``res://`` afterwards, which needs the same absolute root.
+    """
+    absolute = _expand_user(project)
+    if not absolute.is_absolute():
+        absolute = Path.cwd() / absolute
+    return absolute
+
+
+def containment_refusal(target: str, project: Path | None) -> "Failure | None":
+    """The refusal when ``target`` does not belong to ``project`` — or ``None`` (#802).
+
+    THE gate behind ``target_outside_project``, and the whole of it: the one
+    question "does this target belong to the resolved project?", asked in one
+    order, answered in one pair of envelopes. Three commands ask it — ``script
+    validate`` per batch entry, ``script run`` for its entry script, ``resource
+    import`` per asset — and until #802 each wrote the composition by hand, so the
+    ordering rule, the four coordinates and the ``.resolve()`` discipline were
+    interface cost every one of them paid. They had drifted once already (#763's
+    postmortem, then #799's), which is why the cross-gate consistency test exists;
+    it now guards this function's output rather than being the only thing holding
+    three copies together.
+
+    **Ordering: ownership first, containment second.** Ownership is the more
+    specific diagnosis — it names the project that CAN serve the call and the
+    spelling to address the target by, so following the sentence verbatim works —
+    while containment can only say "not here, and I found no owner to send you
+    to". The two never both fire on one target (:func:`owning_project` answers
+    ``None`` for anything not inside the resolved tree, which is exactly what
+    :func:`path_outside_project` refuses), so the order is about which diagnosis a
+    caller gets, not about precedence between rival verdicts. Ownership is also
+    the only half a PROJECTLESS call can make: with no root there is nothing to be
+    outside OF, so containment is skipped and a standalone file that no
+    ``project.godot`` claims is served, as ADR-0006's projectless fallback
+    promises.
+
+    **Normalization: the project is cwd-absolutized** (:func:`project_absolute`),
+    the form ``resource import`` adopted in #738 — the checks read the project as
+    SPELLED (the double reading is theirs to make) but they must read it in one
+    coordinate system, or a relative ``--project`` meets an absolute candidate on
+    the lexical fallback. The refusals report it RESOLVED, which is what
+    ``FailureEvidence.project_root`` publishes: "in its resolved form — the same
+    value a successful result reports".
+
+    ``target`` is the caller's own spelling in any form the command accepts —
+    ``res://`` address, project-relative path, or absolute path — because
+    :func:`_anchored_target` anchors each of them the way the engine would.
+    ``project`` is the already-resolved directory (resolution stays CLI-side,
+    ADR-0006); ``None`` means projectless.
+    """
+    # Imported here, not at module scope: `gda.errors` imports `gda.models`, which
+    # imports this module for `is_engine_virtual_path`, so a top-level import would
+    # cycle. The dependency is genuinely one-way in every other direction — the
+    # authority owns the RULE, the taxonomy owns the ENVELOPE — and this is the one
+    # place the two meet.
+    from gda.errors import (
+        target_outside_project_failure,
+        target_owned_by_another_project_failure,
+    )
+
+    if project is None:
+        anchor = root = None
+    else:
+        anchor = project_absolute(project)
+        root = anchor.resolve()
+    owner = owning_project(target, anchor)
+    if owner is not None:
+        return target_owned_by_another_project_failure(
+            target_location(target, anchor),
+            owner.resolve(),
+            root,
+            owner_relative_target(target, anchor, owner),
+        )
+    # `root` is set exactly when `anchor` is; both are named so the narrowing stays
+    # local to the branch that uses them.
+    if anchor is not None and root is not None:
+        outside = path_outside_project(target, anchor)
+        if outside is not None:
+            return target_outside_project_failure(outside, root)
     return None
 
 

--- a/src/gda/project.py
+++ b/src/gda/project.py
@@ -525,26 +525,41 @@ def project_absolute(project: Path) -> Path:
 def containment_refusal(target: str, project: Path | None) -> "Failure | None":
     """The refusal when ``target`` does not belong to ``project`` — or ``None`` (#802).
 
-    THE gate behind ``target_outside_project``, and the whole of it: the one
+    THE gate behind ``target_outside_project`` once a project is RESOLVED: the one
     question "does this target belong to the resolved project?", asked in one
     order, answered in one pair of envelopes. Three commands ask it — ``script
     validate`` per batch entry, ``script run`` for its entry script, ``resource
     import`` per asset — and until #802 each wrote the composition by hand, so the
     ordering rule, the four coordinates and the ``.resolve()`` discipline were
-    interface cost every one of them paid. They had drifted once already (#763's
+    interface cost every one of them paid. They had drifted twice already (#763's
     postmortem, then #799's), which is why the cross-gate consistency test exists;
     it now guards this function's output rather than being the only thing holding
     three copies together.
 
-    **Ordering: ownership first, containment second.** Ownership is the more
-    specific diagnosis — it names the project that CAN serve the call and the
-    spelling to address the target by, so following the sentence verbatim works —
-    while containment can only say "not here, and I found no owner to send you
-    to". The two never both fire on one target (:func:`owning_project` answers
-    ``None`` for anything not inside the resolved tree, which is exactly what
-    :func:`path_outside_project` refuses), so the order is about which diagnosis a
-    caller gets, not about precedence between rival verdicts. Ownership is also
-    the only half a PROJECTLESS call can make: with no root there is nothing to be
+    One builder of that same code stays OUTSIDE this gate, deliberately:
+    :func:`gda.errors.script_escapes_project_failure`, ``script run``'s
+    pre-resolution address gate (ADR-0031). It decides on the spelling alone,
+    before there is a project to be outside OF, so it holds none of the four
+    coordinates a refusal from here reports; it reaches the same rule through
+    :func:`res_escape_remainder`, and the argument for keeping it apart is at the
+    builder. Everything downstream of a resolved project is here.
+
+    **Ordering: ownership first, containment second.** A real precedence rule, not
+    only a choice of wording, because the two halves CAN both fire on one target:
+    their bounds differ. :func:`owning_project` stops its walk by :func:`_within`,
+    which consults the lexical spelling unconditionally, while
+    :func:`path_outside_project` WITHHOLDS the lexical reading when either side
+    carries a ``..``. A file symlinked into the project from a tree that is itself
+    a project, addressed with a ``..``, therefore satisfies the walk's bound and
+    the containment refusal at once — the monorepo shared-addon layout
+    :func:`path_outside_project` exists for, plus a ``..`` in the spelling.
+    Ownership wins because it is the more specific diagnosis — it names the
+    project that CAN serve the call and the spelling to address the target by, so
+    following the sentence verbatim works — while containment can only say "not
+    here, and I found no owner to send you to". Swapping the two loses the
+    actionable half on exactly that layout, so the order is pinned by a test of
+    its own (#807 review) and not by this paragraph alone. Ownership is also the
+    only half a PROJECTLESS call can make: with no root there is nothing to be
     outside OF, so containment is skipped and a standalone file that no
     ``project.godot`` claims is served, as ADR-0006's projectless fallback
     promises.
@@ -567,7 +582,10 @@ def containment_refusal(target: str, project: Path | None) -> "Failure | None":
     # imports this module for `is_engine_virtual_path`, so a top-level import would
     # cycle. The dependency is genuinely one-way in every other direction — the
     # authority owns the RULE, the taxonomy owns the ENVELOPE — and this is the one
-    # place the two meet.
+    # place the two meet. Hosting the composition in `gda.errors` instead would need
+    # no lazy import (it already reaches this module through `gda.models`), and that
+    # is the alternative #802 weighed and declined: the rule belongs with the
+    # authority that owns it, and the deferred import is the price of the placement.
     from gda.errors import (
         target_outside_project_failure,
         target_owned_by_another_project_failure,

--- a/src/gda/project.py
+++ b/src/gda/project.py
@@ -28,25 +28,22 @@ they are pure lexical address rules, so they belong beside
 :data:`ENGINE_VIRTUAL_PREFIXES` and :func:`_lexical_abs` rather than in the
 stderr parser that first needed one (:mod:`gda.script_errors`, now a consumer).
 
-Since #802 the authority owns the **gate** as well as the primitives:
-:func:`containment_refusal` is the whole ordered composition — normalize the
-project, ask ownership, ask containment, build whichever refusal fired — so a
-command module states only WHICH target it is asking about. Before it, three call
-sites wrote that orchestration by hand and the ordering rule, the argument shapes
-and the ``.resolve()`` discipline were interface cost each of them paid.
+Since #802 the authority owns the **decision** as well as the primitives:
+:func:`containment_violation` is the whole ordered composition — normalize the
+project, ask ownership, ask containment, report whichever half fired with its
+coordinates. The ENVELOPES stay with the taxonomy: `gda.errors.containment_refusal`
+maps the decision to the two refusals, so a command module states only WHICH
+target it is asking about while the dependency direction stays
+``errors -> foundation`` (ADR-0040 §5; #807 review — the composition briefly
+lived here whole and needed a deferred ``gda.errors`` import to hide the
+inverted edge).
 """
 
 import os
 import posixpath
 from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:  # pragma: no cover - typing only
-    # `gda.errors` imports `gda.models`, which imports THIS module, so the two
-    # refusal builders `containment_refusal` needs can only be imported inside
-    # it (see the note there). The name is still needed at type-check time.
-    from gda.errors import Failure
 
 GDA_PROJECT_ENV = "GDA_PROJECT"
 
@@ -522,27 +519,39 @@ def project_absolute(project: Path) -> Path:
     return absolute
 
 
-def containment_refusal(target: str, project: Path | None) -> "Failure | None":
-    """The refusal when ``target`` does not belong to ``project`` — or ``None`` (#802).
+@dataclass(frozen=True)
+class ForeignOwnerViolation:
+    """The ownership half of the containment decision: a nearer project owns it."""
 
-    THE gate behind ``target_outside_project`` once a project is RESOLVED: the one
-    question "does this target belong to the resolved project?", asked in one
-    order, answered in one pair of envelopes. Three commands ask it — ``script
-    validate`` per batch entry, ``script run`` for its entry script, ``resource
-    import`` per asset — and until #802 each wrote the composition by hand, so the
-    ordering rule, the four coordinates and the ``.resolve()`` discipline were
-    interface cost every one of them paid. They had drifted twice already (#763's
-    postmortem, then #799's), which is why the cross-gate consistency test exists;
-    it now guards this function's output rather than being the only thing holding
-    three copies together.
+    location: Path
+    owner: Path
+    root: Path | None
+    owner_relative: str
 
-    One builder of that same code stays OUTSIDE this gate, deliberately:
-    :func:`gda.errors.script_escapes_project_failure`, ``script run``'s
-    pre-resolution address gate (ADR-0031). It decides on the spelling alone,
-    before there is a project to be outside OF, so it holds none of the four
-    coordinates a refusal from here reports; it reaches the same rule through
-    :func:`res_escape_remainder`, and the argument for keeping it apart is at the
-    builder. Everything downstream of a resolved project is here.
+
+@dataclass(frozen=True)
+class OutsideRootViolation:
+    """The containment half of the decision: the target escapes the root."""
+
+    outside: Path
+    root: Path
+
+
+def containment_violation(
+    target: str, project: Path | None
+) -> ForeignOwnerViolation | OutsideRootViolation | None:
+    """The ordered containment decision for ``target`` under ``project`` (#802).
+
+    The one question "does this target belong to the resolved project?", asked in
+    one order, answered with the fired half and its coordinates — no envelope is
+    built here. `gda.errors.containment_refusal` maps the decision to the two
+    refusals and is what the three commands call (``script validate`` per batch
+    entry, ``script run`` for its entry script, ``resource import`` per asset);
+    until #802 each wrote this composition by hand, so the ordering rule, the four
+    coordinates and the ``.resolve()`` discipline were interface cost every one of
+    them paid. They had drifted twice already (#763's postmortem, then #799's),
+    which is why the cross-gate consistency test exists; it now guards the gate's
+    output rather than being the only thing holding three copies together.
 
     **Ordering: ownership first, containment second.** A real precedence rule, not
     only a choice of wording, because the two halves CAN both fire on one target:
@@ -578,19 +587,6 @@ def containment_refusal(target: str, project: Path | None) -> "Failure | None":
     ``project`` is the already-resolved directory (resolution stays CLI-side,
     ADR-0006); ``None`` means projectless.
     """
-    # Imported here, not at module scope: `gda.errors` imports `gda.models`, which
-    # imports this module for `is_engine_virtual_path`, so a top-level import would
-    # cycle. The dependency is genuinely one-way in every other direction — the
-    # authority owns the RULE, the taxonomy owns the ENVELOPE — and this is the one
-    # place the two meet. Hosting the composition in `gda.errors` instead would need
-    # no lazy import (it already reaches this module through `gda.models`), and that
-    # is the alternative #802 weighed and declined: the rule belongs with the
-    # authority that owns it, and the deferred import is the price of the placement.
-    from gda.errors import (
-        target_outside_project_failure,
-        target_owned_by_another_project_failure,
-    )
-
     if project is None:
         anchor = root = None
     else:
@@ -598,18 +594,18 @@ def containment_refusal(target: str, project: Path | None) -> "Failure | None":
         root = anchor.resolve()
     owner = owning_project(target, anchor)
     if owner is not None:
-        return target_owned_by_another_project_failure(
-            target_location(target, anchor),
-            owner.resolve(),
-            root,
-            owner_relative_target(target, anchor, owner),
+        return ForeignOwnerViolation(
+            location=target_location(target, anchor),
+            owner=owner.resolve(),
+            root=root,
+            owner_relative=owner_relative_target(target, anchor, owner),
         )
     # `root` is set exactly when `anchor` is; both are named so the narrowing stays
     # local to the branch that uses them.
     if anchor is not None and root is not None:
         outside = path_outside_project(target, anchor)
         if outside is not None:
-            return target_outside_project_failure(outside, root)
+            return OutsideRootViolation(outside=outside, root=root)
     return None
 
 

--- a/tests/test_res_containment_consistency.py
+++ b/tests/test_res_containment_consistency.py
@@ -23,8 +23,9 @@ What is deliberately NOT uniform is stated as such below: ``script run`` refuses
 few shapes the other two accept, and those refusals are its own — verdict-matching
 rules about how the engine echoes an address back on stderr, not containment.
 
-Since #802 the three gates are one function
-(:func:`gda.project.containment_refusal`), so this module is no longer the only
+Since #802 the three gates are one function — the decision on ``gda.project``
+(:func:`gda.project.containment_violation`), its envelopes mapped by
+:func:`gda.errors.containment_refusal` (ADR-0040 §5, #807 review) — so this module is no longer the only
 thing holding three copies together: it is the OUTER guard over the one gate's
 output, driven through each command's own entry point so a call site cannot quietly
 stop routing through it. The last section pins that structurally as well.
@@ -36,7 +37,7 @@ from pathlib import Path
 import pytest
 
 import gda.commands
-import gda.project as project_module
+import gda.errors as errors_module
 from gda.commands.resource import _asset_res_path
 from gda.commands.script import (
     ScriptValidateParams,
@@ -44,10 +45,9 @@ from gda.commands.script import (
     _script_validate_recipe,
     run_script_run_operation,
 )
-from gda.errors import Failure
+from gda.errors import Failure, containment_refusal
 from gda.project import (
     PROJECT_MARKER,
-    containment_refusal,
     owning_project,
     path_outside_project,
 )
@@ -466,6 +466,24 @@ def test_the_gate_reads_the_project_as_spelled_rather_than_pre_resolved(
         assert outcome.error.code == "target_outside_project", name
 
 
+def test_a_project_directory_literally_named_like_a_home_reference_is_served(tmp_path):
+    # #807 review: the gate normalizes with the module's total `_expand_user`, so a
+    # project directory literally named `~<no-such-user>` stays literal. At the
+    # merge base the same call leaked `RuntimeError: Could not determine home
+    # directory` (exit 1) out of the per-entry composition; the issue widened to
+    # accept the structured refusal as the pinned behavior.
+    project = tmp_path / "~gda_no_such_user_802"
+    project.mkdir()
+    (project / PROJECT_MARKER).write_text("", encoding="utf-8")
+    outside = tmp_path / "outside.gd"
+    outside.write_text("extends Node\n", encoding="utf-8")
+
+    refusal = containment_refusal(str(outside), project)
+
+    assert refusal is not None
+    assert refusal.error.code == "target_outside_project"
+
+
 @pytest.mark.parametrize("spelling", OWNED_SPELLINGS)
 def test_the_three_gates_now_emit_ONE_envelope(project, nested, spelling):
     # The sharpest form of the invariant, and the one only #802 makes checkable: the
@@ -535,9 +553,10 @@ def test_no_command_module_builds_a_containment_refusal_itself():
 
 def test_the_gate_is_where_both_refusals_are_built():
     # The other side of the same claim: the builders did not simply lose their
-    # callers. `gda.project.containment_refusal` is the one function that calls both,
-    # so the ordering rule its docstring records is the ordering every command gets.
-    source = ast.parse(Path(project_module.__file__).read_text(encoding="utf-8"))
+    # callers. `gda.errors.containment_refusal` is the one function that calls both
+    # (the DECISION it maps is `gda.project.containment_violation`'s, ADR-0040 §5),
+    # so the ordering the decision's docstring records is what every command gets.
+    source = ast.parse(Path(errors_module.__file__).read_text(encoding="utf-8"))
     gate = next(
         node
         for node in ast.walk(source)
@@ -547,3 +566,7 @@ def test_the_gate_is_where_both_refusals_are_built():
     assert _called_names(gate) & CONTAINMENT_REFUSAL_BUILDERS == (
         CONTAINMENT_REFUSAL_BUILDERS
     )
+    # And the gate builds NOTHING itself beyond mapping the decision: the only
+    # gda.project name it calls is the decision function, so ordering and
+    # coordinates cannot quietly grow a second home here.
+    assert "containment_violation" in _called_names(gate)

--- a/tests/test_res_containment_consistency.py
+++ b/tests/test_res_containment_consistency.py
@@ -605,7 +605,12 @@ def test_the_gate_is_where_both_refusals_are_built():
     assert _called_names(gate) & CONTAINMENT_REFUSAL_BUILDERS == (
         CONTAINMENT_REFUSAL_BUILDERS
     )
-    # And the gate builds NOTHING itself beyond mapping the decision: the only
-    # gda.project name it calls is the decision function, so ordering and
-    # coordinates cannot quietly grow a second home here.
-    assert "containment_violation" in _called_names(gate)
+    # And the mapper's COMPLETE call set is pinned (#807 round 5): the decision,
+    # the two builders, and the isinstance dispatch — nothing else. Any new call
+    # inside the gate (a third builder, a probe of its own, a second decision
+    # source) fails here by construction, so ordering and coordinates cannot
+    # quietly grow a second home.
+    assert _called_names(gate) == CONTAINMENT_REFUSAL_BUILDERS | {
+        "containment_violation",
+        "isinstance",
+    }

--- a/tests/test_res_containment_consistency.py
+++ b/tests/test_res_containment_consistency.py
@@ -45,7 +45,12 @@ from gda.commands.script import (
     run_script_run_operation,
 )
 from gda.errors import Failure
-from gda.project import PROJECT_MARKER, path_outside_project
+from gda.project import (
+    PROJECT_MARKER,
+    containment_refusal,
+    owning_project,
+    path_outside_project,
+)
 
 # (spelling, contained) — the ONE verdict every gate must reach.
 CONTAINMENT = [
@@ -311,6 +316,13 @@ SCRIPT_RUN_SPELLINGS = [spelling for spelling, _ in CONTAINMENT] + [
     "res://bar.gd ",
     "res://ba\nr.gd",
     "user://x.gd",
+    # ...and the OTHER form the address gate accepts, which the claim below covers
+    # and this table did not (#807 review): a project-relative path, which
+    # `_project_scoped_res_path` lifts to `res://` before canonicalizing it. Plain,
+    # traversing-but-contained, and escaping.
+    "inner/main.gd",
+    "addons/lib/../lib/tool.gd",
+    "../outside.gd",
 ]
 
 
@@ -351,7 +363,10 @@ def test_every_gate_answers_a_relative_project_spelling_identically(
     # It does NOT discriminate between those two normalizations, and cannot: they
     # agree, which is the finding that let the gate adopt one of them. What it holds
     # is the agreement itself — a future normalization that anchored anywhere but the
-    # cwd, or resolved the project before the probes rather than after, fails here.
+    # cwd fails here. The other way to break the normalization, RESOLVING the project
+    # before the probes rather than after, is invisible to these rows and is pinned
+    # by `test_the_gate_reads_the_project_as_spelled_rather_than_pre_resolved`
+    # instead (#807 review).
     absolute = _envelopes(project, spelling)
 
     monkeypatch.chdir(project.parent)
@@ -362,6 +377,93 @@ def test_every_gate_answers_a_relative_project_spelling_identically(
     (project.parent / "alias").mkdir()
     assert _envelopes(Path(f"./{project.name}"), spelling) == absolute
     assert _envelopes(Path("alias") / ".." / project.name, spelling) == absolute
+
+
+@pytest.fixture
+def monorepo(project: Path) -> Path:
+    """``project`` with two sibling directories symlinked in (#807 review).
+
+    The shared-addon layout :func:`gda.project.path_outside_project`'s ``..`` guard
+    exists for, and the only input that can tell the gate's two halves — and its
+    two candidate normalizations — apart. ``addons/lib`` links to a tree that IS a
+    project, so ownership fires on it; ``addons/plain`` links to one that is not,
+    so ownership is silent and containment decides alone. Returns the sibling tree.
+    """
+    libs = project.parent / "libs"
+    (libs / "lib").mkdir(parents=True)
+    (libs / "lib" / PROJECT_MARKER).write_text("config_version=5\n", encoding="utf-8")
+    (libs / "lib" / "tool.gd").write_text("extends Node\n", encoding="utf-8")
+    (libs / "plain").mkdir()
+    (libs / "plain" / "tool.gd").write_text("extends Node\n", encoding="utf-8")
+    (project / "addons").mkdir()
+    (project / "addons" / "lib").symlink_to(Path("../../libs/lib"))
+    (project / "addons" / "plain").symlink_to(Path("../../libs/plain"))
+    return libs
+
+
+def test_ownership_wins_when_both_halves_of_the_gate_fire(project, monorepo):
+    # The ordering pin (#807 review). The gate's own docstring used to argue that
+    # the two halves never both fire; they can, because their bounds differ —
+    # `owning_project` stops its walk by a lexical reading it always consults, while
+    # `path_outside_project` withholds the lexical reading when either side carries
+    # a `..`. This target satisfies both at once: it is lexically inside `project`,
+    # it resolves into a sibling tree that is its OWN project, and the `..` in its
+    # spelling is what keeps containment from reading it lexically.
+    #
+    # Ownership must win, because it is the half that names the project to re-issue
+    # against and the spelling to use. Swapping the two halves in the gate answers
+    # the bare outside-root refusal on the two gates that take a filesystem path,
+    # while `script run` — whose canonical `res://` address makes the containment
+    # half inert — keeps answering ownership. So the assertions below are both
+    # halves of the same pin: the right diagnosis, and all three still agreeing.
+    target = "addons/lib/../lib/tool.gd"
+    assert owning_project(target, project) is not None, "ownership half fires"
+    assert path_outside_project(target, project) is not None, "containment half too"
+
+    envelopes = _envelopes(project, target)
+    for name, envelope in envelopes.items():
+        assert envelope["code"] == "target_outside_project", name
+        assert envelope["evidence"]["owning_project"] == str(
+            (monorepo / "lib").resolve()
+        ), name
+    values = list(envelopes.values())
+    assert values[1:] == values[:-1]
+
+
+def test_the_gate_reads_the_project_as_spelled_rather_than_pre_resolved(
+    project, monorepo
+):
+    # The other half of the normalization claim, which the spelling-equality rows
+    # above cannot carry (#807 review). `project_absolute` absolutizes the project
+    # but does NOT resolve it, because the double reading belongs to the probes:
+    # `path_outside_project` withholds its lexical reading when either side carries
+    # a `..`, so whether the PROJECT was spelled with one changes the verdict on a
+    # symlinked-in target. Pre-resolving here would strip the `..` before the probe
+    # ever reads it, re-enable the lexical reading, and turn this refusal into an
+    # acceptance — with every other assertion in this module still green.
+    #
+    # `script run` is absent for the reason its own inertness test states: it reaches
+    # the gate with a canonical `res://` address, which `path_outside_project`
+    # answers on the escape rule alone and never reads through the filesystem.
+    target = "addons/plain/tool.gd"
+    (project.parent / "alias").mkdir()
+    spelled = project.parent / "alias" / ".." / project.name
+
+    # Spelled without a `..`, the lexical reading stands and the target is inside...
+    assert containment_refusal(target, project) is None
+    assert _import_verdict(project, target) == "res://addons/plain/tool.gd"
+    # ...spelled through one, it is not, and both filesystem-path gates say so.
+    for name, outcome in (
+        (
+            "script validate",
+            _script_validate_recipe(
+                ScriptValidateParams(paths=[target]), project=spelled, godot=None
+            ),
+        ),
+        ("resource import", _import_verdict(spelled, target)),
+    ):
+        assert isinstance(outcome, Failure), name
+        assert outcome.error.code == "target_outside_project", name
 
 
 @pytest.mark.parametrize("spelling", OWNED_SPELLINGS)
@@ -375,11 +477,19 @@ def test_the_three_gates_now_emit_ONE_envelope(project, nested, spelling):
     assert envelopes[1:] == envelopes[:-1]
 
 
-#: The two builders that construct a `target_outside_project` refusal. #802's first
-#: acceptance criterion is that no command module calls either: the gate owns the
-#: ordering AND the envelopes, so a command states only which target it is asking
-#: about. Named here rather than inferred, so adding a third builder is a change
-#: this test makes someone look at.
+#: The two builders that construct a `target_outside_project` refusal once a project
+#: is RESOLVED. #802's first acceptance criterion is that no command module calls
+#: either: the gate owns the ordering AND the envelopes, so a command states only
+#: which target it is asking about. Named here rather than inferred, so adding a
+#: builder is a change this test makes someone look at.
+#:
+#: `gda.errors.script_escapes_project_failure` is the recorded EXCLUSION, not an
+#: omission (#807 review): it builds the same code from `gda.commands.script`, and
+#: legitimately, because it is `script run`'s pre-resolution address gate (ADR-0031)
+#: — it decides on the spelling alone, before there is a project to be outside of,
+#: and so holds none of the coordinates the gate below reports. The set is therefore
+#: "the builders a command must route through the gate for", not "every builder of
+#: the code".
 CONTAINMENT_REFUSAL_BUILDERS = {
     "target_outside_project_failure",
     "target_owned_by_another_project_failure",
@@ -387,11 +497,21 @@ CONTAINMENT_REFUSAL_BUILDERS = {
 
 
 def _called_names(node: ast.AST) -> "set[str]":
-    return {
-        call.func.id
-        for call in ast.walk(node)
-        if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
-    }
+    """Every name called under ``node``, plain or module-qualified.
+
+    `ast.Attribute` is read as well as `ast.Name` because the guard below is a
+    STRUCTURAL claim: `gda.errors.target_outside_project_failure(...)` is the same
+    fourth copy as the bare name, and it passed the name-only form (#807 review).
+    """
+    names: set[str] = set()
+    for call in ast.walk(node):
+        if not isinstance(call, ast.Call):
+            continue
+        if isinstance(call.func, ast.Name):
+            names.add(call.func.id)
+        elif isinstance(call.func, ast.Attribute):
+            names.add(call.func.attr)
+    return names
 
 
 def test_no_command_module_builds_a_containment_refusal_itself():
@@ -400,11 +520,12 @@ def test_no_command_module_builds_a_containment_refusal_itself():
     # how the copies drifted in the first place (#763, then #799). Read out of the
     # source, over the whole `gda.commands` package rather than the three modules
     # that used to do it, because a NEW command asking the same question is exactly
-    # the case that must route through the gate.
+    # the case that must route through the gate — recursively, so a future
+    # `gda/commands/<group>/` subpackage is scanned too (#807 review).
     package = Path(gda.commands.__file__).parent
     offenders = {
         module.name
-        for module in sorted(package.glob("*.py"))
+        for module in sorted(package.rglob("*.py"))
         if _called_names(ast.parse(module.read_text(encoding="utf-8")))
         & CONTAINMENT_REFUSAL_BUILDERS
     }

--- a/tests/test_res_containment_consistency.py
+++ b/tests/test_res_containment_consistency.py
@@ -495,6 +495,33 @@ def test_a_project_directory_literally_named_like_a_home_reference_is_served(
     assert outcome.error.code == "target_outside_project"
 
 
+def test_inside_targets_under_a_literal_tilde_project_are_served(tmp_path, monkeypatch):
+    # The other half of the accepted widening (#807 round 4): the total expansion
+    # changes ACCEPTED paths too. At the merge base an inside target under a
+    # relative `~<no-such-user>` project crashed the same way the refusal did;
+    # now it is served normally. Pinned engine-free at three depths: the decision
+    # accepts, `resource import`'s gate maps the address, and `script validate`'s
+    # recipe gets PAST containment (a nonexistent binary is the failure it then
+    # reports — an environment verdict, not a containment one, not a crash).
+    project = tmp_path / "~gda_no_such_user_802"
+    project.mkdir()
+    (project / PROJECT_MARKER).write_text("", encoding="utf-8")
+    (project / "inner.gd").write_text("extends Node\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    spelled = Path("~gda_no_such_user_802")
+
+    assert containment_refusal("inner.gd", spelled) is None
+    assert _import_verdict(spelled, "inner.gd") == "res://inner.gd"
+
+    outcome = _script_validate_recipe(
+        ScriptValidateParams(paths=["inner.gd"]),
+        project=spelled,
+        godot="/nonexistent/gda-802-binary",
+    )
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "binary_not_found"
+
+
 @pytest.mark.parametrize("spelling", OWNED_SPELLINGS)
 def test_the_three_gates_now_emit_ONE_envelope(project, nested, spelling):
     # The sharpest form of the invariant, and the one only #802 makes checkable: the
@@ -508,9 +535,10 @@ def test_the_three_gates_now_emit_ONE_envelope(project, nested, spelling):
 
 #: The two builders that construct a `target_outside_project` refusal once a project
 #: is RESOLVED. #802's first acceptance criterion is that no command module calls
-#: either: the gate owns the ordering AND the envelopes, so a command states only
-#: which target it is asking about. Named here rather than inferred, so adding a
-#: builder is a change this test makes someone look at.
+#: either: the decision (`gda.project.containment_violation`) owns the ordering and
+#: the mapper (`gda.errors.containment_refusal`) owns the envelopes, so a command
+#: states only which target it is asking about. Named here rather than inferred, so
+#: adding a builder is a change this test makes someone look at.
 #:
 #: `gda.errors.script_escapes_project_failure` is the recorded EXCLUSION, not an
 #: omission (#807 review): it builds the same code from `gda.commands.script`, and

--- a/tests/test_res_containment_consistency.py
+++ b/tests/test_res_containment_consistency.py
@@ -22,12 +22,21 @@ The gates, at the level where each makes the decision (no engine needed):
 What is deliberately NOT uniform is stated as such below: ``script run`` refuses a
 few shapes the other two accept, and those refusals are its own — verdict-matching
 rules about how the engine echoes an address back on stderr, not containment.
+
+Since #802 the three gates are one function
+(:func:`gda.project.containment_refusal`), so this module is no longer the only
+thing holding three copies together: it is the OUTER guard over the one gate's
+output, driven through each command's own entry point so a call site cannot quietly
+stop routing through it. The last section pins that structurally as well.
 """
 
+import ast
 from pathlib import Path
 
 import pytest
 
+import gda.commands
+import gda.project as project_module
 from gda.commands.resource import _asset_res_path
 from gda.commands.script import (
     ScriptValidateParams,
@@ -271,3 +280,149 @@ def test_every_gate_states_the_same_reissue(project, nested, spelling):
             f"--project {nested.resolve()} and address the target as 'main.gd'"
             in outcome.error.message
         ), name
+
+
+# --- The one gate (#802) -----------------------------------------------------
+#
+# Three call sites used to WRITE the composition above — ask ownership, build the
+# four-coordinate refusal, ask containment, build the outside-root refusal — and
+# the assertions before this point checked the three answers coordinate by
+# coordinate. They now check the output of one function. What this section adds is
+# what folding the three into it had to be checked FOR: that the site whose copy
+# was ownership-only is unchanged by gaining the containment half, that the
+# normalization the gate adopted answers the same on a relative `--project`, and
+# that no command module can grow a fourth copy.
+
+
+def _envelopes(project: Path, spelling: str) -> "dict[str, dict]":
+    """The three gates' refusal envelopes for one target, keyed by command."""
+    envelopes = {}
+    for name, outcome in _ownership_refusals(project, spelling):
+        assert isinstance(outcome, Failure), name
+        envelopes[name] = outcome.error.model_dump()
+    return envelopes
+
+
+# Every spelling `script run`'s address gate is asked about anywhere in this
+# module: the shared containment table plus the shapes that stay its own.
+SCRIPT_RUN_SPELLINGS = [spelling for spelling, _ in CONTAINMENT] + [
+    "res://",
+    "res://.",
+    "res://bar.gd ",
+    "res://ba\nr.gd",
+    "user://x.gd",
+]
+
+
+@pytest.mark.parametrize("spelling", SCRIPT_RUN_SPELLINGS)
+def test_the_containment_half_script_run_folded_in_is_inert(project, spelling):
+    # #802's fold, VERIFIED rather than assumed. `script run`'s copy asked ownership
+    # only, because its address gate has already decided containment; folding it
+    # into the whole gate adds the containment half, and the claim is that the
+    # addition can never fire. That is exactly this assertion: whatever address
+    # survives `_project_scoped_res_path` — it returns only a canonical `res://`
+    # whose `res_escape_remainder` is None, refusing every other spelling first —
+    # is one `path_outside_project` reads through its lexical `res://` branch and
+    # answers None for. So the folded gate can only ever return what the
+    # ownership-only copy returned, which is what makes the fold behavior-identical
+    # and not merely equivalent on the cases someone thought to try.
+    #
+    # The answer is lexical, so it does not depend on the fixture holding the file;
+    # the project is here only because the gate takes one.
+    address = _project_scoped_res_path(spelling)
+    if isinstance(address, Failure):
+        # Refused at the address gate, before the shared gate is reached at all.
+        return
+    assert path_outside_project(address, project) is None, address
+
+
+@pytest.mark.parametrize("spelling", OWNED_SPELLINGS)
+def test_every_gate_answers_a_relative_project_spelling_identically(
+    project, nested, spelling, monkeypatch
+):
+    # The row the #802 normalization needs. The gate adopts `resource import`'s
+    # cwd-absolutized form (#738) for all three sites, where the two script sites
+    # used to hand `owning_project` / `path_outside_project` the project AS SPELLED.
+    # The two spellings were measured to agree on a relative `--project` — every
+    # probe the gate makes anchors a relative path at the cwd, `Path.resolve()` and
+    # `os.path.abspath` alike — and this is that measurement kept executable,
+    # against the ABSOLUTE spelling's own answer rather than a restated expectation.
+    #
+    # It does NOT discriminate between those two normalizations, and cannot: they
+    # agree, which is the finding that let the gate adopt one of them. What it holds
+    # is the agreement itself — a future normalization that anchored anywhere but the
+    # cwd, or resolved the project before the probes rather than after, fails here.
+    absolute = _envelopes(project, spelling)
+
+    monkeypatch.chdir(project.parent)
+    assert _envelopes(Path(project.name), spelling) == absolute
+    # ...and the two spellings a relative one can also carry, which the two
+    # normalizations reach by different routes (`Path("./game")` drops the `.`
+    # before the join; `alias/../game` keeps a `..` both readings then see).
+    (project.parent / "alias").mkdir()
+    assert _envelopes(Path(f"./{project.name}"), spelling) == absolute
+    assert _envelopes(Path("alias") / ".." / project.name, spelling) == absolute
+
+
+@pytest.mark.parametrize("spelling", OWNED_SPELLINGS)
+def test_the_three_gates_now_emit_ONE_envelope(project, nested, spelling):
+    # The sharpest form of the invariant, and the one only #802 makes checkable: the
+    # three commands do not merely agree on the code and the coordinates, they emit
+    # the same envelope — because one function builds it. `script run` reaches the
+    # gate with the canonical `res://` address rather than the caller's spelling, so
+    # this is also the statement that the anchoring makes the two forms one target.
+    envelopes = list(_envelopes(project, spelling).values())
+    assert envelopes[1:] == envelopes[:-1]
+
+
+#: The two builders that construct a `target_outside_project` refusal. #802's first
+#: acceptance criterion is that no command module calls either: the gate owns the
+#: ordering AND the envelopes, so a command states only which target it is asking
+#: about. Named here rather than inferred, so adding a third builder is a change
+#: this test makes someone look at.
+CONTAINMENT_REFUSAL_BUILDERS = {
+    "target_outside_project_failure",
+    "target_owned_by_another_project_failure",
+}
+
+
+def _called_names(node: ast.AST) -> "set[str]":
+    return {
+        call.func.id
+        for call in ast.walk(node)
+        if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+    }
+
+
+def test_no_command_module_builds_a_containment_refusal_itself():
+    # The structural half of "one gate". The behavioural tests above would still
+    # pass if a command grew a fourth copy that happened to agree today — which is
+    # how the copies drifted in the first place (#763, then #799). Read out of the
+    # source, over the whole `gda.commands` package rather than the three modules
+    # that used to do it, because a NEW command asking the same question is exactly
+    # the case that must route through the gate.
+    package = Path(gda.commands.__file__).parent
+    offenders = {
+        module.name
+        for module in sorted(package.glob("*.py"))
+        if _called_names(ast.parse(module.read_text(encoding="utf-8")))
+        & CONTAINMENT_REFUSAL_BUILDERS
+    }
+
+    assert offenders == set()
+
+
+def test_the_gate_is_where_both_refusals_are_built():
+    # The other side of the same claim: the builders did not simply lose their
+    # callers. `gda.project.containment_refusal` is the one function that calls both,
+    # so the ordering rule its docstring records is the ordering every command gets.
+    source = ast.parse(Path(project_module.__file__).read_text(encoding="utf-8"))
+    gate = next(
+        node
+        for node in ast.walk(source)
+        if isinstance(node, ast.FunctionDef) and node.name == "containment_refusal"
+    )
+
+    assert _called_names(gate) & CONTAINMENT_REFUSAL_BUILDERS == (
+        CONTAINMENT_REFUSAL_BUILDERS
+    )

--- a/tests/test_res_containment_consistency.py
+++ b/tests/test_res_containment_consistency.py
@@ -466,22 +466,33 @@ def test_the_gate_reads_the_project_as_spelled_rather_than_pre_resolved(
         assert outcome.error.code == "target_outside_project", name
 
 
-def test_a_project_directory_literally_named_like_a_home_reference_is_served(tmp_path):
-    # #807 review: the gate normalizes with the module's total `_expand_user`, so a
-    # project directory literally named `~<no-such-user>` stays literal. At the
-    # merge base the same call leaked `RuntimeError: Could not determine home
-    # directory` (exit 1) out of the per-entry composition; the issue widened to
-    # accept the structured refusal as the pinned behavior.
+def test_a_project_directory_literally_named_like_a_home_reference_is_served(
+    tmp_path, monkeypatch
+):
+    # #807 review, round 3: the discriminating spelling is the RELATIVE one —
+    # `Path.expanduser()` leaves a tilde alone inside an absolute path, so only a
+    # relative `~<no-such-user>` project reaches the expansion and raised
+    # `RuntimeError: Can't determine home directory` (exit 1) at the merge base.
+    # The gate normalizes with the module's total `_expand_user`, which keeps the
+    # unresolvable spelling literal; the issue widened to accept the structured
+    # refusal as the pinned behavior, asserted through a command entry point.
     project = tmp_path / "~gda_no_such_user_802"
     project.mkdir()
     (project / PROJECT_MARKER).write_text("", encoding="utf-8")
     outside = tmp_path / "outside.gd"
     outside.write_text("extends Node\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    spelled = Path("~gda_no_such_user_802")
 
-    refusal = containment_refusal(str(outside), project)
-
+    refusal = containment_refusal(str(outside), spelled)
     assert refusal is not None
     assert refusal.error.code == "target_outside_project"
+
+    outcome = _script_validate_recipe(
+        ScriptValidateParams(paths=[str(outside)]), project=spelled, godot=None
+    )
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "target_outside_project"
 
 
 @pytest.mark.parametrize("spelling", OWNED_SPELLINGS)


### PR DESCRIPTION
## What

`gda.project` owned the containment **primitives**; three command sites owned the **composition** over them. This lifts that composition into one gate, split per ADR-0040 §5 (round-2 review): the ordered DECISION on the authority, its envelopes mapped by the taxonomy:

```python
gda.project.containment_violation(target, project) -> ForeignOwnerViolation | OutsideRootViolation | None
gda.errors.containment_refusal(target: str, project: Path | None) -> Failure | None  # what commands call
```

plus `gda.project.project_absolute(project)` beside the decision — the shared cwd-absolutized normalization it adopts (`resource import`'s #738 form), still called directly by `resource import` because it also maps an accepted path back onto `res://` afterwards.

The gate's docstring records what was interface cost at every call site: the **ordering rule** (ownership first — the more specific diagnosis, and the only half a projectless call can make), the four-coordinate evidence shape, the `.resolve()` discipline, and the normalization it adopts.

## Why

The ordering rule, the argument shapes and the `.resolve()` discipline were paid three times, and the copies had already drifted twice — #763's own postmortem (`resource import` refused a net-inside `..`, and read `\\` as a filename character) and #799's (`resource import` reported the project as SPELLED where the two script gates reported it RESOLVED). `tests/test_res_containment_consistency.py` existed precisely to catch that; it now guards **one function's output** instead of being the only thing holding three copies together.

## The three sites

| Site | Before | After |
| --- | --- | --- |
| `_script_validate_recipe` (`src/gda/commands/script.py`) | full copy: ownership → `target_owned_by_another_project_failure`, containment → `target_outside_project_failure`, per batch entry | `containment_refusal(path, project)` per batch entry; first offender still refuses the whole batch |
| `run_script_run_operation` (`src/gda/commands/script.py`) | **ownership-only** copy (its address gate has already decided containment) | `containment_refusal(script, project)` — the whole gate |
| `_asset_res_path` (`src/gda/commands/resource.py`) | full copy, plus its own project normalization and resolved `root` | `containment_refusal(raw, project)`; keeps `project_absolute` only for the `res://` mapping below it |

Neither command module imports `target_outside_project_failure` or `target_owned_by_another_project_failure` any more.

### The `script run` fold, verified not assumed

The claim is that adding the containment half to the ownership-only site changes nothing. It is a theorem, not a sample: `_project_scoped_res_path` returns **only** a canonical `res://` address whose `res_escape_remainder` is `None` — every other spelling is refused there first — and that is exactly the input `path_outside_project` answers `None` for on its lexical `res://` branch. So the folded gate can only ever return what the ownership-only copy returned.

`test_the_containment_half_script_run_folded_in_is_inert` drives that spelling by spelling over the shared `CONTAINMENT` table **plus** the shapes that stay `script run`'s own (`res://`, `res://.`, the trailing-`strip_edges` suffix, the log-line boundary, `user://`), asserting `path_outside_project` is inert for every address that survives. Red-proofed: deleting the address gate's escape clause fails 5 of its rows.

## Byte-identity proof

46 cases driven through the real CLI (`python -m gda … --json`) against a **fixed** fixture tree, at the base commit `fe72700ec` and at this head, then `diff`ed:

```
$ diff base.txt head.txt && echo "FINAL: 46/46 envelopes byte-identical"
FINAL: 46/46 envelopes byte-identical
```

Cases: foreign-owned target (nested project) × 3 commands × {project-relative, `res://`, absolute} spellings; outside-root target × {`res://../`, `res://..\\`, `res://a/../../`, `res://..`, absolute fs path, relative fs path}; **relative `--project`** (`outer`, `./outer`, `alias/../outer`) × 3 commands; projectless call on an owned target; a batch whose second entry offends; and three accepted controls that must stay accepted (`script validate bar.gd`, `resource import res://pic.png`, `resource import res://foo/../pic.png`). 43 refusals + 3 successes, each captured with its exit code, its `--json` body and its stderr.

Sample row (relative `--project`, `script run`), identical on both sides:

```json
{
  "error": {
    "category": "operation",
    "code": "target_outside_project",
    "diagnostics": "",
    "evidence": {
      "owning_project": "/private/tmp/gda802-fixture/outer/inner",
      "project_root": "/private/tmp/gda802-fixture/outer",
      "target_location": "/private/tmp/gda802-fixture/outer/inner/main.gd"
    },
    "message": "/private/tmp/gda802-fixture/outer/inner/main.gd belongs to the Godot project /private/tmp/gda802-fixture/outer/inner, but this call resolved the resolved project /private/tmp/gda802-fixture/outer: its own res:// references would resolve against the wrong root, so nothing was run. Pass --project /private/tmp/gda802-fixture/outer/inner and address the target as 'main.gd' to work on it in the project that owns it."
  }
}
```

## Surface diff: **none**

```
$ gda schema --json | diff base-schema.json -   →  no output
$ gda [--help | <group> --help] ×9 | diff base-help.txt -  →  no output
sha256 base-schema.json = head-schema.json = 27663f01e3e559b21c9202b6db4708789d3b9743b001b5f90ac47bfb49e527f9
sha256 base-help.txt    = head-help.txt    = 7e6be531bedee7136b1245c8b75d236897133b84695175b6f9c33282727587a4
```

Expected, and confirmed: no params model, result model, descriptor, error code or option changed — this is internal orchestration. `docs/command-catalog.md` is untouched for the same reason.

## Tests

`tests/test_res_containment_consistency.py` keeps every existing assertion **unchanged** (it now guards the gate's output) and gains NINE test functions across the four rounds, each red-proofed against a deliberate mutation — among them the both-halves-fire ordering proof (`test_ownership_wins_when_both_halves_of_the_gate_fire`, the discriminating pin for the ordering rule), the two literal-tilde pins (refusal AND inside-target service, both red under a swap back to `Path.expanduser()`), the mapper-purity AST assertion, and:

| New pin | Red-proof |
| --- | --- |
| `test_the_containment_half_script_run_folded_in_is_inert` | delete `_project_scoped_res_path`'s escape clause → 5 rows fail |
| `test_every_gate_answers_a_relative_project_spelling_identically` | anchor `project_absolute` anywhere but the cwd → both rows fail |
| `test_the_three_gates_now_emit_ONE_envelope` | restore an ownership-only copy in `script run` with a drifted re-issue → both rows fail |
| `test_no_command_module_builds_a_containment_refusal_itself` (AST over the whole `gda.commands` package) | call a builder from `resource.py` again → fails |
| `test_the_gate_is_where_both_refusals_are_built` (AST over `gda.errors.containment_refusal`, which must also call the decision and build nothing else) | swap one builder for the other → fails |

**Honest note on the relative-`--project` row:** it does not discriminate between the as-spelled and cwd-absolutized normalizations, and cannot — they genuinely agree, which is the measurement that let the gate adopt one of them. What the row holds is the **agreement**: a normalization that anchors somewhere other than the cwd fails the row. A normalization that RESOLVES before the probes is caught by a different test — `test_the_gate_reads_the_project_as_spelled_rather_than_pre_resolved`, added in round 2 exactly because the row cannot see it (round-5 correction: an earlier version of this note attributed both mutations to the row).

## Verification

- `uv run pytest tests/ -q -m "not e2e"` → **2420 passed, 0 skipped** on the author machine (2390 at merge base); the reviewer's sandbox reports **2418 passed, 2 skipped** — the same set, two environment-gated tests skipping there
- `uv run pytest tests/test_e2e_res_containment.py -m e2e` → **19 passed**, real Godot 4.6.3
- `uv run pytest tests/test_e2e_script.py tests/test_e2e_script_run.py tests/test_e2e_resource.py -m e2e` → **148 passed**, real engine
- `uvx ruff check` / `uvx ruff format --check` → clean (197 files)
- `uv run pyright` (the repo's own src + tests scope, what CI runs) → 0 errors, 0 warnings

## One decision beyond the issue text

**(Superseded in round 2.)** The gate first lived whole on `gda.project` and imported the two builders inside the function to hide a `project → errors → models → project` cycle; the round-2 review found that inverts ADR-0040 §5 and the split above replaced it — no deferred import remains. The normalization knock-on became an ACCEPTED, pinned widening (round 3): a project directory literally named `~<no-such-user>`, spelled RELATIVE, raised `RuntimeError` (exit 1) at the merge base and now gets the structured `target_outside_project` refusal (exit 4); the regression discriminates (it fails under a swap back to `Path.expanduser()`), and issue #802's AC4 records the widening. Round 4 measured that the same normalization changes ACCEPTED paths too — an inside target under the relative tilde project crashed identically at the base and is now served by `script validate` and `resource import` — so the widening is authorized WHOLE on #802's AC4 and pinned on both halves. The change is behavior-preserving on every path except that complete, named, accepted literal-tilde case.

Closes #802

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjjKc1dRim7zkAYp3rUDnL



