### PR TITLE
docs(gda): align repository positioning with product site

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -394,19 +394,19 @@ _Avoid_: command spec, command config, command registry entry
 ### Public-facing copy
 
 **Positioning descriptor**:
-The single authoritative one-line phrase naming what `gda` *is* — currently "Godot AI
-agent CLI, Skill, and MCP server" — front-loading the primary search terms (Godot · AI
-agent · CLI/Skill/MCP). One positioning source, mirrored across three surfaces that change
-together and must not drift: the README **H1** (Title Case), the `pyproject` `description`,
-and the GitHub repository `description` (the metadata pair in sentence case, optionally
-extended with "… with structured JSON/schema output, headless automation, and live runtime
-control"). Its head noun stays "CLI, Skill, and MCP server", so it names a *tool* — not a
-claim that `gda` is itself an agent.
+The single authoritative core phrase naming what `gda` *is* — "Godot automation for AI
+agents" — front-loading the product category, engine, and audience. The README **H1** uses
+that phrase in Title Case. The `pyproject` and GitHub repository descriptions lead with the
+same phrase and extend it with the three access paths and the main verification capabilities:
+"Godot automation for AI agents through a CLI, Agent Skill, and MCP server, with structured
+results, headless validation, and live runtime control." These three surfaces change together
+and must not drift. The phrase names an automation toolchain, not an agent.
 _Avoid_: tagline, slogan, hero, the value sentence
 
 **Hero**:
-The README's opening *value* statement — what `gda` does for you ("`gda` gives your AI
-coding agent … structured, machine-readable control of the Godot Engine", headless then
-live). README-only and free to evolve there; it does **not** mirror the `Positioning
-descriptor` and is never replicated into `pyproject` or the repo metadata.
+The README's opening *value* statement — what `gda` does for you ("Build and verify Godot
+projects from AI coding agents, shell scripts, and CI"), followed by its shared operation
+surface and structured-result proof. README-only and free to evolve there; it does **not**
+mirror the extended metadata description and is never replicated into `pyproject` or the
+repo metadata.
 _Avoid_: tagline, subtitle, positioning descriptor

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -403,9 +403,29 @@ results, headless validation, and live runtime control." These three surfaces ch
 and must not drift. The phrase names an automation toolchain, not an agent.
 _Avoid_: tagline, slogan, hero, the value sentence
 
+**Brand slogan**:
+The website-only brand promise — "The game dev arsenal built for AI agents." It leads
+campaign and website hero copy, where the surrounding text supplies the literal product
+category. It complements the `Positioning descriptor`; it never replaces the README H1,
+package description, or GitHub repository description.
+_Avoid_: positioning descriptor, product category, README title
+
+**Verification message**:
+The public evidence hierarchy for the verified agent workflow: Headless validation confirms
+project readiness; Live operations return runtime evidence about actual behavior. Use both
+parts when explaining how `gda` closes the loop beyond a file edit.
+_Avoid_: treating a file edit as a verified game change, treating Headless and Live as rivals
+
+**Access-path message**:
+The public relationship among the three agent-facing channels — one `gda` operation surface,
+three complementary access paths. The CLI executes operations directly, the Agent Skill gives
+reusable guidance for choosing and running CLI commands, and `gda-mcp` maps the same public
+Schema to MCP tools. The access path changes; the operations and structured results do not.
+_Avoid_: three products, feature tiers, independent operation surfaces
+
 **Hero**:
 The README's opening *value* statement — what `gda` does for you ("Build and verify Godot
