### PR TITLE
test(gda): build the surface manifest once, shorten two test-chosen teardown deadlines (#815)

### DIFF
--- a/tests/mcp_support.py
+++ b/tests/mcp_support.py
@@ -14,6 +14,7 @@ The fast tiers drive the surface from the **real** aggregate dump
 true mirror of the live ``gda`` surface, not a hand-stubbed subset.
 """
 
+import functools
 import warnings
 from pathlib import Path
 from typing import Callable, Optional
@@ -55,12 +56,15 @@ class FakeGdaRunner:
         return self.responder(args, stdin)
 
 
+@functools.cache
 def real_manifest_json() -> str:
     """The live ``gda schema`` manifest as JSON, built in-process (no subprocess).
 
     ``gda schema`` spawns no Godot (ADR-0012), so the manifest is produced
     directly from the Typer tree — giving the fake seam the *real* whole surface
-    to register against.
+    to register against. Built ONCE per process (#815): the surface is immutable
+    for the process lifetime (the registration tests assert exactly that for the
+    server's cache hint), and every ``schema_then`` responder used to rebuild it.
     """
     return build_surface_manifest(app).model_dump_json()
 

--- a/tests/test_daemon_socket_lifecycle.py
+++ b/tests/test_daemon_socket_lifecycle.py
@@ -1232,7 +1232,10 @@ def test_the_owner_keeps_the_group_a_reaped_leader_cannot_name(tmp_path):
         assert _capture_owned_pgid(leader) is None, (
             "the reaped leader still names a group"
         )
-        session.close(time.monotonic() + 5.0)
+        # The deadline is this test's own, not a product constant: the descendant
+        # ignores SIGTERM, so the teardown polls it out in full before it
+        # escalates. 0.2s is the outcome's cost, not 5s (#815).
+        session.close(time.monotonic() + 0.2)
         _assert_gone(descendant, "descendant")
     finally:
         _reap_group(descendant, leader.pid)
@@ -1313,7 +1316,9 @@ def test_the_group_is_retired_even_when_the_leader_obeys_sigterm(monkeypatch):
         _OBEYS_SIGTERM_WITH_STUBBORN_CHILD
     )
     try:
-        _terminate(leader, time.monotonic() + 5.0, owned_pgid=owned_pgid)
+        # Same test-chosen deadline as above: the stubborn descendant makes the
+        # wait run to the deadline, so it is kept short (#815).
+        _terminate(leader, time.monotonic() + 0.2, owned_pgid=owned_pgid)
         assert leader.returncode == -signal.SIGTERM  # the leader DID obey
         _assert_gone(descendant, "descendant")
     finally:

--- a/tests/test_live_contract_guards.py
+++ b/tests/test_live_contract_guards.py
@@ -16,6 +16,7 @@ descriptors off the LIVE Typer tree — the same authority ``gda.surface`` walks
 so they stay correct wherever the descriptors and result models physically live.
 """
 
+import functools
 import json
 import math
 import re
@@ -157,13 +158,20 @@ def _live_operations() -> set[str]:
     return {d.operation for d in _descriptors() if d.kind is ExecutionKind.LIVE}
 
 
-def _live_leaves():
-    """Every LIVE leaf as ``(name, descriptor)``, read off the live Typer tree."""
+@functools.cache
+def _live_leaves() -> "tuple[tuple[str, Any], ...]":
+    """Every LIVE leaf as ``(name, descriptor)``, read off the live Typer tree ONCE.
+
+    The tree is immutable for the process, so the walk is memoized (#815); the
+    tuple keeps the callers' ``for name, descriptor in _live_leaves()`` shape.
+    """
     root = typer.main.get_command(app)
+    leaves = []
     for name, command in _leaf_commands(root, []):
         descriptor = getattr(command, "gda_command", None)
         if descriptor is not None and descriptor.kind is ExecutionKind.LIVE:
-            yield name, descriptor
+            leaves.append((name, descriptor))
+    return tuple(leaves)
 
 
 def test_relayed_live_params_models_carry_the_wire_number_policy():

--- a/tests/test_schema_aggregate.py
+++ b/tests/test_schema_aggregate.py
@@ -19,6 +19,7 @@ only in-process. That one is deliberately NOT marked `e2e`: this repo's `e2e` ma
 this check is cheap and deterministic and belongs in the default PR gate.
 """
 
+import functools
 import json
 import subprocess
 
@@ -29,10 +30,34 @@ from gda.cli import app
 from tests.support import GDA_CMD
 
 
-def _manifest() -> dict:
+@functools.cache
+def _manifest_json() -> str:
+    """The ``gda schema`` emission, produced ONCE per process (#815).
+
+    The surface is immutable for the process lifetime — the product asserts as
+    much for gda-mcp's cache hint — so every test reads the same emission
+    instead of walking the whole command tree again. ``_manifest`` hands each
+    caller its own parse, so no test can mutate what another reads.
+    """
     result = CliRunner().invoke(app, ["schema"])
     assert result.exit_code == 0, result.stdout
-    return json.loads(result.stdout)
+    return result.stdout
+
+
+def _manifest() -> dict:
+    return json.loads(_manifest_json())
+
+
+@functools.cache
+def _own_schema_json(name: str) -> str:
+    """A command's own ``--schema`` emission, produced ONCE per command (#815).
+
+    The four aggregate-versus-own comparisons below read the same table rather
+    than each re-dispatching every command.
+    """
+    result = CliRunner().invoke(app, [*name.split(" "), "--schema"])
+    assert result.exit_code == 0, result.stdout
+    return result.stdout
 
 
 def _live_dispatchable_command_names() -> set[str]:
@@ -109,9 +134,7 @@ def test_each_entry_matches_the_commands_own_schema():
     # command emits under its own `--schema` (ADR-0004): one source of truth,
     # derived through the same CommandSchema.of, not a parallel projection.
     for entry in _manifest()["commands"]:
-        result = CliRunner().invoke(app, [*entry["name"].split(" "), "--schema"])
-        assert result.exit_code == 0, result.stdout
-        own = json.loads(result.stdout)
+        own = json.loads(_own_schema_json(entry["name"]))
         assert entry["input"] == own["input"]
         assert entry["output"] == own["output"]
         assert entry["error"] == own["error"]
@@ -175,9 +198,7 @@ def test_entry_kind_matches_the_commands_own_schema_kind():
     # under its own `--schema` (ADR-0004 / ADR-0012): one descriptor field, not a
     # parallel projection — so the aggregate and per-command forms must agree.
     for entry in _manifest()["commands"]:
-        result = CliRunner().invoke(app, [*entry["name"].split(" "), "--schema"])
-        assert result.exit_code == 0, result.stdout
-        own = json.loads(result.stdout)
+        own = json.loads(_own_schema_json(entry["name"]))
         assert entry["kind"] == own["kind"], entry["name"]
 
 
@@ -202,9 +223,7 @@ def test_entry_constraints_match_the_commands_own_schema_constraints():
     # projection — so the aggregate and per-command forms must agree exactly,
     # including the null case.
     for entry in _manifest()["commands"]:
-        result = CliRunner().invoke(app, [*entry["name"].split(" "), "--schema"])
-        assert result.exit_code == 0, result.stdout
-        own = json.loads(result.stdout)
+        own = json.loads(_own_schema_json(entry["name"]))
         assert entry["constraints"] == own["constraints"], entry["name"]
 
 
@@ -379,9 +398,8 @@ def test_entry_argv_matches_the_commands_own_schema_argv():
     # (ADR-0012's live-tree walk, ADR-0023 §2's "projections, not parallel
     # registries"), so the aggregate and per-command forms cannot drift.
     for entry in _manifest()["commands"]:
-        result = CliRunner().invoke(app, [*entry["name"].split(" "), "--schema"])
-        assert result.exit_code == 0, result.stdout
-        assert entry["argv"] == json.loads(result.stdout)["argv"], entry["name"]
+        own = json.loads(_own_schema_json(entry["name"]))
+        assert entry["argv"] == own["argv"], entry["name"]
 
 
 def test_every_argv_binding_is_constructible_into_a_command_line():


### PR DESCRIPTION
Closes #815

## What

Two unit-tier hot paths, tests only. No product change, no assertion change, no test added or removed.

- **Surface manifest built once.** `test_schema_aggregate` produces the `gda schema` emission once per process (memoized helper; every caller still gets its own parse, so nothing shared is mutable) and the four aggregate-versus-own comparison tests read one memoized per-command `--schema` table. `mcp_support.real_manifest_json` is memoized, so every `schema_then` responder shares one `build_surface_manifest`. `test_live_contract_guards._live_leaves` is memoized as a tuple. The product asserts the surface is immutable for the process lifetime (the `tools/list` cache-hint test), so the caches state nothing new.
- **Two test-chosen deadlines shortened.** `test_the_owner_keeps_the_group_a_reaped_leader_cannot_name` and `test_the_group_is_retired_even_when_the_leader_obeys_sigterm` waited out a 5.0 s deadline they chose themselves (the descendant ignores SIGTERM, so the poll runs to the deadline before escalating). They now pass 0.2 s through the existing `deadline` seam, as a sibling test already does with 0.05 s, and still assert the descendant is gone. The launch tests' 1.0 s ceilings are untouched (they pin the public bound, #655 / #728).

## Evidence (local macOS, serial)

| scope | before | after |
| --- | --- | --- |
| the 7 touched/affected modules (140 tests) | 33.2 s | 9.6 s |
| full unit tier, 2,429 tests | 67.4 s | 47.5 s |

- `pytest --collect-only -q -m "not e2e"` ID list byte-identical before and after (2,429 IDs)
- 2,429 passed; ruff check / format, bare pyright: 0 findings
- Surface diff (schema / help / catalog): none — tests only
