### PR TITLE
fix(gda): script validate help names the code the refusal emits (#811)

### DIFF
--- a/src/gda/commands/script.py
+++ b/src/gda/commands/script.py
@@ -2519,8 +2519,8 @@ def validate_script(
     errors derived from them.
 
     A path OUTSIDE the resolved project refuses the whole batch with
-    'project_not_found' before anything is parsed, naming both the file and the
-    project, rather than reporting that false cascade. gda never derives the
+    'target_outside_project' before anything is parsed, naming both the file and
+    the project, rather than reporting that false cascade. gda never derives the
     project from a script's own path (ADR-0006), so pass --project for the project
     that owns the files. A missing file or a non-.gd path likewise refuses the
     batch (path_not_found / invalid_path) instead of becoming a verdict.


### PR DESCRIPTION
`gda script validate --help` promised `project_not_found` for a path outside the resolved project; the code has emitted `target_outside_project` for that condition since #697, and #802 made the refusal single-sourced. An agent branching on the code the help names writes a branch that never fires. One sentence fixed — the sweep at this head confirms it was the only stale copy (every other `project_not_found` mention is a correct use: project-resolution failures and `script run`'s own pre-run edges).

## Surface diff (enumerated)

- `gda script validate --help`: the one sentence.
- `gda schema`: 1,038,261 → 1,038,266 bytes — +5, exactly the length delta between the two code names; the same docstring feeds the command description.
- Nothing else: catalog, SKILL, README untouched (verified clean pre-fix).

## Validation

- Rendered help re-read at the head: the sentence now names `target_outside_project`.
- `pytest -m "not e2e"`: 2429 passed. ruff check/format, bare pyright: clean.
- Behavior unchanged — text only.

Closes #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjjKc1dRim7zkAYp3rUDnL