-projects from AI coding agents, shell scripts, and CI"), followed by its shared operation
+projects with AI coding agents, shell scripts, and CI"), followed by its shared operation
 surface and structured-result proof. README-only and free to evolve there; it does **not**
 mirror the extended metadata description and is never replicated into `pyproject` or the
 repo metadata.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [CLI, Agent Skill, or MCP?](https://aigengame.xyz/godot-mcp/) ·
 [PyPI](https://pypi.org/project/gda/)
 
-> **Build and verify Godot projects from AI coding agents, shell scripts, and CI.**
+> **Build and verify Godot projects with AI coding agents, shell scripts, and CI.**
 > `gda` exposes one Godot-native operation surface through a CLI, a bundled
 > Agent Skill, and an MCP server, returning structured results agents can act on.
 
@@ -60,7 +60,7 @@ complementary modes:
 - **Three complementary access paths.** Run the CLI directly from an agent, shell, or
   CI; install the bundled Agent Skill for reusable guidance; or expose the same
   operations as MCP tools. See [CLI, Agent Skill, or MCP?](https://aigengame.xyz/godot-mcp/)
-  for setup details and tradeoffs.
+  for comparison and tradeoffs.
 - **Bounded automation with actionable failures.** Timeouts, bounded output, typed
   failures, diagnostics, and mutation reports help agents decide what happened and how
   to recover.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
-# godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
+# gda — Godot Automation for AI Agents
 
-![godot-agent title image](https://raw.githubusercontent.com/aigengame/godot-agent/main/assets/godot-agent-title.png)
+[![gda — Godot automation for AI agents](https://raw.githubusercontent.com/aigengame/godot-agent/main/assets/godot-agent-title.png)](https://aigengame.xyz/)
 
 **Read this in:** [简体中文](docs/README.zh-CN.md) · [Español](docs/README.es.md) · [日本語](docs/README.ja.md)
 
-> **`gda` gives your AI coding agent — or your shell scripts and CI — structured, machine-readable
-> control of the [Godot Engine](https://godotengine.org).** Create scenes, edit nodes & scripts,
-> and export builds headlessly, then drive a *running* game live: runtime tree, input,
-> screenshots, performance — one command surface, three ways in.
+[Product overview](https://aigengame.xyz/) ·
+[CLI, Agent Skill, or MCP?](https://aigengame.xyz/godot-mcp/) ·
+[PyPI](https://pypi.org/project/gda/)
+
+> **Build and verify Godot projects from AI coding agents, shell scripts, and CI.**
+> `gda` exposes one Godot-native operation surface through a CLI, a bundled
+> Agent Skill, and an MCP server, returning structured results agents can act on.
 
 [![pre-1.0](https://img.shields.io/badge/status-pre--1.0-orange)](https://pypi.org/project/gda/)
 [![CI](https://github.com/aigengame/godot-agent/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/aigengame/godot-agent/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush)
@@ -17,18 +20,15 @@
 [![MCP](https://img.shields.io/badge/MCP-server-000)](https://modelcontextprotocol.io)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-AI agents are great at writing GDScript and terrible at *seeing what happened*. `gda`
-closes that loop: your agent issues one operation and gets back a single clean JSON
-result it can act on — never engine logs it has to scrape. It runs in **two modes**:
+A file edit is not a verified game change. `gda` closes that loop in two
+complementary modes:
 
-- **Headless** — one-shot and stateless, zero setup. No editor plugin, no daemon,
-  nothing to install in your project. Create and edit scenes, nodes, scripts, resources,
-  shaders and themes; analyze the project; export builds.
-- **Live** — drive a *running* game through a background daemon for everything only a
-  live engine can do: read the runtime scene tree, get/set runtime properties, simulate
-  input, capture screenshots, and sample performance.
+- **Headless** — create and edit project content, compile scripts, validate and boot
+  scenes, inspect projects, and export builds without an editor plugin or daemon.
+- **Live** — inspect and drive the running game through a per-project daemon: runtime
+  tree and state, input simulation, frame capture, logs, errors, and performance.
 
-> `gda` is **pre-1.0**: every command works end-to-end today, but the CLI surface may
+> `gda` is **pre-1.0**: every command works end to end today, but the command surface may
 > still change before 1.0.
 
 ---
@@ -50,39 +50,35 @@ result it can act on — never engine logs it has to scrape. It runs in **two mo
 
 ## Why `gda`?
 
-- **🤖 Structured output, built for agents.** Every command emits **exactly one** JSON
-  object on stdout (`--json`); engine banners, warnings and `print()` go to stderr. Your
-  agent parses one result, not a wall of logs.
-- **📐 Typed & self-describing.** Every command's input and output are typed models that
-  also back a machine-readable `--schema` (a JSON-Schema contract), so an agent can
-  discover and validate the whole surface programmatically instead of guessing.
-- **🔀 CLI, Skill, and MCP — your agent's choice.** Drive Godot from a terminal or CI with the
-  raw `gda` CLI, hand your agent a bundled **Skill** (`gda skill`) that teaches it how and when
-  to use the CLI, or expose the same operations as **MCP** tools (`gda-mcp`, generated from the
-  CLI's own schemas). One command surface, three ways in — pick whatever your agent supports.
-- **🧩 Godot-native commands.** Grouped by Godot object (`gda scene create`,
-  `gda node add`, `gda game set`) with a tiny, consistent verb vocabulary — zero learning
-  curve if you already know Godot.
-- **⚡ Headless by default, live when you need it.** Headless operations need no daemon
-  and no editor — just a Godot binary. Live operations add real-time control of a running
-  game over a Unix-domain-socket daemon, addressed by the same CLI grammar.
-- **🛡️ Fails loudly, never silently.** A missing engine fails at once and a hung one at a
-  timeout; both map to a **stable non-zero exit code** plus an Error envelope carrying the
-  failure's category, code, and any typed evidence it computed — so a shell or agent branches
-  on the failure instead of parsing prose. A command `gda` does not recognize is refused the
-  same way, with a `hint` naming the invocation to use instead.
+- **Verification beyond file edits.** Headless validation confirms project readiness;
+  Live operations return runtime evidence about actual behavior.
+- **Structured results and discoverable schemas.** With `--json`, each command emits
+  exactly one result object on stdout. Typed input and output models also power
+  `--schema` and the generated MCP tool surface.
+- **Godot-native operations.** Commands follow Godot objects and vocabulary, such as
+  `gda scene create`, `gda node add`, and `gda game get`.
+- **Three complementary access paths.** Run the CLI directly from an agent, shell, or
+  CI; install the bundled Agent Skill for reusable guidance; or expose the same
+  operations as MCP tools. See [CLI, Agent Skill, or MCP?](https://aigengame.xyz/godot-mcp/)
+  for setup details and tradeoffs.
+- **Bounded automation with actionable failures.** Timeouts, bounded output, typed
+  failures, diagnostics, and mutation reports help agents decide what happened and how
+  to recover.
+
+These capabilities were refined through a
+[public real-game production dogfooding record](https://github.com/aigengame/godot-agent/milestone/10).
 
 ---
 
 ## Capabilities at a glance
 
-| What you need | Reach for |
-| --- | --- |
-| Build project files from an agent or script | `scene` / `node` / `script` / `resource` / `shader` / `theme` — create & edit headlessly |
-| Parse results instead of scraping engine logs | `--json` (one clean object) and `--schema` (a JSON-Schema contract) |
-| Hand an agent Godot tools | the bundled **Skill** (`gda skill`) or the **`gda-mcp`** server |
-| Automate CI, exports, and project analysis | headless commands — no editor, no plugin, just a Godot binary |
-| Debug a *running* game's runtime behavior | `gda daemon start`, then `game` / `diag` / `logger` / `perf` / `input` / `screen` |
+| Goal | What `gda` provides | Start with |
+| --- | --- | --- |
+| Build Godot project content (Headless) | Create and edit scenes, nodes, scripts, resources, project settings, shaders, and themes | `scene` / `node` / `script` / `resource` / `project` / `shader` / `theme` |
+| Verify project readiness (Headless) | Compile scripts, validate dependencies, boot scenes in a bounded preflight, inspect projects, and export builds | `script validate` / `scene validate` / `scene preflight` / `project` / `export` |
+| Verify runtime behavior (Live) | Read runtime state, call declared methods, simulate input, capture frames, collect logs and errors, and sample performance | `gda daemon start`, then `game` / `input` / `screen` / `diag` / `logger` / `perf` |
+| Connect an AI coding agent | Use direct CLI execution, reusable Agent Skill guidance, or MCP tool discovery and calling | `gda` / `gda skill` / `gda-mcp` |
+| Run reliably in automation | Receive structured results, typed schemas and failures, bounded execution, isolated logs, and actionable diagnostics | `--json` / `--schema` / `--user-data-root` / timeouts |
 
 ---
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=da92f08b3efc565aabfaa217fc98b488f1088dd58758ba94f432b46a84048d14 -->
+<!-- gda-readme-i18n: source=README.md sha256=2e633d09b48794d0d129d4ec85bd48d23cec200fab96ad0803f0c5727e8ec6a5 -->
 
 # gda — Automatización de Godot para agentes de IA
 
@@ -63,7 +63,8 @@ ese ciclo con dos modos complementarios:
 - **Tres vías de acceso complementarias.** Ejecuta la CLI directamente desde un agente,
   shell o CI; instala la Agent Skill incluida para obtener orientación reutilizable; o
   expón las mismas operaciones como herramientas MCP. Consulta
-  [¿CLI, Agent Skill o MCP?](https://aigengame.xyz/godot-mcp/) para ver la configuración y las diferencias.
+  [¿CLI, Agent Skill o MCP?](https://aigengame.xyz/godot-mcp/) para comparar las
+  opciones y sus diferencias.
 - **Automatización acotada y fallos útiles.** Los timeouts, los límites de salida, los
   fallos tipados, los diagnósticos y los informes de cambios ayudan al agente a saber qué
   ocurrió y cómo recuperarse.

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=f16edb8309c514c091979325f1561031d92fe21fbe3c82c7cb9e7c7fa37ebe7c -->
+<!-- gda-readme-i18n: source=README.md sha256=da92f08b3efc565aabfaa217fc98b488f1088dd58758ba94f432b46a84048d14 -->
 
 # gda — Automatización de Godot para agentes de IA
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,15 +1,18 @@
-<!-- gda-readme-i18n: source=README.md sha256=465ec4f02a22747e675bfbee6bdba48edd474a3da79ec654943c9741a747c302 -->
+<!-- gda-readme-i18n: source=README.md sha256=f16edb8309c514c091979325f1561031d92fe21fbe3c82c7cb9e7c7fa37ebe7c -->
 
-# godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
+# gda — Automatización de Godot para agentes de IA
 
-![godot-agent title image](https://raw.githubusercontent.com/aigengame/godot-agent/main/assets/godot-agent-title.png)
+[![gda — Automatización de Godot para agentes de IA](https://raw.githubusercontent.com/aigengame/godot-agent/main/assets/godot-agent-title.png)](https://aigengame.xyz/)
 
 **Otros idiomas:** [English](../README.md) · [简体中文](README.zh-CN.md) · **Español** · [日本語](README.ja.md)
 
-> **`gda` da a tu agente de programación con IA — o a tus scripts de shell y a tu CI — control
-> estructurado y legible por máquina del [Godot Engine](https://godotengine.org).** Crea escenas, edita nodos y scripts,
-> y exporta builds en modo headless; luego controla un juego *en ejecución* en vivo: árbol de runtime, entrada,
-> capturas de pantalla, rendimiento — una sola superficie de comandos, tres formas de entrar.
+[Descripción del producto](https://aigengame.xyz/) ·
+[¿CLI, Agent Skill o MCP?](https://aigengame.xyz/godot-mcp/) ·
+[PyPI](https://pypi.org/project/gda/)
+
+> **Crea y verifica proyectos de Godot desde agentes de programación con IA, scripts de shell y CI.**
+> `gda` ofrece el mismo conjunto de operaciones nativas de Godot mediante una CLI, una
+> Agent Skill incluida y un servidor MCP, con resultados estructurados que los agentes pueden usar.
 
 [![pre-1.0](https://img.shields.io/badge/status-pre--1.0-orange)](https://pypi.org/project/gda/)
 [![CI](https://github.com/aigengame/godot-agent/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/aigengame/godot-agent/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush)
@@ -19,18 +22,15 @@
 [![MCP](https://img.shields.io/badge/MCP-server-000)](https://modelcontextprotocol.io)
 [![License](https://img.shields.io/badge/license-MIT-green)](../LICENSE)
 
-Los agentes de IA son excelentes escribiendo GDScript y pésimos *viendo qué pasó*. `gda`
-cierra ese ciclo: tu agente emite una operación y recibe a cambio un único resultado JSON
-limpio sobre el que actuar — nunca registros del motor que tenga que rascar. Funciona en **dos modos**:
+Editar un archivo no significa que el cambio en el juego esté verificado. `gda` cierra
+ese ciclo con dos modos complementarios:
 
-- **Headless** — de una sola pasada y sin estado, sin configuración. Sin plugin de editor, sin daemon,
-  nada que instalar en tu proyecto. Crea y edita escenas, nodos, scripts, recursos,
-  shaders y temas; analiza el proyecto; exporta builds.
-- **Live** — controla un juego *en ejecución* a través de un daemon en segundo plano para todo lo que solo
-  un motor en vivo puede hacer: leer el árbol de escena de runtime, leer/escribir propiedades de runtime, simular
-  entrada, capturar pantallas y muestrear el rendimiento.
+- **Headless** — crea y edita contenido del proyecto, compila scripts, valida e inicia
+  escenas, inspecciona proyectos y exporta builds sin plugin de editor ni daemon.
+- **Live** — inspecciona y controla el juego en ejecución mediante un daemon por proyecto:
+  árbol y estado de runtime, simulación de entrada, captura de frames, registros, errores y rendimiento.
 
-> `gda` está en **pre-1.0**: hoy cada comando funciona de extremo a extremo, pero la superficie de la CLI
+> `gda` está en **pre-1.0**: hoy cada comando funciona de extremo a extremo, pero la superficie de comandos
 > todavía puede cambiar antes de 1.0.
 
 ---
@@ -53,40 +53,36 @@ limpio sobre el que actuar — nunca registros del motor que tenga que rascar. F
 <a id="why-gda"></a>
 ## ¿Por qué `gda`?
 
-- **🤖 Salida estructurada, pensada para agentes.** Cada comando emite **exactamente un** objeto JSON
-  en stdout (`--json`); los banners del motor, las advertencias y `print()` van a stderr. Tu
-  agente analiza un único resultado, no un muro de registros.
-- **📐 Tipado y autodescriptivo.** La entrada y la salida de cada comando son modelos tipados que
-  además respaldan un `--schema` legible por máquina (un contrato JSON-Schema), de modo que un agente puede
-  descubrir y validar toda la superficie de forma programática en lugar de adivinar.
-- **🔀 CLI, Skill y MCP — la elección de tu agente.** Controla Godot desde una terminal o tu CI con la
-  CLI `gda` directa, entrega a tu agente una **Skill** incluida (`gda skill`) que le enseña cómo y cuándo
-  usar la CLI, o expón las mismas operaciones como herramientas **MCP** (`gda-mcp`, generadas a partir de
-  los propios esquemas de la CLI). Una sola superficie de comandos, tres formas de entrar — elige la que tu agente admita.
-- **🧩 Comandos nativos de Godot.** Agrupados por objeto de Godot (`gda scene create`,
-  `gda node add`, `gda game set`) con un vocabulario de verbos minúsculo y consistente — curva de aprendizaje
-  nula si ya conoces Godot.
-- **⚡ Headless por defecto, en vivo cuando lo necesites.** Las operaciones headless no requieren daemon
-  ni editor — solo un binario de Godot. Las operaciones live añaden control en tiempo real de un juego
-  en ejecución a través de un daemon sobre socket de dominio Unix, direccionadas con la misma gramática de la CLI.
-- **🛡️ Errores claros, nunca silenciosos.** Si falta el motor, `gda` falla de inmediato; si el motor se bloquea,
-  falla al agotarse el timeout. En ambos casos devuelve un **código de salida no nulo estable** y un objeto de
-  error con la categoría del fallo, su código y la evidencia tipada que se haya calculado — de modo que
-  un shell o un agente puede actuar según el tipo de fallo en vez de analizar prosa. Un comando que `gda` no reconoce
-  se rechaza del mismo modo, con un `hint` que nombra la invocación que debe usarse en su lugar.
+- **Verificación más allá de la edición de archivos.** La validación Headless confirma
+  que el proyecto está listo; las operaciones Live aportan evidencia del comportamiento real.
+- **Resultados estructurados y esquemas consultables.** Con `--json`, cada comando emite
+  exactamente un objeto de resultado en stdout. Los modelos tipados de entrada y salida
+  también sustentan `--schema` y la superficie de herramientas MCP generada.
+- **Operaciones nativas de Godot.** Los comandos siguen los objetos y el vocabulario de
+  Godot, como `gda scene create`, `gda node add` y `gda game get`.
+- **Tres vías de acceso complementarias.** Ejecuta la CLI directamente desde un agente,
+  shell o CI; instala la Agent Skill incluida para obtener orientación reutilizable; o
+  expón las mismas operaciones como herramientas MCP. Consulta
+  [¿CLI, Agent Skill o MCP?](https://aigengame.xyz/godot-mcp/) para ver la configuración y las diferencias.
+- **Automatización acotada y fallos útiles.** Los timeouts, los límites de salida, los
+  fallos tipados, los diagnósticos y los informes de cambios ayudan al agente a saber qué
+  ocurrió y cómo recuperarse.
+
+Estas capacidades se perfeccionaron mediante un
+[registro público de uso en la producción de un juego real](https://github.com/aigengame/godot-agent/milestone/10).
 
 ---
 
 <a id="capabilities-at-a-glance"></a>
 ## Capacidades de un vistazo
 
-| Lo que necesitas | Usa |
-| --- | --- |
-| Construir archivos del proyecto desde un agente o script | `scene` / `node` / `script` / `resource` / `shader` / `theme` — crear y editar en modo headless |
-| Analizar resultados en lugar de rascar registros del motor | `--json` (un objeto limpio) y `--schema` (un contrato JSON-Schema) |
-| Entregar a un agente herramientas de Godot | la **Skill** incluida (`gda skill`) o el servidor **`gda-mcp`** |
-| Automatizar CI, exportaciones y análisis del proyecto | comandos headless — sin editor, sin plugin, solo un binario de Godot |
-| Depurar el comportamiento en runtime de un juego *en ejecución* | `gda daemon start`, luego `game` / `diag` / `logger` / `perf` / `input` / `screen` |
+| Objetivo | Lo que ofrece `gda` | Empieza por |
+| --- | --- | --- |
+| Crear contenido de proyectos Godot (Headless) | Crear y editar escenas, nodos, scripts, recursos, ajustes del proyecto, shaders y temas | `scene` / `node` / `script` / `resource` / `project` / `shader` / `theme` |
+| Verificar que el proyecto está listo (Headless) | Compilar scripts, validar dependencias, iniciar escenas con un preflight acotado, inspeccionar proyectos y exportar builds | `script validate` / `scene validate` / `scene preflight` / `project` / `export` |
+| Verificar el comportamiento en runtime (Live) | Leer el estado de runtime, llamar a métodos declarados, simular entradas, capturar frames, recopilar registros y errores, y medir el rendimiento | `gda daemon start`, luego `game` / `input` / `screen` / `diag` / `logger` / `perf` |
+| Conectar un agente de programación con IA | Usar la CLI directamente, la orientación reutilizable de Agent Skill o el descubrimiento y las llamadas de herramientas MCP | `gda` / `gda skill` / `gda-mcp` |
+| Ejecutar automatización de forma fiable | Recibir resultados estructurados, esquemas y fallos tipados, ejecución acotada, registros aislados y diagnósticos útiles | `--json` / `--schema` / `--user-data-root` / timeouts |
 
 ---
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,12 +1,18 @@
-<!-- gda-readme-i18n: source=README.md sha256=465ec4f02a22747e675bfbee6bdba48edd474a3da79ec654943c9741a747c302 -->
+<!-- gda-readme-i18n: source=README.md sha256=f16edb8309c514c091979325f1561031d92fe21fbe3c82c7cb9e7c7fa37ebe7c -->
 
-# godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
+# gda — AI エージェント向け Godot オートメーション
 
-![godot-agent title image](https://raw.githubusercontent.com/aigengame/godot-agent/main/assets/godot-agent-title.png)
+[![gda — AI エージェント向け Godot オートメーション](https://raw.githubusercontent.com/aigengame/godot-agent/main/assets/godot-agent-title.png)](https://aigengame.xyz/)
 
 **他の言語:** [English](../README.md) · [简体中文](README.zh-CN.md) · [Español](README.es.md) · **日本語**
 
-> **`gda` は、あなたの AI コーディングエージェント — あるいはシェルスクリプトや CI — に、[Godot Engine](https://godotengine.org) を構造化された機械可読な形で制御する手段を与えます。** シーンの作成、ノードやスクリプトの編集、ビルドのエクスポートを Headless で行い、さらに *実行中の* ゲームを Live で操作します。ランタイムツリー、入力、スクリーンショット、パフォーマンス — 単一のコマンド体系を、3 つの入口から。
+[製品概要](https://aigengame.xyz/) ·
+[CLI、Agent Skill、MCP のどれを選ぶ？](https://aigengame.xyz/godot-mcp/) ·
+[PyPI](https://pypi.org/project/gda/)
+
+> **AI コーディングエージェント、シェルスクリプト、CI から Godot プロジェクトを構築・検証できます。**
+> `gda` は、CLI、同梱の Agent Skill、MCP サーバーを通じて同じ Godot ネイティブな
+> 操作体系を提供し、エージェントがそのまま処理できる構造化結果を返します。
 
 [![pre-1.0](https://img.shields.io/badge/status-pre--1.0-orange)](https://pypi.org/project/gda/)
 [![CI](https://github.com/aigengame/godot-agent/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/aigengame/godot-agent/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush)
@@ -16,19 +22,15 @@
 [![MCP](https://img.shields.io/badge/MCP-server-000)](https://modelcontextprotocol.io)
 [![License](https://img.shields.io/badge/license-MIT-green)](../LICENSE)
 
-AI エージェントは GDScript を書くのは得意ですが、*何が起きたかを見る* のはとても苦手です。`gda`
-はそのループを閉じます。エージェントは 1 つの操作を発行すると、そのまま処理に使える 1 つの
-クリーンな JSON 結果を受け取ります — かき集める必要のあるエンジンログではなく。`gda` は **2 つの
-モード** で動作します。
+ファイルを編集しただけでは、ゲームの変更を検証したことにはなりません。`gda` は、
+次の 2 つの相補的なモードで変更から検証までのループを閉じます。
 
-- **Headless** — ワンショットかつステートレスで、セットアップ不要。エディタプラグインもデーモンも、
-  プロジェクトにインストールするものは何もありません。シーン、ノード、スクリプト、リソース、
-  シェーダー、テーマの作成と編集、プロジェクトの解析、ビルドのエクスポートが行えます。
-- **Live** — バックグラウンドのデーモンを通じて *実行中の* ゲームを操作し、ライブのエンジンでしか
-  できないことすべてを行います。ランタイムのシーンツリーの読み取り、ランタイムプロパティの取得・
-  設定、入力のシミュレート、スクリーンショットの取得、パフォーマンスのサンプリングなど。
+- **Headless** — エディタプラグインやデーモンを使わずに、プロジェクト内容の作成・編集、
+  スクリプトのコンパイル、シーンの検証と起動、プロジェクトの検査、ビルドのエクスポートを行います。
+- **Live** — プロジェクトごとのデーモンを通じて実行中のゲームを検査・操作します。
+  ランタイムツリーと状態、入力シミュレーション、フレーム取得、ログ、エラー、パフォーマンスを扱えます。
 
-> `gda` は **pre-1.0** です。現時点ですべてのコマンドがエンドツーエンドで動作しますが、CLI の
+> `gda` は **pre-1.0** です。現時点ですべてのコマンドがエンドツーエンドで動作しますが、
 > コマンド体系は 1.0 までにまだ変わる可能性があります。
 
 ---
@@ -51,40 +53,35 @@ AI エージェントは GDScript を書くのは得意ですが、*何が起き
 <a id="why-gda"></a>
 ## なぜ `gda`？
 
-- **🤖 エージェントのために設計された構造化出力。** すべてのコマンドは stdout に **ちょうど 1 つ**
-  の JSON オブジェクトを出力します (`--json`)。エンジンのバナー、警告、`print()` は stderr に
-  流れます。エージェントが解析するのは大量のログではなく、1 つの結果だけです。
-- **📐 型付き、かつ自己記述的。** すべてのコマンドの入力と出力は型付きモデルであり、それが機械
-  可読な `--schema`(JSON Schema による契約)の裏付けにもなっています。そのためエージェントは、
-  推測ではなくプログラム的にコマンド体系全体を発見し検証できます。
-- **🔀 CLI、Skill、MCP — エージェントが選べる。** 生の `gda` CLI を使ってターミナルや CI から Godot を
-  操作する、CLI の使い方とタイミングを教える同梱の **Skill**(`gda skill`)をエージェントに渡す、
-  あるいは同じ操作を **MCP** ツール(`gda-mcp`、CLI 自身のスキーマから生成)として公開する。
-  単一のコマンド体系を 3 つの入口から — エージェントが対応している方法を選んでください。
-- **🧩 Godot ネイティブなコマンド。** Godot のオブジェクトごとにグループ化され(`gda scene create`、
-  `gda node add`、`gda game set`)、小さく一貫した動詞の語彙を使います。すでに Godot を知っていれば
-  学習コストはゼロです。
-- **⚡ デフォルトは Headless、必要なときに Live。** Headless 操作にデーモンもエディタも不要で、
-  必要なのは Godot バイナリだけです。Live 操作は、Unix ドメインソケットのデーモンを介して実行中
-  ゲームのリアルタイム制御を加え、同じ CLI の文法で指定できます。
-- **🛡️ 静かに失敗せず、はっきり失敗する。** エンジンが見つからなければ即座に、ハングしていればタイムアウトで
-  失敗し、どちらも **安定した非ゼロの終了コード** と Error エンベロープになります。エンベロープには失敗の
-  カテゴリとコード、算出できた場合は型付きの証拠が含まれるので、シェルやエージェントは文章を解析せずに
-  失敗の種類ごとに処理を分けられます。`gda` が認識しないコマンドも同じ形で拒否され、代わりに使うべき
-  呼び出しが `hint` に入ります。
+- **ファイル編集を超える検証。** Headless 検証はプロジェクトが実行可能な状態かを確認し、
+  Live 操作は実際の挙動に関するランタイム証拠を返します。
+- **構造化結果と参照可能なスキーマ。** `--json` を使うと、各コマンドは stdout に結果
+  オブジェクトを 1 つだけ出力します。型付きの入出力モデルは、`--schema` と生成される
+  MCP ツール体系にも使われます。
+- **Godot ネイティブな操作。** `gda scene create`、`gda node add`、`gda game get`
+  のように、Godot のオブジェクトと用語に沿ったコマンドを提供します。
+- **相補的な 3 つのアクセス方法。** エージェント、シェル、CI から CLI を直接実行する、
+  再利用可能なガイダンスとして同梱の Agent Skill をインストールする、または同じ操作を
+  MCP ツールとして公開できます。設定方法と違いは
+  [CLI、Agent Skill、MCP のどれを選ぶ？](https://aigengame.xyz/godot-mcp/)を参照してください。
+- **範囲を制御でき、失敗後に対応できる自動化。** タイムアウト、出力上限、型付きの失敗、
+  診断情報、変更レポートにより、エージェントは何が起きたかと復旧方法を判断できます。
+
+これらの機能は、[実際のゲーム制作で行った公開 dogfooding の記録](https://github.com/aigengame/godot-agent/milestone/10)
+を通じて改善されました。
 
 ---
 
 <a id="capabilities-at-a-glance"></a>
 ## ひと目でわかる機能
 
-| やりたいこと | 使うもの |
-| --- | --- |
-| エージェントやスクリプトからプロジェクトファイルを構築する | `scene` / `node` / `script` / `resource` / `shader` / `theme` — Headless で作成・編集 |
-| エンジンログをかき集めず、結果を解析する | `--json`(1 つのクリーンなオブジェクト)と `--schema`(JSON Schema による契約) |
-| エージェントに Godot のツールを渡す | 同梱の **Skill**(`gda skill`)または **`gda-mcp`** サーバー |
-| CI、エクスポート、プロジェクト解析を自動化する | Headless コマンド — エディタもプラグインも不要、必要なのは Godot バイナリだけ |
-| *実行中の* ゲームのランタイム挙動をデバッグする | `gda daemon start`、その後 `game` / `diag` / `logger` / `perf` / `input` / `screen` |
+| 目的 | `gda` が提供するもの | 最初に使うもの |
+| --- | --- | --- |
+| Godot プロジェクトの内容を構築する（Headless） | シーン、ノード、スクリプト、リソース、プロジェクト設定、シェーダー、テーマの作成と編集 | `scene` / `node` / `script` / `resource` / `project` / `shader` / `theme` |
+| プロジェクトの実行準備を検証する（Headless） | スクリプトのコンパイル、依存関係の検証、時間制限付き preflight でのシーン起動、プロジェクトの検査、ビルドのエクスポート | `script validate` / `scene validate` / `scene preflight` / `project` / `export` |
+| ランタイム挙動を検証する（Live） | ランタイム状態の読み取り、宣言済みメソッドの呼び出し、入力シミュレーション、フレーム取得、ログとエラーの収集、パフォーマンス計測 | `gda daemon start`、その後 `game` / `input` / `screen` / `diag` / `logger` / `perf` |
+| AI コーディングエージェントを接続する | CLI の直接実行、Agent Skill の再利用可能なガイダンス、または MCP ツールの検出と呼び出し | `gda` / `gda skill` / `gda-mcp` |
+| 自動化環境で安定して実行する | 構造化結果、型付きのスキーマと失敗、範囲を制御した実行、分離されたログ、復旧に使える診断情報 | `--json` / `--schema` / `--user-data-root` / タイムアウト |
 
 ---
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=da92f08b3efc565aabfaa217fc98b488f1088dd58758ba94f432b46a84048d14 -->
+<!-- gda-readme-i18n: source=README.md sha256=2e633d09b48794d0d129d4ec85bd48d23cec200fab96ad0803f0c5727e8ec6a5 -->
 
 # gda — AI エージェント向け Godot オートメーション
 
@@ -62,8 +62,8 @@
   のように、Godot のオブジェクトと用語に沿ったコマンドを提供します。
 - **相補的な 3 つのアクセス方法。** エージェント、シェル、CI から CLI を直接実行する、
   再利用可能なガイダンスとして同梱の Agent Skill をインストールする、または同じ操作を
-  MCP ツールとして公開できます。設定方法と違いは
-  [CLI、Agent Skill、MCP のどれを選ぶ？](https://aigengame.xyz/godot-mcp/)を参照してください。
+  MCP ツールとして公開できます。各方式の比較と違いは
+  [CLI、Agent Skill、MCP のどれを選ぶ？](https://aigengame.xyz/godot-mcp/)で確認できます。
 - **範囲を制御でき、失敗後に対応できる自動化。** タイムアウト、出力上限、型付きの失敗、
   診断情報、変更レポートにより、エージェントは何が起きたかと復旧方法を判断できます。
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=f16edb8309c514c091979325f1561031d92fe21fbe3c82c7cb9e7c7fa37ebe7c -->
+<!-- gda-readme-i18n: source=README.md sha256=da92f08b3efc565aabfaa217fc98b488f1088dd58758ba94f432b46a84048d14 -->
 
 # gda — AI エージェント向け Godot オートメーション
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,15 +1,18 @@
-<!-- gda-readme-i18n: source=README.md sha256=465ec4f02a22747e675bfbee6bdba48edd474a3da79ec654943c9741a747c302 -->
+<!-- gda-readme-i18n: source=README.md sha256=f16edb8309c514c091979325f1561031d92fe21fbe3c82c7cb9e7c7fa37ebe7c -->
 
-# godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
+# gda — 面向 AI Agent 的 Godot 自动化
 
-![godot-agent title image](https://raw.githubusercontent.com/aigengame/godot-agent/main/assets/godot-agent-title.png)
+[![gda — 面向 AI Agent 的 Godot 自动化](https://raw.githubusercontent.com/aigengame/godot-agent/main/assets/godot-agent-title.png)](https://aigengame.xyz/zh/)
 
 **其他语言:** [English](../README.md) · **简体中文** · [Español](README.es.md) · [日本語](README.ja.md)
 
-> **`gda` 让你的 AI 编程 agent——或者你的 shell 脚本和 CI——以结构化、机器可读的方式
-> 操控 [Godot Engine](https://godotengine.org)。** 以 Headless 方式创建场景、编辑节点和脚本、
-> 导出构建产物，然后实时操控*正在运行*的游戏：运行时树、输入、
-> 截图、性能——一套命令界面，三种接入方式。
+[产品概览](https://aigengame.xyz/zh/) ·
+[CLI、Agent Skill 还是 MCP？](https://aigengame.xyz/zh/godot-mcp/) ·
+[PyPI](https://pypi.org/project/gda/)
+
+> **让 Coding Agent、Shell 脚本与 CI 构建并验证 Godot 项目。**
+> `gda` 通过 CLI、随包附带的 Agent Skill 和 MCP server 提供同一套遵循 Godot
+> 语义的操作，并返回 Agent 可直接处理的结构化结果。
 
 [![pre-1.0](https://img.shields.io/badge/status-pre--1.0-orange)](https://pypi.org/project/gda/)
 [![CI](https://github.com/aigengame/godot-agent/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/aigengame/godot-agent/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush)
@@ -19,17 +22,14 @@
 [![MCP](https://img.shields.io/badge/MCP-server-000)](https://modelcontextprotocol.io)
 [![License](https://img.shields.io/badge/license-MIT-green)](../LICENSE)
 
-AI agent 擅长编写 GDScript，却很难看到*发生了什么*。`gda` 帮你补上这一环：你的 agent
-发出一个操作，拿回一个干净的 JSON 结果就能据此行动——无需费力查找引擎日志。
-它有**两种模式**：
+文件修改完成，不代表游戏改动已经通过验证。`gda` 用两种互补模式补上验证环节：
 
-- **Headless（无头）** — 一次性、无状态、零配置。无需编辑器插件、无需 daemon，
-  无需往你的项目里安装任何东西。创建和编辑场景、节点、脚本、资源、着色器和主题；
-  分析项目；导出构建产物。
-- **Live（实时）** — 通过一个后台 daemon 操控*正在运行*的游戏，完成所有只有运行中的引擎才能做的事：
-  读取运行时场景树、读写运行时属性、模拟输入、捕获截图、采样性能。
+- **Headless** — 无需编辑器插件或 daemon，即可创建和编辑项目内容、编译脚本、
+  校验并启动场景、检查项目以及导出构建产物。
+- **Live** — 通过项目级 daemon 检查并操控运行中的游戏：读取运行时场景树与状态、
+  模拟输入、捕获画面、收集日志和错误以及测量性能。
 
-> `gda` 处于 **pre-1.0** 阶段：目前每条命令都能端到端跑通，但在 1.0 之前 CLI 界面
+> `gda` 处于 **pre-1.0** 阶段：目前每条命令都能端到端跑通，但在 1.0 之前命令界面
 > 仍可能变化。
 
 ---
@@ -52,38 +52,33 @@ AI agent 擅长编写 GDScript，却很难看到*发生了什么*。`gda` 帮你
 <a id="why-gda"></a>
 ## 为什么选择 `gda`？
 
-- **🤖 结构化输出，为 agent 而生。** 每条命令在 stdout 上只输出**恰好一个** JSON
-  对象（`--json`）；引擎横幅、警告和 `print()` 都走 stderr。你的 agent 解析的是一个结果，
-  而不是被大量日志淹没。
-- **📐 带类型、可自描述。** 每条命令的输入和输出都是带类型的模型，它们同时提供一份机器可读的
-  `--schema`（JSON-Schema 契约），让 agent 能以编程方式发现并校验整个命令界面，而不必猜测。
-- **🔀 CLI、Skill、MCP——交给你的 agent 自选。** 用原生的 `gda` CLI 从终端或 CI 操控 Godot，
-  把随包附带的 **Skill**（`gda skill`）交给你的 agent、教它何时以及如何使用 CLI，或者把同一套操作以
-  **MCP** 工具的形式暴露出来（`gda-mcp`，由 CLI 自身的 schema 生成）。一套命令界面，三种接入方式——
-  你的 agent 支持哪种就用哪种。
-- **🧩 Godot 原生命令。** 按 Godot 对象分组（`gda scene create`、
-  `gda node add`、`gda game set`），配上一套精简、统一的动词——只要你懂 Godot，
-  就几乎没有学习成本。
-- **⚡ 默认 Headless，需要时再 Live。** Headless 操作不需要 daemon、也不需要编辑器——
-  只要一个 Godot 二进制文件。Live 操作则通过一个基于 Unix 域套接字的 daemon，为正在运行的游戏
-  加上实时控制能力，用的还是同一套 CLI 语法。
-- **🛡️ 出错时明确报告，绝不静默忽略。** 引擎缺失会立即报错，引擎卡死则由超时兜底；两者都会返回一个
-  **稳定的非零退出码**和一个 Error envelope（错误封装），其中包含失败类别、错误码，以及（如有）已计算出的类型化证据——
-  shell 或 agent 据此分支处理即可，不必解析文本。`gda` 不认识的命令同样以这种方式拒绝，并在 `hint`
-  中给出应当改用的调用方式。
+- **验证不止于文件修改。** Headless 校验确认项目已具备运行条件；Live 操作则以运行时
+  证据验证实际行为。
+- **结构化结果与可发现的 Schema。** 使用 `--json` 时，每条命令只在 stdout 输出一个
+  结果对象。带类型的输入和输出模型同时支撑 `--schema` 与自动生成的 MCP 工具界面。
+- **遵循 Godot 语义的操作。** 命令沿用 Godot 的对象和术语，例如
+  `gda scene create`、`gda node add` 和 `gda game get`。
+- **三种互补接入方式。** Agent、Shell 或 CI 可直接运行 CLI；需要可复用的操作指导时安装
+  随包附带的 Agent Skill；需要工具发现与调用时，将同一套操作暴露为 MCP 工具。
+  配置方法与取舍详见 [CLI、Agent Skill 还是 MCP？](https://aigengame.xyz/zh/godot-mcp/)。
+- **边界明确，失败后可恢复。** 超时、输出上限、类型化失败、诊断信息和变更报告，能帮助
+  Agent 判断发生了什么以及如何恢复。
+
+这些能力经过[真实游戏制作中的公开 dogfooding](https://github.com/aigengame/godot-agent/milestone/10)
+持续验证与打磨。
 
 ---
 
 <a id="capabilities-at-a-glance"></a>
 ## 能力速览
 
-| 你的需求 | 用这个 |
-| --- | --- |
-| 从 agent 或脚本生成项目文件 | `scene` / `node` / `script` / `resource` / `shader` / `theme`——以 Headless 方式创建和编辑 |
-| 解析结果，而不是查找引擎日志 | `--json`（一个干净的对象）和 `--schema`（JSON-Schema 契约） |
-| 把 Godot 工具交给 agent | 随包附带的 **Skill**（`gda skill`）或 **`gda-mcp`** 服务器 |
-| 自动化 CI、导出和项目分析 | Headless 命令——无需编辑器、无需插件，只要一个 Godot 二进制文件 |
-| 调试*正在运行*的游戏的运行时行为 | `gda daemon start`，然后用 `game` / `diag` / `logger` / `perf` / `input` / `screen` |
+| 目标 | `gda` 提供 | 从这里开始 |
+| --- | --- | --- |
+| 构建 Godot 项目内容（Headless） | 创建和编辑场景、节点、脚本、资源、项目设置、着色器与主题 | `scene` / `node` / `script` / `resource` / `project` / `shader` / `theme` |
+| 验证项目就绪状态（Headless） | 编译脚本、校验依赖、在限定时间内启动场景、检查项目以及导出构建产物 | `script validate` / `scene validate` / `scene preflight` / `project` / `export` |
+| 验证运行时行为（Live） | 读取运行时状态、调用已声明的方法、模拟输入、捕获画面、收集日志和错误以及测量性能 | `gda daemon start`，然后使用 `game` / `input` / `screen` / `diag` / `logger` / `perf` |
+| 接入 Coding Agent | 使用 CLI 直接执行、Agent Skill 可复用指导，或 MCP 工具发现与调用 | `gda` / `gda skill` / `gda-mcp` |
+| 在自动化环境中可靠运行 | 获得结构化结果、带类型的 Schema 与失败信息、明确的执行边界、隔离日志和可直接处理的诊断信息 | `--json` / `--schema` / `--user-data-root` / 超时设置 |
 
 ---
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=f16edb8309c514c091979325f1561031d92fe21fbe3c82c7cb9e7c7fa37ebe7c -->
+<!-- gda-readme-i18n: source=README.md sha256=da92f08b3efc565aabfaa217fc98b488f1088dd58758ba94f432b46a84048d14 -->
 
 # gda — 面向 AI Agent 的 Godot 自动化
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=da92f08b3efc565aabfaa217fc98b488f1088dd58758ba94f432b46a84048d14 -->
+<!-- gda-readme-i18n: source=README.md sha256=2e633d09b48794d0d129d4ec85bd48d23cec200fab96ad0803f0c5727e8ec6a5 -->
 
 # gda — 面向 AI Agent 的 Godot 自动化
 
@@ -60,7 +60,7 @@
   `gda scene create`、`gda node add` 和 `gda game get`。
 - **三种互补接入方式。** Agent、Shell 或 CI 可直接运行 CLI；需要可复用的操作指导时安装
   随包附带的 Agent Skill；需要工具发现与调用时，将同一套操作暴露为 MCP 工具。
-  配置方法与取舍详见 [CLI、Agent Skill 还是 MCP？](https://aigengame.xyz/zh/godot-mcp/)。
+  接入方式的对比与取舍详见 [CLI、Agent Skill 还是 MCP？](https://aigengame.xyz/zh/godot-mcp/)。
 - **边界明确，失败后可恢复。** 超时、输出上限、类型化失败、诊断信息和变更报告，能帮助
   Agent 判断发生了什么以及如何恢复。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "gda"
 version = "0.13.0"
-description = "Godot AI agent CLI, Skill, and MCP server with structured JSON/schema output — headless scene/script/export automation plus live runtime control."
+description = "Godot automation for AI agents through a CLI, Agent Skill, and MCP server, with structured results, headless validation, and live runtime control."
 readme = "README.md"
 authors = [
     { name = "haihong.qin", email = "haihongqin@gmail.com" }
@@ -25,7 +25,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/aigengame/godot-agent"
+Homepage = "https://aigengame.xyz/"
 Repository = "https://github.com/aigengame/godot-agent"
 Issues = "https://github.com/aigengame/godot-agent/issues"
 Changelog = "https://github.com/aigengame/godot-agent/blob/main/CHANGELOG.md"

--- a/scripts/update_readme_i18n.py
+++ b/scripts/update_readme_i18n.py
@@ -26,8 +26,14 @@ TRANSLATIONS = [ROOT / "docs" / f"README.{lang}.md" for lang in ("zh-CN", "es", 
 MARKER_RE = re.compile(r"<!--\s*gda-readme-i18n:.*?-->", re.DOTALL)
 
 
+def _normalized_hash(path: Path) -> str:
+    """Hash text content with platform line endings normalized to LF."""
+    content = path.read_bytes().replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+    return hashlib.sha256(content).hexdigest()
+
+
 def main() -> None:
-    digest = hashlib.sha256(README.read_bytes()).hexdigest()
+    digest = _normalized_hash(README)
     marker = f"<!-- gda-readme-i18n: source=README.md sha256={digest} -->"
 
     for path in TRANSLATIONS:

--- a/tests/test_readme_i18n_sync.py
+++ b/tests/test_readme_i18n_sync.py
@@ -19,10 +19,11 @@ The marker format is mirrored in ``scripts/update_readme_i18n.py``; keep them in
 sync if it ever changes.
 """
 
-import hashlib
 import re
 import unicodedata
 from pathlib import Path
+
+from scripts.update_readme_i18n import _normalized_hash
 
 ROOT = Path(__file__).resolve().parents[1]
 README = ROOT / "README.md"
@@ -36,12 +37,6 @@ TRANSLATIONS = {
 MARKER_RE = re.compile(
     r"<!--\s*gda-readme-i18n:\s*source=README\.md\s+sha256=([0-9a-f]{64})\s*-->"
 )
-
-
-def _normalized_hash(path: Path) -> str:
-    """Hash text content with platform line endings normalized to LF."""
-    content = path.read_bytes().replace(b"\r\n", b"\n").replace(b"\r", b"\n")
-    return hashlib.sha256(content).hexdigest()
 
 
 def _english_hash() -> str:

--- a/tests/test_readme_i18n_sync.py
+++ b/tests/test_readme_i18n_sync.py
@@ -38,8 +38,14 @@ MARKER_RE = re.compile(
 )
 
 
+def _normalized_hash(path: Path) -> str:
+    """Hash text content with platform line endings normalized to LF."""
+    content = path.read_bytes().replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+    return hashlib.sha256(content).hexdigest()
+
+
 def _english_hash() -> str:
-    return hashlib.sha256(README.read_bytes()).hexdigest()
+    return _normalized_hash(README)
 
 
 def _recorded_hash(text: str) -> str | None:
@@ -70,6 +76,15 @@ def test_all_translations_present():
         "Create docs/README.<lang>.md for each, then run "
         "`uv run python scripts/update_readme_i18n.py`."
     )
+
+
+def test_readme_hash_is_independent_of_platform_line_endings(tmp_path: Path):
+    lf = tmp_path / "lf.md"
+    crlf = tmp_path / "crlf.md"
+    lf.write_bytes(b"first\nsecond\n")
+    crlf.write_bytes(b"first\r\nsecond\r\n")
+
+    assert _normalized_hash(lf) == _normalized_hash(crlf)
 
 
 def test_translations_are_in_sync_with_english_readme():


### PR DESCRIPTION
## Summary

- reposition the README as the technical evaluation and onboarding surface for gda
- lead with Godot automation for AI agents and the build-and-verify workflow
- distinguish Headless readiness checks from Live runtime evidence
- present CLI, Agent Skill, and MCP as complementary access paths
- link to aigengame.xyz for the product overview and detailed access-path comparison
- synchronize the public-copy authority, package metadata, and translated READMEs
- normalize README translation hashes so Windows worktrees and Linux CI produce the same marker

The repository About, Homepage, and Topics were aligned separately before this branch was created.

## Validation

- `tests/test_readme_i18n_sync.py`: 6 passed, including LF/CRLF regression coverage
- `ruff check`: passed for the changed Python files
- `ruff format --check`: passed for the changed Python files
- `git diff --check`: passed
- parsed `pyproject.toml` successfully
- confirmed the versioned description and Homepage match the live repository metadata