### PR TITLE
refactor(tests): one deep command invoker for the unit tier (#816)

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -19,11 +19,15 @@ import sys
 import tempfile
 from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
 from typer.testing import CliRunner, Result
 
 from gda.cli import app
 from gda.runner import RunResult
+
+if TYPE_CHECKING:  # the daemon imports stay deferred; the annotation does not
+    from gda.daemon.server import DaemonServer
 
 # Typer renders help and usage errors through Rich, which colorizes when it
 # believes it is on a terminal — under GitHub Actions it does, while a local
@@ -217,7 +221,7 @@ def inject_live_runner(monkeypatch, result: RunResult) -> FakeRunner:
     return fake
 
 
-def recording_runner(monkeypatch, result: RunResult) -> list:
+def recording_runner(monkeypatch, result: RunResult) -> list[Path | None]:
     """Swap the runner seam for one that RECORDS the project it was built with.
 
     :func:`inject_runner` throws the factory's arguments away; this keeps them.
@@ -227,7 +231,7 @@ def recording_runner(monkeypatch, result: RunResult) -> list:
     entry per runner built, in order — so a caller reads the project it expects,
     or the whole list where the number of builds is the point.
     """
-    projects: list = []
+    projects: list[Path | None] = []
 
     def record(binary, project=None):
         projects.append(project)
@@ -257,6 +261,8 @@ def invoke_cli(
     stdout: str = "",
     stderr: str = "",
     exit_code: int = 0,
+    banner: bool = True,
+    stdin: str | None = None,
 ) -> tuple[Result, FakeRunner]:
     """Run ``argv`` through the CLI against ONE canned engine run.
 
@@ -266,12 +272,25 @@ def invoke_cli(
     ``CliRunner`` result and the fake, so a test that only reads the result
     writes ``result, _ = invoke_cli(...)`` and one that also checks what was
     dispatched keeps the fake.
+
+    ``banner=False`` stages the ``stdout`` bytes ALONE. A real run always writes
+    the banner, so the default is what a test wants — except where the staged
+    stdout is itself the input under test (a frame with no result sentinel, a
+    malformed one), and adding a preamble would change the subject rather than
+    make the fixture faithful.
+
+    ``stdin`` is the text the CLI reads from standard input, for the one channel
+    that takes its payload there (``--params-json -``).
     """
     fake = inject_runner(
         monkeypatch,
-        RunResult(stdout=ENGINE_BANNER + stdout, stderr=stderr, exit_code=exit_code),
+        RunResult(
+            stdout=(ENGINE_BANNER + stdout) if banner else stdout,
+            stderr=stderr,
+            exit_code=exit_code,
+        ),
     )
-    return CliRunner().invoke(app, argv), fake
+    return CliRunner().invoke(app, argv, input=stdin), fake
 
 
 def invoke_operation_error(
@@ -320,7 +339,7 @@ def operation_error_invoker(
 
 
 def assert_operation_error(
-    result, code: str, needle: str | None = None, diagnostics: str | None = None
+    result: Result, code: str, needle: str | None = None, diagnostics: str | None = None
 ) -> dict:
     """Assert ``result`` is the operation-category failure for ``code``, and return it.
 
@@ -354,6 +373,11 @@ class FakeProc:
     process group it owns, and the own-group guard then resolves this stand-in to
     no group at all. An invented pid would instead resolve to whichever real
     process holds it — which a test would then signal.
+
+    NOT :class:`RecordingSpawn`'s ``_CannedProcess``: this one answers liveness and
+    nothing else, and no test reads a stream from it. Reach for the other when the
+    subject is a SPAWN — an argv, a cwd, an environment, and real readable streams
+    for the launch primitive to drain.
     """
 
     pid = os.getpid()
@@ -365,7 +389,9 @@ class FakeProc:
         return self.returncode
 
 
-def server_with_session(tmp_path: Path, log_file: Path, alive: bool = True):
+def server_with_session(
+    tmp_path: Path, log_file: Path, alive: bool = True
+) -> "DaemonServer":
     """A ``DaemonServer`` holding a stand-in :class:`FakeProc` session.
 
     The fixture the log-backed live reads need (``diag errors``, ``logger tail``,
@@ -373,8 +399,6 @@ def server_with_session(tmp_path: Path, log_file: Path, alive: bool = True):
     the test writes a log and asks the server, with no engine and no socket.
     ``alive`` decides whether the session's process still polls as running.
     """
-    from typing import cast
-
     from gda.daemon.discovery import daemon_paths
     from gda.daemon.server import DaemonServer
     from gda.daemon.session import EngineSession
@@ -1231,7 +1255,12 @@ class RecordingSpawn:
 
 
 class _CannedProcess:
-    """The child :class:`RecordingSpawn` hands back — see its docstring."""
+    """The child :class:`RecordingSpawn` hands back — see its docstring.
+
+    The heavier of the two process doubles: real readable streams, a wait that can
+    time out, a terminate that ends it. A daemon test that only needs the session
+    to answer "still alive?" wants :class:`FakeProc` instead.
+    """
 
     def __init__(
         self, stdout: bytes, stderr: bytes, returncode: int, *, alive: bool

--- a/tests/support.py
+++ b/tests/support.py
@@ -12,11 +12,17 @@ between modules or imported test-module-to-test-module (issue #39).
 """
 
 import json
+import os
 import re
 import subprocess
 import sys
 import tempfile
+from collections.abc import Callable
+from pathlib import Path
 
+from typer.testing import CliRunner, Result
+
+from gda.cli import app
 from gda.runner import RunResult
 
 # Typer renders help and usage errors through Rich, which colorizes when it
@@ -146,6 +152,14 @@ class FakeExportRunner:
         return self.output
 
 
+# The line every real engine run writes before anything a command cares about.
+# A canned stdout carries it so the fake run looks like a real one and the
+# sentinel parser has the same preamble to skip. Spelled ONCE: the version in it
+# is arbitrary fixture data, and 65 hand-typed copies made it read like a version
+# each test depended on (issue #816).
+ENGINE_BANNER = "Godot Engine v4.6.3.stable.official\n"
+
+
 def sentinel(payload: dict) -> str:
     """Wrap ``payload`` in the ADR-0002 result sentinels, as operations.gd emits."""
     return raw_sentinel(json.dumps(payload))
@@ -201,6 +215,177 @@ def inject_live_runner(monkeypatch, result: RunResult) -> FakeRunner:
         "gda.dispatch.make_live_runner", lambda binary, project=None: fake
     )
     return fake
+
+
+def recording_runner(monkeypatch, result: RunResult) -> list:
+    """Swap the runner seam for one that RECORDS the project it was built with.
+
+    :func:`inject_runner` throws the factory's arguments away; this keeps them.
+    The seam ``gda.dispatch.make_runner(binary, project)`` is where the resolved
+    ``--project`` becomes visible to a test, because the runner turns it into the
+    engine's ``--path`` (issue #32). Returns the list the factory appends to — one
+    entry per runner built, in order — so a caller reads the project it expects,
+    or the whole list where the number of builds is the point.
+    """
+    projects: list = []
+
+    def record(binary, project=None):
+        projects.append(project)
+        return FakeRunner(result)
+
+    monkeypatch.setattr("gda.dispatch.make_runner", record)
+    return projects
+
+
+def minimal_project(directory: Path) -> Path:
+    """Make ``directory`` the minimum a Godot project needs, and return it.
+
+    A ``project.godot`` holding a ``config_version`` is all that makes a directory
+    a project (ADR-0006), so this is what a command test needs whenever the CLI
+    must resolve one. The directory is created when it does not exist, so a test
+    can name a subdirectory of ``tmp_path`` in one call.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    return directory
+
+
+def invoke_cli(
+    monkeypatch,
+    argv: list[str],
+    *,
+    stdout: str = "",
+    stderr: str = "",
+    exit_code: int = 0,
+) -> tuple[Result, FakeRunner]:
+    """Run ``argv`` through the CLI against ONE canned engine run.
+
+    The invocation ritual every headless command test repeats: prefix the
+    :data:`ENGINE_BANNER` to the canned ``stdout``, swap the runner seam for a
+    :class:`FakeRunner` that replays it, and invoke the Typer app. Returns the
+    ``CliRunner`` result and the fake, so a test that only reads the result
+    writes ``result, _ = invoke_cli(...)`` and one that also checks what was
+    dispatched keeps the fake.
+    """
+    fake = inject_runner(
+        monkeypatch,
+        RunResult(stdout=ENGINE_BANNER + stdout, stderr=stderr, exit_code=exit_code),
+    )
+    return CliRunner().invoke(app, argv), fake
+
+
+def invoke_operation_error(
+    monkeypatch,
+    argv: list[str],
+    code: str,
+    message: str,
+    operation: str | None = None,
+) -> Result:
+    """Run ``argv`` against an engine run that REPORTED ``code``/``message``.
+
+    The failure twin of :func:`invoke_cli`: the canned run carries an ADR-0002
+    operation-error envelope instead of a result payload, exits non-zero, and
+    writes the runner's own progress notice on stderr — which the envelope then
+    echoes as ``diagnostics``. ``operation`` names the operation in that notice;
+    leave it out where the notice names none.
+    """
+    named = f": {operation}" if operation else ""
+    return invoke_cli(
+        monkeypatch,
+        argv,
+        stdout=error_sentinel(code, message),
+        stderr=f"gda: running operation{named}\n",
+        exit_code=1,
+    )[0]
+
+
+def operation_error_invoker(
+    argv: list[str] | Callable[..., list[str]], operation: str | None = None
+) -> Callable[..., Result]:
+    """Bind one command to :func:`invoke_operation_error`.
+
+    An error-test module states a command's argv and operation name ONCE and gets
+    back an ``invoke(monkeypatch, code, message)`` its tests call, so each test
+    names only the failure it stages. ``argv`` may instead be a callable that
+    BUILDS the command line — the form a command needs whose argv varies per test
+    (a node path, a uid target); the bound invoker forwards its extra keywords to
+    that callable.
+    """
+
+    def invoke(monkeypatch, code: str, message: str, **argv_kwargs):
+        command = argv(**argv_kwargs) if callable(argv) else argv
+        return invoke_operation_error(monkeypatch, command, code, message, operation)
+
+    return invoke
+
+
+def assert_operation_error(
+    result, code: str, needle: str | None = None, diagnostics: str | None = None
+) -> dict:
+    """Assert ``result`` is the operation-category failure for ``code``, and return it.
+
+    The read side of :func:`invoke_operation_error`, and the one place the ADR-0002
+    operation-failure contract is spelled: exit 4 for the category, the
+    ``operation`` category on the envelope, and the stable code an agent branches
+    on. ``needle`` additionally asserts a fragment of the message; ``diagnostics``
+    asserts the raw stderr the envelope carries, and is always passed EXPLICITLY —
+    a module that checks it says so at the call site rather than inheriting it.
+    Returns the parsed error, so a caller asserts anything further on it.
+    """
+    assert result.exit_code == 4, result.stdout
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == code
+    if needle is not None:
+        assert needle in err["message"]
+    if diagnostics is not None:
+        assert err["diagnostics"] == diagnostics
+    return err
+
+
+class FakeProc:
+    """A stand-in ``subprocess.Popen``: ``poll()`` returns ``returncode``.
+
+    ``None`` means alive, so a test flips liveness by assigning ``returncode``.
+    One double for every daemon test that needs an engine process without
+    spawning one — the session only ever polls it and reads its pid.
+
+    ``pid`` is gda's OWN pid, deliberately: teardown reads the pid to find the
+    process group it owns, and the own-group guard then resolves this stand-in to
+    no group at all. An invented pid would instead resolve to whichever real
+    process holds it — which a test would then signal.
+    """
+
+    pid = os.getpid()
+
+    def __init__(self, returncode: int | None = None) -> None:
+        self.returncode = returncode
+
+    def poll(self):
+        return self.returncode
+
+
+def server_with_session(tmp_path: Path, log_file: Path, alive: bool = True):
+    """A ``DaemonServer`` holding a stand-in :class:`FakeProc` session.
+
+    The fixture the log-backed live reads need (``diag errors``, ``logger tail``,
+    #224/#281): the server serves them from the session's remembered log file, so
+    the test writes a log and asks the server, with no engine and no socket.
+    ``alive`` decides whether the session's process still polls as running.
+    """
+    from typing import cast
+
+    from gda.daemon.discovery import daemon_paths
+    from gda.daemon.server import DaemonServer
+    from gda.daemon.session import EngineSession
+
+    server = DaemonServer(daemon_paths(minimal_project(tmp_path)), godot="godot")
+    server._session = EngineSession(
+        cast(subprocess.Popen, FakeProc(None if alive else 0)),
+        conn=None,
+        log_file=log_file,
+    )
+    return server
 
 
 def capture_receipt_reply(**overrides) -> dict:

--- a/tests/test_asset_file_commands.py
+++ b/tests/test_asset_file_commands.py
@@ -10,17 +10,13 @@ edit-mode interface is the script set interface (issue #118), reused here.
 
 import json
 
-from typer.testing import CliRunner
 
-from gda.cli import app
 from gda.commands.script import ScriptSetMode
-from gda.runner import RunResult
 from tests.support import (
     SHADER_CREATE_RESULT,
     SHADER_GET_RESULT,
     SHADER_SET_RESULT,
     THEME_CREATE_RESULT,
-    inject_runner,
     invoke_cli,
     sentinel,
 )
@@ -66,13 +62,10 @@ def test_shader_create_json_maps_success_to_json_object_and_exit_zero(monkeypatc
 def test_shader_create_default_template_passes_null_content_and_type(monkeypatch):
     # The bare template: no --content, no --shader-type. Both pass through as
     # null, so the operation writes its default canvas_item template.
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_CREATE_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["shader", "create", "/tmp/proj/wave.gdshader", "--json"]
+        ["shader", "create", "/tmp/proj/wave.gdshader", "--json"],
+        stdout=sentinel(SHADER_CREATE_RESULT),
     )
 
     assert result.exit_code == 0
@@ -85,23 +78,8 @@ def test_shader_create_default_template_passes_null_content_and_type(monkeypatch
 
 
 def test_shader_create_content_passes_verbatim_source(monkeypatch):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=sentinel(
-                {
-                    "path": "/tmp/proj/x.gdshader",
-                    "shader_type": "spatial",
-                    "created_dirs": [],
-                }
-            ),
-            stderr="",
-            exit_code=0,
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "shader",
             "create",
@@ -110,6 +88,13 @@ def test_shader_create_content_passes_verbatim_source(monkeypatch):
             "shader_type spatial;\n",
             "--json",
         ],
+        stdout=sentinel(
+            {
+                "path": "/tmp/proj/x.gdshader",
+                "shader_type": "spatial",
+                "created_dirs": [],
+            }
+        ),
     )
 
     assert result.exit_code == 0
@@ -128,13 +113,8 @@ def test_shader_create_content_passes_verbatim_source(monkeypatch):
 def test_shader_create_content_and_type_are_mutually_exclusive(monkeypatch):
     # Verbatim content is not templated, so a shader_type has nowhere to go;
     # supplying both is a usage error (exit 2), never a silent precedence rule.
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_CREATE_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "shader",
             "create",
@@ -145,6 +125,7 @@ def test_shader_create_content_and_type_are_mutually_exclusive(monkeypatch):
             "spatial",
             "--json",
         ],
+        stdout=sentinel(SHADER_CREATE_RESULT),
     )
 
     assert result.exit_code == 2
@@ -178,13 +159,8 @@ def test_shader_set_search_replace_dispatches_search_and_replace(monkeypatch):
     # search-replace mode: --search/--replace ride through; the other mode params
     # pass as null. The CLI resolves the edit mode once and stamps the explicit
     # `mode` discriminator (issue #133) — the SAME ScriptSetMode as script set.
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "shader",
             "set",
@@ -195,6 +171,7 @@ def test_shader_set_search_replace_dispatches_search_and_replace(monkeypatch):
             "spatial",
             "--json",
         ],
+        stdout=sentinel(SHADER_SET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -215,13 +192,8 @@ def test_shader_set_search_replace_dispatches_search_and_replace(monkeypatch):
 
 
 def test_shader_set_line_range_dispatches_start_end_and_content(monkeypatch):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "shader",
             "set",
@@ -234,6 +206,7 @@ def test_shader_set_line_range_dispatches_start_end_and_content(monkeypatch):
             "shader_type spatial;",
             "--json",
         ],
+        stdout=sentinel(SHADER_SET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -254,13 +227,8 @@ def test_shader_set_line_range_dispatches_start_end_and_content(monkeypatch):
 
 
 def test_shader_set_full_overwrite_dispatches_content_only(monkeypatch):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "shader",
             "set",
@@ -269,6 +237,7 @@ def test_shader_set_full_overwrite_dispatches_content_only(monkeypatch):
             "shader_type spatial;\n",
             "--json",
         ],
+        stdout=sentinel(SHADER_SET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -296,39 +265,28 @@ def _assert_set_usage_error(fake, result):
 
 
 def test_shader_set_no_flags_is_a_usage_error(monkeypatch):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["shader", "set", "/tmp/proj/wave.gdshader", "--json"]
+        ["shader", "set", "/tmp/proj/wave.gdshader", "--json"],
+        stdout=sentinel(SHADER_SET_RESULT),
     )
 
     _assert_set_usage_error(fake, result)
 
 
 def test_shader_set_search_without_replace_is_a_usage_error(monkeypatch):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["shader", "set", "/tmp/proj/wave.gdshader", "--search", "x", "--json"]
+        ["shader", "set", "/tmp/proj/wave.gdshader", "--search", "x", "--json"],
+        stdout=sentinel(SHADER_SET_RESULT),
     )
 
     _assert_set_usage_error(fake, result)
 
 
 def test_shader_set_search_replace_and_content_are_mutually_exclusive(monkeypatch):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "shader",
             "set",
@@ -341,6 +299,7 @@ def test_shader_set_search_replace_and_content_are_mutually_exclusive(monkeypatc
             "z",
             "--json",
         ],
+        stdout=sentinel(SHADER_SET_RESULT),
     )
 
     _assert_set_usage_error(fake, result)
@@ -369,12 +328,11 @@ def test_theme_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch
 
 
 def test_shader_create_human_output(monkeypatch):
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_CREATE_RESULT), stderr="", exit_code=0),
+        ["shader", "create", "/tmp/proj/wave.gdshader"],
+        stdout=sentinel(SHADER_CREATE_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["shader", "create", "/tmp/proj/wave.gdshader"])
 
     assert result.exit_code == 0
     assert (
@@ -384,12 +342,11 @@ def test_shader_create_human_output(monkeypatch):
 
 
 def test_shader_get_human_output_renders_metadata_then_source(monkeypatch):
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_GET_RESULT), stderr="", exit_code=0),
+        ["shader", "get", "/tmp/proj/wave.gdshader"],
+        stdout=sentinel(SHADER_GET_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["shader", "get", "/tmp/proj/wave.gdshader"])
 
     assert result.exit_code == 0
     assert "/tmp/proj/wave.gdshader (shader_type canvas_item)" in result.stdout
@@ -397,13 +354,10 @@ def test_shader_get_human_output_renders_metadata_then_source(monkeypatch):
 
 
 def test_shader_set_human_output_renders_metadata(monkeypatch):
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["shader", "set", "/tmp/proj/wave.gdshader", "--content", "x"]
+        ["shader", "set", "/tmp/proj/wave.gdshader", "--content", "x"],
+        stdout=sentinel(SHADER_SET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -411,12 +365,11 @@ def test_shader_set_human_output_renders_metadata(monkeypatch):
 
 
 def test_theme_create_human_output(monkeypatch):
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(THEME_CREATE_RESULT), stderr="", exit_code=0),
+        ["theme", "create", "/tmp/proj/ui.tres"],
+        stdout=sentinel(THEME_CREATE_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["theme", "create", "/tmp/proj/ui.tres"])
 
     assert result.exit_code == 0
     assert result.stdout.strip() == "created /tmp/proj/ui.tres (Theme)"

--- a/tests/test_asset_file_commands.py
+++ b/tests/test_asset_file_commands.py
@@ -21,6 +21,7 @@ from tests.support import (
     SHADER_SET_RESULT,
     THEME_CREATE_RESULT,
     inject_runner,
+    invoke_cli,
     sentinel,
 )
 
@@ -29,13 +30,8 @@ from tests.support import (
 
 def test_shader_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
     # Engine banner noise around the sentinel, diagnostics on stderr (ADR-0002).
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(SHADER_CREATE_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "shader",
             "create",
@@ -44,6 +40,8 @@ def test_shader_create_json_maps_success_to_json_object_and_exit_zero(monkeypatc
             "canvas_item",
             "--json",
         ],
+        stdout=sentinel(SHADER_CREATE_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -160,11 +158,10 @@ def test_shader_create_content_and_type_are_mutually_exclusive(monkeypatch):
 def test_shader_get_json_emits_source_and_metadata_and_exit_zero(monkeypatch):
     # shader get is the verifier (issue #115): it reads a shader's source back as
     # raw text with its shader_type, so a create round-trips.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(SHADER_GET_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["shader", "get", "/tmp/proj/wave.gdshader", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["shader", "get", "/tmp/proj/wave.gdshader", "--json"],
+        stdout=sentinel(SHADER_GET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -353,12 +350,12 @@ def test_shader_set_search_replace_and_content_are_mutually_exclusive(monkeypatc
 
 
 def test_theme_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(THEME_CREATE_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["theme", "create", "/tmp/proj/ui.tres", "--json"],
+        stdout=sentinel(THEME_CREATE_RESULT),
+        stderr="engine diagnostic\n",
     )
-
-    result = CliRunner().invoke(app, ["theme", "create", "/tmp/proj/ui.tres", "--json"])
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)

--- a/tests/test_asset_file_errors.py
+++ b/tests/test_asset_file_errors.py
@@ -10,51 +10,24 @@ no_search_match / invalid_line_range) rather than minting parallel ones, exactly
 as the script group did.
 """
 
-import json
+from tests.support import assert_operation_error, operation_error_invoker
 
-from typer.testing import CliRunner
+_shader_create = operation_error_invoker(
+    ["shader", "create", "/x/wave.gdshader", "--json"], "shader-create"
+)
 
-from gda.cli import app
-from gda.runner import RunResult
-from tests.support import error_sentinel, inject_runner
+_shader_get = operation_error_invoker(
+    ["shader", "get", "/x/wave.gdshader", "--json"], "shader-get"
+)
 
+_shader_set = operation_error_invoker(
+    ["shader", "set", "/x/wave.gdshader", "--search", "a", "--replace", "b", "--json"],
+    "shader-set",
+)
 
-def _invoke(monkeypatch, argv, code, message, op):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr=f"gda: running operation: {op}\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, argv)
-
-
-def _create_argv():
-    return ["shader", "create", "/x/wave.gdshader", "--json"]
-
-
-def _get_argv():
-    return ["shader", "get", "/x/wave.gdshader", "--json"]
-
-
-def _set_argv():
-    return [
-        "shader",
-        "set",
-        "/x/wave.gdshader",
-        "--search",
-        "a",
-        "--replace",
-        "b",
-        "--json",
-    ]
-
-
-def _theme_argv():
-    return ["theme", "create", "/x/ui.tres", "--json"]
+_theme_create = operation_error_invoker(
+    ["theme", "create", "/x/ui.tres", "--json"], "theme-create"
+)
 
 
 # --- shader create: path collision (no-clobber) + wrong extension ----------
@@ -64,95 +37,61 @@ def test_shader_create_collision_reuses_stable_already_exists_code(monkeypatch):
     # No-clobber: a create whose target already exists reuses the registered
     # already_exists code (the same one scene/script create use), leaving the
     # file untouched — the shader group mints no parallel collision code.
-    result = _invoke(
-        monkeypatch,
-        _create_argv(),
-        "already_exists",
-        "shader target already exists: /x/wave.gdshader",
-        "shader-create",
+    result = _shader_create(
+        monkeypatch, "already_exists", "shader target already exists: /x/wave.gdshader"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "already_exists"
-    assert "/x/wave.gdshader" in err["message"]
-    assert err["diagnostics"] == "gda: running operation: shader-create\n"
+    assert_operation_error(
+        result,
+        "already_exists",
+        "/x/wave.gdshader",
+        diagnostics="gda: running operation: shader-create\n",
+    )
 
 
 def test_shader_create_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
-    result = _invoke(
-        monkeypatch,
-        _create_argv(),
-        "invalid_path",
-        "shader path must end in .gdshader: /x/wave.txt",
-        "shader-create",
+    result = _shader_create(
+        monkeypatch, "invalid_path", "shader path must end in .gdshader: /x/wave.txt"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "invalid_path"
-    assert ".gdshader" in err["message"]
+    assert_operation_error(result, "invalid_path", ".gdshader")
 
 
 def test_shader_create_unwritable_target_reuses_stable_save_failed_code(monkeypatch):
-    result = _invoke(
-        monkeypatch,
-        _create_argv(),
-        "save_failed",
-        "failed to save shader to /x/wave.gdshader",
-        "shader-create",
+    result = _shader_create(
+        monkeypatch, "save_failed", "failed to save shader to /x/wave.gdshader"
     )
 
-    assert result.exit_code == 4
-    assert json.loads(result.stdout)["error"]["code"] == "save_failed"
+    assert_operation_error(result, "save_failed")
 
 
 # --- shader get/set: file not found + wrong extension ----------------------
 
 
 def test_shader_get_missing_file_reuses_stable_path_not_found_code(monkeypatch):
-    result = _invoke(
-        monkeypatch,
-        _get_argv(),
-        "path_not_found",
-        "shader file does not exist: /x/wave.gdshader",
-        "shader-get",
+    result = _shader_get(
+        monkeypatch, "path_not_found", "shader file does not exist: /x/wave.gdshader"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/wave.gdshader" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/wave.gdshader")
 
 
 def test_shader_get_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
-    result = _invoke(
-        monkeypatch,
-        _get_argv(),
-        "invalid_path",
-        "shader path must end in .gdshader: /x/notes.txt",
-        "shader-get",
+    result = _shader_get(
+        monkeypatch, "invalid_path", "shader path must end in .gdshader: /x/notes.txt"
     )
 
-    assert result.exit_code == 4
-    assert json.loads(result.stdout)["error"]["code"] == "invalid_path"
+    assert_operation_error(result, "invalid_path")
 
 
 def test_shader_set_missing_file_reuses_stable_path_not_found_code(monkeypatch):
     # set edits an existing shader; a missing target is path_not_found, never a
     # silent create (the same rule as script set).
-    result = _invoke(
-        monkeypatch,
-        _set_argv(),
-        "path_not_found",
-        "shader file does not exist: /x/wave.gdshader",
-        "shader-set",
+    result = _shader_set(
+        monkeypatch, "path_not_found", "shader file does not exist: /x/wave.gdshader"
     )
 
-    assert result.exit_code == 4
-    assert json.loads(result.stdout)["error"]["code"] == "path_not_found"
+    assert_operation_error(result, "path_not_found")
 
 
 # --- shader set: bad edit range / no search-replace match (reused codes) ----
@@ -162,80 +101,47 @@ def test_shader_set_no_search_match_maps_to_stable_no_search_match_code(monkeypa
     # search-replace mode: a search string the source does not contain is the
     # registered no_search_match code (reused from script set), so an agent
     # learns the edit landed nowhere rather than parsing prose.
-    result = _invoke(
-        monkeypatch,
-        _set_argv(),
-        "no_search_match",
-        'search string not found in shader: "xyzzy"',
-        "shader-set",
+    result = _shader_set(
+        monkeypatch, "no_search_match", 'search string not found in shader: "xyzzy"'
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "no_search_match"
-    assert "xyzzy" in err["message"]
+    assert_operation_error(result, "no_search_match", "xyzzy")
 
 
 def test_shader_set_invalid_line_range_maps_to_stable_invalid_line_range_code(
     monkeypatch,
 ):
-    result = _invoke(
+    result = _shader_set(
         monkeypatch,
-        _set_argv(),
         "invalid_line_range",
         "line range 5..9 is outside the shader's bounds (1..3) or ends before it starts",
-        "shader-set",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "invalid_line_range"
-    assert "1..3" in err["message"]
+    assert_operation_error(result, "invalid_line_range", "1..3")
 
 
 # --- theme create: path collision + wrong extension ------------------------
 
 
 def test_theme_create_collision_reuses_stable_already_exists_code(monkeypatch):
-    result = _invoke(
-        monkeypatch,
-        _theme_argv(),
-        "already_exists",
-        "theme target already exists: /x/ui.tres",
-        "theme-create",
+    result = _theme_create(
+        monkeypatch, "already_exists", "theme target already exists: /x/ui.tres"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "already_exists"
-    assert "/x/ui.tres" in err["message"]
+    assert_operation_error(result, "already_exists", "/x/ui.tres")
 
 
 def test_theme_create_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
-    result = _invoke(
-        monkeypatch,
-        _theme_argv(),
-        "invalid_path",
-        "theme path must end in .tres: /x/ui.txt",
-        "theme-create",
+    result = _theme_create(
+        monkeypatch, "invalid_path", "theme path must end in .tres: /x/ui.txt"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "invalid_path"
-    assert ".tres" in err["message"]
+    assert_operation_error(result, "invalid_path", ".tres")
 
 
 def test_theme_create_unwritable_target_reuses_stable_save_failed_code(monkeypatch):
-    result = _invoke(
-        monkeypatch,
-        _theme_argv(),
-        "save_failed",
-        "failed to save theme to /x/ui.tres",
-        "theme-create",
+    result = _theme_create(
+        monkeypatch, "save_failed", "failed to save theme to /x/ui.tres"
     )
 
-    assert result.exit_code == 4
-    assert json.loads(result.stdout)["error"]["code"] == "save_failed"
+    assert_operation_error(result, "save_failed")

--- a/tests/test_daemon_diag.py
+++ b/tests/test_daemon_diag.py
@@ -24,37 +24,21 @@ from gda.daemon.protocol import write_frame
 from gda.daemon.server import DaemonServer
 from gda.daemon.session import EngineSession, SceneMismatch, launch_session
 from gda.parser import parse_result
-from tests.support import no_engine_teardown
+from tests.support import (
+    FakeProc,
+    minimal_project,
+    no_engine_teardown,
+    server_with_session,
+)
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
-
-
-class _FakeProc:
-    """A stand-in subprocess.Popen: ``poll()`` returns ``returncode`` (None = alive)."""
-
-    def __init__(self, returncode=None):
-        self.returncode = returncode
-
-    def poll(self):
-        return self.returncode
-
-    # gda's OWN pid, deliberately: teardown reads the pid to find the process
-    # group it owns, and the own-group guard then resolves this stand-in to no
-    # group at all. An invented pid would instead resolve to whichever real
-    # process holds it — which a test would then signal.
-    pid = os.getpid()
-
-
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
 
 
 # --- Slice 1: launch carries --log-file and the session remembers the path ---
 
 
 def test_launch_session_passes_log_file_arg_and_remembers_path(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     log_file = tmp_path / "session.log"
     captured = {}
 
@@ -100,7 +84,7 @@ def test_launch_session_passes_log_file_arg_and_remembers_path(monkeypatch, tmp_
 def test_engine_session_exposes_its_log_file_path(tmp_path):
     log_file = tmp_path / "s.log"
     session = EngineSession(
-        cast(subprocess.Popen, _FakeProc()), conn=None, log_file=log_file
+        cast(subprocess.Popen, FakeProc()), conn=None, log_file=log_file
     )
     assert session.log_file == log_file
 
@@ -143,7 +127,7 @@ def _capture_launch_argv(monkeypatch, project, **launch_kw):
 
 
 def test_launch_session_inserts_scene_before_path_when_set(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     argv = _capture_launch_argv(monkeypatch, project, scene="res://B.tscn")
 
     # `--scene <path>` is an ENGINE option: present, paired, and BEFORE `--path`
@@ -163,7 +147,7 @@ def test_launch_session_inserts_scene_before_path_when_set(monkeypatch, tmp_path
 def test_launch_session_accepts_a_uid_scene_selector(monkeypatch, tmp_path):
     # Godot's `--scene` accepts a `uid://…` value too; the launch passes it through
     # verbatim in the same engine-option slot AND in the harness tail.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     argv = _capture_launch_argv(monkeypatch, project, scene="uid://abc123")
 
     assert argv[argv.index("--scene") + 1] == "uid://abc123"
@@ -175,7 +159,7 @@ def test_launch_session_omits_scene_by_default(monkeypatch, tmp_path):
     # No selector: behaviour unchanged — the engine runs the project's main_scene,
     # so no `--scene` engine option appears in the argv. The harness tail still
     # carries a slot for the selector — an EMPTY string (no selector requested).
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     argv = _capture_launch_argv(monkeypatch, project)
 
     assert "--scene" not in argv
@@ -213,7 +197,7 @@ def _launch_with_fake_harness(monkeypatch, tmp_path, *, token, verify, scene):
     second frame. Returns the launch_session outcome (or the raised exception class
     via pytest.raises in the caller).
     """
-    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc())
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: FakeProc())
     no_engine_teardown(monkeypatch)
     daemon_end, harness_end = socket.socketpair()
     # The harness presents its token, then the scene-verification frame.
@@ -240,7 +224,7 @@ def _launch_with_fake_harness(monkeypatch, tmp_path, *, token, verify, scene):
 
 
 def test_launch_returns_verified_session_when_scene_ok(monkeypatch, tmp_path):
-    _project(tmp_path)
+    minimal_project(tmp_path)
     session = _launch_with_fake_harness(
         monkeypatch,
         tmp_path,
@@ -252,7 +236,7 @@ def test_launch_returns_verified_session_when_scene_ok(monkeypatch, tmp_path):
 
 
 def test_launch_raises_scene_mismatch_when_loaded_scene_differs(monkeypatch, tmp_path):
-    _project(tmp_path)
+    minimal_project(tmp_path)
     with pytest.raises(SceneMismatch):
         _launch_with_fake_harness(
             monkeypatch,
@@ -268,7 +252,7 @@ def test_launch_with_no_selector_does_not_require_a_verification_frame(
 ):
     # No selector: scene_ok is trivially true (the harness sends it as ok), and the
     # session is verified — the main_scene default is unchanged.
-    _project(tmp_path)
+    minimal_project(tmp_path)
     session = _launch_with_fake_harness(
         monkeypatch,
         tmp_path,
@@ -280,10 +264,10 @@ def test_launch_with_no_selector_does_not_require_a_verification_frame(
 
 
 def test_launch_returns_none_on_bad_token(monkeypatch, tmp_path):
-    _project(tmp_path)
+    minimal_project(tmp_path)
     # A wrong token aborts the handshake BEFORE the verification frame: a generic
     # launch failure (None), distinct from a scene mismatch.
-    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc())
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: FakeProc())
     no_engine_teardown(monkeypatch)
     daemon_end, harness_end = socket.socketpair()
     write_frame(harness_end, b"WRONG")
@@ -321,10 +305,10 @@ class _NoAcceptListener:
 def test_failed_launch_records_signal_death_when_child_already_died(
     monkeypatch, tmp_path
 ):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     # A child that reports it aborted by SIGABRT (returncode -6) — what a windowed
     # session with no usable DisplayServer does before the harness can connect.
-    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc(-6))
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: FakeProc(-6))
     no_engine_teardown(monkeypatch)
 
     diagnostics: list[str] = []
@@ -347,10 +331,10 @@ def test_failed_launch_records_signal_death_when_child_already_died(
 def test_failed_launch_records_harness_hung_when_child_still_alive(
     monkeypatch, tmp_path
 ):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     # A child still alive (poll() is None) when the harness never connected: the
     # "engine up, harness hung" case, distinct from a crashed child.
-    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc(None))
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: FakeProc(None))
     no_engine_teardown(monkeypatch)
 
     diagnostics: list[str] = []
@@ -377,14 +361,14 @@ def test_failed_launch_diagnostics_excludes_stale_session_log(
     # the deterministic session-log path. If a PREVIOUS session left content there, it
     # must NOT leak into the current failure's diagnostics. launch_session truncates
     # the log BEFORE spawning, so the tail reads EMPTY for a pre-logger abort.
-    server = DaemonServer(daemon_paths(_project(tmp_path)), godot="godot")
+    server = DaemonServer(daemon_paths(minimal_project(tmp_path)), godot="godot")
     log_path = server.paths.session_log
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_path.write_text("STALE-PREVIOUS-SESSION-OUTPUT", encoding="utf-8")
 
     # A REAL launch_session runs (truncating the log), spawns a fake child that dies
     # pre-logger by SIGABRT and writes nothing, and no harness connects -> None.
-    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc(-6))
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: FakeProc(-6))
     no_engine_teardown(monkeypatch)
     server._harness_listener = cast(socket.socket, _NoAcceptListener())
 
@@ -404,22 +388,12 @@ def test_failed_launch_diagnostics_excludes_stale_session_log(
 # --- Slice 2: the daemon serves diag from the remembered log file ---
 
 
-def _server_with_session(tmp_path, log_file, alive=True):
-    server = DaemonServer(daemon_paths(_project(tmp_path)), godot="godot")
-    server._session = EngineSession(
-        cast(subprocess.Popen, _FakeProc(None if alive else 0)),
-        conn=None,
-        log_file=log_file,
-    )
-    return server
-
-
 def test_diag_errors_reads_structured_errors_from_the_log(tmp_path):
     log_file = tmp_path / "session.log"
     log_file.write_text(
         "print output\nERROR: boom\n   at: _ready (res://main.gd:9)\n", encoding="utf-8"
     )
-    server = _server_with_session(tmp_path, log_file)
+    server = server_with_session(tmp_path, log_file)
 
     reply = server._handle({"op": "diag-errors", "params": {}})
     assert reply is not None
@@ -437,7 +411,7 @@ def test_diag_errors_limit_tails_the_most_recent_n(tmp_path):
         "ERROR: one\n   at: a (res://a.gd:1)\nERROR: two\n   at: b (res://b.gd:2)\n",
         encoding="utf-8",
     )
-    server = _server_with_session(tmp_path, log_file)
+    server = server_with_session(tmp_path, log_file)
 
     reply = server._handle({"op": "diag-errors", "params": {"limit": 1}})
     assert reply is not None
@@ -454,7 +428,7 @@ def test_diag_serves_even_when_the_session_process_has_died(tmp_path):
     log_file.write_text(
         "ERROR: crashed\n   at: _ready (res://main.gd:3)\n", encoding="utf-8"
     )
-    server = _server_with_session(tmp_path, log_file, alive=False)
+    server = server_with_session(tmp_path, log_file, alive=False)
 
     reply = server._handle({"op": "diag-errors", "params": {}})
     assert reply is not None
@@ -466,7 +440,7 @@ def test_diag_serves_even_when_the_session_process_has_died(tmp_path):
 def test_diag_empty_log_is_an_empty_result_not_an_error(tmp_path):
     log_file = tmp_path / "session.log"
     log_file.write_text("", encoding="utf-8")
-    server = _server_with_session(tmp_path, log_file)
+    server = server_with_session(tmp_path, log_file)
 
     errors_reply = server._handle({"op": "diag-errors", "params": {}})
     assert errors_reply is not None
@@ -483,7 +457,7 @@ def test_diag_with_no_session_launched_is_engine_session_not_running(
     # spawn an engine session as a side effect, even with a Godot binary set (that
     # hidden project-code-execution side effect is the bug under ADR-0009).
     op = "diag-errors"
-    server = DaemonServer(daemon_paths(_project(tmp_path)), godot="godot")
+    server = DaemonServer(daemon_paths(minimal_project(tmp_path)), godot="godot")
 
     # Trip-wire: if diag tries to launch a session, fail loudly.
     def _boom(*args, **kwargs):
@@ -506,7 +480,7 @@ def test_diag_with_a_remembered_session_but_missing_file_is_live_log_unavailable
 ):
     # A session was launched (remembered) but its log file is gone/unreadable.
     log_file = tmp_path / "missing.log"  # never created
-    server = _server_with_session(tmp_path, log_file, alive=False)
+    server = server_with_session(tmp_path, log_file, alive=False)
 
     reply = server._handle({"op": "diag-errors", "params": {}})
     assert reply is not None

--- a/tests/test_daemon_lifecycle_payload.py
+++ b/tests/test_daemon_lifecycle_payload.py
@@ -61,6 +61,12 @@ def _unavailable(
 
 
 def _project(tmp_path):
+    """Not support.minimal_project: the payload reports the application NAME.
+
+    The daemon lifecycle payload echoes the project name it read, so this suite
+    needs a project.godot that carries one — a different file, not the shared
+    minimum plus a second write of the same path.
+    """
     (tmp_path / "project.godot").write_text(
         'config_version=5\n\n[application]\n\nconfig/name="t"\n', encoding="utf-8"
     )

--- a/tests/test_daemon_logger.py
+++ b/tests/test_daemon_logger.py
@@ -9,40 +9,15 @@ log file, plus the same no-session / missing-file typed errors ``diag`` returns.
 """
 
 import os
-import subprocess
-from typing import cast
 
 import pytest
 
 from gda.daemon.discovery import daemon_paths
 from gda.daemon.server import DaemonServer
-from gda.daemon.session import EngineSession
 from gda.parser import parse_result
+from tests.support import minimal_project, server_with_session
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
-
-
-class _FakeProc:
-    def __init__(self, returncode=None):
-        self.returncode = returncode
-
-    def poll(self):
-        return self.returncode
-
-
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
-
-
-def _server_with_session(tmp_path, log_file, alive=True):
-    server = DaemonServer(daemon_paths(_project(tmp_path)), godot="godot")
-    server._session = EngineSession(
-        cast(subprocess.Popen, _FakeProc(None if alive else 0)),
-        conn=None,
-        log_file=log_file,
-    )
-    return server
 
 
 def test_logger_tail_reads_structured_records_from_the_log(tmp_path):
@@ -50,7 +25,7 @@ def test_logger_tail_reads_structured_records_from_the_log(tmp_path):
     log_file.write_text(
         "print output\nERROR: boom\n   at: _ready (res://main.gd:9)\n", encoding="utf-8"
     )
-    server = _server_with_session(tmp_path, log_file)
+    server = server_with_session(tmp_path, log_file)
 
     reply = server._handle({"op": "logger-tail", "params": {}})
     assert reply is not None
@@ -70,7 +45,7 @@ def test_logger_tail_raw_returns_verbatim_info_records(tmp_path):
     # LogRecord[]), so even an `ERROR:` header stays an unclassified info line.
     log_file = tmp_path / "session.log"
     log_file.write_text("known line\nERROR: boom\n", encoding="utf-8")
-    server = _server_with_session(tmp_path, log_file)
+    server = server_with_session(tmp_path, log_file)
 
     reply = server._handle({"op": "logger-tail", "params": {"raw": True}})
     assert reply is not None
@@ -88,7 +63,7 @@ def test_logger_tail_level_filters_by_minimum_severity(tmp_path):
         "ERROR: boom\n   at: g (res://b.gd:2)\n",
         encoding="utf-8",
     )
-    server = _server_with_session(tmp_path, log_file)
+    server = server_with_session(tmp_path, log_file)
 
     reply = server._handle({"op": "logger-tail", "params": {"level": "warning"}})
     assert reply is not None
@@ -102,7 +77,7 @@ def test_logger_tail_level_filters_by_minimum_severity(tmp_path):
 def test_logger_tail_limit_tails_the_most_recent_n(tmp_path):
     log_file = tmp_path / "session.log"
     log_file.write_text("one\ntwo\nthree\n", encoding="utf-8")
-    server = _server_with_session(tmp_path, log_file)
+    server = server_with_session(tmp_path, log_file)
 
     reply = server._handle({"op": "logger-tail", "params": {"limit": 1}})
     assert reply is not None
@@ -119,7 +94,7 @@ def test_logger_tail_serves_even_when_the_session_process_has_died(tmp_path):
     log_file.write_text(
         "ERROR: crashed\n   at: _ready (res://main.gd:3)\n", encoding="utf-8"
     )
-    server = _server_with_session(tmp_path, log_file, alive=False)
+    server = server_with_session(tmp_path, log_file, alive=False)
 
     reply = server._handle({"op": "logger-tail", "params": {}})
     assert reply is not None
@@ -132,7 +107,7 @@ def test_logger_tail_serves_even_when_the_session_process_has_died(tmp_path):
 def test_logger_tail_empty_log_is_an_empty_result_not_an_error(tmp_path):
     log_file = tmp_path / "session.log"
     log_file.write_text("", encoding="utf-8")
-    server = _server_with_session(tmp_path, log_file)
+    server = server_with_session(tmp_path, log_file)
 
     reply = server._handle({"op": "logger-tail", "params": {}})
     assert reply is not None
@@ -144,7 +119,7 @@ def test_logger_tail_empty_log_is_an_empty_result_not_an_error(tmp_path):
 def test_logger_tail_with_no_session_is_engine_session_not_running(tmp_path):
     # ADR-0022: a daemon-served log op observes an already-launched session; it does
     # NOT launch one. With none launched this lifetime it is a structured error.
-    server = DaemonServer(daemon_paths(_project(tmp_path)), godot="godot")
+    server = DaemonServer(daemon_paths(minimal_project(tmp_path)), godot="godot")
 
     reply = server._handle({"op": "logger-tail", "params": {}})
     assert reply is not None
@@ -159,7 +134,7 @@ def test_logger_tail_with_a_remembered_session_but_missing_file_is_live_log_unav
     tmp_path,
 ):
     log_file = tmp_path / "missing.log"  # never created
-    server = _server_with_session(tmp_path, log_file, alive=False)
+    server = server_with_session(tmp_path, log_file, alive=False)
 
     reply = server._handle({"op": "logger-tail", "params": {}})
     assert reply is not None

--- a/tests/test_daemon_ops.py
+++ b/tests/test_daemon_ops.py
@@ -21,6 +21,7 @@ from gda.commands.daemon import (
     run_daemon_stop_operation,
 )
 from gda.harness.install import HARNESS_VERSION
+from tests.support import minimal_project
 
 pytestmark = [
     pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"),
@@ -33,13 +34,8 @@ pytestmark = [
 _OK_VERSION = lambda binary: (4, 6)  # noqa: E731
 
 
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
-
-
 def test_daemon_start_status_stop_lifecycle(tmp_path, daemon_runtime_dir):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     paths = daemon_paths(project)
 
     try:
@@ -81,7 +77,7 @@ def test_daemon_status_reports_a_windowed_daemons_mode(tmp_path, daemon_runtime_
     # read back by `daemon status`. No engine session is launched here (lazy launch,
     # ADR-0017) — the daemon process merely records the declared mode — so this needs
     # no display and is headless-CI safe.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
 
     try:
         started = run_daemon_start_operation(
@@ -108,7 +104,7 @@ def test_daemon_status_reports_a_windowed_daemons_mode(tmp_path, daemon_runtime_
 def test_live_version_gate_rejects_below_4_6(tmp_path, daemon_runtime_dir):
     from gda.errors import Failure
 
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     outcome = run_daemon_start_operation(
         project, None, version_check=lambda binary: (4, 5)
     )
@@ -118,7 +114,7 @@ def test_live_version_gate_rejects_below_4_6(tmp_path, daemon_runtime_dir):
 
 
 def test_daemon_status_and_stop_when_not_running(tmp_path, daemon_runtime_dir):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
 
     status = run_daemon_status_operation(project)
     assert isinstance(status, DaemonStatusResult) and status.running is False

--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -25,13 +25,9 @@ from gda.commands.daemon import (
 )
 from gda.errors import Failure
 from gda.parser import build_result, parse_result
+from tests.support import FakeProc, minimal_project
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
-
-
-class _FakeProc:
-    def poll(self):
-        return None
 
 
 def _unavailable(
@@ -47,7 +43,7 @@ def _unavailable(
 
 
 def test_live_op_without_a_launchable_session_is_engine_session_not_running(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     # No Godot binary -> ensure_session cannot launch -> engine_session_not_running.
     server = DaemonServer(daemon_paths(tmp_path), godot="")
 
@@ -82,8 +78,7 @@ def test_malformed_control_request_is_dropped_not_raised(tmp_path):
 
 
 def _project_with_marker(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return daemon_paths(tmp_path)
+    return daemon_paths(minimal_project(tmp_path))
 
 
 def test_scene_mismatch_at_launch_is_a_typed_live_scene_not_found(
@@ -120,7 +115,7 @@ def test_a_verified_session_is_reused_without_re_checking_the_scene(
     # multiple live ops (no per-request disk/scene re-validation), so deleting the
     # scene file after launch cannot break a live op.
     calls = {"n": 0}
-    served = EngineSession(cast(subprocess.Popen, _FakeProc()), conn=None)
+    served = EngineSession(cast(subprocess.Popen, FakeProc()), conn=None)
     monkeypatch.setattr(
         served,
         "request",
@@ -230,7 +225,7 @@ def test_windowed_no_display_is_live_windowed_unavailable_without_launching(
     # windowed daemon on a host with no usable DisplayServer refuses a live op with the
     # typed live_windowed_unavailable AND never calls launch_session — so a doomed
     # windowed Godot is never spawned, even if `daemon start --windowed` slipped through.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
 
     def _must_not_launch(*a, **k):
         raise AssertionError("launch_session must not be called with no usable display")
@@ -264,7 +259,7 @@ def test_windowed_denied_relays_the_permission_code_not_the_capability_one(
     # so it also carries the machine-readable `probe` — deliberately widening the live
     # wire envelope with that ONE optional key (#667 review), rather than reporting
     # less here than the optional CLI fail-fast reports.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
 
     def _must_not_launch(*a, **k):
         raise AssertionError("launch_session must not be called with no usable display")
@@ -299,7 +294,7 @@ def test_a_relayed_refusal_without_a_probe_keeps_the_narrow_wire_shape(
     # The widening is OPTIONAL: every live reply that has no probe — which is all of
     # them except the windowed refusals — is byte-identical to before, so the key can
     # never appear as a null for the harness-emitted and daemon-synthesized codes.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     monkeypatch.setattr("gda.daemon.server.launch_session", lambda *a, **k: None)
     server = DaemonServer(daemon_paths(tmp_path), godot="godot")
     server._harness_listener = cast(socket.socket, object())
@@ -316,7 +311,7 @@ def test_windowed_with_a_usable_display_reaches_launch(tmp_path, monkeypatch):
     # The guard is display-gated: a usable display (the check returns None) does NOT
     # short-circuit — the launch proceeds (here to the generic engine_session_not_running
     # via a patched None launch), proving the guard fires ONLY on no-display.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     calls = {"n": 0}
 
     def _launch(*a, **k):
@@ -345,7 +340,7 @@ def test_headless_windowed_false_never_consults_the_display_check(
 ):
     # A default (headless) daemon must never consult the display check — a headless
     # session needs no window server; only a windowed session is gated.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
 
     def _boom() -> WindowedUnavailable | None:
         raise AssertionError("a headless daemon must not run the display check")
@@ -366,7 +361,7 @@ def test_headless_windowed_false_never_consults_the_display_check(
 def test_no_scene_selector_runs_main_scene_unchanged(tmp_path):
     # The selector-less default is unchanged: straight to the launch path (which here
     # is engine_session_not_running with no real binary), no scene verification.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     server = DaemonServer(daemon_paths(tmp_path), godot="")
 
     reply = server._handle({"op": "game-tree", "params": {}})
@@ -410,7 +405,7 @@ def test_engine_session_request_times_out_as_live_timeout(monkeypatch):
     # hang the daemon forever (ADR-0021).
     monkeypatch.setattr("gda.daemon.session.OP_TIMEOUT", 0.2)
     daemon_end, silent_harness = socket.socketpair()
-    session = EngineSession(cast(subprocess.Popen, _FakeProc()), daemon_end)
+    session = EngineSession(cast(subprocess.Popen, FakeProc()), daemon_end)
     try:
         reply = session.request("game-tree", {})
         assert parse_result(reply["stdout"])["error"]["code"] == "live_timeout"
@@ -444,7 +439,7 @@ def test_the_live_timeout_message_hedges_its_causes_and_rules_out_a_pause(monkey
     # unactionable class would repeat #684's mistake in a third direction.
     monkeypatch.setattr("gda.daemon.session.OP_TIMEOUT", 0.2)
     daemon_end, silent_harness = socket.socketpair()
-    session = EngineSession(cast(subprocess.Popen, _FakeProc()), daemon_end)
+    session = EngineSession(cast(subprocess.Popen, FakeProc()), daemon_end)
     try:
         reply = session.request("game-tree", {})
     finally:
@@ -475,7 +470,7 @@ def test_a_trickled_reply_cannot_outlast_the_relays_own_bound(monkeypatch):
     # bound rather than a defence.
     monkeypatch.setattr("gda.daemon.session.OP_TIMEOUT", 0.3)
     daemon_end, harness = socket.socketpair()
-    session = EngineSession(cast(subprocess.Popen, _FakeProc()), daemon_end)
+    session = EngineSession(cast(subprocess.Popen, FakeProc()), daemon_end)
 
     def _trickle() -> None:
         # A WELL-FORMED reply, so a relay that waits it out succeeds — the point
@@ -515,7 +510,7 @@ def test_a_timed_out_relay_leaves_the_session_dead_to_the_daemon(monkeypatch):
     # the next session-needing op rebuilds it through the launch boundary.
     monkeypatch.setattr("gda.daemon.session.OP_TIMEOUT", 0.2)
     daemon_end, harness = socket.socketpair()
-    proc = _FakeProc()
+    proc = FakeProc()
     session = EngineSession(cast(subprocess.Popen, proc), daemon_end)
     try:
         first = session.request("game-tree", {})

--- a/tests/test_daemon_socket_lifecycle.py
+++ b/tests/test_daemon_socket_lifecycle.py
@@ -50,7 +50,7 @@ from gda.daemon.session import (
 from gda.errors import Failure
 from gda.live_runner import DaemonRunner
 from gda.parser import build_result, parse_result
-from tests.support import no_engine_teardown
+from tests.support import FakeProc, minimal_project, no_engine_teardown
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
@@ -159,27 +159,6 @@ def _stubborn_child(**kwargs) -> subprocess.Popen:
     return proc
 
 
-def _project(tmp_path: Path) -> Path:
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
-
-
-class _Proc:
-    """A stand-in engine process whose liveness the test flips."""
-
-    def __init__(self, code: "int | None" = None) -> None:
-        self.code = code
-
-    def poll(self):
-        return self.code
-
-    # gda's OWN pid, deliberately: teardown reads the pid to find the process
-    # group it owns, and the own-group guard then resolves this stand-in to no
-    # group at all. An invented pid would instead resolve to whichever real
-    # process holds it — which a test would then signal.
-    pid = os.getpid()
-
-
 class _ServedSession:
     """A fake session that serves every relayed op — a structural SessionHandle."""
 
@@ -250,7 +229,7 @@ def _no_launch(*args, **kwargs):
 def test_serve_binds_both_sockets_and_answers_status(
     tmp_path, daemon_runtime_dir, monkeypatch
 ):
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_no_launch)
 
     with _serving(server, paths, monkeypatch):
@@ -271,7 +250,7 @@ def test_a_stale_slot_left_by_a_crash_is_reclaimed(
 ):
     # A crashed predecessor leaves socket files bound-then-abandoned and a pidfile
     # whose advisory lock nobody holds. A fresh serve() must reclaim the slot.
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     paths.runtime_dir.mkdir(parents=True, exist_ok=True)
     for stale in (paths.cli_socket, paths.harness_socket):
         abandoned = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -294,7 +273,7 @@ def test_a_double_start_loses_without_touching_the_live_daemons_slot(
     # reachable ones), and not its pidfile CONTENT either — a pre-lock
     # truncation erases the winner's recorded identity, so status, attach, and
     # stop all read the live daemon as not running (#723 review).
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     winner = DaemonServer(paths, godot="godot", launch=_no_launch)
 
     with _serving(winner, paths, monkeypatch):
@@ -322,7 +301,7 @@ def test_cleanup_removes_the_slot_before_releasing_the_lock(
     # fresh slot inside the cleanup window — which the predecessor's remaining
     # unlinks then destroy. Instrumenting unlink pins the order: every slot
     # path must be removed while the lock is still held.
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_no_launch)
     slot = {paths.cli_socket, paths.harness_socket, paths.pidfile}
     held_at_unlink: dict = {}
@@ -354,7 +333,7 @@ def test_cleanup_removes_the_slot_before_releasing_the_lock(
 def test_stop_op_unlinks_the_sockets_and_pidfile(
     tmp_path, daemon_runtime_dir, monkeypatch
 ):
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_no_launch)
 
     with _serving(server, paths, monkeypatch) as thread:
@@ -375,7 +354,7 @@ def test_a_termination_signal_cleans_up_the_slot(tmp_path, daemon_runtime_dir):
     # re-enactment is deliberately NOT used here — on Linux, closing a listener
     # from another thread does not wake a blocked accept, which is a fact about
     # threads, not about the signal path under test.
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_no_launch)
 
     child = os.fork()
@@ -418,7 +397,7 @@ def test_an_overlong_socket_path_is_refused_at_start(tmp_path, monkeypatch):
     # spawn, instead of the daemon's bind() failing and start timing out vaguely.
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / ("x" * 150)))
 
-    outcome = run_daemon_start_operation(_project(tmp_path), "godot")
+    outcome = run_daemon_start_operation(minimal_project(tmp_path), "godot")
 
     assert isinstance(outcome, Failure)
     assert outcome.error.code == "daemon_not_running"
@@ -438,7 +417,7 @@ def test_the_first_live_op_launches_the_session_lazily_and_reuses_it(
         calls["n"] += 1
         return session
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     with _serving(server, paths, monkeypatch):
@@ -457,7 +436,7 @@ def test_a_failed_launch_is_the_typed_engine_session_not_running(
     def _launch(*args, **kwargs):
         return None
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     with _serving(server, paths, monkeypatch):
@@ -479,7 +458,7 @@ def test_a_session_dying_mid_request_reports_disconnect_then_relaunches(
     no_engine_teardown(monkeypatch)  # the dying session is a stand-in, not a child
     ours, theirs = socket.socketpair()
     theirs.close()  # the harness end is gone: the relay write breaks mid-request
-    proc = _Proc(code=None)  # alive at the pre-request liveness check
+    proc = FakeProc(returncode=None)  # alive at the pre-request liveness check
     dying = EngineSession(cast(subprocess.Popen, proc), conn=ours)
 
     launches: list = []
@@ -490,12 +469,12 @@ def test_a_session_dying_mid_request_reports_disconnect_then_relaunches(
             return dying
         return _ServedSession()
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     with _serving(server, paths, monkeypatch):
         first = _request(paths, {"op": "game-tree", "params": {}})
-        proc.code = 1  # the engine process is now observed dead
+        proc.returncode = 1  # the engine process is now observed dead
         second = _request(paths, {"op": "game-tree", "params": {}})
 
     assert first is not None
@@ -520,7 +499,7 @@ def test_wait_ready_launches_once_and_reports_the_bounded_wait(
         launches.append(kwargs.get("deadline"))
         return session
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     with _serving(server, paths, monkeypatch):
@@ -568,7 +547,7 @@ def test_status_reports_the_minted_session_identity_across_the_lifecycle(
         sessions.append(session)
         return session
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     with _serving(server, paths, monkeypatch):
@@ -618,7 +597,7 @@ def test_a_failed_replacement_launch_retains_the_last_established_identity(
         sessions.append(session)
         return session
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     with _serving(server, paths, monkeypatch):
@@ -652,11 +631,11 @@ def test_launch_session_places_the_identity_on_the_harness_tail(
 
     def _record_spawn(argv, **kwargs):
         spawned.append(argv)
-        return _Proc(code=None)
+        return FakeProc(returncode=None)
 
     monkeypatch.setattr(subprocess, "Popen", _record_spawn)
     no_engine_teardown(monkeypatch)
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     paths.runtime_dir.mkdir(parents=True, exist_ok=True)
     listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     listener.bind(str(paths.harness_socket))
@@ -696,7 +675,7 @@ def test_wait_ready_relays_the_typed_launch_failure(
     def _launch(*args, **kwargs):
         return None
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     with _serving(server, paths, monkeypatch):
@@ -715,9 +694,11 @@ def test_a_silent_handshake_peer_cannot_hold_the_launch_past_the_deadline(
     # accept, the token frame, and the verification frame. A peer that connects
     # and then never speaks used to block the token read forever — here the
     # REAL launch_session must give up within the bound and record why.
-    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _Proc(code=None))
+    monkeypatch.setattr(
+        subprocess, "Popen", lambda argv, **kw: FakeProc(returncode=None)
+    )
     no_engine_teardown(monkeypatch)
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     paths.runtime_dir.mkdir(parents=True, exist_ok=True)
     listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     listener.bind(str(paths.harness_socket))
@@ -758,9 +739,11 @@ def test_a_trickling_handshake_peer_cannot_hold_the_launch_past_the_deadline(
     # to be recomputed per recv, not set once per frame. Measured before the fix
     # at a 0.04s/byte trickle on a 0.05s bound: 0.7s for the token frame, 2.1s
     # for the verification frame — and the trickle rate is the peer's to choose.
-    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _Proc(code=None))
+    monkeypatch.setattr(
+        subprocess, "Popen", lambda argv, **kw: FakeProc(returncode=None)
+    )
     no_engine_teardown(monkeypatch)
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     paths.runtime_dir.mkdir(parents=True, exist_ok=True)
     listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     listener.bind(str(paths.harness_socket))
@@ -817,10 +800,10 @@ def test_a_slow_spawn_cannot_revive_the_callers_expired_deadline(
 
     def _slow_popen(argv, **kwargs):
         time.sleep(0.12)  # a spawn that costs more than the whole budget
-        return _Proc(code=None)
+        return FakeProc(returncode=None)
 
     monkeypatch.setattr(subprocess, "Popen", _slow_popen)
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     paths.runtime_dir.mkdir(parents=True, exist_ok=True)
     listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     listener.bind(str(paths.harness_socket))
@@ -858,7 +841,7 @@ def test_launch_preparation_that_crosses_the_deadline_spawns_nothing(
 
     def _record_spawn(argv, **kwargs):
         spawned.append(time.monotonic())
-        return _Proc(code=None)
+        return FakeProc(returncode=None)
 
     real_write = Path.write_bytes
 
@@ -869,7 +852,7 @@ def test_launch_preparation_that_crosses_the_deadline_spawns_nothing(
     monkeypatch.setattr(subprocess, "Popen", _record_spawn)
     monkeypatch.setattr(Path, "write_bytes", _slow_write)
     no_engine_teardown(monkeypatch)
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     paths.runtime_dir.mkdir(parents=True, exist_ok=True)
     listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     listener.bind(str(paths.harness_socket))
@@ -904,11 +887,11 @@ def test_a_deadline_spent_by_the_spawn_is_not_blamed_on_the_harness(
     # failure and plainly false here: the token is already queued.
     def _slow_popen(argv, **kwargs):
         time.sleep(0.12)
-        return _Proc(code=None)
+        return FakeProc(returncode=None)
 
     monkeypatch.setattr(subprocess, "Popen", _slow_popen)
     no_engine_teardown(monkeypatch)
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     paths.runtime_dir.mkdir(parents=True, exist_ok=True)
     listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     listener.bind(str(paths.harness_socket))
@@ -961,7 +944,7 @@ def test_retiring_a_stale_session_is_charged_to_the_callers_deadline(
         launches.append(kwargs.get("deadline"))
         return stale if len(launches) == 1 else None
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
     queued: list = []
 
@@ -1128,7 +1111,7 @@ def test_the_live_clients_ceiling_covers_the_whole_round_trip(
     # INACTIVITY timeout, not a round-trip ceiling — a trickling daemon could
     # hold the CLI indefinitely. Same absolute-instant rule as every other read.
     monkeypatch.setattr("gda.live_runner.LIVE_REQUEST_TIMEOUT", 0.3)
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     paths.runtime_dir.mkdir(parents=True, exist_ok=True)
     listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     listener.bind(str(paths.cli_socket))
@@ -1280,7 +1263,7 @@ def test_a_permission_error_does_not_mean_the_group_is_empty(monkeypatch):
 
     monkeypatch.setattr(os, "killpg", _permission_denied)
 
-    assert _group_standing(1234, cast(subprocess.Popen, _Proc()))
+    assert _group_standing(1234, cast(subprocess.Popen, FakeProc()))
 
 
 def test_a_descendant_may_finish_its_own_cleanup_inside_the_deadline(tmp_path):
@@ -1385,9 +1368,11 @@ def test_a_stuck_handshake_does_not_freeze_the_daemon(
     # serve loop while a peer occupies the harness socket silently. wait-ready
     # must come back typed within its bound, and — the daemon serving one
     # request at a time — the NEXT control request must still be served.
-    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _Proc(code=None))
+    monkeypatch.setattr(
+        subprocess, "Popen", lambda argv, **kw: FakeProc(returncode=None)
+    )
     no_engine_teardown(monkeypatch)
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot")  # the real launch seam default
 
     with _serving(server, paths, monkeypatch):
@@ -1422,7 +1407,7 @@ def test_wait_ready_rebuilds_a_session_whose_channel_broke(
     no_engine_teardown(monkeypatch)
     ours, theirs = socket.socketpair()
     theirs.close()
-    zombie = EngineSession(cast(subprocess.Popen, _Proc(code=None)), conn=ours)
+    zombie = EngineSession(cast(subprocess.Popen, FakeProc(returncode=None)), conn=ours)
 
     launches: list = []
 
@@ -1430,7 +1415,7 @@ def test_wait_ready_rebuilds_a_session_whose_channel_broke(
         launches.append(1)
         return zombie if len(launches) == 1 else _ServedSession()
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     with _serving(server, paths, monkeypatch):
@@ -1457,7 +1442,9 @@ def test_wait_ready_rebuilds_a_session_whose_relay_timed_out(
     monkeypatch.setattr("gda.daemon.session.OP_TIMEOUT", 0.2)
     no_engine_teardown(monkeypatch)
     ours, silent_harness = socket.socketpair()
-    desynced = EngineSession(cast(subprocess.Popen, _Proc(code=None)), conn=ours)
+    desynced = EngineSession(
+        cast(subprocess.Popen, FakeProc(returncode=None)), conn=ours
+    )
 
     launches: list = []
 
@@ -1465,7 +1452,7 @@ def test_wait_ready_rebuilds_a_session_whose_relay_timed_out(
         launches.append(1)
         return desynced if len(launches) == 1 else _ServedSession()
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     try:
@@ -1501,7 +1488,7 @@ def test_a_teardown_cannot_outlast_the_readiness_deadline(
         return proc
 
     monkeypatch.setattr(subprocess, "Popen", _spawn_stubborn_child)
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot")  # the real launch + teardown
     queued: list = []
 
@@ -1567,7 +1554,7 @@ def test_launched_is_reported_by_the_launch_owner(
         launches.append(1)
         return flip if len(launches) == 1 else _ServedSession()
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     with _serving(server, paths, monkeypatch):
@@ -1604,7 +1591,7 @@ def test_every_declared_daemon_served_op_is_intercepted_not_relayed(
     def _launch(*args, **kwargs):
         return session
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     with _serving(server, paths, monkeypatch):
@@ -1623,7 +1610,7 @@ def test_the_wire_boundary_re_enforces_the_wait_ready_bound(
     # #725 review finding 4: the finite (0, 50] rule holds at the IPC boundary
     # too — this socket can be driven by clients other than gda's CLI, and an
     # unbounded or non-finite value would defeat the bound the op promises.
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_no_launch)
 
     with _serving(server, paths, monkeypatch):

--- a/tests/test_daemon_wait_ready_commands.py
+++ b/tests/test_daemon_wait_ready_commands.py
@@ -14,12 +14,12 @@ from typer.testing import CliRunner
 from gda.cli import app
 from gda.exit_codes import EXIT_LIVE
 from gda.runner import RunResult
-from tests.support import inject_live_runner, sentinel
-
-
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
+from tests.support import (
+    assert_operation_error,
+    inject_live_runner,
+    minimal_project,
+    sentinel,
+)
 
 
 READY = {"pid": 4242, "launched": True}
@@ -31,7 +31,8 @@ def test_wait_ready_reports_the_established_session_as_json(monkeypatch, tmp_pat
     )
 
     result = CliRunner().invoke(
-        app, ["daemon", "wait-ready", "--project", str(_project(tmp_path)), "--json"]
+        app,
+        ["daemon", "wait-ready", "--project", str(minimal_project(tmp_path)), "--json"],
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -54,7 +55,7 @@ def test_wait_ready_passes_the_caller_bound_through(monkeypatch, tmp_path):
             "--timeout",
             "10",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -69,7 +70,7 @@ def test_wait_ready_human_output_names_the_launch_state(monkeypatch, tmp_path):
     )
 
     result = CliRunner().invoke(
-        app, ["daemon", "wait-ready", "--project", str(_project(tmp_path))]
+        app, ["daemon", "wait-ready", "--project", str(minimal_project(tmp_path))]
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -87,7 +88,7 @@ def test_wait_ready_human_output_reports_an_already_serving_session(
     )
 
     result = CliRunner().invoke(
-        app, ["daemon", "wait-ready", "--project", str(_project(tmp_path))]
+        app, ["daemon", "wait-ready", "--project", str(minimal_project(tmp_path))]
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -99,7 +100,8 @@ def test_wait_ready_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_p
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
 
     result = CliRunner().invoke(
-        app, ["daemon", "wait-ready", "--project", str(_project(tmp_path)), "--json"]
+        app,
+        ["daemon", "wait-ready", "--project", str(minimal_project(tmp_path)), "--json"],
     )
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
@@ -112,7 +114,7 @@ def test_wait_ready_refuses_an_out_of_range_bound_on_argv(monkeypatch, tmp_path)
     # The params model owns the (0, 50] bound (ADR-0015): the argv path
     # translates its refusal into the Click usage error. 50 caps the wait under
     # the live channel's 60s client-side round-trip bound.
-    project = str(_project(tmp_path))
+    project = str(minimal_project(tmp_path))
     for bad in ("0", "60", "inf", "nan"):
         result = CliRunner().invoke(
             app, ["daemon", "wait-ready", "--timeout", bad, "--project", project]
@@ -130,10 +132,9 @@ def test_wait_ready_refuses_an_out_of_range_bound_on_params_json(monkeypatch, tm
             "--params-json",
             json.dumps({"timeout": 60}),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
 
-    assert result.exit_code == 4, result.stdout + result.stderr
-    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+    assert_operation_error(result, "invalid_params")

--- a/tests/test_diag_commands.py
+++ b/tests/test_diag_commands.py
@@ -20,12 +20,8 @@ from tests.support import (
     error_sentinel,
     inject_live_runner,
     sentinel,
+    minimal_project,
 )
-
-
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
 
 
 def test_diag_errors_emits_structured_errors_json_through_the_live_channel(
@@ -37,7 +33,7 @@ def test_diag_errors_emits_structured_errors_json_through_the_live_channel(
     )
 
     result = CliRunner().invoke(
-        app, ["diag", "errors", "--project", str(_project(tmp_path)), "--json"]
+        app, ["diag", "errors", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -69,7 +65,7 @@ def test_diag_errors_passes_limit_through(monkeypatch, tmp_path):
             "--limit",
             "5",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -91,7 +87,7 @@ def test_diag_errors_rejects_a_non_positive_limit_on_the_argv_path(tmp_path):
                 "--limit",
                 bad,
                 "--project",
-                str(_project(tmp_path)),
+                str(minimal_project(tmp_path)),
                 "--json",
             ],
         )
@@ -105,7 +101,7 @@ def test_diag_errors_human_output_renders_levels(monkeypatch, tmp_path):
     )
 
     result = CliRunner().invoke(
-        app, ["diag", "errors", "--project", str(_project(tmp_path))]
+        app, ["diag", "errors", "--project", str(minimal_project(tmp_path))]
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -122,7 +118,7 @@ def test_diag_errors_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
 
     result = CliRunner().invoke(
-        app, ["diag", "errors", "--project", str(_project(tmp_path)), "--json"]
+        app, ["diag", "errors", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
@@ -144,7 +140,7 @@ def test_diag_errors_log_unavailable_is_a_typed_live_error(monkeypatch, tmp_path
     )
 
     result = CliRunner().invoke(
-        app, ["diag", "errors", "--project", str(_project(tmp_path)), "--json"]
+        app, ["diag", "errors", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
@@ -169,7 +165,7 @@ def test_diag_params_json_rejects_a_non_positive_limit_as_invalid_params(
                 "--params-json",
                 json.dumps({"limit": bad}),
                 "--project",
-                str(_project(tmp_path)),
+                str(minimal_project(tmp_path)),
                 "--json",
             ],
         )

--- a/tests/test_export_commands.py
+++ b/tests/test_export_commands.py
@@ -17,7 +17,6 @@ from gda.runner import RunResult
 from tests.support import (
     EXPORT_GET_RESULT as GET_RESULT,
     EXPORT_LIST_RESULT as LIST_RESULT,
-    inject_runner,
     invoke_cli,
     minimal_project,
     recording_runner,
@@ -90,11 +89,9 @@ def test_export_get_json_reports_preset_details_and_template_status(monkeypatch)
 def test_export_get_missing_preset_flag_is_a_usage_error(monkeypatch):
     # --preset is required: export get always needs a preset to address. Its
     # absence is a usage error (exit 2) that fires before any dispatch.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch, ["export", "get", "--json"], stdout=sentinel(GET_RESULT)
     )
-
-    result = CliRunner().invoke(app, ["export", "get", "--json"])
 
     assert result.exit_code == 2
     assert fake.calls == []

--- a/tests/test_export_commands.py
+++ b/tests/test_export_commands.py
@@ -17,8 +17,10 @@ from gda.runner import RunResult
 from tests.support import (
     EXPORT_GET_RESULT as GET_RESULT,
     EXPORT_LIST_RESULT as LIST_RESULT,
-    FakeRunner,
     inject_runner,
+    invoke_cli,
+    minimal_project,
+    recording_runner,
     sentinel,
 )
 
@@ -27,14 +29,12 @@ def test_export_list_json_enumerates_presets_and_exit_zero(monkeypatch, tmp_path
     # export list enumerates the resolved project's export presets (issue #114):
     # each entry carries its index, name, platform, and runnable flag, read
     # cheaply from export_presets.cfg.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(LIST_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["export", "list", "--project", str(tmp_path), "--json"]
+    minimal_project(tmp_path)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["export", "list", "--project", str(tmp_path), "--json"],
+        stdout=sentinel(LIST_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -52,23 +52,17 @@ def test_export_list_json_enumerates_presets_and_exit_zero(monkeypatch, tmp_path
 def test_export_list_passes_resolved_project_to_the_runner(monkeypatch, tmp_path):
     # export list reads export_presets.cfg in the resolved project, so --project
     # must reach the runner (which hands it to the engine as --path, issue #32).
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    seen: dict = {}
-
-    def record(binary, project):
-        seen["project"] = project
-        return FakeRunner(
-            RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
-        )
-
-    monkeypatch.setattr("gda.dispatch.make_runner", record)
+    minimal_project(tmp_path)
+    projects = recording_runner(
+        monkeypatch, RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(
         app, ["export", "list", "--project", str(tmp_path), "--json"]
     )
 
     assert result.exit_code == 0
-    assert seen["project"] == tmp_path
+    assert projects[0] == tmp_path
 
 
 def test_export_get_json_reports_preset_details_and_template_status(monkeypatch):
@@ -76,10 +70,11 @@ def test_export_get_json_reports_preset_details_and_template_status(monkeypatch)
     # (issue #114): the preset is addressed by --preset (its display name), and
     # the result carries templates_installed/templates_version so an agent can
     # check readiness before an export run.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(GET_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(app, ["export", "get", "--preset", "Web", "--json"])
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["export", "get", "--preset", "Web", "--json"],
+        stdout=sentinel(GET_RESULT),
+    )
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -110,10 +105,11 @@ def test_export_get_templates_missing_rides_through_false(monkeypatch):
     # templates_installed=false rides through to the result so the agent knows it
     # must install templates before an export run.
     payload = {**GET_RESULT, "templates_installed": False, "export_path": ""}
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(payload)
-    inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(app, ["export", "get", "--preset", "Web", "--json"])
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["export", "get", "--preset", "Web", "--json"],
+        stdout=sentinel(payload),
+    )
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)

--- a/tests/test_export_errors.py
+++ b/tests/test_export_errors.py
@@ -9,39 +9,19 @@ group mints two new codes for the modes that had no existing code
 ``project_not_found`` for the projectless mode.
 """
 
-import json
-
-from typer.testing import CliRunner
-
-from gda.cli import app
-from gda.runner import RunResult
-from tests.support import error_sentinel, inject_runner
+from tests.support import assert_operation_error, operation_error_invoker
 
 
-def _invoke_export_list(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: export-list\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, ["export", "list", "--json"])
+_export_list = operation_error_invoker(
+    ["export", "list", "--json"],
+    "export-list",
+)
 
 
-def _invoke_export_get(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: export-get\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, ["export", "get", "--preset", "Web", "--json"])
+_export_get = operation_error_invoker(
+    ["export", "get", "--preset", "Web", "--json"],
+    "export-get",
+)
 
 
 def test_export_list_no_export_presets_maps_to_export_presets_not_found(monkeypatch):
@@ -49,19 +29,19 @@ def test_export_list_no_export_presets_maps_to_export_presets_not_found(monkeypa
     # this is the new export_presets_not_found code (distinct from a generic
     # missing-path), so an agent knows the project defines no presets rather than
     # mistaking it for an empty listing.
-    result = _invoke_export_list(
+    result = _export_list(
         monkeypatch,
         "export_presets_not_found",
         "project has no export_presets.cfg; no export presets are defined",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "export_presets_not_found"
-    assert "export_presets.cfg" in err["message"]
     # The raw stderr still rides along as diagnostics (ADR-0002).
-    assert err["diagnostics"] == "gda: running operation: export-list\n"
+    assert_operation_error(
+        result,
+        "export_presets_not_found",
+        "export_presets.cfg",
+        diagnostics="gda: running operation: export-list\n",
+    )
 
 
 def test_export_list_without_project_reuses_stable_project_not_found_code(monkeypatch):
@@ -69,59 +49,48 @@ def test_export_list_without_project_reuses_stable_project_not_found_code(monkey
     # projectless: with no resolvable project, the operation reuses the registered
     # project_not_found code (the same one scene/script list use) so an agent
     # knows to pass --project rather than retry.
-    result = _invoke_export_list(
+    result = _export_list(
         monkeypatch,
         "project_not_found",
         "export list requires a Godot project; none was resolved — pass --project",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "project_not_found"
-    assert "--project" in err["message"]
+    assert_operation_error(result, "project_not_found", "--project")
 
 
 def test_export_get_unknown_preset_maps_to_export_preset_not_found(monkeypatch):
     # A preset name not present in export_presets.cfg is the new
     # export_preset_not_found code, so an agent branches on the unknown-preset
     # mode (and re-lists to find the real names) without parsing prose.
-    result = _invoke_export_get(
+    result = _export_get(
         monkeypatch, "export_preset_not_found", "no export preset named: Web"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "export_preset_not_found"
-    assert "Web" in err["message"]
-    assert err["diagnostics"] == "gda: running operation: export-get\n"
+    assert_operation_error(
+        result,
+        "export_preset_not_found",
+        "Web",
+        diagnostics="gda: running operation: export-get\n",
+    )
 
 
 def test_export_get_no_export_presets_maps_to_export_presets_not_found(monkeypatch):
     # export get over a project with no export_presets.cfg reports the same
     # export_presets_not_found mode as export list — there is nothing to address.
-    result = _invoke_export_get(
+    result = _export_get(
         monkeypatch,
         "export_presets_not_found",
         "project has no export_presets.cfg; no export presets are defined",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "export_presets_not_found"
+    assert_operation_error(result, "export_presets_not_found")
 
 
 def test_export_get_without_project_reuses_stable_project_not_found_code(monkeypatch):
-    result = _invoke_export_get(
+    result = _export_get(
         monkeypatch,
         "project_not_found",
         "export get requires a Godot project; none was resolved — pass --project",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "project_not_found"
-    assert "--project" in err["message"]
+    assert_operation_error(result, "project_not_found", "--project")

--- a/tests/test_export_run_commands.py
+++ b/tests/test_export_run_commands.py
@@ -33,8 +33,10 @@ from typer.testing import CliRunner
 from gda.cli import app
 from gda.runner import RunResult
 from tests.support import (
+    ENGINE_BANNER,
     FakeExportRunner,
-    FakeRunner,
+    inject_runner,
+    minimal_project,
     plain_text,
     sentinel,
 )
@@ -52,15 +54,9 @@ GET_RESULT = {
 
 def _inject(monkeypatch, *, get=GET_RESULT, export=None):
     """Wire both seams: the sentinel runner for export-get, the export runner."""
-    get_runner = FakeRunner(
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n" + sentinel(get),
-            stderr="",
-            exit_code=0,
-        )
-    )
-    monkeypatch.setattr(
-        "gda.dispatch.make_runner", lambda binary, project=None: get_runner
+    get_runner = inject_runner(
+        monkeypatch,
+        RunResult(stdout=ENGINE_BANNER + sentinel(get), stderr="", exit_code=0),
     )
     if export is None:
         export = RunResult(stdout="", stderr="", exit_code=0)
@@ -84,7 +80,7 @@ def test_export_run_params_json_drives_the_native_export_runner(monkeypatch, tmp
     # sentinel pipeline. --params-json (ADR-0015) must drive that SAME recipe, so
     # the export runner is actually invoked — a regression guard against the
     # generic dispatch hook routing it through the wrong (sentinel) path.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     _, export_runner = _inject(monkeypatch)
 
     result = CliRunner().invoke(
@@ -114,7 +110,7 @@ def test_export_run_json_reports_configured_path_and_exit_zero(monkeypatch, tmp_
     # acceptance behavior) and reports the result (preset, platform, mode,
     # output_path, warnings) as typed JSON. The mode is always release in #121; an
     # agent's template-readiness check via export get is now also gda's preflight.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     _, export_runner = _inject(monkeypatch)
 
     result = CliRunner().invoke(
@@ -149,7 +145,7 @@ def test_export_run_json_reports_configured_path_and_exit_zero(monkeypatch, tmp_
 def test_export_run_json_keeps_native_progress_on_stderr(monkeypatch, tmp_path):
     # issue #431: the native export phase gets a progress line, but JSON stdout
     # remains exactly one machine-readable result object.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     _, export_runner = _inject(monkeypatch)
 
     result = CliRunner().invoke(
@@ -187,7 +183,7 @@ def test_export_run_default_mode_is_release(monkeypatch, tmp_path):
     # #170 adds --mode but keeps release the default: omitting --mode runs the
     # native --export-release invocation and reports mode == "release", the #121
     # behavior preserved.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     _, export_runner = _inject(monkeypatch)
 
     result = CliRunner().invoke(
@@ -214,7 +210,7 @@ def test_export_run_mode_selects_export_flavor(monkeypatch, tmp_path):
     # --mode (issue #170) selects the export flavor, reflected in BOTH the native
     # invocation (the mode string the runner is asked to export) and the result's
     # `mode` field. Each of debug/pack flows end-to-end through the pipeline.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     for mode in ("debug", "pack"):
         _, export_runner = _inject(monkeypatch)
 
@@ -245,7 +241,7 @@ def test_export_run_mode_selects_export_flavor(monkeypatch, tmp_path):
 def test_export_run_rejects_unknown_mode(monkeypatch, tmp_path):
     # --mode is a closed set (release/debug/pack); an unrecognized value is a
     # Typer usage error (exit 2) and spawns no engine.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
 
     def _boom(*args, **kwargs):
         raise AssertionError("a rejected --mode must not spawn any engine")
@@ -275,7 +271,7 @@ def test_export_run_output_overrides_configured_path(monkeypatch, tmp_path):
     # native export is driven to the override, NOT the configured "build/game.x86_64",
     # and the result's output_path reports the effective destination.
     monkeypatch.chdir(tmp_path)
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     _, export_runner = _inject(monkeypatch)
 
     result = CliRunner().invoke(
@@ -309,7 +305,7 @@ def test_export_run_relative_output_resolves_against_invoker_cwd(monkeypatch, tm
     # reaches Godot. The JSON result reports the same absolute artifact path.
     project = tmp_path / "project"
     project.mkdir()
-    (project / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(project)
     invoker_cwd = tmp_path / "caller"
     invoker_cwd.mkdir()
     monkeypatch.chdir(invoker_cwd)
@@ -344,7 +340,7 @@ def test_export_run_output_expands_leading_tilde(monkeypatch, tmp_path):
     # the artifact lands in $HOME, not a literal "~" directory.
     home = tmp_path / "home"
     monkeypatch.setenv("HOME", str(home))
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     _, export_runner = _inject(monkeypatch)
 
     result = CliRunner().invoke(
@@ -376,7 +372,7 @@ def test_export_run_output_overrides_unset_configured_path(monkeypatch, tmp_path
     # is empty: the export_path_unset preflight no longer fires (there IS a place to
     # write), and the export runs to the override.
     monkeypatch.chdir(tmp_path)
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     get = {**GET_RESULT, "export_path": ""}
     _, export_runner = _inject(monkeypatch, get=get)
 
@@ -407,7 +403,7 @@ def test_export_run_surfaces_advisory_warnings(monkeypatch, tmp_path):
     # A clean export (exit 0) that still emits engine WARNING lines surfaces them
     # advisorily on the success result (ADR-0002: stderr is advisory for success),
     # not as a failure — the export succeeded.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     _inject(
         monkeypatch,
         export=RunResult(
@@ -451,7 +447,7 @@ def test_export_run_missing_templates_is_structured_preflight(monkeypatch, tmp_p
     # templates_installed=False, so gda fails with export_templates_missing BEFORE
     # spawning any native export — no stderr string-matching (ADR-0002), no native
     # run. The message names the templates_version the agent must install.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     get = {
         **GET_RESULT,
         "templates_installed": False,
@@ -487,7 +483,7 @@ def test_export_run_pack_skips_template_preflight_when_missing(monkeypatch, tmp_
     # templates_installed=False, pack must NOT emit export_templates_missing — it
     # proceeds straight to the native runner. (release/debug, which DO need
     # templates, still fail fast — asserted by the parametric test below.)
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     get = {
         **GET_RESULT,
         "templates_installed": False,
@@ -523,7 +519,7 @@ def test_export_run_release_debug_still_require_templates_when_missing(
     # The counterpart guard: release and debug DO need platform templates, so with
     # templates_installed=False they still fail fast with export_templates_missing
     # before any native run — only pack is exempt (#170).
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     for mode in ("release", "debug"):
         get = {
             **GET_RESULT,
@@ -557,7 +553,7 @@ def test_export_run_release_debug_still_require_templates_when_missing(
 def test_export_run_generic_failure_is_structured(monkeypatch, tmp_path):
     # A non-zero export with no recognized stderr signature is the generic
     # export_failed code; the engine's stderr is preserved as diagnostics.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     _inject(
         monkeypatch,
         export=RunResult(
@@ -589,7 +585,7 @@ def test_export_run_unset_path_is_structured(monkeypatch, tmp_path):
     # A preset whose configured export_path is empty is the export_path_unset
     # failure — reported BEFORE the native export runs (no --output to fall back
     # on; that override is deferred to #170).
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     get = {**GET_RESULT, "export_path": ""}
     _, export_runner = _inject(monkeypatch, get=get)
 
@@ -615,8 +611,9 @@ def test_export_run_unset_path_is_structured(monkeypatch, tmp_path):
 def test_export_run_unknown_preset_reuses_export_get_error(monkeypatch, tmp_path):
     # An unknown preset surfaces export-get's clean export_preset_not_found,
     # reused verbatim — and no native export is attempted.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    get_runner = FakeRunner(
+    minimal_project(tmp_path)
+    inject_runner(
+        monkeypatch,
         RunResult(
             stdout=sentinel(
                 {
@@ -628,10 +625,7 @@ def test_export_run_unknown_preset_reuses_export_get_error(monkeypatch, tmp_path
             ),
             stderr="",
             exit_code=4,
-        )
-    )
-    monkeypatch.setattr(
-        "gda.dispatch.make_runner", lambda binary, project=None: get_runner
+        ),
     )
     export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
     monkeypatch.setattr(
@@ -699,7 +693,7 @@ def test_export_run_help_documents_output_resolution():
 
 def test_export_run_human_output_echoes_artifact(monkeypatch, tmp_path):
     # Without --json the command renders a human line naming the artifact.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     _inject(monkeypatch)
 
     result = CliRunner().invoke(

--- a/tests/test_export_run_commands.py
+++ b/tests/test_export_run_commands.py
@@ -36,6 +36,7 @@ from tests.support import (
     ENGINE_BANNER,
     FakeExportRunner,
     inject_runner,
+    invoke_cli,
     minimal_project,
     plain_text,
     sentinel,
@@ -612,29 +613,18 @@ def test_export_run_unknown_preset_reuses_export_get_error(monkeypatch, tmp_path
     # An unknown preset surfaces export-get's clean export_preset_not_found,
     # reused verbatim — and no native export is attempted.
     minimal_project(tmp_path)
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout=sentinel(
-                {
-                    "error": {
-                        "code": "export_preset_not_found",
-                        "message": "no such preset",
-                    }
-                }
-            ),
-            stderr="",
-            exit_code=4,
-        ),
-    )
     export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
     monkeypatch.setattr(
         "gda.dispatch.make_export_runner", lambda binary, project=None: export_runner
     )
 
-    result = CliRunner().invoke(
-        app,
+    result, _ = invoke_cli(
+        monkeypatch,
         ["export", "run", "--preset", "Nope", "--project", str(tmp_path), "--json"],
+        stdout=sentinel(
+            {"error": {"code": "export_preset_not_found", "message": "no such preset"}}
+        ),
+        exit_code=4,
     )
 
     assert result.exit_code == 4

--- a/tests/test_export_run_operation.py
+++ b/tests/test_export_run_operation.py
@@ -31,7 +31,13 @@ from gda.errors import Failure
 from gda.execution import ExecutionKind
 from gda.harness.install import install_harness, uninstall_harness
 from gda.runner import RunResult
-from tests.support import FakeExportRunner, FakeRunner, error_sentinel, sentinel
+from tests.support import (
+    ENGINE_BANNER,
+    FakeExportRunner,
+    FakeRunner,
+    error_sentinel,
+    sentinel,
+)
 
 
 def test_export_run_command_is_the_native_export_channel():
@@ -58,7 +64,7 @@ def _get_runner(get=GET_RESULT) -> FakeRunner:
     """A FakeRunner that returns ``get`` wrapped in an ADR-0002 success sentinel."""
     return FakeRunner(
         RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n" + sentinel(get),
+            stdout=ENGINE_BANNER + sentinel(get),
             stderr="",
             exit_code=0,
         )

--- a/tests/test_game_commands.py
+++ b/tests/test_game_commands.py
@@ -25,12 +25,8 @@ from tests.support import (
     inject_live_runner,
     panel_text,
     sentinel,
+    minimal_project,
 )
-
-
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
 
 
 def test_game_tree_emits_runtime_tree_json_through_the_live_channel(
@@ -42,7 +38,7 @@ def test_game_tree_emits_runtime_tree_json_through_the_live_channel(
     )
 
     result = CliRunner().invoke(
-        app, ["game", "tree", "--project", str(_project(tmp_path)), "--json"]
+        app, ["game", "tree", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -59,7 +55,7 @@ def test_game_tree_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_pa
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
 
     result = CliRunner().invoke(
-        app, ["game", "tree", "--project", str(_project(tmp_path)), "--json"]
+        app, ["game", "tree", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
@@ -95,7 +91,7 @@ def test_game_tree_on_non_unix_reports_live_unsupported_platform(monkeypatch, tm
     monkeypatch.setattr("gda.live_runner._is_unix", lambda: False)
 
     result = CliRunner().invoke(
-        app, ["game", "tree", "--project", str(_project(tmp_path)), "--json"]
+        app, ["game", "tree", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code != 0, result.stdout
@@ -120,7 +116,7 @@ def test_game_get_emits_runtime_properties_through_the_live_channel(
             "get",
             "/root/Main/Player",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -157,7 +153,7 @@ def test_game_get_passes_the_property_filter_through_the_live_channel(
             "--property",
             "position",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -196,7 +192,7 @@ def test_game_get_threads_the_texture_digest_opt_in(monkeypatch, tmp_path):
             "sprite_texture",
             "--texture-digest",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -265,7 +261,7 @@ def test_game_get_missing_node_reports_live_node_not_found(monkeypatch, tmp_path
             "get",
             "/root/Main/Ghost",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -295,7 +291,7 @@ def test_game_get_unknown_property_reports_live_unknown_property(monkeypatch, tm
             "--property",
             "nope",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -316,7 +312,7 @@ def test_game_get_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_pat
             "get",
             "/root/Main/Player",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -352,7 +348,7 @@ def test_game_rect_emits_rendered_control_rect_through_the_live_channel(
             "rect",
             "/root/Main/HUD/Stats",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -380,7 +376,7 @@ def test_game_rect_non_control_reports_live_not_control(monkeypatch, tmp_path):
             "rect",
             "/root/Main/Player",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -408,7 +404,7 @@ def test_game_rect_missing_node_reports_live_node_not_found(monkeypatch, tmp_pat
             "rect",
             "/root/Main/Ghost",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -441,7 +437,7 @@ def test_game_set_mutates_and_echoes_coerced_value_through_the_live_channel(
             "--value",
             "10,20",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -484,7 +480,7 @@ def test_game_set_missing_node_reports_live_node_not_found(monkeypatch, tmp_path
             "--value",
             "1,2",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -516,7 +512,7 @@ def test_game_set_unknown_property_reports_live_unknown_property(monkeypatch, tm
             "--value",
             "1",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -550,7 +546,7 @@ def test_game_set_uncoercible_value_reports_live_uncoercible_value(
             "--value",
             "not-a-vector",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -575,7 +571,7 @@ def test_game_set_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_pat
             "--value",
             "1,2",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -617,7 +613,7 @@ def test_game_call_invokes_the_method_and_projects_its_return(monkeypatch, tmp_p
             "--method",
             "qa_current_state_contract",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -662,7 +658,7 @@ def test_game_call_threads_json_args_as_values(monkeypatch, tmp_path):
             "--args",
             '[2, "peak", {"deep": [1]}]',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -700,7 +696,7 @@ def test_game_call_non_json_args_is_refused_before_the_wire(monkeypatch, tmp_pat
             "--args",
             "not json",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -731,7 +727,7 @@ def test_game_call_undeclared_method_reports_not_allowlisted(monkeypatch, tmp_pa
             "--method",
             "undeclared_secret",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -763,7 +759,7 @@ def test_game_call_distinguishes_missing_from_undeclared_and_bad_args(
                 "--method",
                 "whatever",
                 "--project",
-                str(_project(tmp_path)),
+                str(minimal_project(tmp_path)),
                 "--json",
             ],
         )
@@ -788,7 +784,7 @@ def test_game_call_human_render_names_the_method_and_value(monkeypatch, tmp_path
             "--method",
             "qa_current_state_contract",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
         ],
     )
 
@@ -903,7 +899,7 @@ def test_game_call_refuses_non_finite_args_on_both_paths(monkeypatch, tmp_path):
     # bound, gets live_timeout, and the session is retired (state lost). The
     # params model is the one authority both paths share (ADR-0015), so both
     # are refused structurally, before the wire.
-    project = str(_project(tmp_path))
+    project = str(minimal_project(tmp_path))
     for argv in (
         ["--method", "m", "--args", "[NaN]"],
         ["--method", "m", "--args", '[{"deep": [Infinity]}]'],
@@ -962,7 +958,7 @@ def test_game_call_accepts_finite_nested_json_args(monkeypatch, tmp_path):
             "--args",
             '[1, 2.5, {"a": [3.5, "x"]}]',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -973,7 +969,7 @@ def test_game_call_accepts_finite_nested_json_args(monkeypatch, tmp_path):
 
 def test_game_call_accepts_large_finite_float_args_on_both_paths(monkeypatch, tmp_path):
     """High-range floats already are binary64 and do not inherit the int bound."""
-    project = str(_project(tmp_path))
+    project = str(minimal_project(tmp_path))
     expected = [1e17, 2.5e17, {"deep": [1e300]}]
 
     invocations = (
@@ -1018,7 +1014,7 @@ def test_game_call_refuses_integers_beyond_the_exact_json_range(monkeypatch, tmp
     # nested positions are covered; the boundary value still rides through.
     from gda.commands.game import MAX_EXACT_JSON_INT
 
-    project = str(_project(tmp_path))
+    project = str(minimal_project(tmp_path))
     for argv in (
         ["--method", "m", "--args", f"[{MAX_EXACT_JSON_INT + 2}]"],
         ["--method", "m", "--args", f"[-{MAX_EXACT_JSON_INT + 2}]"],

--- a/tests/test_human_failure_output.py
+++ b/tests/test_human_failure_output.py
@@ -40,7 +40,7 @@ from gda.models import (
 from gda.render import render_failure
 from gda.runner import LaunchFailure, RunResult, TimeoutBound
 from gda.script_errors import ScriptError, ScriptErrorKind
-from tests.support import error_sentinel, inject_runner, sentinel
+from tests.support import error_sentinel, inject_runner, minimal_project, sentinel
 
 
 def _error(**overrides) -> GdaError:
@@ -461,12 +461,6 @@ def test_a_usage_refusal_without_json_is_rendered_by_the_same_one_renderer():
 # passed the whole suite. One CLI case each closes that, all four engine-free.
 
 
-def _project(tmp_path):
-    """The minimum that makes a directory a Godot project (ADR-0006)."""
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
-
-
 def test_an_unresolvable_project_is_refused_in_lines_on_the_dispatch_tail(tmp_path):
     # `dispatch._resolve_project_or_fail`, the shared project-resolution point: it
     # refuses BEFORE any command runs, so the flag is the one the tail carries down.
@@ -493,7 +487,7 @@ def test_a_recipe_failure_is_refused_in_lines_too(monkeypatch, tmp_path):
             "--output",
             str(tmp_path / "shot.png"),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
         ],
     )
 
@@ -515,7 +509,7 @@ def test_the_params_json_conflict_is_refused_in_lines(tmp_path):
             '{"path": "res://a.tscn", "root_type": "Node2D"}',
             "res://b.tscn",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
         ],
     )
 
@@ -536,7 +530,7 @@ def test_an_invalid_params_json_object_is_refused_in_lines(tmp_path):
             "--params-json",
             "{}",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
         ],
     )
 
@@ -578,7 +572,7 @@ def _preflight(tmp_path, *extra: str):
             "preflight",
             "res://nope.tscn",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             *extra,
         ],
     )

--- a/tests/test_human_failure_output.py
+++ b/tests/test_human_failure_output.py
@@ -40,7 +40,13 @@ from gda.models import (
 from gda.render import render_failure
 from gda.runner import LaunchFailure, RunResult, TimeoutBound
 from gda.script_errors import ScriptError, ScriptErrorKind
-from tests.support import error_sentinel, inject_runner, minimal_project, sentinel
+from tests.support import (
+    error_sentinel,
+    inject_runner,
+    invoke_cli,
+    minimal_project,
+    sentinel,
+)
 
 
 def _error(**overrides) -> GdaError:
@@ -302,6 +308,9 @@ def test_a_human_invocation_gets_the_lines_and_never_the_envelope(monkeypatch):
     # End to end through the real CLI: no `--json`, so the failure arrives as text.
     # `gda info` with a hung runner is the fast engine-free fixture that carries
     # typed evidence as well as prose.
+    # Staged as a whole raw run, not through `invoke_cli`: the LAUNCH FAILURE
+    # this run carries is the input under test, and the invoker stages only the
+    # three canned streams.
     inject_runner(
         monkeypatch,
         RunResult(
@@ -328,6 +337,9 @@ def test_the_same_failure_under_json_is_the_envelope_and_nothing_else(monkeypatc
     # The scope-defining half, at the CLI: `--json` must be exactly what it was —
     # ONE line, the model's own `exclude_none` dump, with no rendered text anywhere
     # near it.
+    # Staged as a whole raw run, not through `invoke_cli`: the LAUNCH FAILURE
+    # this run carries is the input under test, and the invoker stages only the
+    # three canned streams.
     inject_runner(
         monkeypatch,
         RunResult(
@@ -360,9 +372,7 @@ def test_a_raw_stderr_failure_reaches_a_human_once_not_twice(monkeypatch):
     # emission point when the bytes are identical, so a human reads ONE copy, on
     # the channel the layout owns.
     raw = "Godot Engine v4.6.stable\nERROR: the operation said no\n"
-    inject_runner(monkeypatch, RunResult(stdout="", stderr=raw, exit_code=1))
-
-    result = CliRunner().invoke(app, ["info"])
+    result, _ = invoke_cli(monkeypatch, ["info"], stderr=raw, exit_code=1)
 
     assert result.exit_code == EXIT_OPERATION
     assert result.stdout.startswith("error: operation_failed (operation)\n")
@@ -375,9 +385,7 @@ def test_the_same_raw_failure_under_json_keeps_its_stderr_tee(monkeypatch):
     # The scope boundary: `--json`'s streams are exactly what they were — the
     # envelope alone on stdout, the child's stderr forwarded in full.
     raw = "Godot Engine v4.6.stable\nERROR: the operation said no\n"
-    inject_runner(monkeypatch, RunResult(stdout="", stderr=raw, exit_code=1))
-
-    result = CliRunner().invoke(app, ["info", "--json"])
+    result, _ = invoke_cli(monkeypatch, ["info", "--json"], stderr=raw, exit_code=1)
 
     assert result.exit_code == EXIT_OPERATION
     assert json.loads(result.stdout)["error"]["code"] == "operation_failed"
@@ -389,6 +397,9 @@ def test_a_capped_diagnostics_failure_keeps_the_full_stderr_tee(monkeypatch):
     # COMPOSED tail-capped capture, not the raw stream, so its tee — the only
     # complete copy — survives for a human too.
     raw = "Godot Engine v4.6.stable\n"
+    # Staged as a whole raw run, not through `invoke_cli`: the LAUNCH FAILURE
+    # this run carries is the input under test, and the invoker stages only the
+    # three canned streams.
     inject_runner(
         monkeypatch,
         RunResult(

--- a/tests/test_human_output.py
+++ b/tests/test_human_output.py
@@ -22,11 +22,8 @@ These run engine-free (FakeRunner) under ``-m "not e2e"``.
 """
 
 import pytest
-from typer.testing import CliRunner
 
-from gda.cli import app
-from gda.runner import RunResult
-from tests.support import inject_runner, sentinel
+from tests.support import invoke_cli, sentinel
 
 # Each case: (id, argv-without-`--json`, success-payload, expected-stdout-text).
 # The payload is wrapped in the result sentinel as operations.gd emits it; the
@@ -498,11 +495,7 @@ def test_human_mode_cli_output_is_exactly_the_rendered_text(
     # with a fake runner, and assert the exact stdout: the renderer's text plus
     # the single trailing newline typer.echo adds. This pins #139's render
     # dispatch + #140's gda.render end-to-end, per command.
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(app, argv)
+    result, _ = invoke_cli(monkeypatch, argv, stdout=sentinel(payload))
 
     assert result.exit_code == 0
     assert result.stdout == expected + "\n"

--- a/tests/test_info_command.py
+++ b/tests/test_info_command.py
@@ -7,10 +7,9 @@ from typer.testing import CliRunner
 from gda.cli import app
 from gda.runner import RunResult
 from tests.support import (
-    ENGINE_BANNER,
     VERSION_INFO,
     assert_operation_error,
-    inject_runner,
+    invoke_cli,
     minimal_project,
     recording_runner,
     sentinel,
@@ -19,12 +18,12 @@ from tests.support import (
 
 def test_info_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
     # Engine banner / warnings around the sentinel, plus diagnostics on stderr.
-    stdout = ENGINE_BANNER + "WARNING: benign\n" + sentinel(VERSION_INFO)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["info", "--json"],
+        stdout="WARNING: benign\n" + sentinel(VERSION_INFO),
+        stderr="engine diagnostic\n",
     )
-
-    result = CliRunner().invoke(app, ["info", "--json"])
 
     assert result.exit_code == 0
     # stdout carries ONLY the result payload — a single valid JSON object.

--- a/tests/test_info_command.py
+++ b/tests/test_info_command.py
@@ -6,14 +6,20 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import RunResult
-from tests.support import FakeRunner, VERSION_INFO, inject_runner, sentinel
+from tests.support import (
+    ENGINE_BANNER,
+    VERSION_INFO,
+    assert_operation_error,
+    inject_runner,
+    minimal_project,
+    recording_runner,
+    sentinel,
+)
 
 
 def test_info_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
     # Engine banner / warnings around the sentinel, plus diagnostics on stderr.
-    stdout = "Godot Engine v4.6.3.stable.official\nWARNING: benign\n" + sentinel(
-        VERSION_INFO
-    )
+    stdout = ENGINE_BANNER + "WARNING: benign\n" + sentinel(VERSION_INFO)
     fake = inject_runner(
         monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
     )
@@ -35,19 +41,6 @@ def test_info_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
 # --- `gda info --project`: accepted, validated, never inherited (#670) ---------
 
 
-def _record_project(monkeypatch, result: RunResult) -> list:
-    """Swap the runner seam for one that records the project it was built with."""
-    fake = FakeRunner(result)
-    projects: list = []
-
-    def factory(binary, project=None):
-        projects.append(project)
-        return fake
-
-    monkeypatch.setattr("gda.dispatch.make_runner", factory)
-    return projects
-
-
 def _ok(monkeypatch) -> RunResult:
     return RunResult(stdout=sentinel(VERSION_INFO), stderr="", exit_code=0)
 
@@ -58,9 +51,8 @@ def test_info_accepts_an_explicit_project_and_runs_against_it(monkeypatch, tmp_p
     # and honoured the way every other command honours it — handed to the engine as
     # its project (ADR-0006).
     project = tmp_path / "game"
-    project.mkdir()
-    (project / "project.godot").write_text("")
-    projects = _record_project(monkeypatch, _ok(monkeypatch))
+    minimal_project(project)
+    projects = recording_runner(monkeypatch, _ok(monkeypatch))
 
     result = CliRunner().invoke(app, ["info", "--project", str(project), "--json"])
 
@@ -72,12 +64,11 @@ def test_info_accepts_an_explicit_project_and_runs_against_it(monkeypatch, tmp_p
 def test_info_refuses_an_explicit_project_that_is_not_one(monkeypatch, tmp_path):
     # Validated, not merely accepted: a `--project` that names no Godot project is the
     # ordinary structured refusal, not a silent run against the wrong root.
-    _record_project(monkeypatch, _ok(monkeypatch))
+    recording_runner(monkeypatch, _ok(monkeypatch))
 
     result = CliRunner().invoke(app, ["info", "--project", str(tmp_path), "--json"])
 
-    assert result.exit_code == 4, result.stdout
-    assert json.loads(result.stdout)["error"]["code"] == "project_not_found"
+    assert_operation_error(result, "project_not_found")
 
 
 def test_info_ignores_an_inherited_project_context(monkeypatch, tmp_path):
@@ -85,7 +76,7 @@ def test_info_ignores_an_inherited_project_context(monkeypatch, tmp_path):
     # a stale $GDA_PROJECT in the shell would otherwise break the one command an agent
     # runs to find out whether anything works at all (#357's rule, same reasoning).
     monkeypatch.setenv("GDA_PROJECT", str(tmp_path / "gone"))
-    projects = _record_project(monkeypatch, _ok(monkeypatch))
+    projects = recording_runner(monkeypatch, _ok(monkeypatch))
 
     result = CliRunner().invoke(app, ["info", "--json"])
 
@@ -95,14 +86,13 @@ def test_info_ignores_an_inherited_project_context(monkeypatch, tmp_path):
 
 def test_the_params_json_path_validates_the_project_the_same_way(monkeypatch, tmp_path):
     # ADR-0015 parity: the form gda-mcp dispatches must refuse identically.
-    _record_project(monkeypatch, _ok(monkeypatch))
+    recording_runner(monkeypatch, _ok(monkeypatch))
 
     result = CliRunner().invoke(
         app, ["info", "--params-json", "{}", "--project", str(tmp_path), "--json"]
     )
 
-    assert result.exit_code == 4, result.stdout
-    assert json.loads(result.stdout)["error"]["code"] == "project_not_found"
+    assert_operation_error(result, "project_not_found")
 
 
 def test_the_project_option_is_not_an_operation_param(monkeypatch):

--- a/tests/test_info_errors.py
+++ b/tests/test_info_errors.py
@@ -15,7 +15,7 @@ from typer.testing import CliRunner
 from gda.cli import app
 from gda.runner import LaunchFailure, RunResult, TimeoutBound
 from tests.support import inject_runner as _inject
-from tests.support import raw_sentinel, sentinel
+from tests.support import assert_operation_error, raw_sentinel, sentinel
 
 
 def test_binary_not_found_maps_to_environment_error(monkeypatch):
@@ -88,10 +88,7 @@ def test_operation_failure_maps_to_operation_error_distinct_from_environment(
 
     result = CliRunner().invoke(app, ["info", "--json"])
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "operation_failed"
+    assert_operation_error(result, "operation_failed")
     assert "unknown operation" in result.stderr
 
 
@@ -108,12 +105,8 @@ def test_engine_signal_crash_maps_to_operation_error_distinct_from_clean_exit(
 
     result = CliRunner().invoke(app, ["info", "--json"])
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "engine_crashed"
     # The signal number is surfaced for diagnosis.
-    assert "11" in err["message"]
+    assert_operation_error(result, "engine_crashed", "11")
 
 
 def test_missing_sentinel_maps_to_parse_error_distinct_from_operation(monkeypatch):

--- a/tests/test_input_commands.py
+++ b/tests/test_input_commands.py
@@ -30,12 +30,8 @@ from tests.support import (
     error_sentinel,
     inject_live_runner,
     sentinel,
+    minimal_project,
 )
-
-
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
 
 
 # --- input key (single-frame) -------------------------------------------------
@@ -48,7 +44,15 @@ def test_input_key_injects_a_key_event_through_the_live_channel(monkeypatch, tmp
     )
 
     result = CliRunner().invoke(
-        app, ["input", "key", "Right", "--project", str(_project(tmp_path)), "--json"]
+        app,
+        [
+            "input",
+            "key",
+            "Right",
+            "--project",
+            str(minimal_project(tmp_path)),
+            "--json",
+        ],
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -81,7 +85,7 @@ def test_input_key_threads_modifiers_and_released(monkeypatch, tmp_path):
             "ctrl",
             "--released",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -105,7 +109,8 @@ def test_input_key_unresolvable_name_reports_live_invalid_key(monkeypatch, tmp_p
     )
 
     result = CliRunner().invoke(
-        app, ["input", "key", "Nope", "--project", str(_project(tmp_path)), "--json"]
+        app,
+        ["input", "key", "Nope", "--project", str(minimal_project(tmp_path)), "--json"],
     )
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
@@ -118,7 +123,15 @@ def test_input_key_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_pa
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
 
     result = CliRunner().invoke(
-        app, ["input", "key", "Right", "--project", str(_project(tmp_path)), "--json"]
+        app,
+        [
+            "input",
+            "key",
+            "Right",
+            "--project",
+            str(minimal_project(tmp_path)),
+            "--json",
+        ],
     )
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
@@ -158,7 +171,7 @@ def test_input_mouse_click_injects_the_whole_gesture_through_the_live_channel(
             "right",
             "--double",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -236,7 +249,7 @@ def test_input_mouse_move_injects_a_motion_through_the_live_channel(
             "50",
             "60",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -262,7 +275,7 @@ def test_input_mouse_click_default_button_is_left(monkeypatch, tmp_path):
             "1",
             "2",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -287,7 +300,7 @@ def test_input_mouse_click_unknown_button_argv_is_a_usage_error(monkeypatch, tmp
             "--button",
             "scroll",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -314,7 +327,14 @@ def test_input_action_presses_an_action_through_the_live_channel(monkeypatch, tm
 
     result = CliRunner().invoke(
         app,
-        ["input", "action", "jump", "--project", str(_project(tmp_path)), "--json"],
+        [
+            "input",
+            "action",
+            "jump",
+            "--project",
+            str(minimal_project(tmp_path)),
+            "--json",
+        ],
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -341,7 +361,7 @@ def test_input_action_release_and_strength_are_threaded(monkeypatch, tmp_path):
             "--strength",
             "0.5",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -362,7 +382,15 @@ def test_input_action_unknown_action_reports_live_unknown_action(monkeypatch, tm
     )
 
     result = CliRunner().invoke(
-        app, ["input", "action", "nope", "--project", str(_project(tmp_path)), "--json"]
+        app,
+        [
+            "input",
+            "action",
+            "nope",
+            "--project",
+            str(minimal_project(tmp_path)),
+            "--json",
+        ],
     )
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
@@ -386,7 +414,7 @@ def test_input_action_strength_over_range_argv_is_a_usage_error(monkeypatch, tmp
             "--strength",
             "2.0",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -419,7 +447,7 @@ def test_input_tap_key_dispatches_the_press_hold_release_window(monkeypatch, tmp
             "--key",
             "Right",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -473,7 +501,7 @@ def test_input_tap_action_threads_strength_and_frame_counts(monkeypatch, tmp_pat
             "--settle-frames",
             "0",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -506,7 +534,7 @@ def test_input_tap_requires_exactly_one_target(monkeypatch, tmp_path):
 
     neither = CliRunner().invoke(
         app,
-        ["input", "tap", "--project", str(_project(tmp_path)), "--json"],
+        ["input", "tap", "--project", str(minimal_project(tmp_path)), "--json"],
     )
     both = CliRunner().invoke(
         app,
@@ -518,7 +546,7 @@ def test_input_tap_requires_exactly_one_target(monkeypatch, tmp_path):
             "--action",
             "jump",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -547,7 +575,7 @@ def test_input_tap_rejects_the_other_targets_fields(monkeypatch, tmp_path):
             "--modifiers",
             "shift",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -561,7 +589,7 @@ def test_input_tap_rejects_the_other_targets_fields(monkeypatch, tmp_path):
             "--strength",
             "0.5",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -593,7 +621,7 @@ def test_input_tap_window_is_bounded_to_the_shared_ceiling(monkeypatch, tmp_path
             "--settle-frames",
             "0",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -621,7 +649,7 @@ def test_input_tap_hold_frames_zero_is_a_usage_error(monkeypatch, tmp_path):
             "--hold-frames",
             "0",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -672,7 +700,7 @@ def test_input_tap_omitted_action_strength_is_normalized_model_side(
             "--action",
             "jump",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -684,7 +712,7 @@ def test_input_tap_omitted_action_strength_is_normalized_model_side(
             "--params-json",
             '{"action": "jump"}',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -705,7 +733,7 @@ def test_input_tap_omitted_action_strength_is_normalized_model_side(
             "--key",
             "Right",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -775,7 +803,7 @@ def test_malformed_tap_reply_is_a_contract_violation(monkeypatch, tmp_path):
                 "--key",
                 "Right",
                 "--project",
-                str(_project(tmp_path)),
+                str(minimal_project(tmp_path)),
                 "--json",
             ],
         )
@@ -799,7 +827,7 @@ def test_malformed_click_reply_is_a_contract_violation(monkeypatch, tmp_path):
                 "1",
                 "2",
                 "--project",
-                str(_project(tmp_path)),
+                str(minimal_project(tmp_path)),
                 "--json",
             ],
         )
@@ -829,7 +857,7 @@ def test_malformed_mouse_move_reply_is_a_contract_violation(monkeypatch, tmp_pat
                 "1",
                 "2",
                 "--project",
-                str(_project(tmp_path)),
+                str(minimal_project(tmp_path)),
                 "--json",
             ],
         )
@@ -863,7 +891,7 @@ def test_input_sequence_injects_events_across_frames_through_the_live_channel(
             "--events",
             json.dumps(events),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -917,7 +945,7 @@ def test_input_sequence_physics_frame_offsets_dispatch_through_the_live_channel(
             "--events",
             json.dumps(events),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -963,7 +991,7 @@ def test_input_sequence_accepts_mouse_button_press_move_release(monkeypatch, tmp
             "--events",
             json.dumps(events),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -997,7 +1025,7 @@ def test_input_sequence_with_no_daemon_reports_daemon_not_running(
             "--events",
             json.dumps([{"type": "key", "key": "Right"}]),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1029,7 +1057,7 @@ def test_input_sequence_invalid_event_spec_reports_the_typed_error(
             "--events",
             json.dumps([{"type": "key", "key": "Right"}]),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1054,7 +1082,7 @@ def test_input_sequence_non_json_events_argv_is_a_usage_error(monkeypatch, tmp_p
             "--events",
             "not json",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1077,7 +1105,7 @@ def test_input_sequence_empty_events_argv_is_a_usage_error(monkeypatch, tmp_path
             "--events",
             "[]",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1102,7 +1130,7 @@ def test_input_sequence_malformed_event_argv_is_a_usage_error(monkeypatch, tmp_p
             "--events",
             json.dumps([{"type": "key", "frame": 0}]),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1129,7 +1157,7 @@ def test_input_sequence_over_window_frame_argv_is_a_usage_error(monkeypatch, tmp
             "--events",
             json.dumps([{"type": "key", "key": "Right", "frame": 999999}]),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1162,7 +1190,7 @@ def test_input_sequence_over_window_physics_frame_argv_is_a_usage_error(
                 ]
             ),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1196,7 +1224,7 @@ def test_input_sequence_mixed_process_and_physics_clocks_argv_is_a_usage_error(
                 ]
             ),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1223,7 +1251,7 @@ def test_input_sequence_at_the_window_boundary_argv_is_accepted(monkeypatch, tmp
                 [{"type": "key", "key": "Right", "frame": MAX_WINDOW_FRAMES - 1}]
             ),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1298,7 +1326,7 @@ def test_input_key_params_json_bad_modifier_is_invalid_params(monkeypatch, tmp_p
             "--params-json",
             '{"key": "A", "modifiers": ["control"]}',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1323,7 +1351,7 @@ def test_input_action_params_json_strength_over_range_is_invalid_params(
             "--params-json",
             '{"action": "jump", "strength": 2.0}',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1348,7 +1376,7 @@ def test_input_sequence_params_json_empty_events_is_invalid_params(
             "--params-json",
             '{"events": []}',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1373,7 +1401,7 @@ def test_input_sequence_params_json_malformed_event_is_invalid_params(
             "--params-json",
             '{"events": [{"type": "mouse_click", "x": 1.0}]}',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1398,7 +1426,7 @@ def test_input_sequence_params_json_mouse_button_without_phase_is_invalid_params
             "--params-json",
             '{"events": [{"type": "mouse_button", "x": 1.0, "y": 2.0}]}',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1426,7 +1454,7 @@ def test_input_sequence_params_json_mouse_button_conflicting_phase_is_invalid_pa
                 '"pressed": true, "release": true}]}'
             ),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1454,7 +1482,7 @@ def test_input_sequence_params_json_mouse_button_pressed_false_is_invalid_params
                 '"pressed": false}]}'
             ),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1479,7 +1507,7 @@ def test_input_sequence_params_json_pressed_on_mouse_move_is_invalid_params(
             "--params-json",
             '{"events": [{"type": "mouse_move", "x": 1.0, "y": 2.0, "pressed": true}]}',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1507,7 +1535,7 @@ def test_input_sequence_params_json_over_window_frame_is_invalid_params(
             "--params-json",
             json.dumps({"events": [{"type": "key", "key": "Right", "frame": 999999}]}),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1543,7 +1571,7 @@ def test_input_sequence_params_json_mixed_clock_fields_is_invalid_params(
                 }
             ),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1576,7 +1604,7 @@ def test_input_sequence_params_json_at_the_window_boundary_dispatches(
                 }
             ),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1626,7 +1654,7 @@ def test_input_sequence_params_json_physics_frame_dispatches(monkeypatch, tmp_pa
                 }
             ),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1653,7 +1681,7 @@ def test_input_key_params_json_dispatches_like_argv(monkeypatch, tmp_path):
             "--params-json",
             '{"key": "Right", "modifiers": ["shift"]}',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1778,7 +1806,7 @@ def _reject(monkeypatch, tmp_path, event: dict) -> str:
             "--params-json",
             json.dumps({"events": [event]}),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1941,7 +1969,7 @@ def test_an_explicit_null_button_still_means_the_left_button(monkeypatch, tmp_pa
             "--events",
             json.dumps(events),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )

--- a/tests/test_json_flag_acceptance.py
+++ b/tests/test_json_flag_acceptance.py
@@ -36,11 +36,10 @@ from typer.testing import CliRunner
 from gda.cli import app
 from gda.commands.meta import read_skill_text
 from gda.headless import adopt_group_json
-from gda.runner import RunResult
 from tests.support import (
     SCENE_GET_RESULT,
     GDA_CMD,
-    inject_runner,
+    invoke_cli,
     panel_text,
     plain_text,
     sentinel,
@@ -137,18 +136,16 @@ def test_both_spellings_together_are_not_a_conflict():
 def test_root_json_reaches_a_domain_command(monkeypatch):
     # Not just the meta commands: the inherited flag rides the shared sentinel
     # dispatch tail, so a domain command emits its JSON result too.
-    inject_runner(
+    root_spelling, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCENE_GET_RESULT), stderr="", exit_code=0),
+        ["--json", "scene", "get", "/tmp/x.tscn"],
+        stdout=sentinel(SCENE_GET_RESULT),
     )
-    root_spelling = CliRunner().invoke(app, ["--json", "scene", "get", "/tmp/x.tscn"])
 
-    inject_runner(
+    command_spelling, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCENE_GET_RESULT), stderr="", exit_code=0),
-    )
-    command_spelling = CliRunner().invoke(
-        app, ["scene", "get", "/tmp/x.tscn", "--json"]
+        ["scene", "get", "/tmp/x.tscn", "--json"],
+        stdout=sentinel(SCENE_GET_RESULT),
     )
 
     assert root_spelling.exit_code == 0, root_spelling.stdout
@@ -176,11 +173,7 @@ def _scene_get(monkeypatch, args: list[str]):
     default: a flag that parsed but did not reach the command would show up here as
     that text, which is the failure mode acceptance alone would hide.
     """
-    inject_runner(
-        monkeypatch,
-        RunResult(stdout=sentinel(SCENE_GET_RESULT), stderr="", exit_code=0),
-    )
-    return CliRunner().invoke(app, args)
+    return invoke_cli(monkeypatch, args, stdout=sentinel(SCENE_GET_RESULT))[0]
 
 
 def test_group_json_is_equivalent_to_the_commands_own_json(monkeypatch):

--- a/tests/test_live_contract_guards.py
+++ b/tests/test_live_contract_guards.py
@@ -40,6 +40,7 @@ from gda.runner import RunResult
 from tests.support import (
     PNG_1X1_B64,
     inject_live_runner,
+    minimal_project,
     panel_text,
     screen_capture_reply,
     sentinel,
@@ -626,7 +627,7 @@ def test_the_classify_path_hands_back_the_engines_own_floats(monkeypatch, tmp_pa
     # values Godot's DEFAULT writer would have lost (1e-300 flattens, and
     # 3.141592653589793 loses its last digits), so the assertion would also fail
     # if anything CLI-side re-rendered the value.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     reply = {
         "path": "/root/Main/Player",
         "name": "Player",

--- a/tests/test_logger_commands.py
+++ b/tests/test_logger_commands.py
@@ -21,12 +21,8 @@ from tests.support import (
     error_sentinel,
     inject_live_runner,
     sentinel,
+    minimal_project,
 )
-
-
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
 
 
 def test_logger_tail_emits_structured_records_json_through_the_live_channel(
@@ -38,7 +34,7 @@ def test_logger_tail_emits_structured_records_json_through_the_live_channel(
     )
 
     result = CliRunner().invoke(
-        app, ["logger", "tail", "--project", str(_project(tmp_path)), "--json"]
+        app, ["logger", "tail", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -67,7 +63,7 @@ def test_logger_tail_passes_level_and_limit_through(monkeypatch, tmp_path):
             "--limit",
             "5",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -87,7 +83,15 @@ def test_logger_tail_raw_passes_raw_flag_and_returns_verbatim_info_records(
     )
 
     result = CliRunner().invoke(
-        app, ["logger", "tail", "--raw", "--project", str(_project(tmp_path)), "--json"]
+        app,
+        [
+            "logger",
+            "tail",
+            "--raw",
+            "--project",
+            str(minimal_project(tmp_path)),
+            "--json",
+        ],
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -113,7 +117,7 @@ def test_logger_tail_rejects_a_non_positive_limit_on_the_argv_path(tmp_path):
                 "--limit",
                 bad,
                 "--project",
-                str(_project(tmp_path)),
+                str(minimal_project(tmp_path)),
                 "--json",
             ],
         )
@@ -130,7 +134,7 @@ def test_logger_tail_rejects_an_unknown_level_on_the_argv_path(tmp_path):
             "--level",
             "trace",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -144,7 +148,7 @@ def test_logger_tail_human_output_renders_records(monkeypatch, tmp_path):
     )
 
     result = CliRunner().invoke(
-        app, ["logger", "tail", "--project", str(_project(tmp_path))]
+        app, ["logger", "tail", "--project", str(minimal_project(tmp_path))]
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -161,7 +165,7 @@ def test_logger_tail_raw_human_output_renders_lines(monkeypatch, tmp_path):
     )
 
     result = CliRunner().invoke(
-        app, ["logger", "tail", "--raw", "--project", str(_project(tmp_path))]
+        app, ["logger", "tail", "--raw", "--project", str(minimal_project(tmp_path))]
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -173,7 +177,7 @@ def test_logger_tail_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
 
     result = CliRunner().invoke(
-        app, ["logger", "tail", "--project", str(_project(tmp_path)), "--json"]
+        app, ["logger", "tail", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
@@ -193,7 +197,7 @@ def test_logger_tail_log_unavailable_is_a_typed_live_error(monkeypatch, tmp_path
     )
 
     result = CliRunner().invoke(
-        app, ["logger", "tail", "--project", str(_project(tmp_path)), "--json"]
+        app, ["logger", "tail", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
@@ -214,7 +218,7 @@ def test_logger_tail_params_json_rejects_a_non_positive_limit_as_invalid_params(
                 "--params-json",
                 json.dumps({"limit": bad}),
                 "--project",
-                str(_project(tmp_path)),
+                str(minimal_project(tmp_path)),
                 "--json",
             ],
         )

--- a/tests/test_mcp_project_context.py
+++ b/tests/test_mcp_project_context.py
@@ -10,17 +10,11 @@ ADR-0014 / #194 acceptance criterion).
 from pathlib import Path
 
 from gda.mcp.project_context import resolve_project_dir
-
-
-def _project(dir_path: Path) -> Path:
-    """Mark ``dir_path`` a Godot project (a ``project.godot`` is all that counts)."""
-    dir_path.mkdir(parents=True, exist_ok=True)
-    (dir_path / "project.godot").write_text("", encoding="utf-8")
-    return dir_path
+from tests.support import minimal_project
 
 
 def test_gda_project_env_resolves_to_that_project(tmp_path):
-    proj = _project(tmp_path)
+    proj = minimal_project(tmp_path)
     result = resolve_project_dir(
         env={"GDA_PROJECT": str(proj)}, roots=[], cwd=Path("/nonexistent")
     )
@@ -28,13 +22,13 @@ def test_gda_project_env_resolves_to_that_project(tmp_path):
 
 
 def test_root_resolves_when_gda_project_unset(tmp_path):
-    proj = _project(tmp_path)
+    proj = minimal_project(tmp_path)
     result = resolve_project_dir(env={}, roots=[str(proj)], cwd=Path("/nonexistent"))
     assert result == proj
 
 
 def test_cwd_used_when_it_is_a_project_and_nothing_else_resolves(tmp_path):
-    proj = _project(tmp_path)
+    proj = minimal_project(tmp_path)
     result = resolve_project_dir(env={}, roots=[], cwd=proj)
     assert result == proj
 
@@ -42,8 +36,8 @@ def test_cwd_used_when_it_is_a_project_and_nothing_else_resolves(tmp_path):
 def test_first_valid_root_wins_invalid_roots_skipped(tmp_path):
     not_a_project = tmp_path / "plain"
     not_a_project.mkdir()
-    proj = _project(tmp_path / "game")
-    later = _project(tmp_path / "other")
+    proj = minimal_project(tmp_path / "game")
+    later = minimal_project(tmp_path / "other")
     result = resolve_project_dir(
         env={},
         roots=[str(not_a_project), str(proj), str(later)],
@@ -60,8 +54,8 @@ def test_nothing_resolves_to_none(tmp_path):
 
 
 def test_gda_project_takes_precedence_over_root(tmp_path):
-    pinned = _project(tmp_path / "pinned")
-    root = _project(tmp_path / "root")
+    pinned = minimal_project(tmp_path / "pinned")
+    root = minimal_project(tmp_path / "root")
     result = resolve_project_dir(
         env={"GDA_PROJECT": str(pinned)}, roots=[str(root)], cwd=Path("/nonexistent")
     )
@@ -75,7 +69,7 @@ def test_invalid_gda_project_does_not_fall_through_to_root(tmp_path):
     # GDA_PROJECT and surfaces its own typed error for project-taking commands.
     bad = tmp_path / "not-a-project"
     bad.mkdir()
-    valid_root = _project(tmp_path / "game")
+    valid_root = minimal_project(tmp_path / "game")
     result = resolve_project_dir(
         env={"GDA_PROJECT": str(bad)},
         roots=[str(valid_root)],

--- a/tests/test_mcp_project_injection.py
+++ b/tests/test_mcp_project_injection.py
@@ -12,7 +12,6 @@ engine-free. The real MCP -> gda -> engine chain is the L4 e2e gate.
 
 import json
 import sys
-from pathlib import Path
 
 from gda.mcp.runner import SubprocessGdaRunner
 from gda.mcp.server import build_server, dispatch
@@ -24,14 +23,7 @@ from tests.mcp_support import (
     roots_changed_call,
     schema_then,
 )
-from tests.support import SCENE_CREATE_RESULT
-
-
-def _project(dir_path: Path) -> Path:
-    """Mark ``dir_path`` a Godot project (a ``project.godot`` is all that counts)."""
-    dir_path.mkdir(parents=True, exist_ok=True)
-    (dir_path / "project.godot").write_text("", encoding="utf-8")
-    return dir_path
+from tests.support import SCENE_CREATE_RESULT, minimal_project
 
 
 def test_no_tool_inputschema_carries_a_project_field():
@@ -88,7 +80,7 @@ def test_server_resolves_gda_project_env_and_injects_it_on_dispatch(
 ):
     # The full env -> resolve -> inject glue: GDA_PROJECT points at a real project,
     # so every tool call dispatches gda against it (here observed at the seam).
-    proj = _project(tmp_path)
+    proj = minimal_project(tmp_path)
     monkeypatch.setenv("GDA_PROJECT", str(proj))
     runner = FakeGdaRunner(
         schema_then(lambda args, stdin: gda_result(json.dumps(SCENE_CREATE_RESULT)))
@@ -109,7 +101,7 @@ def _scene_create_runner():
 
 def test_client_root_resolves_project_when_gda_project_unset(tmp_path, monkeypatch):
     monkeypatch.delenv("GDA_PROJECT", raising=False)
-    proj = _project(tmp_path / "game")
+    proj = minimal_project(tmp_path / "game")
     runner = _scene_create_runner()
     server = build_server(runner)
 
@@ -125,8 +117,8 @@ def test_client_root_resolves_project_when_gda_project_unset(tmp_path, monkeypat
 
 
 def test_gda_project_env_beats_client_roots(tmp_path, monkeypatch):
-    pinned = _project(tmp_path / "pinned")
-    other = _project(tmp_path / "other")
+    pinned = minimal_project(tmp_path / "pinned")
+    other = minimal_project(tmp_path / "other")
     monkeypatch.setenv("GDA_PROJECT", str(pinned))
     runner = _scene_create_runner()
     server = build_server(runner)
@@ -146,7 +138,7 @@ def test_invalid_client_roots_skipped_first_valid_used(tmp_path, monkeypatch):
     monkeypatch.delenv("GDA_PROJECT", raising=False)
     not_a_project = tmp_path / "plain"
     not_a_project.mkdir()
-    proj = _project(tmp_path / "game")
+    proj = minimal_project(tmp_path / "game")
     runner = _scene_create_runner()
     server = build_server(runner)
 
@@ -169,8 +161,8 @@ def test_project_is_snapshotted_on_first_call_then_cached(tmp_path, monkeypatch)
     # snapshot. (Re-resolution on a roots/list_changed notification — a different
     # trigger — is exercised by the two tests below.)
     monkeypatch.delenv("GDA_PROJECT", raising=False)
-    first = _project(tmp_path / "first")
-    second = _project(tmp_path / "second")
+    first = minimal_project(tmp_path / "first")
+    second = minimal_project(tmp_path / "second")
     runner = _scene_create_runner()
     server = build_server(runner)
 
@@ -196,8 +188,8 @@ def test_roots_list_changed_reresolves_to_the_new_active_project(tmp_path, monke
     # gda-mcp invalidates its cached project so the NEXT tool call re-runs the
     # ADR-0014 precedence against the now-current roots.
     monkeypatch.delenv("GDA_PROJECT", raising=False)
-    first = _project(tmp_path / "first")
-    second = _project(tmp_path / "second")
+    first = minimal_project(tmp_path / "first")
+    second = minimal_project(tmp_path / "second")
     runner = _scene_create_runner()
     server = build_server(runner)
 
@@ -216,8 +208,8 @@ def test_roots_list_changed_reresolves_to_the_new_active_project(tmp_path, monke
 def test_roots_list_changed_does_not_override_pinned_gda_project(tmp_path, monkeypatch):
     # #209: an explicitly pinned GDA_PROJECT wins regardless of a roots change —
     # resolve_project_dir reads env first, so re-resolution returns the pin.
-    pinned = _project(tmp_path / "pinned")
-    other = _project(tmp_path / "other")
+    pinned = minimal_project(tmp_path / "pinned")
+    other = minimal_project(tmp_path / "other")
     monkeypatch.setenv("GDA_PROJECT", str(pinned))
     runner = _scene_create_runner()
     server = build_server(runner)
@@ -261,7 +253,7 @@ def test_stateless_connection_degrades_to_no_project_without_error(
     # projectless (no NoBackChannelError escapes the server), landing on the
     # env→cwd tail of the ADR-0014 precedence.
     monkeypatch.delenv("GDA_PROJECT", raising=False)
-    unreachable = _project(tmp_path / "game")
+    unreachable = minimal_project(tmp_path / "game")
     runner = _scene_create_runner()
     server = build_server(runner)
 
@@ -282,7 +274,7 @@ def test_gda_project_env_resolves_on_stateless_connection(tmp_path, monkeypatch)
     # ADR-0039 promotes GDA_PROJECT to the durable anchor: on a 2026-07-28
     # connection (no roots signal at all) the env pin must keep resolving exactly
     # as it does for legacy clients.
-    proj = _project(tmp_path)
+    proj = minimal_project(tmp_path)
     monkeypatch.setenv("GDA_PROJECT", str(proj))
     runner = _scene_create_runner()
     server = build_server(runner)

--- a/tests/test_node_commands.py
+++ b/tests/test_node_commands.py
@@ -22,6 +22,7 @@ from tests.support import (
     NODE_REMOVE_RESULT as REMOVE_RESULT,
     NODE_SET_RESULT as SET_RESULT,
     inject_runner,
+    invoke_cli,
     sentinel,
 )
 
@@ -46,11 +47,8 @@ def test_node_add_instance_json_dispatches_instance_param_and_echoes_source(
     # carries the instance path instead of a type, the name defaults to the
     # instanced scene's filename stem (model-side, ADR-0015), and the result
     # echoes the instanced res:// path alongside the resolved root type.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(ADD_INSTANCE_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "node",
             "add",
@@ -59,6 +57,7 @@ def test_node_add_instance_json_dispatches_instance_param_and_echoes_source(
             "res://hud.tscn",
             "--json",
         ],
+        stdout=sentinel(ADD_INSTANCE_RESULT),
     )
 
     assert result.exit_code == 0
@@ -124,13 +123,8 @@ def test_node_add_without_type_or_instance_is_a_usage_error(monkeypatch):
 
 def test_node_add_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
     # Engine banner noise around the sentinel, diagnostics on stderr (ADR-0002).
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(ADD_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "node",
             "add",
@@ -143,6 +137,8 @@ def test_node_add_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
             "Hero",
             "--json",
         ],
+        stdout=sentinel(ADD_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -215,10 +211,11 @@ def test_node_list_json_emits_node_tree_with_paths_and_exit_zero(monkeypatch):
     # node list is the node-group verifier (issue #53): it reports the scene's
     # tree like scene get, but each node carries its node path — the address an
     # agent feeds back into node add's --parent.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(LIST_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(app, ["node", "list", "/tmp/proj/main.tscn", "--json"])
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["node", "list", "/tmp/proj/main.tscn", "--json"],
+        stdout=sentinel(LIST_RESULT),
+    )
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -235,11 +232,10 @@ def test_node_get_json_emits_typed_properties_and_exit_zero(monkeypatch):
     # node get is the read half of issue #55: it loads a scene and reports the
     # addressed node's properties as typed JSON — the read an agent verifies a
     # `set` against.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(GET_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["node", "get", "/tmp/proj/main.tscn", "--node", "Hero", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["node", "get", "/tmp/proj/main.tscn", "--node", "Hero", "--json"],
+        stdout=sentinel(GET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -305,11 +301,10 @@ def test_node_remove_json_echoes_the_removed_node_and_exit_zero(monkeypatch):
     # node remove is the first structural edit (issue #56): it deletes a node
     # and its subtree, echoing the removed node's address/name/type — the result
     # an agent asserts. The node is addressed by node path, dispatched by name.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(REMOVE_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["node", "remove", "/tmp/proj/main.tscn", "--node", "Hero", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["node", "remove", "/tmp/proj/main.tscn", "--node", "Hero", "--json"],
+        stdout=sentinel(REMOVE_RESULT),
     )
 
     assert result.exit_code == 0
@@ -325,11 +320,10 @@ def test_node_duplicate_json_echoes_the_new_copy_and_exit_zero(monkeypatch):
     # node duplicate (issue #56) copies a node and its subtree under the source's
     # own parent with a fresh name, echoing the source and the new copy's
     # address/name/type — the result an agent feeds back into other node commands.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(DUPLICATE_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["node", "duplicate", "/tmp/proj/main.tscn", "--node", "Hero", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["node", "duplicate", "/tmp/proj/main.tscn", "--node", "Hero", "--json"],
+        stdout=sentinel(DUPLICATE_RESULT),
     )
 
     assert result.exit_code == 0
@@ -346,11 +340,8 @@ def test_node_move_json_echoes_the_reparented_node_and_exit_zero(monkeypatch):
     # echoing the source, the new parent, and the node's new address — the
     # result an agent feeds back into other node commands. Both node paths are
     # passed through as raw strings; the operation resolves them.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(MOVE_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "node",
             "move",
@@ -361,6 +352,7 @@ def test_node_move_json_echoes_the_reparented_node_and_exit_zero(monkeypatch):
             "Enemies",
             "--json",
         ],
+        stdout=sentinel(MOVE_RESULT),
     )
 
     assert result.exit_code == 0
@@ -384,11 +376,8 @@ def test_node_move_index_dispatches_destination_index(monkeypatch):
     # Issue #415: `node move --index` requests the moved node's final 0-based
     # sibling position under --to. The operation validates the range after it
     # resolves the source and destination parents.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(MOVE_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "node",
             "move",
@@ -401,6 +390,7 @@ def test_node_move_index_dispatches_destination_index(monkeypatch):
             "1",
             "--json",
         ],
+        stdout=sentinel(MOVE_RESULT),
     )
 
     assert result.exit_code == 0
@@ -450,11 +440,8 @@ def test_node_connect_signal_json_dispatches_the_four_part_connection(monkeypatc
     # parts are addressed by --from/--signal/--to/--method; the wire param key
     # for the source is `from` (matching the .tscn [connection] key), since
     # `from` is a Python keyword only at the model layer.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(CONNECT_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "node",
             "connect-signal",
@@ -469,6 +456,7 @@ def test_node_connect_signal_json_dispatches_the_four_part_connection(monkeypatc
             "on_timeout",
             "--json",
         ],
+        stdout=sentinel(CONNECT_RESULT),
     )
 
     assert result.exit_code == 0

--- a/tests/test_node_commands.py
+++ b/tests/test_node_commands.py
@@ -8,10 +8,7 @@ parse → typed model → JSON — with canned engine output, no real Godot.
 
 import json
 
-from typer.testing import CliRunner
 
-from gda.cli import app
-from gda.runner import RunResult
 from tests.support import (
     NODE_ADD_RESULT as ADD_RESULT,
     NODE_CONNECT_RESULT as CONNECT_RESULT,
@@ -21,7 +18,6 @@ from tests.support import (
     NODE_MOVE_RESULT as MOVE_RESULT,
     NODE_REMOVE_RESULT as REMOVE_RESULT,
     NODE_SET_RESULT as SET_RESULT,
-    inject_runner,
     invoke_cli,
     sentinel,
 )
@@ -86,12 +82,8 @@ def test_node_add_type_and_instance_together_is_a_usage_error(monkeypatch):
     # them is a usage error (exit 2) that fires before any dispatch — the
     # engine is never reached. The rule lives model-side (ADR-0015), so the
     # --params-json path surfaces the same violation as invalid_params.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(ADD_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "node",
             "add",
@@ -102,6 +94,7 @@ def test_node_add_type_and_instance_together_is_a_usage_error(monkeypatch):
             "res://hud.tscn",
             "--json",
         ],
+        stdout=sentinel(ADD_RESULT),
     )
 
     assert result.exit_code == 2
@@ -111,11 +104,11 @@ def test_node_add_type_and_instance_together_is_a_usage_error(monkeypatch):
 def test_node_add_without_type_or_instance_is_a_usage_error(monkeypatch):
     # No mode at all is a usage error too: add always needs exactly one of
     # --type/--instance.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(ADD_RESULT), stderr="", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["node", "add", "/tmp/proj/main.tscn", "--json"],
+        stdout=sentinel(ADD_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["node", "add", "/tmp/proj/main.tscn", "--json"])
 
     assert result.exit_code == 2
     assert fake.calls == []
@@ -173,10 +166,8 @@ def test_node_add_index_dispatches_destination_index(monkeypatch):
     # operation owns range validation because the valid upper bound depends on
     # the resolved parent at runtime.
     stdout = sentinel({**ADD_RESULT, "path": "Level", "name": "Level"})
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "node",
             "add",
@@ -189,6 +180,7 @@ def test_node_add_index_dispatches_destination_index(monkeypatch):
             "1",
             "--json",
         ],
+        stdout=stdout,
     )
 
     assert result.exit_code == 0
@@ -257,10 +249,8 @@ def test_node_set_json_echoes_the_coerced_property_and_exit_zero(monkeypatch):
     # to the property's declared type, saves, and echoes the coerced property —
     # the result an agent asserts (and which round-trips via node get).
     stdout = sentinel(SET_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "node",
             "set",
@@ -273,6 +263,7 @@ def test_node_set_json_echoes_the_coerced_property_and_exit_zero(monkeypatch):
             "3,4",
             "--json",
         ],
+        stdout=stdout,
     )
 
     assert result.exit_code == 0
@@ -412,11 +403,10 @@ def test_node_add_defaults_parent_to_root_and_name_to_type(monkeypatch):
     # scene root ('.'), and omitting --name names the node after its type —
     # mirroring how the Godot editor names a freshly added node.
     stdout = sentinel({**ADD_RESULT, "path": "Sprite2D", "name": "Sprite2D"})
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         ["node", "add", "/tmp/proj/main.tscn", "--type", "Sprite2D", "--json"],
+        stdout=stdout,
     )
 
     assert result.exit_code == 0
@@ -482,10 +472,8 @@ def test_node_disconnect_signal_json_dispatches_the_four_part_connection(monkeyp
     # node disconnect-signal is the unwire half of issue #57: same four-part
     # addressing, dispatched by its own operation name.
     stdout = sentinel(CONNECT_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "node",
             "disconnect-signal",
@@ -500,6 +488,7 @@ def test_node_disconnect_signal_json_dispatches_the_four_part_connection(monkeyp
             "on_timeout",
             "--json",
         ],
+        stdout=stdout,
     )
 
     assert result.exit_code == 0
@@ -523,12 +512,8 @@ def test_node_connect_signal_requires_all_four_connection_flags(monkeypatch):
     # The four connection flags are mandatory (no sensible default for any part
     # of a connection): omitting one is a usage error (exit 2), surfaced before
     # any engine path so no Godot process is spawned.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(CONNECT_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "node",
             "connect-signal",
@@ -542,6 +527,7 @@ def test_node_connect_signal_requires_all_four_connection_flags(monkeypatch):
             # --method omitted
             "--json",
         ],
+        stdout=sentinel(CONNECT_RESULT),
     )
 
     assert result.exit_code == 2

--- a/tests/test_node_errors.py
+++ b/tests/test_node_errors.py
@@ -6,46 +6,28 @@ registered operation codes (ADR-0002) — exit 4 for the operation category,
 finer stable codes so an agent can branch on the mode without parsing prose.
 """
 
-import json
+from tests.support import assert_operation_error, operation_error_invoker
 
-from typer.testing import CliRunner
-
-from gda.cli import app
-from gda.runner import RunResult
-from tests.support import error_sentinel, inject_runner
-
-
-def _invoke_node_add(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: node-add\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app,
-        ["node", "add", "/x/main.tscn", "--type", "Sprite2D", "--json"],
-    )
+_node_add = operation_error_invoker(
+    ["node", "add", "/x/main.tscn", "--type", "Sprite2D", "--json"], "node-add"
+)
 
 
 def test_node_add_bad_parent_maps_to_stable_parent_not_found_code(monkeypatch):
     # The scene exists but the requested parent node path resolves to nothing —
     # a new node-group code, distinct from the file-level path_not_found, so an
     # agent knows to fix the node path, not the scene path.
-    result = _invoke_node_add(
+    result = _node_add(
         monkeypatch, "parent_not_found", "parent node not found in scene: Bogus/Path"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "parent_not_found"
-    assert "Bogus/Path" in err["message"]
     # The raw stderr still rides along as diagnostics (ADR-0002).
-    assert err["diagnostics"] == "gda: running operation: node-add\n"
+    assert_operation_error(
+        result,
+        "parent_not_found",
+        "Bogus/Path",
+        diagnostics="gda: running operation: node-add\n",
+    )
 
 
 def test_node_add_non_canonical_parent_maps_to_stable_parent_not_found_code(
@@ -58,57 +40,39 @@ def test_node_add_non_canonical_parent_maps_to_stable_parent_not_found_code(
     # nothing — with a message naming the canonical form. Mapping pin: the
     # envelope rides through the same parent_not_found path as a missing
     # canonical parent.
-    result = _invoke_node_add(
+    result = _node_add(
         monkeypatch,
         "parent_not_found",
         "non-canonical parent path: A/.. — address the parent exactly as "
         "node list reports it: '.' for the root, 'A/B' for a descendant",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "parent_not_found"
-    assert "A/.." in err["message"]
+    err = assert_operation_error(result, "parent_not_found", "A/..")
     assert "non-canonical" in err["message"]
 
 
 def test_node_add_unknown_type_maps_to_stable_invalid_node_type_code(monkeypatch):
-    result = _invoke_node_add(
+    result = _node_add(
         monkeypatch,
         "invalid_node_type",
         "not an instantiable Node class or registered class_name: Foo",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "invalid_node_type"
-    assert "Foo" in err["message"]
+    assert_operation_error(result, "invalid_node_type", "Foo")
 
 
 def test_node_add_name_collision_maps_to_stable_duplicate_node_name_code(monkeypatch):
-    result = _invoke_node_add(
+    result = _node_add(
         monkeypatch, "duplicate_node_name", "parent already has a child named: Hero"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "duplicate_node_name"
-    assert "Hero" in err["message"]
+    assert_operation_error(result, "duplicate_node_name", "Hero")
 
 
 def test_node_add_bad_name_maps_to_stable_invalid_node_name_code(monkeypatch):
-    result = _invoke_node_add(
-        monkeypatch, "invalid_node_name", "invalid name: Bad%Name"
-    )
+    result = _node_add(monkeypatch, "invalid_node_name", "invalid name: Bad%Name")
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "invalid_node_name"
-    assert "Bad%Name" in err["message"]
+    assert_operation_error(result, "invalid_node_name", "Bad%Name")
 
 
 def test_node_add_vanished_instance_maps_to_stable_missing_dependency_code(monkeypatch):
@@ -116,18 +80,14 @@ def test_node_add_vanished_instance_maps_to_stable_missing_dependency_code(monke
     # would lose the whole instance on re-save; the refusal surfaces as the
     # registered missing_dependency code so an agent knows to fix the scene's
     # dependencies or its project context rather than retry the add.
-    result = _invoke_node_add(
+    result = _node_add(
         monkeypatch,
         "missing_dependency",
         "scene nodes vanished on load (unresolvable instanced sub-scene?): "
         "ChildInstance — re-saving would silently drop them",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "missing_dependency"
-    assert "ChildInstance" in err["message"]
+    assert_operation_error(result, "missing_dependency", "ChildInstance")
 
 
 def test_node_add_substituted_class_maps_to_stable_missing_dependency_code(monkeypatch):
@@ -135,7 +95,7 @@ def test_node_add_substituted_class_maps_to_stable_missing_dependency_code(monke
     # run materializes as a substitute node, so a re-save would rewrite its
     # type. The refusal reuses missing_dependency — an unavailable class IS a
     # missing dependency (extension/module), the same agent fix applies.
-    result = _invoke_node_add(
+    result = _node_add(
         monkeypatch,
         "missing_dependency",
         "scene nodes vanished or degraded on load: "
@@ -143,11 +103,9 @@ def test_node_add_substituted_class_maps_to_stable_missing_dependency_code(monke
         "re-saving would silently drop or downgrade them",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "missing_dependency"
-    assert "declared TotallyMissingClass, materialized Node" in err["message"]
+    assert_operation_error(
+        result, "missing_dependency", "declared TotallyMissingClass, materialized Node"
+    )
 
 
 def test_node_add_broken_class_name_maps_to_stable_uninstantiable_script_code(
@@ -157,74 +115,46 @@ def test_node_add_broken_class_name_maps_to_stable_uninstantiable_script_code(
     # script broke after registration is a script problem, not an unknown type.
     # The refusal surfaces as the registered uninstantiable_script code so an
     # agent knows to repair the script rather than the type name.
-    result = _invoke_node_add(
+    result = _node_add(
         monkeypatch,
         "uninstantiable_script",
         "registered class_name Hero script cannot be instantiated: "
         "res://hero.gd — it no longer compiles; see diagnostics",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "uninstantiable_script"
-    assert "res://hero.gd" in err["message"]
+    assert_operation_error(result, "uninstantiable_script", "res://hero.gd")
 
 
 def test_node_add_missing_scene_reuses_stable_path_not_found_code(monkeypatch):
     # The scene-file-level failure reuses the registered scene code: the
     # node group introduces no parallel code for the same mode.
-    result = _invoke_node_add(
+    result = _node_add(
         monkeypatch, "path_not_found", "scene file does not exist: /x/main.tscn"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/main.tscn" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/main.tscn")
 
 
-def _invoke_node_get(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: node-get\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app, ["node", "get", "/x/main.tscn", "--node", "Bogus", "--json"]
-    )
+_node_get = operation_error_invoker(
+    ["node", "get", "/x/main.tscn", "--node", "Bogus", "--json"], "node-get"
+)
 
 
-def _invoke_node_set(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: node-set\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app,
-        [
-            "node",
-            "set",
-            "/x/main.tscn",
-            "--node",
-            "Hero",
-            "--property",
-            "position",
-            "--value",
-            "3,4",
-            "--json",
-        ],
-    )
+_node_set = operation_error_invoker(
+    [
+        "node",
+        "set",
+        "/x/main.tscn",
+        "--node",
+        "Hero",
+        "--property",
+        "position",
+        "--value",
+        "3,4",
+        "--json",
+    ],
+    "node-set",
+)
 
 
 def test_node_get_missing_node_maps_to_stable_node_not_found_code(monkeypatch):
@@ -232,60 +162,41 @@ def test_node_get_missing_node_maps_to_stable_node_not_found_code(monkeypatch):
     # distinct from the file-level path_not_found and from node add's
     # parent_not_found, so an agent knows the node, not the file or parent, is
     # the thing that's missing.
-    result = _invoke_node_get(
-        monkeypatch, "node_not_found", "node not found in scene: Bogus"
-    )
+    result = _node_get(monkeypatch, "node_not_found", "node not found in scene: Bogus")
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "node_not_found"
-    assert "Bogus" in err["message"]
+    assert_operation_error(result, "node_not_found", "Bogus")
 
 
 def test_node_set_missing_node_maps_to_stable_node_not_found_code(monkeypatch):
-    result = _invoke_node_set(
-        monkeypatch, "node_not_found", "node not found in scene: Hero"
-    )
+    result = _node_set(monkeypatch, "node_not_found", "node not found in scene: Hero")
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "node_not_found"
-    assert "Hero" in err["message"]
+    assert_operation_error(result, "node_not_found", "Hero")
 
 
 def test_node_set_unknown_property_maps_to_stable_unknown_property_code(monkeypatch):
     # issue #55: setting a property the node does not declare is a clean
     # unknown_property error, so an agent can branch on a typo'd or absent
     # property name rather than parsing prose.
-    result = _invoke_node_set(
+    result = _node_set(
         monkeypatch,
         "unknown_property",
         "node Hero has no settable property: positon",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "unknown_property"
-    assert "positon" in err["message"]
+    assert_operation_error(result, "unknown_property", "positon")
 
 
 def test_node_set_uncoercible_value_maps_to_stable_uncoercible_value_code(monkeypatch):
     # issue #55's type-coercion contract: a value that cannot be coerced to the
     # property's declared Godot type is a clean uncoercible_value error naming
     # the value, the target type, and the property — never a silent wrong value.
-    result = _invoke_node_set(
+    result = _node_set(
         monkeypatch,
         "uncoercible_value",
         'cannot coerce value "nope" to Vector2 for property position on node Hero',
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "uncoercible_value"
-    assert "Vector2" in err["message"]
+    assert_operation_error(result, "uncoercible_value", "Vector2")
 
 
 def test_node_set_missing_dependency_maps_to_stable_missing_dependency_code(
@@ -295,145 +206,104 @@ def test_node_set_missing_dependency_maps_to_stable_missing_dependency_code(
     # (issue #64) via the shared mutate-entry: a scene whose instance vanishes
     # on load is refused with missing_dependency, the same as node add, leaving
     # the file untouched rather than dropping the instance on re-save.
-    result = _invoke_node_set(
+    result = _node_set(
         monkeypatch,
         "missing_dependency",
         "scene nodes vanished or degraded on load: ChildInstance (vanished) — "
         "re-saving would silently drop or downgrade them",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "missing_dependency"
-    assert "ChildInstance" in err["message"]
+    assert_operation_error(result, "missing_dependency", "ChildInstance")
 
 
 def test_node_get_missing_scene_reuses_stable_path_not_found_code(monkeypatch):
-    result = _invoke_node_get(
+    result = _node_get(
         monkeypatch, "path_not_found", "scene file does not exist: /x/main.tscn"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "path_not_found"
-    assert "/x/main.tscn" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/main.tscn")
 
 
-def _invoke_node_remove(monkeypatch, code: str, message: str, node: str = "Hero"):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: node-remove\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app, ["node", "remove", "/x/main.tscn", "--node", node, "--json"]
-    )
+_node_remove = operation_error_invoker(
+    lambda node="Hero": ["node", "remove", "/x/main.tscn", "--node", node, "--json"],
+    "node-remove",
+)
 
 
 def test_node_remove_missing_node_maps_to_stable_node_not_found_code(monkeypatch):
     # issue #56: removing a node path that resolves to nothing reuses the
     # node-group's node_not_found code — the same mode node get / node set
     # report, so an agent branches on a missing node without a parallel code.
-    result = _invoke_node_remove(
+    result = _node_remove(
         monkeypatch, "node_not_found", "node not found in scene: Bogus", node="Bogus"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "node_not_found"
-    assert "Bogus" in err["message"]
+    assert_operation_error(result, "node_not_found", "Bogus")
 
 
 def test_node_remove_root_maps_to_stable_cannot_target_root_code(monkeypatch):
     # issue #56: removing the scene root is refused with the new structural-edit
     # code cannot_target_root — the root has no parent to be removed from, so
     # the agent learns to delete the scene file rather than retry the removal.
-    result = _invoke_node_remove(
+    result = _node_remove(
         monkeypatch,
         "cannot_target_root",
         "cannot remove the scene root: . — the root has no parent to be removed from",
         node=".",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "cannot_target_root"
-    assert "root" in err["message"]
+    assert_operation_error(result, "cannot_target_root", "root")
 
 
-def _invoke_node_duplicate(monkeypatch, code: str, message: str, node: str = "Hero"):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: node-duplicate\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app, ["node", "duplicate", "/x/main.tscn", "--node", node, "--json"]
-    )
+_node_duplicate = operation_error_invoker(
+    lambda node="Hero": ["node", "duplicate", "/x/main.tscn", "--node", node, "--json"],
+    "node-duplicate",
+)
 
 
 def test_node_duplicate_missing_node_maps_to_stable_node_not_found_code(monkeypatch):
     # issue #56: duplicating a node path that resolves to nothing reuses the
     # node-group's node_not_found code.
-    result = _invoke_node_duplicate(
+    result = _node_duplicate(
         monkeypatch, "node_not_found", "node not found in scene: Bogus", node="Bogus"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "node_not_found"
-    assert "Bogus" in err["message"]
+    assert_operation_error(result, "node_not_found", "Bogus")
 
 
 def test_node_duplicate_root_maps_to_stable_cannot_target_root_code(monkeypatch):
     # issue #56: the scene root has no parent to host a sibling copy, so
     # duplicating '.' reuses the shared cannot_target_root code.
-    result = _invoke_node_duplicate(
+    result = _node_duplicate(
         monkeypatch,
         "cannot_target_root",
         "cannot duplicate the scene root: . — the root has no parent to host a sibling copy",
         node=".",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "cannot_target_root"
-    assert "root" in err["message"]
+    assert_operation_error(result, "cannot_target_root", "root")
 
 
-def _invoke_node_move(
-    monkeypatch, code: str, message: str, node: str = "Hero", to: str = "Enemies"
-):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: node-move\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app,
-        ["node", "move", "/x/main.tscn", "--node", node, "--to", to, "--json"],
-    )
+_node_move = operation_error_invoker(
+    lambda node="Hero", to="Enemies": [
+        "node",
+        "move",
+        "/x/main.tscn",
+        "--node",
+        node,
+        "--to",
+        to,
+        "--json",
+    ],
+    "node-move",
+)
 
 
 def test_node_move_cyclic_target_maps_to_stable_cyclic_target_code(monkeypatch):
     # issue #56: moving a node under its own descendant would detach the subtree
     # from the scene. The refusal surfaces as the new cyclic_target code so an
     # agent branches on the cyclic mistake rather than parsing prose.
-    result = _invoke_node_move(
+    result = _node_move(
         monkeypatch,
         "cyclic_target",
         "cyclic move target: A/B is the moved node A or one of its descendants",
@@ -441,129 +311,93 @@ def test_node_move_cyclic_target_maps_to_stable_cyclic_target_code(monkeypatch):
         to="A/B",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "cyclic_target"
-    assert "A/B" in err["message"]
+    assert_operation_error(result, "cyclic_target", "A/B")
 
 
 def test_node_move_missing_target_maps_to_stable_parent_not_found_code(monkeypatch):
     # An invalid move target reuses the node group's parent_not_found code (the
     # same code node add reports for a bad --parent).
-    result = _invoke_node_move(
+    result = _node_move(
         monkeypatch,
         "parent_not_found",
         "target parent node not found in scene: Bogus",
         to="Bogus",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "parent_not_found"
-    assert "Bogus" in err["message"]
+    assert_operation_error(result, "parent_not_found", "Bogus")
 
 
 def test_node_move_name_collision_maps_to_stable_duplicate_node_name_code(monkeypatch):
     # A name collision at the destination reuses duplicate_node_name.
-    result = _invoke_node_move(
+    result = _node_move(
         monkeypatch,
         "duplicate_node_name",
         "target Enemies already has a child named: Hero",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "duplicate_node_name"
-    assert "Hero" in err["message"]
+    assert_operation_error(result, "duplicate_node_name", "Hero")
 
 
 def test_node_move_missing_node_maps_to_stable_node_not_found_code(monkeypatch):
-    result = _invoke_node_move(
+    result = _node_move(
         monkeypatch, "node_not_found", "node not found in scene: Bogus", node="Bogus"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "node_not_found"
-    assert "Bogus" in err["message"]
+    assert_operation_error(result, "node_not_found", "Bogus")
 
 
 def test_node_move_root_maps_to_stable_cannot_target_root_code(monkeypatch):
     # Moving the scene root is refused with cannot_target_root — the root has no
     # parent to be reparented out of.
-    result = _invoke_node_move(
+    result = _node_move(
         monkeypatch,
         "cannot_target_root",
         "cannot move the scene root: . — the root has no parent to be reparented out of",
         node=".",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "cannot_target_root"
-    assert "root" in err["message"]
+    assert_operation_error(result, "cannot_target_root", "root")
 
 
 # --- node connect-signal / disconnect-signal (issue #57) ---
 
 
-def _invoke_connect_signal(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: node-connect-signal\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app,
-        [
-            "node",
-            "connect-signal",
-            "/x/main.tscn",
-            "--from",
-            "Emitter",
-            "--signal",
-            "timeout",
-            "--to",
-            "Receiver",
-            "--method",
-            "on_timeout",
-            "--json",
-        ],
-    )
+_connect_signal = operation_error_invoker(
+    [
+        "node",
+        "connect-signal",
+        "/x/main.tscn",
+        "--from",
+        "Emitter",
+        "--signal",
+        "timeout",
+        "--to",
+        "Receiver",
+        "--method",
+        "on_timeout",
+        "--json",
+    ],
+    "node-connect-signal",
+)
 
 
-def _invoke_disconnect_signal(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: node-disconnect-signal\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app,
-        [
-            "node",
-            "disconnect-signal",
-            "/x/main.tscn",
-            "--from",
-            "Emitter",
-            "--signal",
-            "timeout",
-            "--to",
-            "Receiver",
-            "--method",
-            "on_timeout",
-            "--json",
-        ],
-    )
+_disconnect_signal = operation_error_invoker(
+    [
+        "node",
+        "disconnect-signal",
+        "/x/main.tscn",
+        "--from",
+        "Emitter",
+        "--signal",
+        "timeout",
+        "--to",
+        "Receiver",
+        "--method",
+        "on_timeout",
+        "--json",
+    ],
+    "node-disconnect-signal",
+)
 
 
 def test_connect_signal_missing_signal_maps_to_stable_signal_not_found_code(
@@ -572,40 +406,30 @@ def test_connect_signal_missing_signal_maps_to_stable_signal_not_found_code(
     # issue #57's design decision: the signal MUST exist on the source node — a
     # typo or wrong node is a clean signal_not_found error, so an agent branches
     # on a bad signal name rather than parsing prose.
-    result = _invoke_connect_signal(
+    result = _connect_signal(
         monkeypatch, "signal_not_found", "source node Emitter has no signal: timoeut"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "signal_not_found"
-    assert "timoeut" in err["message"]
+    assert_operation_error(result, "signal_not_found", "timoeut")
 
 
 def test_connect_signal_missing_source_node_reuses_node_not_found_code(monkeypatch):
     # The source node path resolving to nothing reuses the node group's
     # node_not_found code (issue #55) — the node group introduces no parallel
     # code for the same mode.
-    result = _invoke_connect_signal(
+    result = _connect_signal(
         monkeypatch, "node_not_found", "source node not found in scene: Emitter"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "node_not_found"
-    assert "Emitter" in err["message"]
+    assert_operation_error(result, "node_not_found", "Emitter")
 
 
 def test_connect_signal_missing_target_node_reuses_node_not_found_code(monkeypatch):
-    result = _invoke_connect_signal(
+    result = _connect_signal(
         monkeypatch, "node_not_found", "target node not found in scene: Receiver"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "node_not_found"
-    assert "Receiver" in err["message"]
+    assert_operation_error(result, "node_not_found", "Receiver")
 
 
 def test_connect_signal_already_connected_maps_to_stable_already_connected_code(
@@ -615,17 +439,13 @@ def test_connect_signal_already_connected_maps_to_stable_already_connected_code(
     # already_connected error rather than a silent no-op or a noisy engine
     # ERR_INVALID_PARAMETER — so an agent can tell "already there" apart from
     # "newly wired".
-    result = _invoke_connect_signal(
+    result = _connect_signal(
         monkeypatch,
         "already_connected",
         "Emitter.timeout is already connected to Receiver.on_timeout",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "already_connected"
-    assert "on_timeout" in err["message"]
+    assert_operation_error(result, "already_connected", "on_timeout")
 
 
 def test_disconnect_signal_absent_connection_maps_to_connection_not_found_code(
@@ -634,53 +454,39 @@ def test_disconnect_signal_absent_connection_maps_to_connection_not_found_code(
     # issue #57's acceptance: disconnecting a connection that does not exist is a
     # clean connection_not_found error, not a silent success — so an agent knows
     # the unwiring had nothing to remove.
-    result = _invoke_disconnect_signal(
+    result = _disconnect_signal(
         monkeypatch,
         "connection_not_found",
         "no such connection: Emitter.timeout -> Receiver.on_timeout",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "connection_not_found"
-    assert "Emitter.timeout" in err["message"]
+    assert_operation_error(result, "connection_not_found", "Emitter.timeout")
 
 
 def test_disconnect_signal_missing_signal_maps_to_signal_not_found_code(monkeypatch):
     # A missing source signal on disconnect is signal_not_found, symmetric with
     # connect-signal and the documented contract (issue #57 review) — it is not
     # collapsed into connection_not_found.
-    result = _invoke_disconnect_signal(
+    result = _disconnect_signal(
         monkeypatch,
         "signal_not_found",
         "source node Emitter has no signal: timoeut",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "signal_not_found"
-    assert "timoeut" in err["message"]
+    assert_operation_error(result, "signal_not_found", "timoeut")
 
 
 def test_disconnect_signal_missing_node_reuses_node_not_found_code(monkeypatch):
-    result = _invoke_disconnect_signal(
+    result = _disconnect_signal(
         monkeypatch, "node_not_found", "source node not found in scene: Emitter"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "node_not_found"
-    assert "Emitter" in err["message"]
+    assert_operation_error(result, "node_not_found", "Emitter")
 
 
 def test_connect_signal_missing_scene_reuses_path_not_found_code(monkeypatch):
-    result = _invoke_connect_signal(
+    result = _connect_signal(
         monkeypatch, "path_not_found", "scene file does not exist: /x/main.tscn"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "path_not_found"
-    assert "/x/main.tscn" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/main.tscn")

--- a/tests/test_params_json.py
+++ b/tests/test_params_json.py
@@ -16,7 +16,6 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.commands.script import ScriptSetMode
-from gda.runner import RunResult
 from tests.support import (
     NODE_ADD_RESULT,
     NODE_GET_RESULT,
@@ -26,7 +25,7 @@ from tests.support import (
     SCRIPT_CREATE_RESULT,
     SCRIPT_SET_RESULT,
     SHADER_CREATE_RESULT,
-    inject_runner,
+    invoke_cli,
     minimal_project,
     sentinel,
 )
@@ -37,19 +36,15 @@ def test_scene_create_params_json_dispatches_like_argv(monkeypatch):
     # through the SAME runner seam as the argv path, applying the same
     # normalization (~ expanded, root_name derived from the filename). Proves the
     # central mechanism end-to-end and the argv/JSON parity in one shot.
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCENE_CREATE_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "scene",
             "create",
             "--params-json",
             '{"path": "~/proj/main.tscn", "root_type": "Node2D"}',
         ],
+        stdout=sentinel(SCENE_CREATE_RESULT),
     )
 
     assert result.exit_code == 0, result.stdout
@@ -71,13 +66,8 @@ def test_params_json_conflicting_with_individual_args_is_a_structured_usage_erro
     # Mutual exclusivity (ADR-0015): --params-json alongside an individual arg is a
     # registered usage_error (ADR-0002), emitted as a structured GdaError envelope
     # on a non-zero exit — never an ad-hoc message.
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCENE_CREATE_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "scene",
             "create",
@@ -86,6 +76,7 @@ def test_params_json_conflicting_with_individual_args_is_a_structured_usage_erro
             '{"path": "/tmp/proj/main.tscn", "root_type": "Node2D"}',
             "--json",
         ],
+        stdout=sentinel(SCENE_CREATE_RESULT),
     )
 
     assert result.exit_code != 0
@@ -96,13 +87,10 @@ def test_params_json_conflicting_with_individual_args_is_a_structured_usage_erro
 
 def test_invalid_json_params_is_a_structured_error(monkeypatch):
     # Malformed JSON → a registered invalid_params GdaError, not a traceback.
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCENE_CREATE_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["scene", "create", "--params-json", "{not json", "--json"]
+        ["scene", "create", "--params-json", "{not json", "--json"],
+        stdout=sentinel(SCENE_CREATE_RESULT),
     )
 
     assert result.exit_code != 0
@@ -113,13 +101,8 @@ def test_invalid_json_params_is_a_structured_error(monkeypatch):
 
 def test_schema_invalid_params_object_is_a_structured_error(monkeypatch):
     # Valid JSON but missing a required field (root_type) → invalid_params.
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCENE_CREATE_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "scene",
             "create",
@@ -127,6 +110,7 @@ def test_schema_invalid_params_object_is_a_structured_error(monkeypatch):
             '{"path": "/tmp/proj/main.tscn"}',
             "--json",
         ],
+        stdout=sentinel(SCENE_CREATE_RESULT),
     )
 
     assert result.exit_code != 0
@@ -160,13 +144,8 @@ def test_schema_takes_precedence_over_params_json(monkeypatch):
 def test_json_output_composes_with_params_json(monkeypatch):
     # --json (a result projection) composes with --params-json (an input source):
     # the success result is emitted as a single JSON object.
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCENE_CREATE_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "scene",
             "create",
@@ -174,6 +153,7 @@ def test_json_output_composes_with_params_json(monkeypatch):
             '{"path": "/tmp/proj/main.tscn", "root_type": "Node2D"}',
             "--json",
         ],
+        stdout=sentinel(SCENE_CREATE_RESULT),
     )
 
     assert result.exit_code == 0, result.stdout
@@ -185,15 +165,11 @@ def test_json_output_composes_with_params_json(monkeypatch):
 def test_params_json_dash_reads_the_object_from_stdin(monkeypatch):
     # `--params-json -` reads the JSON object from stdin, so large payloads
     # (script/shader content) avoid argv length limits (ADR-0015).
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCENE_CREATE_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         ["scene", "create", "--params-json", "-"],
-        input='{"path": "/tmp/proj/level.tscn", "root_type": "Node2D"}',
+        stdout=sentinel(SCENE_CREATE_RESULT),
+        stdin='{"path": "/tmp/proj/level.tscn", "root_type": "Node2D"}',
     )
 
     assert result.exit_code == 0, result.stdout
@@ -218,13 +194,8 @@ def test_wrong_typed_path_is_a_structured_error_not_a_traceback(monkeypatch):
     # A non-string NormalizedPath value must surface as structured invalid_params,
     # not a TypeError traceback: NormalizedPath uses AfterValidator, so the value is
     # validated as a str FIRST (ADR-0015). Regression for the BeforeValidator crash.
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCENE_CREATE_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "scene",
             "create",
@@ -232,6 +203,7 @@ def test_wrong_typed_path_is_a_structured_error_not_a_traceback(monkeypatch):
             '{"path": 123, "root_type": "Node2D"}',
             "--json",
         ],
+        stdout=sentinel(SCENE_CREATE_RESULT),
     )
 
     assert result.exit_code != 0
@@ -243,18 +215,15 @@ def test_wrong_typed_path_is_a_structured_error_not_a_traceback(monkeypatch):
 def test_node_add_params_json_derives_default_name_like_argv(monkeypatch):
     # Parity: omitting name derives it from the type model-side, exactly like the
     # argv path (which used to do this in the CLI body).
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(NODE_ADD_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "node",
             "add",
             "--params-json",
             '{"path": "/tmp/proj/main.tscn", "type": "Sprite2D"}',
         ],
+        stdout=sentinel(NODE_ADD_RESULT),
     )
 
     assert result.exit_code == 0, result.stdout
@@ -266,13 +235,8 @@ def test_node_add_params_json_derives_default_name_like_argv(monkeypatch):
 def test_script_create_params_json_rejects_content_and_extends(monkeypatch):
     # The content/extends mutual exclusivity is enforced model-side, so
     # --params-json cannot bypass it (it is rejected, not silently resolved).
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCRIPT_CREATE_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "script",
             "create",
@@ -280,6 +244,7 @@ def test_script_create_params_json_rejects_content_and_extends(monkeypatch):
             '{"path": "/tmp/proj/hero.gd", "content": "extends Node\\n", "extends_type": "Node2D"}',
             "--json",
         ],
+        stdout=sentinel(SCRIPT_CREATE_RESULT),
     )
 
     assert result.exit_code != 0
@@ -287,13 +252,8 @@ def test_script_create_params_json_rejects_content_and_extends(monkeypatch):
 
 
 def test_shader_create_params_json_rejects_content_and_shader_type(monkeypatch):
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_CREATE_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "shader",
             "create",
@@ -301,6 +261,7 @@ def test_shader_create_params_json_rejects_content_and_shader_type(monkeypatch):
             '{"path": "/tmp/proj/wave.gdshader", "content": "shader_type spatial;", "shader_type": "spatial"}',
             "--json",
         ],
+        stdout=sentinel(SHADER_CREATE_RESULT),
     )
 
     assert result.exit_code != 0
@@ -310,13 +271,8 @@ def test_shader_create_params_json_rejects_content_and_shader_type(monkeypatch):
 def test_script_set_params_json_rejects_inconsistent_edit_fields(monkeypatch):
     # The edit-mode rule is enforced model-side: a half-specified mode (search
     # without replace) is invalid_params via --params-json, not a silent dispatch.
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCRIPT_SET_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "script",
             "set",
@@ -324,6 +280,7 @@ def test_script_set_params_json_rejects_inconsistent_edit_fields(monkeypatch):
             '{"path": "/tmp/proj/hero.gd", "search": "a"}',
             "--json",
         ],
+        stdout=sentinel(SCRIPT_SET_RESULT),
     )
 
     assert result.exit_code != 0
@@ -399,19 +356,15 @@ def test_perf_monitor_params_json_rejects_frames_below_range(monkeypatch):
 def test_script_set_params_json_derives_mode_like_argv(monkeypatch):
     # Parity: the edit mode is derived from the supplied fields model-side, so a
     # --params-json caller need not (and should not) supply it.
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCRIPT_SET_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "script",
             "set",
             "--params-json",
             '{"path": "/tmp/proj/hero.gd", "content": "extends Node\\n"}',
         ],
+        stdout=sentinel(SCRIPT_SET_RESULT),
     )
 
     assert result.exit_code == 0, result.stdout
@@ -555,25 +508,6 @@ def test_an_unexpandable_tilde_is_structured_on_a_sibling_command(
     # Both channels, because the argv body builds the params model DIRECTLY: a
     # normalizer that raised would still crash here even though --params-json caught it.
     minimal_project(tmp_path)
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout=sentinel(
-                {
-                    "valid": True,
-                    "scripts": [
-                        {
-                            "path": _UNEXPANDABLE,
-                            "valid": True,
-                            "error_string": None,
-                        }
-                    ],
-                }
-            ),
-            stderr="",
-            exit_code=0,
-        ),
-    )
     argv = ["script", "validate"]
     argv += (
         [_UNEXPANDABLE]
@@ -581,7 +515,18 @@ def test_an_unexpandable_tilde_is_structured_on_a_sibling_command(
         else ["--params-json", json.dumps({"paths": [_UNEXPANDABLE]})]
     )
 
-    result = CliRunner().invoke(app, [*argv, "--project", str(tmp_path), "--json"])
+    result, _ = invoke_cli(
+        monkeypatch,
+        [*argv, "--project", str(tmp_path), "--json"],
+        stdout=sentinel(
+            {
+                "valid": True,
+                "scripts": [
+                    {"path": _UNEXPANDABLE, "valid": True, "error_string": None}
+                ],
+            }
+        ),
+    )
 
     assert "Traceback" not in (result.stderr or ""), result.stderr
     assert result.exception is None or result.exit_code != 1, result.exception
@@ -601,16 +546,12 @@ def test_argv_and_params_json_dispatch_identically(
     # logical input (a `~/…` path that normalization must expand), dispatch the
     # IDENTICAL (operation, params) call. Proves argv ≡ JSON parity and catches
     # any path-bearing field that did not get NormalizedPath.
-    argv_fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(canned), stderr="", exit_code=0)
-    )
-    CliRunner().invoke(app, argv)
+    _, argv_fake = invoke_cli(monkeypatch, argv, stdout=sentinel(canned))
 
-    json_fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(canned), stderr="", exit_code=0)
-    )
-    CliRunner().invoke(
-        app, [argv[0], argv[1], "--params-json", json.dumps(params_object)]
+    _, json_fake = invoke_cli(
+        monkeypatch,
+        [argv[0], argv[1], "--params-json", json.dumps(params_object)],
+        stdout=sentinel(canned),
     )
 
     assert argv_fake.calls == json_fake.calls, case_id

--- a/tests/test_params_json.py
+++ b/tests/test_params_json.py
@@ -27,6 +27,7 @@ from tests.support import (
     SCRIPT_SET_RESULT,
     SHADER_CREATE_RESULT,
     inject_runner,
+    minimal_project,
     sentinel,
 )
 
@@ -553,7 +554,7 @@ def test_an_unexpandable_tilde_is_structured_on_a_sibling_command(
     # `invalid_path`), but structured either way, which is what the contract requires.
     # Both channels, because the argv body builds the params model DIRECTLY: a
     # normalizer that raised would still crash here even though --params-json caught it.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     inject_runner(
         monkeypatch,
         RunResult(

--- a/tests/test_perf_commands.py
+++ b/tests/test_perf_commands.py
@@ -27,12 +27,8 @@ from tests.support import (
     perf_sample_reply_all_monitors,
     plain_text,
     sentinel,
+    minimal_project,
 )
-
-
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
 
 
 # --- perf monitors (single-frame snapshot) ------------------------------------
@@ -45,7 +41,7 @@ def test_perf_monitors_emits_a_snapshot_through_the_live_channel(monkeypatch, tm
     )
 
     result = CliRunner().invoke(
-        app, ["perf", "monitors", "--project", str(_project(tmp_path)), "--json"]
+        app, ["perf", "monitors", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -63,7 +59,7 @@ def test_perf_monitors_with_no_daemon_reports_daemon_not_running(monkeypatch, tm
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
 
     result = CliRunner().invoke(
-        app, ["perf", "monitors", "--project", str(_project(tmp_path)), "--json"]
+        app, ["perf", "monitors", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
@@ -101,7 +97,7 @@ def test_perf_monitors_on_non_unix_reports_live_unsupported_platform(
     monkeypatch.setattr("gda.live_runner._is_unix", lambda: False)
 
     result = CliRunner().invoke(
-        app, ["perf", "monitors", "--project", str(_project(tmp_path)), "--json"]
+        app, ["perf", "monitors", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code != 0, result.stdout
@@ -132,7 +128,7 @@ def test_perf_monitor_property_emits_a_timeline_through_the_live_channel(
             "--frames",
             "3",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -176,7 +172,7 @@ def test_perf_monitor_signal_records_emissions_through_the_live_channel(
             "--frames",
             "3",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -217,7 +213,7 @@ def test_perf_monitor_default_frame_count_is_threaded(monkeypatch, tmp_path):
             "--property",
             "position",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -249,7 +245,7 @@ def test_perf_monitor_missing_node_reports_live_perf_node_not_found(
             "--property",
             "position",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -283,7 +279,7 @@ def test_perf_monitor_unknown_property_reports_live_perf_property_not_found(
             "--property",
             "nope",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -313,7 +309,7 @@ def test_perf_monitor_unknown_signal_reports_live_perf_signal_not_found(
             "--signal",
             "nope",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -334,7 +330,7 @@ def test_perf_monitor_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp
             "--property",
             "position",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -370,7 +366,7 @@ def test_perf_monitor_argv_both_selectors_is_a_usage_error(monkeypatch, tmp_path
             "--signal",
             "hit",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -394,7 +390,7 @@ def test_perf_monitor_argv_no_selector_is_a_usage_error(monkeypatch, tmp_path):
             "monitor",
             "/root/Main/Player",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -422,7 +418,7 @@ def test_perf_monitor_argv_frames_over_range_is_a_usage_error(monkeypatch, tmp_p
             "--frames",
             "601",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -466,7 +462,7 @@ def _window(tmp_path, *args):
             "monitors",
             *args,
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -609,7 +605,7 @@ def test_perf_monitors_selection_and_budget_require_frames(monkeypatch, tmp_path
             "--params-json",
             '{"monitors": ["fps"]}',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -641,7 +637,7 @@ def test_perf_monitors_window_unknown_monitor_is_rejected_before_dispatch(
             "--params-json",
             '{"frames": 5, "monitors": ["fpss"]}',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -845,7 +841,7 @@ def test_perf_monitors_budget_path_expands_a_literal_tilde(monkeypatch, tmp_path
             '{"frames": 5, "monitors": ["fps", "draw_calls"], '
             '"budget": "~/budget.json"}',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )

--- a/tests/test_project_analysis_commands.py
+++ b/tests/test_project_analysis_commands.py
@@ -9,16 +9,12 @@ parse → typed model → JSON — with canned engine output, no real Godot.
 
 import json
 
-from typer.testing import CliRunner
 
-from gda.cli import app
-from gda.runner import RunResult
 from tests.support import (
     DEPENDENCIES_RESULT,
     FIND_REFERENCES_RESULT,
     STATISTICS_RESULT,
     UNUSED_RESULT,
-    inject_runner,
     invoke_cli,
     sentinel,
 )
@@ -42,12 +38,9 @@ def test_dependencies_json_maps_success_to_json_object_and_exit_zero(monkeypatch
 
 
 def test_dependencies_human_output_lists_each_scene_and_its_deps(monkeypatch):
-    inject_runner(
-        monkeypatch,
-        RunResult(stdout=sentinel(DEPENDENCIES_RESULT), stderr="", exit_code=0),
+    result, _ = invoke_cli(
+        monkeypatch, ["project", "dependencies"], stdout=sentinel(DEPENDENCIES_RESULT)
     )
-
-    result = CliRunner().invoke(app, ["project", "dependencies"])
 
     assert result.exit_code == 0
     assert "res://main.tscn" in result.stdout
@@ -56,10 +49,10 @@ def test_dependencies_human_output_lists_each_scene_and_its_deps(monkeypatch):
 
 def test_find_references_passes_target_param(monkeypatch):
     stdout = sentinel(FIND_REFERENCES_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["project", "find-references", "res://hero.gd", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["project", "find-references", "res://hero.gd", "--json"],
+        stdout=stdout,
     )
 
     assert result.exit_code == 0
@@ -74,27 +67,22 @@ def test_find_references_passes_target_param(monkeypatch):
 def test_find_references_normalizes_filesystem_target_but_not_res_path(monkeypatch):
     # A res:// virtual path passes through untouched (the engine resolves it);
     # a class_name target (no '://') is left as-is too, not treated as a file.
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=sentinel({"target": "Hero", "references": []}),
-            stderr="",
-            exit_code=0,
-        ),
+        ["project", "find-references", "Hero", "--json"],
+        stdout=sentinel({"target": "Hero", "references": []}),
     )
-
-    result = CliRunner().invoke(app, ["project", "find-references", "Hero", "--json"])
 
     assert result.exit_code == 0
     assert fake.calls == [("project-find-references", {"target": "Hero"})]
 
 
 def test_find_unused_resources_json(monkeypatch):
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(UNUSED_RESULT), stderr="", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["project", "find-unused-resources", "--json"],
+        stdout=sentinel(UNUSED_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["project", "find-unused-resources", "--json"])
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -103,12 +91,11 @@ def test_find_unused_resources_json(monkeypatch):
 
 
 def test_statistics_json(monkeypatch):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(STATISTICS_RESULT), stderr="", exit_code=0),
+        ["project", "statistics", "--json"],
+        stdout=sentinel(STATISTICS_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["project", "statistics", "--json"])
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -119,12 +106,9 @@ def test_statistics_json(monkeypatch):
 
 
 def test_statistics_human_output_summarizes_counts(monkeypatch):
-    inject_runner(
-        monkeypatch,
-        RunResult(stdout=sentinel(STATISTICS_RESULT), stderr="", exit_code=0),
+    result, _ = invoke_cli(
+        monkeypatch, ["project", "statistics"], stdout=sentinel(STATISTICS_RESULT)
     )
-
-    result = CliRunner().invoke(app, ["project", "statistics"])
 
     assert result.exit_code == 0
     assert "5" in result.stdout  # total files

--- a/tests/test_project_analysis_commands.py
+++ b/tests/test_project_analysis_commands.py
@@ -19,17 +19,18 @@ from tests.support import (
     STATISTICS_RESULT,
     UNUSED_RESULT,
     inject_runner,
+    invoke_cli,
     sentinel,
 )
 
 
 def test_dependencies_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(DEPENDENCIES_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["project", "dependencies", "--json"],
+        stdout=sentinel(DEPENDENCIES_RESULT),
+        stderr="engine diagnostic\n",
     )
-
-    result = CliRunner().invoke(app, ["project", "dependencies", "--json"])
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)

--- a/tests/test_project_analysis_errors.py
+++ b/tests/test_project_analysis_errors.py
@@ -8,106 +8,66 @@ agent branches on the mode without parsing prose. The project group reuses
 and mints ``invalid_target`` for a bad find-references target.
 """
 
-import json
-
-from typer.testing import CliRunner
-
-from gda.cli import app
-from gda.runner import RunResult
-from tests.support import error_sentinel, inject_runner
-
-
-def _assert_structured_operation_error(result, code: str) -> None:
-    assert result.exit_code == 4, result.stdout
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == code
+from tests.support import assert_operation_error, invoke_operation_error
 
 
 def test_dependencies_without_project_is_project_not_found(monkeypatch):
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(
-                "project_not_found",
-                "project dependencies requires a Godot project; none was resolved",
-            ),
-            stderr="gda: running operation: project-dependencies\n",
-            exit_code=1,
-        ),
+        ["project", "dependencies", "--json"],
+        "project_not_found",
+        "project dependencies requires a Godot project; none was resolved",
+        "project-dependencies",
     )
 
-    result = CliRunner().invoke(app, ["project", "dependencies", "--json"])
-
-    _assert_structured_operation_error(result, "project_not_found")
+    assert_operation_error(result, "project_not_found")
 
 
 def test_find_unused_without_project_is_project_not_found(monkeypatch):
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout=error_sentinel("project_not_found", "no project resolved"),
-            stderr="",
-            exit_code=1,
-        ),
+        ["project", "find-unused-resources", "--json"],
+        "project_not_found",
+        "no project resolved",
+        "project-find-unused-resources",
     )
 
-    result = CliRunner().invoke(app, ["project", "find-unused-resources", "--json"])
-
-    _assert_structured_operation_error(result, "project_not_found")
+    assert_operation_error(result, "project_not_found")
 
 
 def test_statistics_without_project_is_project_not_found(monkeypatch):
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout=error_sentinel("project_not_found", "no project resolved"),
-            stderr="",
-            exit_code=1,
-        ),
+        ["project", "statistics", "--json"],
+        "project_not_found",
+        "no project resolved",
+        "project-statistics",
     )
 
-    result = CliRunner().invoke(app, ["project", "statistics", "--json"])
-
-    _assert_structured_operation_error(result, "project_not_found")
+    assert_operation_error(result, "project_not_found")
 
 
 def test_find_references_without_project_is_project_not_found(monkeypatch):
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout=error_sentinel("project_not_found", "no project resolved"),
-            stderr="",
-            exit_code=1,
-        ),
+        ["project", "find-references", "res://hero.gd", "--json"],
+        "project_not_found",
+        "no project resolved",
+        "project-find-references",
     )
 
-    result = CliRunner().invoke(
-        app, ["project", "find-references", "res://hero.gd", "--json"]
-    )
-
-    _assert_structured_operation_error(result, "project_not_found")
+    assert_operation_error(result, "project_not_found")
 
 
 def test_find_references_bad_target_is_invalid_target(monkeypatch):
     # A bad find-references target (empty, or not a res:// path / class_name)
     # surfaces as the registered invalid_target operation code.
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(
-                "invalid_target",
-                "find-references target is not a res:// path or class_name: /abs/path",
-            ),
-            stderr="gda: running operation: project-find-references\n",
-            exit_code=1,
-        ),
+        ["project", "find-references", "/abs/path", "--json"],
+        "invalid_target",
+        "find-references target is not a res:// path or class_name: /abs/path",
+        "project-find-references",
     )
 
-    result = CliRunner().invoke(
-        app, ["project", "find-references", "/abs/path", "--json"]
-    )
-
-    _assert_structured_operation_error(result, "invalid_target")
+    assert_operation_error(result, "invalid_target")

--- a/tests/test_project_commands.py
+++ b/tests/test_project_commands.py
@@ -33,7 +33,7 @@ from gda.commands.project import (
 )
 from gda.models import GdaErrorEnvelope
 from gda.runner import RunResult
-from tests.support import VERSION_INFO, FakeRunner, inject_runner, sentinel
+from tests.support import VERSION_INFO, inject_runner, invoke_cli, sentinel
 
 INFO_RESULT = {
     "name": "My Game",
@@ -78,12 +78,12 @@ LIST_RESULT = {
 
 def test_project_info_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
     # Engine banner noise around the sentinel, diagnostics on stderr (ADR-0002).
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(INFO_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["project", "info", "--json"],
+        stdout=sentinel(INFO_RESULT),
+        stderr="engine diagnostic\n",
     )
-
-    result = CliRunner().invoke(app, ["project", "info", "--json"])
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -247,8 +247,9 @@ def test_project_set_human_output_is_set_setting_type_value(monkeypatch):
 def test_project_set_requires_value(monkeypatch):
     # --value is required: a set with no value is a usage error (exit 2), not a
     # silent no-op or an empty write.
-    fake = FakeRunner(RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0))
-    monkeypatch.setattr("gda.dispatch.make_runner", lambda binary, project=None: fake)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(app, ["project", "set", "application/config/name"])
 
@@ -513,10 +514,10 @@ def test_project_add_input_action_dispatches_deadzone_and_physical_overrides(
 def test_project_add_input_action_requires_at_least_one_key(monkeypatch):
     # --key is required: an add with no keys is a usage error (exit 2), not a
     # dispatch of an empty key list.
-    fake = FakeRunner(
-        RunResult(stdout=sentinel(ADD_INPUT_ACTION_RESULT), stderr="", exit_code=0)
+    fake = inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(ADD_INPUT_ACTION_RESULT), stderr="", exit_code=0),
     )
-    monkeypatch.setattr("gda.dispatch.make_runner", lambda binary, project=None: fake)
 
     result = CliRunner().invoke(app, ["project", "add-input-action", "jump"])
 
@@ -527,10 +528,10 @@ def test_project_add_input_action_requires_at_least_one_key(monkeypatch):
 def test_project_add_input_action_rejects_out_of_range_deadzone(monkeypatch):
     # The deadzone bounds (0..1, the editor slider's) are validated model-side
     # (ADR-0015) and surface as a clean usage error before any dispatch.
-    fake = FakeRunner(
-        RunResult(stdout=sentinel(ADD_INPUT_ACTION_RESULT), stderr="", exit_code=0)
+    fake = inject_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(ADD_INPUT_ACTION_RESULT), stderr="", exit_code=0),
     )
-    monkeypatch.setattr("gda.dispatch.make_runner", lambda binary, project=None: fake)
 
     result = CliRunner().invoke(
         app,

--- a/tests/test_project_commands.py
+++ b/tests/test_project_commands.py
@@ -32,8 +32,7 @@ from gda.commands.project import (
     ProjectSetResult,
 )
 from gda.models import GdaErrorEnvelope
-from gda.runner import RunResult
-from tests.support import VERSION_INFO, inject_runner, invoke_cli, sentinel
+from tests.support import VERSION_INFO, invoke_cli, sentinel
 
 INFO_RESULT = {
     "name": "My Game",
@@ -99,11 +98,9 @@ def test_project_info_json_maps_success_to_json_object_and_exit_zero(monkeypatch
 
 
 def test_project_info_human_output_is_a_readable_block(monkeypatch):
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(INFO_RESULT), stderr="", exit_code=0)
+    result, _ = invoke_cli(
+        monkeypatch, ["project", "info"], stdout=sentinel(INFO_RESULT)
     )
-
-    result = CliRunner().invoke(app, ["project", "info"])
 
     assert result.exit_code == 0
     assert "name: My Game" in result.stdout
@@ -115,11 +112,7 @@ def test_project_info_human_output_is_a_readable_block(monkeypatch):
 def test_project_info_human_output_shows_none_for_empty_main_scene(monkeypatch):
     # A new project has no main scene; the human block names that explicitly.
     payload = {**INFO_RESULT, "main_scene": ""}
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(app, ["project", "info"])
+    result, _ = invoke_cli(monkeypatch, ["project", "info"], stdout=sentinel(payload))
 
     assert result.exit_code == 0
     assert "main_scene: (none)" in result.stdout
@@ -129,12 +122,10 @@ def test_project_info_human_output_shows_none_for_empty_main_scene(monkeypatch):
 
 
 def test_project_get_dispatches_setting_param_and_reports_typed_value(monkeypatch):
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["project", "get", "application/config/name", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["project", "get", "application/config/name", "--json"],
+        stdout=sentinel(GET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -145,11 +136,11 @@ def test_project_get_dispatches_setting_param_and_reports_typed_value(monkeypatc
 
 
 def test_project_get_human_output_is_setting_type_value(monkeypatch):
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0)
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["project", "get", "application/config/name"],
+        stdout=sentinel(GET_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["project", "get", "application/config/name"])
 
     assert result.exit_code == 0
     assert result.stdout.strip() == 'application/config/name (String) = "My Game"'
@@ -159,11 +150,9 @@ def test_project_get_carries_packed_value_projection(monkeypatch):
     # A packed-type setting (e.g. a Vector2-ish value) is carried as a JSON list,
     # the same projection node get reports — so get / set round-trip the shape.
     payload = {"setting": "some/vec", "type": "Vector2", "value": [10.0, 20.0]}
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    result, _ = invoke_cli(
+        monkeypatch, ["project", "get", "some/vec", "--json"], stdout=sentinel(payload)
     )
-
-    result = CliRunner().invoke(app, ["project", "get", "some/vec", "--json"])
 
     assert result.exit_code == 0
     assert json.loads(result.stdout)["value"] == [10.0, 20.0]
@@ -179,11 +168,11 @@ def test_project_get_carries_compound_value_projection_untouched(monkeypatch):
         "events": [{"type": "InputEventKey", "keycode": 74, "pressed": False}],
     }
     payload = {"setting": "input/fire", "type": "Dictionary", "value": value}
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["project", "get", "input/fire", "--json"],
+        stdout=sentinel(payload),
     )
-
-    result = CliRunner().invoke(app, ["project", "get", "input/fire", "--json"])
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -197,12 +186,8 @@ def test_project_get_carries_compound_value_projection_untouched(monkeypatch):
 
 
 def test_project_set_dispatches_setting_and_value_and_round_trips(monkeypatch):
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "project",
             "set",
@@ -211,6 +196,7 @@ def test_project_set_dispatches_setting_and_value_and_round_trips(monkeypatch):
             "1920",
             "--json",
         ],
+        stdout=sentinel(SET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -230,12 +216,10 @@ def test_project_set_dispatches_setting_and_value_and_round_trips(monkeypatch):
 
 
 def test_project_set_human_output_is_set_setting_type_value(monkeypatch):
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["project", "set", "display/window/size/viewport_width", "--value", "1920"]
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["project", "set", "display/window/size/viewport_width", "--value", "1920"],
+        stdout=sentinel(SET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -247,11 +231,11 @@ def test_project_set_human_output_is_set_setting_type_value(monkeypatch):
 def test_project_set_requires_value(monkeypatch):
     # --value is required: a set with no value is a usage error (exit 2), not a
     # silent no-op or an empty write.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["project", "set", "application/config/name"],
+        stdout=sentinel(SET_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["project", "set", "application/config/name"])
 
     assert result.exit_code == 2
     assert fake.calls == []
@@ -263,11 +247,9 @@ def test_project_set_requires_value(monkeypatch):
 def test_project_list_bare_dispatches_customized_scope_and_maps_entries(monkeypatch):
     # A bare list lists only customized settings: include_defaults defaults False,
     # section None. Each entry rides through as {setting, type, value, is_default}.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch, ["project", "list", "--json"], stdout=sentinel(LIST_RESULT)
     )
-
-    result = CliRunner().invoke(app, ["project", "list", "--json"])
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -280,11 +262,11 @@ def test_project_list_bare_dispatches_customized_scope_and_maps_entries(monkeypa
 def test_project_list_all_flag_widens_scope_to_engine_defaults(monkeypatch):
     # --all sets include_defaults True so the engine's built-in defaults are listed
     # too, not just the project's customized settings.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["project", "list", "--all", "--json"],
+        stdout=sentinel(LIST_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["project", "list", "--all", "--json"])
 
     assert result.exit_code == 0
     assert fake.calls == [("project-list", {"include_defaults": True, "section": None})]
@@ -293,12 +275,10 @@ def test_project_list_all_flag_widens_scope_to_engine_defaults(monkeypatch):
 def test_project_list_section_filter_rides_through_as_a_param(monkeypatch):
     # --section restricts the listing to keys under a section/ prefix; it composes
     # with --all (both ride through as operation params).
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["project", "list", "--all", "--section", "application/", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["project", "list", "--all", "--section", "application/", "--json"],
+        stdout=sentinel(LIST_RESULT),
     )
 
     assert result.exit_code == 0
@@ -308,11 +288,9 @@ def test_project_list_section_filter_rides_through_as_a_param(monkeypatch):
 
 
 def test_project_list_human_output_lines_settings_and_marks_defaults(monkeypatch):
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
+    result, _ = invoke_cli(
+        monkeypatch, ["project", "list"], stdout=sentinel(LIST_RESULT)
     )
-
-    result = CliRunner().invoke(app, ["project", "list"])
 
     assert result.exit_code == 0
     lines = result.stdout.strip().splitlines()
@@ -322,12 +300,9 @@ def test_project_list_human_output_lines_settings_and_marks_defaults(monkeypatch
 
 
 def test_project_list_human_output_names_an_empty_listing(monkeypatch):
-    inject_runner(
-        monkeypatch,
-        RunResult(stdout=sentinel({"settings": []}), stderr="", exit_code=0),
+    result, _ = invoke_cli(
+        monkeypatch, ["project", "list"], stdout=sentinel({"settings": []})
     )
-
-    result = CliRunner().invoke(app, ["project", "list"])
 
     assert result.exit_code == 0
     assert result.stdout.strip() == "(no settings)"
@@ -347,14 +322,10 @@ REMOVE_AUTOLOAD_RESULT = {
 
 
 def test_project_add_autoload_dispatches_name_and_path_and_reports_result(monkeypatch):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(ADD_AUTOLOAD_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         ["project", "add-autoload", "Global", "res://global.gd", "--json"],
+        stdout=sentinel(ADD_AUTOLOAD_RESULT),
     )
 
     assert result.exit_code == 0
@@ -370,13 +341,10 @@ def test_project_add_autoload_dispatches_name_and_path_and_reports_result(monkey
 
 
 def test_project_add_autoload_human_output_names_the_registered_autoload(monkeypatch):
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(ADD_AUTOLOAD_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["project", "add-autoload", "Global", "res://global.gd"]
+        ["project", "add-autoload", "Global", "res://global.gd"],
+        stdout=sentinel(ADD_AUTOLOAD_RESULT),
     )
 
     assert result.exit_code == 0
@@ -387,12 +355,11 @@ def test_project_add_autoload_human_output_names_the_registered_autoload(monkeyp
 
 
 def test_project_remove_autoload_dispatches_name_and_reports_result(monkeypatch):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(REMOVE_AUTOLOAD_RESULT), stderr="", exit_code=0),
+        ["project", "remove-autoload", "Global", "--json"],
+        stdout=sentinel(REMOVE_AUTOLOAD_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["project", "remove-autoload", "Global", "--json"])
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -403,12 +370,11 @@ def test_project_remove_autoload_dispatches_name_and_reports_result(monkeypatch)
 def test_project_remove_autoload_human_output_names_the_unregistered_autoload(
     monkeypatch,
 ):
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(REMOVE_AUTOLOAD_RESULT), stderr="", exit_code=0),
+        ["project", "remove-autoload", "Global"],
+        stdout=sentinel(REMOVE_AUTOLOAD_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["project", "remove-autoload", "Global"])
 
     assert result.exit_code == 0
     assert result.stdout.strip() == "removed autoload Global"
@@ -434,13 +400,8 @@ REMOVE_INPUT_ACTION_RESULT = {
 def test_project_add_input_action_dispatches_full_params_and_reports_result(
     monkeypatch,
 ):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(ADD_INPUT_ACTION_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "project",
             "add-input-action",
@@ -451,6 +412,7 @@ def test_project_add_input_action_dispatches_full_params_and_reports_result(
             "Space",
             "--json",
         ],
+        stdout=sentinel(ADD_INPUT_ACTION_RESULT),
     )
 
     assert result.exit_code == 0
@@ -482,13 +444,8 @@ def test_project_add_input_action_dispatches_full_params_and_reports_result(
 def test_project_add_input_action_dispatches_deadzone_and_physical_overrides(
     monkeypatch,
 ):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(ADD_INPUT_ACTION_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "project",
             "add-input-action",
@@ -500,6 +457,7 @@ def test_project_add_input_action_dispatches_deadzone_and_physical_overrides(
             "--physical",
             "--json",
         ],
+        stdout=sentinel(ADD_INPUT_ACTION_RESULT),
     )
 
     assert result.exit_code == 0
@@ -514,12 +472,11 @@ def test_project_add_input_action_dispatches_deadzone_and_physical_overrides(
 def test_project_add_input_action_requires_at_least_one_key(monkeypatch):
     # --key is required: an add with no keys is a usage error (exit 2), not a
     # dispatch of an empty key list.
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(ADD_INPUT_ACTION_RESULT), stderr="", exit_code=0),
+        ["project", "add-input-action", "jump"],
+        stdout=sentinel(ADD_INPUT_ACTION_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["project", "add-input-action", "jump"])
 
     assert result.exit_code == 2
     assert fake.calls == []
@@ -528,14 +485,10 @@ def test_project_add_input_action_requires_at_least_one_key(monkeypatch):
 def test_project_add_input_action_rejects_out_of_range_deadzone(monkeypatch):
     # The deadzone bounds (0..1, the editor slider's) are validated model-side
     # (ADR-0015) and surface as a clean usage error before any dispatch.
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(ADD_INPUT_ACTION_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         ["project", "add-input-action", "jump", "--key", "J", "--deadzone", "1.5"],
+        stdout=sentinel(ADD_INPUT_ACTION_RESULT),
     )
 
     assert result.exit_code == 2
@@ -543,13 +496,10 @@ def test_project_add_input_action_rejects_out_of_range_deadzone(monkeypatch):
 
 
 def test_project_add_input_action_human_output_lists_resolved_bindings(monkeypatch):
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(ADD_INPUT_ACTION_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["project", "add-input-action", "jump", "--key", "J", "--key", "Space"]
+        ["project", "add-input-action", "jump", "--key", "J", "--key", "Space"],
+        stdout=sentinel(ADD_INPUT_ACTION_RESULT),
     )
 
     assert result.exit_code == 0
@@ -565,12 +515,10 @@ def test_project_add_input_action_human_output_marks_physical_bindings(monkeypat
         "deadzone": 0.5,
         "events": [{"kind": "key", "key": "J", "keycode": 74, "physical": True}],
     }
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["project", "add-input-action", "jump", "--key", "J", "--physical"]
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["project", "add-input-action", "jump", "--key", "J", "--physical"],
+        stdout=sentinel(payload),
     )
 
     assert result.exit_code == 0
@@ -584,13 +532,10 @@ def test_project_add_input_action_human_output_marks_physical_bindings(monkeypat
 
 
 def test_project_remove_input_action_dispatches_name_and_reports_result(monkeypatch):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(REMOVE_INPUT_ACTION_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["project", "remove-input-action", "jump", "--json"]
+        ["project", "remove-input-action", "jump", "--json"],
+        stdout=sentinel(REMOVE_INPUT_ACTION_RESULT),
     )
 
     assert result.exit_code == 0
@@ -601,12 +546,11 @@ def test_project_remove_input_action_dispatches_name_and_reports_result(monkeypa
 def test_project_remove_input_action_human_output_names_the_removed_action(
     monkeypatch,
 ):
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(REMOVE_INPUT_ACTION_RESULT), stderr="", exit_code=0),
+        ["project", "remove-input-action", "jump"],
+        stdout=sentinel(REMOVE_INPUT_ACTION_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["project", "remove-input-action", "jump"])
 
     assert result.exit_code == 0
     assert result.stdout.strip() == "removed input action jump"

--- a/tests/test_project_errors.py
+++ b/tests/test_project_errors.py
@@ -6,67 +6,44 @@ registered operation codes (ADR-0002) — exit 4 for the operation category, fin
 stable codes so an agent branches on the mode without parsing prose.
 """
 
-import json
-
-from typer.testing import CliRunner
-
-from gda.cli import app
-from gda.runner import RunResult
-from tests.support import error_sentinel, inject_runner
-
-
-def _invoke(monkeypatch, args, code, message, stderr="gda: running operation\n"):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr=stderr,
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, args)
+from tests.support import assert_operation_error, invoke_operation_error
 
 
 def test_project_info_without_project_maps_to_project_not_found(monkeypatch):
     # project info reads ProjectSettings, so a projectless run would report only
     # the engine's bare defaults — refused with project_not_found instead.
-    result = _invoke(
+    result = invoke_operation_error(
         monkeypatch,
         ["project", "info", "--json"],
         "project_not_found",
         "project info requires a Godot project; none was resolved",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "project_not_found"
-    assert "Godot project" in err["message"]
-    assert err["diagnostics"] == "gda: running operation\n"
+    assert_operation_error(
+        result,
+        "project_not_found",
+        "Godot project",
+        diagnostics="gda: running operation\n",
+    )
 
 
 def test_project_get_unknown_setting_maps_to_stable_unknown_setting_code(monkeypatch):
     # A typo'd / absent setting key is unknown_setting, distinct from a setting
     # genuinely holding null — the agent fixes the key, not the value.
-    result = _invoke(
+    result = invoke_operation_error(
         monkeypatch,
         ["project", "get", "application/bogus/key", "--json"],
         "unknown_setting",
         "project setting not found: application/bogus/key",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "unknown_setting"
-    assert "application/bogus/key" in err["message"]
+    assert_operation_error(result, "unknown_setting", "application/bogus/key")
 
 
 def test_project_set_unknown_setting_maps_to_stable_unknown_setting_code(monkeypatch):
     # set edits an existing setting; an unknown key is unknown_setting, never a
     # silent create.
-    result = _invoke(
+    result = invoke_operation_error(
         monkeypatch,
         ["project", "set", "application/bogus/key", "--value", "1", "--json"],
         "unknown_setting",
@@ -74,10 +51,7 @@ def test_project_set_unknown_setting_maps_to_stable_unknown_setting_code(monkeyp
         "existing setting; it never creates one",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "unknown_setting"
-    assert "never creates" in err["message"]
+    assert_operation_error(result, "unknown_setting", "never creates")
 
 
 def test_project_set_uncoercible_value_maps_to_stable_uncoercible_value_code(
@@ -85,7 +59,7 @@ def test_project_set_uncoercible_value_maps_to_stable_uncoercible_value_code(
 ):
     # A value that cannot be coerced to the setting's declared type reuses the
     # node-set #55 code: uncoercible_value (exit 4, project.godot untouched).
-    result = _invoke(
+    result = invoke_operation_error(
         monkeypatch,
         [
             "project",
@@ -100,8 +74,4 @@ def test_project_set_uncoercible_value_maps_to_stable_uncoercible_value_code(
         "display/window/size/viewport_width",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "uncoercible_value"
-    assert "not-a-number" in err["message"]
+    assert_operation_error(result, "uncoercible_value", "not-a-number")

--- a/tests/test_resource_commands.py
+++ b/tests/test_resource_commands.py
@@ -26,8 +26,10 @@ from tests.support import (
     PATH_TO_UID_RESULT,
     UID,
     UID_TO_PATH_RESULT,
-    FakeRunner,
     inject_runner,
+    invoke_cli,
+    minimal_project,
+    recording_runner,
     sentinel,
 )
 
@@ -36,13 +38,8 @@ from tests.support import (
 
 
 def test_resource_set_dispatches_path_property_value_and_round_trips(monkeypatch):
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(SET_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "resource",
             "set",
@@ -53,6 +50,8 @@ def test_resource_set_dispatches_path_property_value_and_round_trips(monkeypatch
             "1",
             "--json",
         ],
+        stdout=sentinel(SET_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -105,8 +104,9 @@ def test_resource_set_human_output_is_set_path_property_type_value(monkeypatch):
 def test_resource_set_requires_value(monkeypatch):
     # --value is required: a set with no value is a usage error (exit 2), not a
     # silent no-op or an empty write.
-    fake = FakeRunner(RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0))
-    monkeypatch.setattr("gda.dispatch.make_runner", lambda binary, project=None: fake)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(
         app, ["resource", "set", "/tmp/proj/palette.tres", "--property", "x"]
@@ -117,8 +117,9 @@ def test_resource_set_requires_value(monkeypatch):
 
 
 def test_resource_set_expands_user_home_in_filesystem_path(monkeypatch):
-    fake = FakeRunner(RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0))
-    monkeypatch.setattr("gda.dispatch.make_runner", lambda binary, project=None: fake)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(
         app,
@@ -144,13 +145,11 @@ def test_resource_set_expands_user_home_in_filesystem_path(monkeypatch):
 
 
 def test_resource_delete_dispatches_path_and_reports_removed(monkeypatch):
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(DELETE_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["resource", "delete", "/tmp/proj/palette.tres", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["resource", "delete", "/tmp/proj/palette.tres", "--json"],
+        stdout=sentinel(DELETE_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -174,8 +173,9 @@ def test_resource_delete_human_output_names_path_and_type(monkeypatch):
 
 
 def test_resource_delete_res_path_passes_through_untouched(monkeypatch):
-    fake = FakeRunner(RunResult(stdout=sentinel(DELETE_RESULT), stderr="", exit_code=0))
-    monkeypatch.setattr("gda.dispatch.make_runner", lambda binary, project=None: fake)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(DELETE_RESULT), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(
         app, ["resource", "delete", "res://palette.tres", "--json"]
@@ -187,13 +187,8 @@ def test_resource_delete_res_path_passes_through_untouched(monkeypatch):
 
 def test_resource_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
     # Engine banner noise around the sentinel, diagnostics on stderr (ADR-0002).
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(CREATE_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "resource",
             "create",
@@ -202,6 +197,8 @@ def test_resource_create_json_maps_success_to_json_object_and_exit_zero(monkeypa
             "Gradient",
             "--json",
         ],
+        stdout=sentinel(CREATE_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -234,11 +231,10 @@ def test_resource_create_human_output_reports_path_and_type(monkeypatch):
 
 
 def test_resource_get_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(GET_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["resource", "get", "/tmp/proj/palette.tres", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["resource", "get", "/tmp/proj/palette.tres", "--json"],
+        stdout=sentinel(GET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -268,8 +264,9 @@ def test_resource_get_human_output_lists_typed_properties(monkeypatch):
 def test_resource_create_expands_user_home_in_filesystem_path(monkeypatch):
     # A filesystem path gets ~ expanded at the CLI layer (issue #32); res://
     # virtual paths pass through untouched. Exercise the expansion seam.
-    fake = FakeRunner(RunResult(stdout=sentinel(CREATE_RESULT), stderr="", exit_code=0))
-    monkeypatch.setattr("gda.dispatch.make_runner", lambda binary, project=None: fake)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(CREATE_RESULT), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(
         app, ["resource", "create", "~/palette.tres", "--type", "Gradient", "--json"]
@@ -282,8 +279,9 @@ def test_resource_create_expands_user_home_in_filesystem_path(monkeypatch):
 
 
 def test_resource_get_res_path_passes_through_untouched(monkeypatch):
-    fake = FakeRunner(RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0))
-    monkeypatch.setattr("gda.dispatch.make_runner", lambda binary, project=None: fake)
+    fake = inject_runner(
+        monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(
         app, ["resource", "get", "res://palette.tres", "--json"]
@@ -296,14 +294,12 @@ def test_resource_get_res_path_passes_through_untouched(monkeypatch):
 def test_resource_uid_resolves_uid_to_path_json_and_exit_zero(monkeypatch, tmp_path):
     # Given a uid://, the command reports the res:// path it resolves to. Engine
     # banner noise around the sentinel, diagnostics on stderr (ADR-0002).
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(UID_TO_PATH_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["resource", "uid", UID, "--project", str(tmp_path), "--json"]
+    minimal_project(tmp_path)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["resource", "uid", UID, "--project", str(tmp_path), "--json"],
+        stdout=sentinel(UID_TO_PATH_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -320,12 +316,11 @@ def test_resource_uid_resolves_uid_to_path_json_and_exit_zero(monkeypatch, tmp_p
 def test_resource_uid_resolves_path_to_uid_json_and_exit_zero(monkeypatch, tmp_path):
     # Given a res:// path, the command reports its assigned uid://. The result is
     # the same shape; only `queried` distinguishes which side was the target.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(PATH_TO_UID_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["resource", "uid", PATH, "--project", str(tmp_path), "--json"]
+    minimal_project(tmp_path)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["resource", "uid", PATH, "--project", str(tmp_path), "--json"],
+        stdout=sentinel(PATH_TO_UID_RESULT),
     )
 
     assert result.exit_code == 0
@@ -340,29 +335,24 @@ def test_resource_uid_resolves_path_to_uid_json_and_exit_zero(monkeypatch, tmp_p
 def test_resource_uid_passes_resolved_project_to_the_runner(monkeypatch, tmp_path):
     # Resolution queries the project's UID cache, so --project must reach the
     # runner (which hands it to the engine as --path, issue #32).
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    seen: dict = {}
-
-    def record(binary, project):
-        seen["project"] = project
-        return FakeRunner(
-            RunResult(stdout=sentinel(UID_TO_PATH_RESULT), stderr="", exit_code=0)
-        )
-
-    monkeypatch.setattr("gda.dispatch.make_runner", record)
+    minimal_project(tmp_path)
+    projects = recording_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(UID_TO_PATH_RESULT), stderr="", exit_code=0),
+    )
 
     result = CliRunner().invoke(
         app, ["resource", "uid", UID, "--project", str(tmp_path), "--json"]
     )
 
     assert result.exit_code == 0
-    assert seen["project"] == tmp_path
+    assert projects[0] == tmp_path
 
 
 def test_resource_uid_expands_tilde_for_a_filesystem_target(monkeypatch, tmp_path):
     # A filesystem path target gets ~ expanded at the CLI layer so a literal ~
     # works without a shell (issue #32); a uid:// / res:// target is untouched.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     fake = inject_runner(
         monkeypatch,
         RunResult(stdout=sentinel(PATH_TO_UID_RESULT), stderr="", exit_code=0),
@@ -386,7 +376,7 @@ def test_resource_uid_expands_tilde_for_a_filesystem_target(monkeypatch, tmp_pat
 def test_resource_uid_human_output_renders_uid_arrow_path(monkeypatch, tmp_path):
     # Without --json, a resolved mapping renders as `<uid> -> <path>`, the same
     # for both directions since the result shape is identical.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     inject_runner(
         monkeypatch,
         RunResult(stdout=sentinel(UID_TO_PATH_RESULT), stderr="", exit_code=0),

--- a/tests/test_resource_commands.py
+++ b/tests/test_resource_commands.py
@@ -26,7 +26,6 @@ from tests.support import (
     PATH_TO_UID_RESULT,
     UID,
     UID_TO_PATH_RESULT,
-    inject_runner,
     invoke_cli,
     minimal_project,
     recording_runner,
@@ -77,12 +76,8 @@ def test_resource_set_dispatches_path_property_value_and_round_trips(monkeypatch
 
 
 def test_resource_set_human_output_is_set_path_property_type_value(monkeypatch):
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, _ = invoke_cli(
+        monkeypatch,
         [
             "resource",
             "set",
@@ -92,6 +87,7 @@ def test_resource_set_human_output_is_set_path_property_type_value(monkeypatch):
             "--value",
             "1",
         ],
+        stdout=sentinel(SET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -104,12 +100,10 @@ def test_resource_set_human_output_is_set_path_property_type_value(monkeypatch):
 def test_resource_set_requires_value(monkeypatch):
     # --value is required: a set with no value is a usage error (exit 2), not a
     # silent no-op or an empty write.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["resource", "set", "/tmp/proj/palette.tres", "--property", "x"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["resource", "set", "/tmp/proj/palette.tres", "--property", "x"],
+        stdout=sentinel(SET_RESULT),
     )
 
     assert result.exit_code == 2
@@ -117,12 +111,8 @@ def test_resource_set_requires_value(monkeypatch):
 
 
 def test_resource_set_expands_user_home_in_filesystem_path(monkeypatch):
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "resource",
             "set",
@@ -133,6 +123,7 @@ def test_resource_set_expands_user_home_in_filesystem_path(monkeypatch):
             "1",
             "--json",
         ],
+        stdout=sentinel(SET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -162,23 +153,21 @@ def test_resource_delete_dispatches_path_and_reports_removed(monkeypatch):
 
 
 def test_resource_delete_human_output_names_path_and_type(monkeypatch):
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(DELETE_RESULT), stderr="", exit_code=0)
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["resource", "delete", "/tmp/proj/palette.tres"],
+        stdout=sentinel(DELETE_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["resource", "delete", "/tmp/proj/palette.tres"])
 
     assert result.exit_code == 0
     assert result.stdout.strip() == "deleted /tmp/proj/palette.tres (Gradient)"
 
 
 def test_resource_delete_res_path_passes_through_untouched(monkeypatch):
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(DELETE_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["resource", "delete", "res://palette.tres", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["resource", "delete", "res://palette.tres", "--json"],
+        stdout=sentinel(DELETE_RESULT),
     )
 
     assert result.exit_code == 0
@@ -216,12 +205,10 @@ def test_resource_create_json_maps_success_to_json_object_and_exit_zero(monkeypa
 
 
 def test_resource_create_human_output_reports_path_and_type(monkeypatch):
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(CREATE_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["resource", "create", "/tmp/proj/palette.tres", "--type", "Gradient"]
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["resource", "create", "/tmp/proj/palette.tres", "--type", "Gradient"],
+        stdout=sentinel(CREATE_RESULT),
     )
 
     assert result.exit_code == 0
@@ -249,11 +236,11 @@ def test_resource_get_json_maps_success_to_json_object_and_exit_zero(monkeypatch
 
 
 def test_resource_get_human_output_lists_typed_properties(monkeypatch):
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0)
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["resource", "get", "/tmp/proj/palette.tres"],
+        stdout=sentinel(GET_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["resource", "get", "/tmp/proj/palette.tres"])
 
     assert result.exit_code == 0
     # The header names the resource and its type; each property is a typed line.
@@ -264,12 +251,10 @@ def test_resource_get_human_output_lists_typed_properties(monkeypatch):
 def test_resource_create_expands_user_home_in_filesystem_path(monkeypatch):
     # A filesystem path gets ~ expanded at the CLI layer (issue #32); res://
     # virtual paths pass through untouched. Exercise the expansion seam.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(CREATE_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["resource", "create", "~/palette.tres", "--type", "Gradient", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["resource", "create", "~/palette.tres", "--type", "Gradient", "--json"],
+        stdout=sentinel(CREATE_RESULT),
     )
 
     assert result.exit_code == 0
@@ -279,12 +264,10 @@ def test_resource_create_expands_user_home_in_filesystem_path(monkeypatch):
 
 
 def test_resource_get_res_path_passes_through_untouched(monkeypatch):
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["resource", "get", "res://palette.tres", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["resource", "get", "res://palette.tres", "--json"],
+        stdout=sentinel(GET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -353,13 +336,10 @@ def test_resource_uid_expands_tilde_for_a_filesystem_target(monkeypatch, tmp_pat
     # A filesystem path target gets ~ expanded at the CLI layer so a literal ~
     # works without a shell (issue #32); a uid:// / res:// target is untouched.
     minimal_project(tmp_path)
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(PATH_TO_UID_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["resource", "uid", "~/data.tres", "--project", str(tmp_path), "--json"]
+        ["resource", "uid", "~/data.tres", "--project", str(tmp_path), "--json"],
+        stdout=sentinel(PATH_TO_UID_RESULT),
     )
 
     assert result.exit_code == 0
@@ -377,13 +357,10 @@ def test_resource_uid_human_output_renders_uid_arrow_path(monkeypatch, tmp_path)
     # Without --json, a resolved mapping renders as `<uid> -> <path>`, the same
     # for both directions since the result shape is identical.
     minimal_project(tmp_path)
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(UID_TO_PATH_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["resource", "uid", UID, "--project", str(tmp_path)]
+        ["resource", "uid", UID, "--project", str(tmp_path)],
+        stdout=sentinel(UID_TO_PATH_RESULT),
     )
 
     assert result.exit_code == 0

--- a/tests/test_resource_errors.py
+++ b/tests/test_resource_errors.py
@@ -17,58 +17,36 @@ malformed ``uid://`` adds ``invalid_uid``, and a projectless run reuses the
 shared ``project_not_found``.
 """
 
-import json
-
-from typer.testing import CliRunner
-
-from gda.cli import app
-from gda.runner import RunResult
-from tests.support import error_sentinel, inject_runner
+from tests.support import assert_operation_error, operation_error_invoker
 
 
-def _invoke_resource_create(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: resource-create\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app, ["resource", "create", "/x/palette.tres", "--type", "Gradient", "--json"]
-    )
+_resource_create = operation_error_invoker(
+    ["resource", "create", "/x/palette.tres", "--type", "Gradient", "--json"],
+    "resource-create",
+)
 
 
-def _invoke_resource_get(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: resource-get\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, ["resource", "get", "/x/palette.tres", "--json"])
+_resource_get = operation_error_invoker(
+    ["resource", "get", "/x/palette.tres", "--json"],
+    "resource-get",
+)
 
 
 def test_resource_create_collision_reuses_stable_already_exists_code(monkeypatch):
     # No-clobber: a create whose target already exists reuses the registered
     # already_exists code (the same one scene/script create use), leaving the
     # file untouched — the resource group mints no parallel collision code.
-    result = _invoke_resource_create(
+    result = _resource_create(
         monkeypatch, "already_exists", "resource target already exists: /x/palette.tres"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "already_exists"
-    assert "/x/palette.tres" in err["message"]
     # The raw stderr still rides along as diagnostics (ADR-0002).
-    assert err["diagnostics"] == "gda: running operation: resource-create\n"
+    assert_operation_error(
+        result,
+        "already_exists",
+        "/x/palette.tres",
+        diagnostics="gda: running operation: resource-create\n",
+    )
 
 
 def test_resource_create_invalid_type_yields_invalid_resource_type(monkeypatch):
@@ -76,248 +54,200 @@ def test_resource_create_invalid_type_yields_invalid_resource_type(monkeypatch):
     # refuses it with the resource group's own invalid_resource_type code —
     # parallel to scene create's invalid_root_type and node add's
     # invalid_node_type, but for the Resource hierarchy.
-    result = _invoke_resource_create(
+    result = _resource_create(
         monkeypatch,
         "invalid_resource_type",
         "not an instantiable Resource class: Bogus",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "invalid_resource_type"
-    assert "Bogus" in err["message"]
+    assert_operation_error(result, "invalid_resource_type", "Bogus")
 
 
 def test_resource_create_non_tres_path_yields_invalid_path(monkeypatch):
-    result = _invoke_resource_create(
+    result = _resource_create(
         monkeypatch, "invalid_path", "resource path must end in .tres: /x/palette.txt"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "invalid_path"
+    assert_operation_error(result, "invalid_path")
 
 
 def test_resource_get_missing_yields_path_not_found(monkeypatch):
     # A get on a path with no resource file reuses the registered path_not_found
     # code (the same one scene/script get use for a missing file).
-    result = _invoke_resource_get(
+    result = _resource_get(
         monkeypatch, "path_not_found", "resource file does not exist: /x/palette.tres"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/palette.tres" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/palette.tres")
 
 
-def _invoke_resource_set(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: resource-set\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app,
-        [
-            "resource",
-            "set",
-            "/x/palette.tres",
-            "--property",
-            "interpolation_mode",
-            "--value",
-            "1",
-            "--json",
-        ],
-    )
+_resource_set = operation_error_invoker(
+    [
+        "resource",
+        "set",
+        "/x/palette.tres",
+        "--property",
+        "interpolation_mode",
+        "--value",
+        "1",
+        "--json",
+    ],
+    "resource-set",
+)
 
 
-def _invoke_resource_delete(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: resource-delete\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, ["resource", "delete", "/x/palette.tres", "--json"])
+_resource_delete = operation_error_invoker(
+    ["resource", "delete", "/x/palette.tres", "--json"],
+    "resource-delete",
+)
 
 
 def test_resource_set_unknown_property_yields_unknown_property(monkeypatch):
     # set edits an existing property; an unknown property is unknown_property
     # (the same #55 code node set uses), never a silent create.
-    result = _invoke_resource_set(
+    result = _resource_set(
         monkeypatch,
         "unknown_property",
         "resource /x/palette.tres has no settable property: bogus",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "unknown_property"
-    assert "bogus" in err["message"]
-    assert err["diagnostics"] == "gda: running operation: resource-set\n"
+    assert_operation_error(
+        result,
+        "unknown_property",
+        "bogus",
+        diagnostics="gda: running operation: resource-set\n",
+    )
 
 
 def test_resource_set_uncoercible_value_yields_uncoercible_value(monkeypatch):
     # A value that cannot be coerced to the property's declared type reuses the
     # node-set #55 code: uncoercible_value (exit 4, the .tres untouched).
-    result = _invoke_resource_set(
+    result = _resource_set(
         monkeypatch,
         "uncoercible_value",
         "cannot coerce value not-a-number to int for property "
         "interpolation_mode on resource /x/palette.tres",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "uncoercible_value"
-    assert "not-a-number" in err["message"]
+    assert_operation_error(result, "uncoercible_value", "not-a-number")
 
 
 def test_resource_set_missing_yields_path_not_found(monkeypatch):
     # A set on a path with no resource file reuses the registered path_not_found
     # code (the same one resource get uses for a missing file).
-    result = _invoke_resource_set(
+    result = _resource_set(
         monkeypatch, "path_not_found", "resource file does not exist: /x/palette.tres"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "path_not_found"
-    assert "/x/palette.tres" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/palette.tres")
 
 
 def test_resource_set_non_tres_path_yields_invalid_path(monkeypatch):
-    result = _invoke_resource_set(
+    result = _resource_set(
         monkeypatch, "invalid_path", "resource path must end in .tres: /x/palette.txt"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "invalid_path"
+    assert_operation_error(result, "invalid_path")
 
 
 def test_resource_delete_missing_yields_path_not_found(monkeypatch):
     # A delete on a path with no resource file reuses path_not_found, so the
     # lifecycle's now-not-found is the same code a fresh get would report.
-    result = _invoke_resource_delete(
+    result = _resource_delete(
         monkeypatch, "path_not_found", "resource file does not exist: /x/palette.tres"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/palette.tres" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/palette.tres")
 
 
 def test_resource_delete_non_tres_path_yields_invalid_path(monkeypatch):
-    result = _invoke_resource_delete(
+    result = _resource_delete(
         monkeypatch, "invalid_path", "resource path must end in .tres: /x/palette.txt"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "invalid_path"
+    assert_operation_error(result, "invalid_path")
 
 
-def _invoke_resource_uid(monkeypatch, code: str, message: str, target: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: resource-uid\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, ["resource", "uid", target, "--json"])
+_resource_uid = operation_error_invoker(
+    lambda target: ["resource", "uid", target, "--json"],
+    "resource-uid",
+)
 
 
-def _assert_operation_error(result, code: str, needle: str) -> dict:
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == code
-    assert needle in err["message"]
-    # The raw stderr still rides along as diagnostics (ADR-0002).
-    assert err["diagnostics"] == "gda: running operation: resource-uid\n"
-    return err
+# The raw stderr still rides along as diagnostics (ADR-0002). Every resource uid
+# test checks it, so the notice is named here and passed at each call site rather
+# than hidden inside a helper's default.
+_UID_NOTICE = "gda: running operation: resource-uid\n"
 
 
 def test_resource_uid_unknown_uid_is_structured_error(monkeypatch):
     # A well-formed uid:// absent from the project's UID cache is unknown_uid —
     # the agent learns the UID is unregistered, not that the syntax was wrong.
-    result = _invoke_resource_uid(
+    result = _resource_uid(
         monkeypatch,
         "unknown_uid",
         "UID is not registered in the project's UID cache: uid://abc",
-        "uid://abc",
+        target="uid://abc",
     )
 
-    _assert_operation_error(result, "unknown_uid", "uid://abc")
+    assert_operation_error(result, "unknown_uid", "uid://abc", diagnostics=_UID_NOTICE)
 
 
 def test_resource_uid_invalid_uid_is_structured_error(monkeypatch):
     # A syntactically malformed uid:// (engine text_to_id == INVALID_ID) is
     # invalid_uid — distinct from an unknown-but-well-formed UID.
-    result = _invoke_resource_uid(
+    result = _resource_uid(
         monkeypatch,
         "invalid_uid",
         "not a valid resource UID: uid://!!!",
-        "uid://!!!",
+        target="uid://!!!",
     )
 
-    _assert_operation_error(result, "invalid_uid", "uid://!!!")
+    assert_operation_error(result, "invalid_uid", "uid://!!!", diagnostics=_UID_NOTICE)
 
 
 def test_resource_uid_path_not_found_is_structured_error(monkeypatch):
     # A res:// path naming no resource is path_not_found — the same registered
     # code the file groups use, not a parallel resource-specific code.
-    result = _invoke_resource_uid(
+    result = _resource_uid(
         monkeypatch,
         "path_not_found",
         "no resource at path: res://missing.tres",
-        "res://missing.tres",
+        target="res://missing.tres",
     )
 
-    _assert_operation_error(result, "path_not_found", "res://missing.tres")
+    assert_operation_error(
+        result, "path_not_found", "res://missing.tres", diagnostics=_UID_NOTICE
+    )
 
 
 def test_resource_uid_no_uid_assigned_is_structured_error(monkeypatch):
     # A resource that exists but carries no UID in the cache is no_uid_assigned —
     # distinct from path_not_found (the file is there) and from a UID-direction
     # failure (the query was a path).
-    result = _invoke_resource_uid(
+    result = _resource_uid(
         monkeypatch,
         "no_uid_assigned",
         "resource has no UID assigned in the project's UID cache: res://plain.txt",
-        "res://plain.txt",
+        target="res://plain.txt",
     )
 
-    _assert_operation_error(result, "no_uid_assigned", "res://plain.txt")
+    assert_operation_error(
+        result, "no_uid_assigned", "res://plain.txt", diagnostics=_UID_NOTICE
+    )
 
 
 def test_resource_uid_projectless_run_is_project_not_found(monkeypatch):
     # Resolution queries the project's UID cache, so a projectless run has no
     # cache to query — refused with the shared project_not_found rather than a
     # misleading "no UID" answer.
-    result = _invoke_resource_uid(
+    result = _resource_uid(
         monkeypatch,
         "project_not_found",
         "resource uid requires a Godot project; none was resolved",
-        "uid://abc",
+        target="uid://abc",
     )
 
-    _assert_operation_error(result, "project_not_found", "requires a Godot project")
+    assert_operation_error(
+        result, "project_not_found", "requires a Godot project", diagnostics=_UID_NOTICE
+    )

--- a/tests/test_resource_import_commands.py
+++ b/tests/test_resource_import_commands.py
@@ -18,14 +18,16 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import LaunchFailure, RunResult, TimeoutBound
+from tests.support import minimal_project
 
 runner_cli = CliRunner()
 
 
 def _project(tmp_path: Path) -> Path:
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    (tmp_path / "icon.png").write_bytes(b"\x89PNG fake bytes")
-    return tmp_path
+    """The shared minimum, plus the one asset the import pass has to see."""
+    project = minimal_project(tmp_path)
+    (project / "icon.png").write_bytes(b"\x89PNG fake bytes")
+    return project
 
 
 def _sidecar(
@@ -741,9 +743,7 @@ def test_an_asset_a_nested_project_owns_is_refused_before_the_pass(tmp_path):
     # `not_importable`, while `--dry-run` predicted a sidecar that would never
     # appear. It now refuses up front and names the project that CAN import it.
     project = _project(tmp_path)
-    nested = project / "vendor"
-    nested.mkdir()
-    (nested / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    nested = minimal_project(project / "vendor")
     (nested / "pic.png").write_bytes(b"\x89PNG")
 
     data = json.loads(_run(project, "res://vendor/pic.png", "--dry-run").stdout)

--- a/tests/test_scene_commands.py
+++ b/tests/test_scene_commands.py
@@ -16,7 +16,6 @@ from tests.support import (
     SCENE_DELETE_RESULT as DELETE_RESULT,
     SCENE_GET_RESULT as GET_RESULT,
     SCENE_LIST_RESULT as LIST_RESULT,
-    inject_runner,
     invoke_cli,
     minimal_project,
     recording_runner,
@@ -58,10 +57,8 @@ def test_scene_create_accepts_explicit_root_name(monkeypatch):
     stdout = sentinel(
         {**CREATE_RESULT, "path": "/tmp/proj/level.v2.tscn", "root_name": "LevelV2"}
     )
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "scene",
             "create",
@@ -72,6 +69,7 @@ def test_scene_create_accepts_explicit_root_name(monkeypatch):
             "LevelV2",
             "--json",
         ],
+        stdout=stdout,
     )
 
     assert result.exit_code == 0
@@ -124,11 +122,11 @@ def test_scene_get_passes_resolved_project_to_the_runner(monkeypatch, tmp_path):
 def test_scene_get_expands_user_home_in_filesystem_path_but_not_res(monkeypatch):
     # Path normalization lives at the CLI layer (issue #32): a filesystem path
     # gets ~ expanded; an engine-resolved res:// path passes through untouched.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0)
+    _, fake = invoke_cli(
+        monkeypatch,
+        ["scene", "get", "~/game/main.tscn", "--json"],
+        stdout=sentinel(GET_RESULT),
     )
-
-    CliRunner().invoke(app, ["scene", "get", "~/game/main.tscn", "--json"])
     assert "~" not in fake.calls[0][1]["path"]
     assert fake.calls[0][1]["path"].endswith("/game/main.tscn")
 
@@ -216,12 +214,11 @@ def test_scene_get_exports_expands_user_home_in_filesystem_path_but_not_res(
 ):
     # Path normalization at the CLI layer (issue #32) applies to get-exports too:
     # a filesystem path gets ~ expanded; a res:// path passes through untouched.
-    fake = inject_runner(
+    _, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(GET_EXPORTS_RESULT), stderr="", exit_code=0),
+        ["scene", "get-exports", "~/game/main.tscn", "--json"],
+        stdout=sentinel(GET_EXPORTS_RESULT),
     )
-
-    CliRunner().invoke(app, ["scene", "get-exports", "~/game/main.tscn", "--json"])
     assert "~" not in fake.calls[0][1]["path"]
     assert fake.calls[0][1]["path"].endswith("/game/main.tscn")
 
@@ -234,10 +231,10 @@ def test_scene_get_exports_empty_scene_is_a_valid_empty_listing(monkeypatch):
     # A scene with no exported variables anywhere is a successful, empty listing
     # (nodes == []), not a failure.
     stdout = sentinel({"path": "/tmp/proj/bare.tscn", "nodes": []})
-    inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["scene", "get-exports", "/tmp/proj/bare.tscn", "--json"]
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["scene", "get-exports", "/tmp/proj/bare.tscn", "--json"],
+        stdout=stdout,
     )
 
     assert result.exit_code == 0
@@ -309,11 +306,11 @@ def test_scene_delete_json_reports_what_was_removed_and_exit_zero(monkeypatch):
 def test_scene_delete_expands_user_home_in_filesystem_path_but_not_res(monkeypatch):
     # Path normalization at the CLI layer (issue #32) applies to delete too: a
     # filesystem path gets ~ expanded; a res:// path passes through untouched.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(DELETE_RESULT), stderr="", exit_code=0)
+    _, fake = invoke_cli(
+        monkeypatch,
+        ["scene", "delete", "~/game/old.tscn", "--json"],
+        stdout=sentinel(DELETE_RESULT),
     )
-
-    CliRunner().invoke(app, ["scene", "delete", "~/game/old.tscn", "--json"])
     assert "~" not in fake.calls[0][1]["path"]
     assert fake.calls[0][1]["path"].endswith("/game/old.tscn")
 

--- a/tests/test_scene_commands.py
+++ b/tests/test_scene_commands.py
@@ -16,22 +16,21 @@ from tests.support import (
     SCENE_DELETE_RESULT as DELETE_RESULT,
     SCENE_GET_RESULT as GET_RESULT,
     SCENE_LIST_RESULT as LIST_RESULT,
-    FakeRunner,
     inject_runner,
+    invoke_cli,
+    minimal_project,
+    recording_runner,
     sentinel,
 )
 
 
 def test_scene_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
     # Engine banner noise around the sentinel, diagnostics on stderr (ADR-0002).
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(CREATE_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         ["scene", "create", "/tmp/proj/main.tscn", "--root-type", "Node2D", "--json"],
+        stdout=sentinel(CREATE_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -90,10 +89,11 @@ def test_scene_create_accepts_explicit_root_name(monkeypatch):
 
 
 def test_scene_get_json_emits_structured_node_tree_and_exit_zero(monkeypatch):
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(GET_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(app, ["scene", "get", "/tmp/proj/main.tscn", "--json"])
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["scene", "get", "/tmp/proj/main.tscn", "--json"],
+        stdout=sentinel(GET_RESULT),
+    )
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -108,23 +108,17 @@ def test_scene_get_json_emits_structured_node_tree_and_exit_zero(monkeypatch):
 def test_scene_get_passes_resolved_project_to_the_runner(monkeypatch, tmp_path):
     # --project resolves to a project dir and is handed to the runner (which
     # turns it into the engine's --path so res:// resolves there, issue #32).
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    seen: dict = {}
-
-    def record(binary, project):
-        seen["project"] = project
-        return FakeRunner(
-            RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0)
-        )
-
-    monkeypatch.setattr("gda.dispatch.make_runner", record)
+    minimal_project(tmp_path)
+    projects = recording_runner(
+        monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(
         app, ["scene", "get", "res://main.tscn", "--project", str(tmp_path), "--json"]
     )
 
     assert result.exit_code == 0
-    assert seen["project"] == tmp_path
+    assert projects[0] == tmp_path
 
 
 def test_scene_get_expands_user_home_in_filesystem_path_but_not_res(monkeypatch):
@@ -191,13 +185,11 @@ def test_scene_get_exports_json_emits_per_node_exports_and_exit_zero(monkeypatch
     # scene get-exports loads a scene and reports, per node (by node path), the
     # @export properties its attached script declares (issue #58): each export's
     # name, declared type, hint/hint_string, and value as typed JSON.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(GET_EXPORTS_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["scene", "get-exports", "/tmp/proj/main.tscn", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["scene", "get-exports", "/tmp/proj/main.tscn", "--json"],
+        stdout=sentinel(GET_EXPORTS_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -256,12 +248,11 @@ def test_scene_list_json_enumerates_project_scenes_and_exit_zero(monkeypatch, tm
     # scene list enumerates the resolved project's .tscn files (issue #54):
     # each entry carries its res:// path plus the root name/type read cheaply
     # from the scene's stored state.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(LIST_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["scene", "list", "--project", str(tmp_path), "--json"]
+    minimal_project(tmp_path)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["scene", "list", "--project", str(tmp_path), "--json"],
+        stdout=sentinel(LIST_RESULT),
     )
 
     assert result.exit_code == 0
@@ -280,36 +271,28 @@ def test_scene_list_json_enumerates_project_scenes_and_exit_zero(monkeypatch, tm
 def test_scene_list_passes_resolved_project_to_the_runner(monkeypatch, tmp_path):
     # scene list enumerates res:// in the resolved project, so --project must
     # reach the runner (which hands it to the engine as --path, issue #32).
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    seen: dict = {}
-
-    def record(binary, project):
-        seen["project"] = project
-        return FakeRunner(
-            RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
-        )
-
-    monkeypatch.setattr("gda.dispatch.make_runner", record)
+    minimal_project(tmp_path)
+    projects = recording_runner(
+        monkeypatch, RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(
         app, ["scene", "list", "--project", str(tmp_path), "--json"]
     )
 
     assert result.exit_code == 0
-    assert seen["project"] == tmp_path
+    assert projects[0] == tmp_path
 
 
 def test_scene_delete_json_reports_what_was_removed_and_exit_zero(monkeypatch):
     # scene delete removes a scene file and names what it deleted (issue #54):
     # the path plus the removed scene's root name/type, so the result names the
     # content, not just the file.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(DELETE_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["scene", "delete", "/tmp/proj/old.tscn", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["scene", "delete", "/tmp/proj/old.tscn", "--json"],
+        stdout=sentinel(DELETE_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0

--- a/tests/test_scene_errors.py
+++ b/tests/test_scene_errors.py
@@ -13,131 +13,91 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import LaunchFailure, RunResult
-from tests.support import error_sentinel, inject_runner
+from tests.support import (
+    assert_operation_error,
+    inject_runner,
+    invoke_cli,
+    invoke_operation_error,
+)
 
 
 def test_scene_get_missing_file_maps_to_stable_path_not_found_code(monkeypatch):
     # The operation found no file at the target path and reported a structured
     # failure: exit 4 (operation category), but a finer stable code than the
     # generic operation_failed so an agent can react to the mode specifically.
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(
-                "path_not_found", "scene file does not exist: /x/missing.tscn"
-            ),
-            stderr="gda: running operation: scene-get\n",
-            exit_code=1,
-        ),
+        ["scene", "get", "/x/missing.tscn", "--json"],
+        "path_not_found",
+        "scene file does not exist: /x/missing.tscn",
+        "scene-get",
     )
 
-    result = CliRunner().invoke(app, ["scene", "get", "/x/missing.tscn", "--json"])
-
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/missing.tscn" in err["message"]
     # The raw stderr still rides along as diagnostics (ADR-0002).
-    assert err["diagnostics"] == "gda: running operation: scene-get\n"
+    assert_operation_error(
+        result,
+        "path_not_found",
+        "/x/missing.tscn",
+        diagnostics="gda: running operation: scene-get\n",
+    )
 
 
 def test_scene_get_unloadable_file_maps_to_stable_not_a_scene_code(monkeypatch):
     # The file exists but Godot cannot load it as a PackedScene — distinct
     # stable code, same operation category and exit code.
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout=error_sentinel(
-                "not_a_scene", "failed to load as a scene: /x/notes.txt"
-            ),
-            stderr="",
-            exit_code=1,
-        ),
+        ["scene", "get", "/x/notes.txt", "--json"],
+        "not_a_scene",
+        "failed to load as a scene: /x/notes.txt",
+        "scene-get",
     )
 
-    result = CliRunner().invoke(app, ["scene", "get", "/x/notes.txt", "--json"])
-
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "not_a_scene"
+    assert_operation_error(result, "not_a_scene")
 
 
 def test_scene_get_exports_missing_file_maps_to_stable_path_not_found_code(monkeypatch):
     # scene get-exports reuses the shared load-failure ladder (issue #58): a
     # target that does not exist is the file-level path_not_found, exit 4, so an
     # agent can tell "no such scene" apart from other get-exports failures.
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(
-                "path_not_found", "scene file does not exist: /x/missing.tscn"
-            ),
-            stderr="gda: running operation: scene-get-exports\n",
-            exit_code=1,
-        ),
+        ["scene", "get-exports", "/x/missing.tscn", "--json"],
+        "path_not_found",
+        "scene file does not exist: /x/missing.tscn",
+        "scene-get-exports",
     )
 
-    result = CliRunner().invoke(
-        app, ["scene", "get-exports", "/x/missing.tscn", "--json"]
-    )
-
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/missing.tscn" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/missing.tscn")
 
 
 def test_scene_get_exports_unloadable_file_maps_to_stable_not_a_scene_code(monkeypatch):
     # The file exists but Godot cannot load it as a PackedScene — get-exports
     # reuses the same stable not_a_scene code scene get / delete report, so a
     # stray non-scene file is refused rather than mis-handled (issue #58).
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout=error_sentinel(
-                "not_a_scene", "failed to load as a scene: /x/notes.txt"
-            ),
-            stderr="",
-            exit_code=1,
-        ),
+        ["scene", "get-exports", "/x/notes.txt", "--json"],
+        "not_a_scene",
+        "failed to load as a scene: /x/notes.txt",
+        "scene-get-exports",
     )
 
-    result = CliRunner().invoke(app, ["scene", "get-exports", "/x/notes.txt", "--json"])
-
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "not_a_scene"
+    assert_operation_error(result, "not_a_scene")
 
 
 def test_scene_create_unknown_root_type_maps_to_stable_invalid_root_type_code(
     monkeypatch,
 ):
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout=error_sentinel(
-                "invalid_root_type", "not an instantiable Node class: Foo"
-            ),
-            stderr="",
-            exit_code=1,
-        ),
+        ["scene", "create", "/x/main.tscn", "--root-type", "Foo", "--json"],
+        "invalid_root_type",
+        "not an instantiable Node class: Foo",
+        "scene-create",
     )
 
-    result = CliRunner().invoke(
-        app, ["scene", "create", "/x/main.tscn", "--root-type", "Foo", "--json"]
-    )
-
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "invalid_root_type"
-    assert "Foo" in err["message"]
+    assert_operation_error(result, "invalid_root_type", "Foo")
 
 
 def test_scene_create_save_failure_maps_to_stable_save_failed_code(monkeypatch):
@@ -145,39 +105,24 @@ def test_scene_create_save_failure_maps_to_stable_save_failed_code(monkeypatch):
     # read-only filesystem): the structured error envelope maps to the stable
     # save_failed code so an agent can tell "fix the destination" apart from
     # "fix the request" (issue #35).
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout=error_sentinel(
-                "save_failed",
-                "failed to save scene to /x/demo/main.tscn: Can't open",
-            ),
-            stderr="",
-            exit_code=1,
-        ),
+        ["scene", "create", "/x/demo/main.tscn", "--root-type", "Node2D", "--json"],
+        "save_failed",
+        "failed to save scene to /x/demo/main.tscn: Can't open",
+        "scene-create",
     )
 
-    result = CliRunner().invoke(
-        app, ["scene", "create", "/x/demo/main.tscn", "--root-type", "Node2D", "--json"]
-    )
-
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "save_failed"
-    assert "/x/demo/main.tscn" in err["message"]
+    assert_operation_error(result, "save_failed", "/x/demo/main.tscn")
 
 
 def test_scene_get_broken_sentinel_maps_to_parse_error(monkeypatch):
     # Exit 0 but no result sentinel: the structured-output contract (ADR-0002)
     # was violated — the shared parse classification applies to scene commands
     # exactly as it does to info.
-    inject_runner(
-        monkeypatch,
-        RunResult(stdout="no sentinel here\n", stderr="", exit_code=0),
+    result, _ = invoke_cli(
+        monkeypatch, ["scene", "get", "/x/main.tscn", "--json"], stdout="no sentinel\n"
     )
-
-    result = CliRunner().invoke(app, ["scene", "get", "/x/main.tscn", "--json"])
 
     assert result.exit_code == 5
     err = json.loads(result.stdout)["error"]
@@ -189,47 +134,30 @@ def test_scene_delete_missing_file_maps_to_stable_path_not_found_code(monkeypatc
     # scene delete reuses the shared load-failure ladder (issue #54): a target
     # that does not exist is the file-level path_not_found, exit 4, so an agent
     # can tell "no such scene" apart from other delete failures.
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout=error_sentinel(
-                "path_not_found", "scene file does not exist: /x/missing.tscn"
-            ),
-            stderr="",
-            exit_code=1,
-        ),
+        ["scene", "delete", "/x/missing.tscn", "--json"],
+        "path_not_found",
+        "scene file does not exist: /x/missing.tscn",
+        "scene-delete",
     )
 
-    result = CliRunner().invoke(app, ["scene", "delete", "/x/missing.tscn", "--json"])
-
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/missing.tscn" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/missing.tscn")
 
 
 def test_scene_delete_non_scene_file_maps_to_stable_not_a_scene_code(monkeypatch):
     # delete refuses a target that is not loadable as a scene (issue #54): the
     # safety boundary is that delete only removes things that load as a
     # PackedScene, so a stray file is not_a_scene rather than silently deleted.
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout=error_sentinel(
-                "not_a_scene", "failed to load as a scene: /x/notes.txt"
-            ),
-            stderr="",
-            exit_code=1,
-        ),
+        ["scene", "delete", "/x/notes.txt", "--json"],
+        "not_a_scene",
+        "failed to load as a scene: /x/notes.txt",
+        "scene-delete",
     )
 
-    result = CliRunner().invoke(app, ["scene", "delete", "/x/notes.txt", "--json"])
-
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "not_a_scene"
+    assert_operation_error(result, "not_a_scene")
 
 
 def test_scene_delete_unlink_failure_maps_to_stable_delete_failed_code(monkeypatch):
@@ -239,25 +167,15 @@ def test_scene_delete_unlink_failure_maps_to_stable_delete_failed_code(monkeypat
     # than reusing save_failed (whose contract is "a scene could not be packed or
     # saved"). An agent can then tell "deletion was blocked" apart from "writing
     # the scene failed".
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout=error_sentinel(
-                "delete_failed",
-                "failed to delete scene /x/main.tscn: Permission denied",
-            ),
-            stderr="",
-            exit_code=1,
-        ),
+        ["scene", "delete", "/x/main.tscn", "--json"],
+        "delete_failed",
+        "failed to delete scene /x/main.tscn: Permission denied",
+        "scene-delete",
     )
 
-    result = CliRunner().invoke(app, ["scene", "delete", "/x/main.tscn", "--json"])
-
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "delete_failed"
-    assert "/x/main.tscn" in err["message"]
+    assert_operation_error(result, "delete_failed", "/x/main.tscn")
 
 
 def test_scene_list_without_project_maps_to_stable_project_not_found_code(monkeypatch):
@@ -265,25 +183,15 @@ def test_scene_list_without_project_maps_to_stable_project_not_found_code(monkey
     # (issue #54): with no resolvable project, the operation reports the new
     # project_not_found code — a finer mode than the generic operation_failed so
     # an agent knows to pass --project rather than retry.
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout=error_sentinel(
-                "project_not_found",
-                "scene list requires a Godot project; none was resolved — pass --project",
-            ),
-            stderr="",
-            exit_code=1,
-        ),
+        ["scene", "list", "--json"],
+        "project_not_found",
+        "scene list requires a Godot project; none was resolved — pass --project",
+        "scene-list",
     )
 
-    result = CliRunner().invoke(app, ["scene", "list", "--json"])
-
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "project_not_found"
-    assert "--project" in err["message"]
+    assert_operation_error(result, "project_not_found", "--project")
 
 
 def test_scene_create_missing_binary_maps_to_environment_error(monkeypatch):

--- a/tests/test_scene_errors.py
+++ b/tests/test_scene_errors.py
@@ -121,7 +121,10 @@ def test_scene_get_broken_sentinel_maps_to_parse_error(monkeypatch):
     # was violated — the shared parse classification applies to scene commands
     # exactly as it does to info.
     result, _ = invoke_cli(
-        monkeypatch, ["scene", "get", "/x/main.tscn", "--json"], stdout="no sentinel\n"
+        monkeypatch,
+        ["scene", "get", "/x/main.tscn", "--json"],
+        stdout="no sentinel here\n",
+        banner=False,
     )
 
     assert result.exit_code == 5
@@ -197,6 +200,9 @@ def test_scene_list_without_project_maps_to_stable_project_not_found_code(monkey
 def test_scene_create_missing_binary_maps_to_environment_error(monkeypatch):
     # The runner's synthetic exit 127 flows through the same shared environment
     # branch for scene commands as for info.
+    # Staged as a whole raw run, not through `invoke_cli`: the LAUNCH FAILURE
+    # this run carries is the input under test, and the invoker stages only the
+    # three canned streams.
     inject_runner(
         monkeypatch,
         RunResult(

--- a/tests/test_scene_preflight_commands.py
+++ b/tests/test_scene_preflight_commands.py
@@ -20,7 +20,7 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import LaunchFailure, RunResult, TimeoutBound
-from tests.support import sentinel
+from tests.support import assert_operation_error, minimal_project, sentinel
 
 READY = sentinel({"path": "res://main.tscn", "status": "ready"})
 
@@ -44,13 +44,8 @@ def _patch_launch(monkeypatch, result: RunResult) -> list:
     return calls
 
 
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
-
-
 def test_a_clean_start_is_ready_and_started(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout=READY, stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -83,7 +78,7 @@ def test_a_script_error_during_startup_is_reported_though_the_scene_reached_read
     # THE DISTINCTION the issue asks for: "compiles and loads" is not "reaches _ready
     # without script errors". The engine says ready; the stderr says otherwise, so
     # `started` is false while `status` still reports how far the boot got.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch, RunResult(stdout=READY, stderr=READY_STDERR, exit_code=0)
     )
@@ -116,7 +111,7 @@ def test_a_run_gda_ends_at_the_bound_is_a_timeout_verdict_not_an_envelope(
     # anything, so the bound is gda's. The answer is still the verdict the caller
     # asked for — "it did not start" — carrying what the engine had already printed,
     # which the streaming capture is what preserves.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -153,7 +148,7 @@ def test_a_run_gda_ends_at_the_bound_is_a_timeout_verdict_not_an_envelope(
 def test_a_missing_binary_is_still_an_error_envelope(monkeypatch, tmp_path):
     # Only the SCENE's fate is a verdict. An environment failure is not about the
     # scene at all, so it stays the shared envelope every channel reports.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -176,7 +171,7 @@ def test_a_missing_binary_is_still_an_error_envelope(monkeypatch, tmp_path):
 def test_an_operation_refusal_survives_the_recipe(monkeypatch, tmp_path):
     # The op's own structured refusals still classify normally: a scene that cannot
     # be instantiated at all is a dependency failure, not a startup verdict.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     payload = sentinel(
         {
             "error": {
@@ -192,12 +187,11 @@ def test_an_operation_refusal_survives_the_recipe(monkeypatch, tmp_path):
         ["scene", "preflight", "res://main.tscn", "--project", str(project), "--json"],
     )
 
-    assert result.exit_code == 4, result.stdout + result.stderr
-    assert json.loads(result.stdout)["error"]["code"] == "missing_dependency"
+    assert_operation_error(result, "missing_dependency")
 
 
 def test_frames_and_timeout_reach_the_launch_through_params_json(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout=READY, stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -221,7 +215,7 @@ def test_frames_and_timeout_reach_the_launch_through_params_json(monkeypatch, tm
 
 @pytest.mark.parametrize("frames", ["0", "-1"])
 def test_a_non_positive_frame_budget_is_a_usage_error(monkeypatch, tmp_path, frames):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout=READY, stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -242,7 +236,7 @@ def test_a_non_positive_frame_budget_is_a_usage_error(monkeypatch, tmp_path, fra
 
 
 def test_a_non_positive_timeout_is_a_usage_error(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout=READY, stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -263,7 +257,7 @@ def test_a_non_positive_timeout_is_a_usage_error(monkeypatch, tmp_path):
 
 
 def test_human_output_leads_with_the_verdict(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch, RunResult(stdout=READY, stderr=READY_STDERR, exit_code=0)
     )
@@ -287,7 +281,7 @@ def test_an_engine_reported_not_ready_projects_as_a_failed_start(monkeypatch, tm
     # The verdict gda cannot produce on a healthy engine but must still project
     # faithfully: readiness is settled before the first observed frame, so a
     # not_ready payload means the propagation never reached the scene at all.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -312,7 +306,7 @@ def test_an_unknown_status_is_a_contract_violation_not_a_verdict(monkeypatch, tm
     # The closed enum is the contract: a payload gda does not understand is a parse
     # failure, never a guess. This is what keeps the GDScript/Python mirror honest at
     # runtime as well as in the pinning test.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -336,7 +330,7 @@ def test_a_timeout_outranks_a_sentinel_that_arrived_before_it(monkeypatch, tmp_p
     # over whatever the partial capture happens to contain. A sentinel in a timed-out
     # capture is not the engine's final answer — the run never finished — and reading
     # it would report a scene as started that gda had just killed.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -368,7 +362,7 @@ def test_this_channel_declares_no_watch_which_is_what_keeps_aborted_unreachable(
     # watch, and ABORTED is unreachable here. The invariant is an argument the launch
     # does NOT get: adding a policy watch later fails this test rather than silently
     # degrading an abort into a contract_violation.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout=READY, stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -395,7 +389,7 @@ def test_params_json_refuses_the_same_bounds_argv_does(monkeypatch, tmp_path, pa
     # argv as a usage error, --params-json as the structured invalid_params. An
     # infinite ceiling is refused because it would never be reached, leaving the run
     # gda promised to bound unbounded.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout=READY, stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -411,8 +405,7 @@ def test_params_json_refuses_the_same_bounds_argv_does(monkeypatch, tmp_path, pa
         ],
     )
 
-    assert result.exit_code == 4, result.stdout + result.stderr
-    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+    assert_operation_error(result, "invalid_params")
     assert calls == []
 
 
@@ -424,7 +417,7 @@ def test_a_project_that_quits_the_engine_is_not_blamed_on_gdas_contract(
     # then exits cleanly with no sentinel, which the shared classifier reads as gda's
     # own output contract being violated. That sends the reader to debug gda for
     # something the project did, so this channel names the real cause instead.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(stdout="Godot Engine v4.6.3\n", stderr="quitting\n", exit_code=0),
@@ -449,7 +442,7 @@ def test_a_quit_after_the_readiness_evidence_keeps_the_ready_verdict(
     # already printed readiness as its own evidence line. That run has a startup
     # verdict — the scene plainly came up — so it is reported as ready, not as an
     # operation failure.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -477,7 +470,7 @@ def test_a_quit_after_readiness_still_combines_the_captured_diagnostics(
     # `started` keeps both halves of the contract on the synthesized verdict too:
     # readiness is proven by the evidence line, and a recognized error captured
     # before the quit still gates a clean start.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -510,7 +503,7 @@ def test_a_payload_that_died_without_reporting_is_still_the_generic_failure(
     # payload quits with a code that DEFAULTS to failure, so every way it can end
     # without emitting exits non-zero — and stays the generic operation_failed rather
     # than being mislabelled as the project's own quit.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(stdout="", stderr="SCRIPT ERROR: in the payload\n", exit_code=1),
@@ -533,7 +526,7 @@ def test_a_begun_but_unterminated_sentinel_stays_a_parse_failure(monkeypatch, tm
     # marker here: a payload that STARTED a result and did not finish one has not
     # been quit out from under — it emitted something gda cannot read. Reported as
     # the parse failure it is, not as the project's own quit.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -560,7 +553,7 @@ def test_a_timeout_verdict_carries_the_elapsed_clock_and_the_ceiling_it_reached(
     # fraction over a tight ceiling from one that was stuck for an hour (GDA-DF-032,
     # reintroduced for this one channel). The evidence is now on the verdict, in the
     # same two words the other timeout surfaces use.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -605,7 +598,7 @@ def test_the_ceiling_is_read_off_the_launch_rather_than_re_derived_from_the_para
     # same fact from the params it happened to pass in. Production keeps the two
     # equal; the divergence here is test-only, and it is what makes the source of
     # the number observable at all.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -643,7 +636,7 @@ def test_an_unmeasured_timeout_reports_the_ceiling_instead_of_claiming_zero(
     # Reporting 0.0 would read as "ended instantly" — the opposite of what happened —
     # so each number degrades to the truthful value the caller's own ceiling
     # guarantees: gda ended this run AT that ceiling, so it ran at least that long.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -695,7 +688,7 @@ def test_a_non_timeout_verdict_omits_the_evidence_keys_entirely(
     # exactly the bytes it always did. The keys are OMITTED rather than serialized as
     # null — gda's omitted-never-null convention (cf. gda.provenance) — because a
     # null would claim a measurement that does not apply to a run nobody bounded.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(monkeypatch, raw)
 
     result = CliRunner().invoke(
@@ -714,7 +707,7 @@ def test_the_human_timeout_verdict_states_both_numbers_too(monkeypatch, tmp_path
     # The rendered output carries the same evidence as the JSON: an agent reading the
     # human channel must not have to re-run with --json to learn whether the scene
     # was slow or stuck.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -750,7 +743,7 @@ def test_the_human_render_of_a_non_timeout_verdict_gains_no_evidence_line(
 ):
     # The same invariance on the human channel: a verdict with nothing to report
     # reports nothing, rather than a line of blanks or zeros.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch, RunResult(stdout=READY, stderr=READY_STDERR, exit_code=0)
     )

--- a/tests/test_scene_validate_commands.py
+++ b/tests/test_scene_validate_commands.py
@@ -15,10 +15,9 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.commands.scene import SceneProblemKind, SceneStartupStatus
-from gda.runner import RunResult
 from tests.support import (
     assert_operation_error,
-    inject_runner,
+    invoke_cli,
     minimal_project,
     sentinel,
 )
@@ -79,13 +78,10 @@ VALID_PAYLOAD = {"path": "res://main.tscn", "valid": True, "problems": []}
 
 def test_valid_scene_reports_the_verdict_and_exits_zero(monkeypatch, tmp_path):
     project = minimal_project(tmp_path)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(VALID_PAYLOAD), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         ["scene", "validate", "res://main.tscn", "--project", str(project), "--json"],
+        stdout=sentinel(VALID_PAYLOAD),
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -106,13 +102,10 @@ def test_invalid_scene_is_a_successful_operation_with_problems(monkeypatch, tmp_
     # the result, never from the process status (the script validate contract, applied
     # to scenes).
     project = minimal_project(tmp_path)
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(INVALID_PAYLOAD), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, _ = invoke_cli(
+        monkeypatch,
         ["scene", "validate", "res://main.tscn", "--project", str(project), "--json"],
+        stdout=sentinel(INVALID_PAYLOAD),
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -134,11 +127,11 @@ def test_projectless_run_reports_a_null_project_root(monkeypatch, tmp_path):
     # present so an agent reads it unconditionally.
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("GDA_PROJECT", raising=False)
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(VALID_PAYLOAD), stderr="", exit_code=0)
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["scene", "validate", "/tmp/loose.tscn", "--json"],
+        stdout=sentinel(VALID_PAYLOAD),
     )
-
-    result = CliRunner().invoke(app, ["scene", "validate", "/tmp/loose.tscn", "--json"])
 
     assert result.exit_code == 0, result.stdout + result.stderr
     assert json.loads(result.stdout)["project_root"] is None
@@ -146,12 +139,8 @@ def test_projectless_run_reports_a_null_project_root(monkeypatch, tmp_path):
 
 def test_params_json_drives_the_same_recipe(monkeypatch, tmp_path):
     project = minimal_project(tmp_path)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(VALID_PAYLOAD), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "scene",
             "validate",
@@ -161,6 +150,7 @@ def test_params_json_drives_the_same_recipe(monkeypatch, tmp_path):
             str(project),
             "--json",
         ],
+        stdout=sentinel(VALID_PAYLOAD),
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -170,12 +160,10 @@ def test_params_json_drives_the_same_recipe(monkeypatch, tmp_path):
 
 def test_human_output_leads_with_the_verdict_then_the_evidence(monkeypatch, tmp_path):
     project = minimal_project(tmp_path)
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(INVALID_PAYLOAD), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["scene", "validate", "res://main.tscn", "--project", str(project)]
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["scene", "validate", "res://main.tscn", "--project", str(project)],
+        stdout=sentinel(INVALID_PAYLOAD),
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -197,14 +185,10 @@ def test_a_composed_verdict_attributes_each_problem_to_the_scene_it_was_found_in
     # parent's, and each problem's `nodes` — relative to the scene that owns
     # them — resolve against the wrong tree.
     project = minimal_project(tmp_path)
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(COMPOSED_PAYLOAD), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         ["scene", "validate", "res://parent.tscn", "--project", str(project), "--json"],
+        stdout=sentinel(COMPOSED_PAYLOAD),
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -221,13 +205,10 @@ def test_a_composed_verdict_attributes_each_problem_to_the_scene_it_was_found_in
 
 def test_human_output_names_the_sub_scene_a_problem_was_found_in(monkeypatch, tmp_path):
     project = minimal_project(tmp_path)
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(COMPOSED_PAYLOAD), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["scene", "validate", "res://parent.tscn", "--project", str(project)]
+        ["scene", "validate", "res://parent.tscn", "--project", str(project)],
+        stdout=sentinel(COMPOSED_PAYLOAD),
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -246,12 +227,10 @@ def test_human_output_stays_silent_about_the_scene_the_command_was_given(
     # The `in` line is attribution, not decoration: an ordinary single-file verdict
     # would only be made longer by repeating the path already in its headline.
     project = minimal_project(tmp_path)
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(INVALID_PAYLOAD), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["scene", "validate", "res://main.tscn", "--project", str(project)]
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["scene", "validate", "res://main.tscn", "--project", str(project)],
+        stdout=sentinel(INVALID_PAYLOAD),
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -265,13 +244,11 @@ def test_an_operation_failure_is_still_an_error_envelope(monkeypatch, tmp_path):
     payload = {
         "error": {"code": "path_not_found", "message": "scene file does not exist"}
     }
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=1)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, _ = invoke_cli(
+        monkeypatch,
         ["scene", "validate", "res://gone.tscn", "--project", str(project), "--json"],
+        stdout=sentinel(payload),
+        exit_code=1,
     )
 
     assert_operation_error(result, "path_not_found")
@@ -325,9 +302,7 @@ def test_the_rendered_help_keeps_the_bracketed_scene_file_tokens():
     # style tags, so an unescaped docstring RENDERS without them — the published
     # help read "no complete  header" (#720 recheck ×2). Pin the rendered output,
     # not the source: the escape is load-bearing.
-    from typer.testing import CliRunner
 
-    from gda.cli import app
     from tests.support import plain_text
 
     result = CliRunner().invoke(app, ["scene", "validate", "--help"])

--- a/tests/test_scene_validate_commands.py
+++ b/tests/test_scene_validate_commands.py
@@ -16,7 +16,12 @@ from typer.testing import CliRunner
 from gda.cli import app
 from gda.commands.scene import SceneProblemKind, SceneStartupStatus
 from gda.runner import RunResult
-from tests.support import inject_runner, sentinel
+from tests.support import (
+    assert_operation_error,
+    inject_runner,
+    minimal_project,
+    sentinel,
+)
 
 # One invalid verdict as the engine reports it: the op's own payload, WITHOUT the
 # project_root the CLI adds afterwards.
@@ -72,13 +77,8 @@ COMPOSED_PAYLOAD = {
 VALID_PAYLOAD = {"path": "res://main.tscn", "valid": True, "problems": []}
 
 
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
-
-
 def test_valid_scene_reports_the_verdict_and_exits_zero(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     fake = inject_runner(
         monkeypatch, RunResult(stdout=sentinel(VALID_PAYLOAD), stderr="", exit_code=0)
     )
@@ -105,7 +105,7 @@ def test_invalid_scene_is_a_successful_operation_with_problems(monkeypatch, tmp_
     # THE CRUX: an invalid scene exits 0 with valid=false — the verdict is read from
     # the result, never from the process status (the script validate contract, applied
     # to scenes).
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     inject_runner(
         monkeypatch, RunResult(stdout=sentinel(INVALID_PAYLOAD), stderr="", exit_code=0)
     )
@@ -145,7 +145,7 @@ def test_projectless_run_reports_a_null_project_root(monkeypatch, tmp_path):
 
 
 def test_params_json_drives_the_same_recipe(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     fake = inject_runner(
         monkeypatch, RunResult(stdout=sentinel(VALID_PAYLOAD), stderr="", exit_code=0)
     )
@@ -169,7 +169,7 @@ def test_params_json_drives_the_same_recipe(monkeypatch, tmp_path):
 
 
 def test_human_output_leads_with_the_verdict_then_the_evidence(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     inject_runner(
         monkeypatch, RunResult(stdout=sentinel(INVALID_PAYLOAD), stderr="", exit_code=0)
     )
@@ -196,7 +196,7 @@ def test_a_composed_verdict_attributes_each_problem_to_the_scene_it_was_found_in
     # both live in `child.tscn`. Without `scene` an agent reads them as the
     # parent's, and each problem's `nodes` — relative to the scene that owns
     # them — resolve against the wrong tree.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     inject_runner(
         monkeypatch,
         RunResult(stdout=sentinel(COMPOSED_PAYLOAD), stderr="", exit_code=0),
@@ -220,7 +220,7 @@ def test_a_composed_verdict_attributes_each_problem_to_the_scene_it_was_found_in
 
 
 def test_human_output_names_the_sub_scene_a_problem_was_found_in(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     inject_runner(
         monkeypatch,
         RunResult(stdout=sentinel(COMPOSED_PAYLOAD), stderr="", exit_code=0),
@@ -245,7 +245,7 @@ def test_human_output_stays_silent_about_the_scene_the_command_was_given(
 ):
     # The `in` line is attribution, not decoration: an ordinary single-file verdict
     # would only be made longer by repeating the path already in its headline.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     inject_runner(
         monkeypatch, RunResult(stdout=sentinel(INVALID_PAYLOAD), stderr="", exit_code=0)
     )
@@ -261,7 +261,7 @@ def test_human_output_stays_silent_about_the_scene_the_command_was_given(
 def test_an_operation_failure_is_still_an_error_envelope(monkeypatch, tmp_path):
     # The shared addressing ladder does not fork for validate: a missing file is a
     # refusal, not a verdict.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     payload = {
         "error": {"code": "path_not_found", "message": "scene file does not exist"}
     }
@@ -274,8 +274,7 @@ def test_an_operation_failure_is_still_an_error_envelope(monkeypatch, tmp_path):
         ["scene", "validate", "res://gone.tscn", "--project", str(project), "--json"],
     )
 
-    assert result.exit_code == 4, result.stdout + result.stderr
-    assert json.loads(result.stdout)["error"]["code"] == "path_not_found"
+    assert_operation_error(result, "path_not_found")
 
 
 # --- The cross-language enum contract (#664) --------------------------------

--- a/tests/test_screen_commands.py
+++ b/tests/test_screen_commands.py
@@ -40,6 +40,7 @@ from tests.support import (
     screen_capture_reply,
     screen_frames_reply,
     usage_error_text,
+    minimal_project,
 )
 
 # A 1x1 transparent PNG (valid, decodes to real bytes) so a written file starts
@@ -47,11 +48,6 @@ from tests.support import (
 # tests.support, which the live-contract guard's capture probe reads too.
 _PNG_B64 = PNG_1X1_B64
 _PNG_1X1 = base64.b64decode(_PNG_B64)
-
-
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
 
 
 # --- input contract: output paths are params, not CLI-only (#222, PR #248) ----
@@ -79,7 +75,7 @@ def test_screen_capture_params_json_supplies_the_output_path(monkeypatch, tmp_pa
             "--params-json",
             payload,
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -100,7 +96,7 @@ def test_screen_capture_params_json_without_output_is_invalid_params(tmp_path):
             "--params-json",
             "{}",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -129,7 +125,7 @@ def test_screen_frames_params_json_supplies_the_output_dir(monkeypatch, tmp_path
             "--params-json",
             payload,
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -180,7 +176,7 @@ def test_screen_capture_writes_a_png_and_returns_its_path(monkeypatch, tmp_path)
             "--output",
             str(out),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -220,7 +216,7 @@ def test_screen_capture_inline_embeds_the_base64(monkeypatch, tmp_path):
             "--output",
             str(out),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -248,7 +244,7 @@ def test_screen_capture_with_no_daemon_reports_daemon_not_running(
             "--output",
             str(tmp_path / "shot.png"),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -285,7 +281,7 @@ def test_screen_capture_on_headless_session_reports_live_display_unavailable(
             "--output",
             str(out),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -343,7 +339,7 @@ def test_screen_frames_writes_each_png_and_returns_paths(monkeypatch, tmp_path):
             "--output-dir",
             str(out_dir),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -378,7 +374,7 @@ def test_screen_frames_with_no_daemon_reports_daemon_not_running(monkeypatch, tm
             "--output-dir",
             str(tmp_path / "frames"),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -407,7 +403,7 @@ def test_screen_frames_argv_frames_over_range_is_a_usage_error(monkeypatch, tmp_
             "--output-dir",
             str(tmp_path / "frames"),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -453,7 +449,7 @@ def test_screen_frames_params_json_over_range_frames_is_invalid_params(
             "screen",
             "frames",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
             "--params-json",
             payload,
@@ -529,7 +525,7 @@ def test_await_predicate_rides_the_wire_with_the_default_ceiling(monkeypatch, tm
     )
     out = tmp_path / "shot.png"
 
-    result = CliRunner().invoke(app, _await_argv(out, _project(tmp_path)))
+    result = CliRunner().invoke(app, _await_argv(out, minimal_project(tmp_path)))
 
     assert result.exit_code == 0, result.stdout + result.stderr
     # One op, the SAME screen-capture op — the predicate is params, not a new
@@ -571,7 +567,12 @@ def test_await_events_ride_the_same_window_and_report_surfaces(monkeypatch, tmp_
     result = CliRunner().invoke(
         app,
         _await_argv(
-            out, _project(tmp_path), "--await-frames", "30", "--await-events", events
+            out,
+            minimal_project(tmp_path),
+            "--await-frames",
+            "30",
+            "--await-events",
+            events,
         ),
     )
 
@@ -612,7 +613,7 @@ def test_await_bare_word_value_is_a_string_predicate(monkeypatch, tmp_path):
         app,
         _capture_argv(
             out,
-            _project(tmp_path),
+            minimal_project(tmp_path),
             "--await-node",
             "/root/Main/VFX",
             "--await-property",
@@ -642,7 +643,7 @@ def test_await_render_carries_the_predicate_line(monkeypatch, tmp_path):
         RunResult(stdout=sentinel(reply), stderr="", exit_code=0),
     )
     out = tmp_path / "shot.png"
-    argv = _await_argv(out, _project(tmp_path))
+    argv = _await_argv(out, minimal_project(tmp_path))
     argv.remove("--json")
 
     result = CliRunner().invoke(app, argv)
@@ -668,7 +669,7 @@ def test_await_unmet_predicate_is_the_typed_live_error(monkeypatch, tmp_path):
     out = tmp_path / "shot.png"
 
     result = CliRunner().invoke(
-        app, _await_argv(out, _project(tmp_path), "--await-frames", "30")
+        app, _await_argv(out, minimal_project(tmp_path), "--await-frames", "30")
     )
 
     assert result.exit_code == EXIT_LIVE
@@ -699,7 +700,7 @@ def test_await_trio_is_all_or_none(monkeypatch, tmp_path):
 
     result = CliRunner().invoke(
         app,
-        _capture_argv(out, _project(tmp_path), "--await-node", "/root/Main/VFX"),
+        _capture_argv(out, minimal_project(tmp_path), "--await-node", "/root/Main/VFX"),
     )
 
     message = _usage_error_message(result)
@@ -713,7 +714,7 @@ def test_await_value_null_is_refused_with_the_trio_message(monkeypatch, tmp_path
         app,
         _capture_argv(
             out,
-            _project(tmp_path),
+            minimal_project(tmp_path),
             "--await-node",
             "/root/Main/VFX",
             "--await-property",
@@ -734,7 +735,7 @@ def test_await_events_need_the_predicate(monkeypatch, tmp_path):
         app,
         _capture_argv(
             out,
-            _project(tmp_path),
+            minimal_project(tmp_path),
             "--await-events",
             '[{"type": "key", "key": "Right"}]',
         ),
@@ -751,7 +752,7 @@ def test_await_events_refuse_the_physics_clock(monkeypatch, tmp_path):
         app,
         _await_argv(
             out,
-            _project(tmp_path),
+            minimal_project(tmp_path),
             "--await-events",
             '[{"type": "key", "key": "Right", "physics_frame": 1}]',
         ),
@@ -782,7 +783,7 @@ def test_out_of_window_event_offset_is_accepted_and_rides_the_wire(
         app,
         _await_argv(
             out,
-            _project(tmp_path),
+            minimal_project(tmp_path),
             "--await-frames",
             "10",
             "--await-events",
@@ -815,7 +816,7 @@ def test_await_event_offset_must_fit_the_shared_total_window(monkeypatch, tmp_pa
         app,
         _await_argv(
             out,
-            _project(tmp_path),
+            minimal_project(tmp_path),
             "--await-frames",
             "10",
             "--await-events",
@@ -841,7 +842,7 @@ def test_await_frames_needs_the_predicate(monkeypatch, tmp_path):
     out = tmp_path / "shot.png"
 
     result = CliRunner().invoke(
-        app, _capture_argv(out, _project(tmp_path), "--await-frames", "30")
+        app, _capture_argv(out, minimal_project(tmp_path), "--await-frames", "30")
     )
 
     message = _usage_error_message(result)
@@ -870,7 +871,7 @@ def test_await_params_json_path_rejects_identically(monkeypatch, tmp_path):
             "--params-json",
             params,
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -913,7 +914,9 @@ def _await_capture(monkeypatch, tmp_path, reply, *extra):
         RunResult(stdout=sentinel(reply), stderr="", exit_code=0),
     )
     out = tmp_path / "shot.png"
-    result = CliRunner().invoke(app, _await_argv(out, _project(tmp_path), *extra))
+    result = CliRunner().invoke(
+        app, _await_argv(out, minimal_project(tmp_path), *extra)
+    )
     return result, out
 
 
@@ -992,7 +995,7 @@ def test_plain_capture_with_unsolicited_predicate_is_contract_violation(
     )
     out = tmp_path / "shot.png"
 
-    result = CliRunner().invoke(app, _capture_argv(out, _project(tmp_path)))
+    result = CliRunner().invoke(app, _capture_argv(out, minimal_project(tmp_path)))
 
     _assert_contract_violation(result, out, "declared no --await predicate")
 
@@ -1018,7 +1021,7 @@ def test_capture_receipt_surfaces_with_the_written_file_hash(monkeypatch, tmp_pa
     )
     out = tmp_path / "shot.png"
 
-    result = CliRunner().invoke(app, _capture_argv(out, _project(tmp_path)))
+    result = CliRunner().invoke(app, _capture_argv(out, minimal_project(tmp_path)))
 
     assert result.exit_code == 0, result.stdout + result.stderr
     receipt = json.loads(result.stdout)["receipt"]
@@ -1044,7 +1047,7 @@ def test_gated_capture_receipt_echoes_the_predicate_evidence(monkeypatch, tmp_pa
     )
     out = tmp_path / "shot.png"
 
-    result = CliRunner().invoke(app, _await_argv(out, _project(tmp_path)))
+    result = CliRunner().invoke(app, _await_argv(out, minimal_project(tmp_path)))
 
     assert result.exit_code == 0, result.stdout + result.stderr
     data = json.loads(result.stdout)
@@ -1067,7 +1070,7 @@ def test_capture_reply_without_a_receipt_is_contract_violation(monkeypatch, tmp_
     )
     out = tmp_path / "shot.png"
 
-    result = CliRunner().invoke(app, _capture_argv(out, _project(tmp_path)))
+    result = CliRunner().invoke(app, _capture_argv(out, minimal_project(tmp_path)))
 
     data = json.loads(result.stdout)
     assert data["error"]["code"] == "contract_violation"
@@ -1086,7 +1089,7 @@ def test_receipt_missing_a_nullable_key_is_contract_violation(monkeypatch, tmp_p
     )
     out = tmp_path / "shot.png"
 
-    result = CliRunner().invoke(app, _capture_argv(out, _project(tmp_path)))
+    result = CliRunner().invoke(app, _capture_argv(out, minimal_project(tmp_path)))
 
     assert json.loads(result.stdout)["error"]["code"] == "contract_violation"
     assert not out.exists()
@@ -1105,7 +1108,7 @@ def test_plain_capture_receipt_with_unsolicited_echo_is_contract_violation(
     )
     out = tmp_path / "shot.png"
 
-    result = CliRunner().invoke(app, _capture_argv(out, _project(tmp_path)))
+    result = CliRunner().invoke(app, _capture_argv(out, minimal_project(tmp_path)))
 
     data = json.loads(result.stdout)
     assert data["error"]["code"] == "contract_violation"
@@ -1145,7 +1148,7 @@ def test_capture_render_carries_the_receipt_line(monkeypatch, tmp_path):
         RunResult(stdout=sentinel(reply), stderr="", exit_code=0),
     )
     out = tmp_path / "shot.png"
-    argv = _capture_argv(out, _project(tmp_path))
+    argv = _capture_argv(out, minimal_project(tmp_path))
     argv.remove("--json")
 
     result = CliRunner().invoke(app, argv)
@@ -1444,7 +1447,7 @@ def test_frames_summary_returns_the_aggregate_and_still_writes_files(
             "--output-dir",
             str(out_dir),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1487,7 +1490,7 @@ def test_frames_default_form_is_unchanged_and_summary_null(monkeypatch, tmp_path
             "--output-dir",
             str(out_dir),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1519,7 +1522,7 @@ def test_frames_summary_rides_params_json_identically(monkeypatch, tmp_path):
             "--params-json",
             payload,
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1593,7 +1596,7 @@ def test_frames_reply_count_mismatch_is_contract_violation(monkeypatch, tmp_path
             "--output-dir",
             str(out_dir),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1628,7 +1631,7 @@ def test_frames_summary_reports_null_dims_for_a_nonuniform_sequence(
             "--output-dir",
             str(out_dir),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1664,7 +1667,7 @@ def test_frames_budget_mismatch_is_contract_violation(monkeypatch, tmp_path):
             "--output-dir",
             str(out_dir),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1741,7 +1744,7 @@ def test_nonuniform_summary_renders_the_varied_size_state(monkeypatch, tmp_path)
             "--output-dir",
             str(out_dir),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
         ],
     )
 
@@ -1812,7 +1815,7 @@ def test_frames_summary_render_is_one_aggregate_line(monkeypatch, tmp_path):
             "--output-dir",
             str(out_dir),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
         ],
     )
 

--- a/tests/test_script_commands.py
+++ b/tests/test_script_commands.py
@@ -23,7 +23,6 @@ from tests.support import (
     SCRIPT_LIST_RESULT as LIST_RESULT,
     SCRIPT_SET_RESULT as SET_RESULT,
     assert_operation_error,
-    inject_runner,
     invoke_cli,
     minimal_project,
     recording_runner,
@@ -66,10 +65,8 @@ def test_script_create_default_template_passes_null_content_and_extends(monkeypa
     # The bare template: no --content, no --extends. Both pass through as null,
     # so the operation writes its default minimal template.
     stdout = sentinel({**CREATE_RESULT, "extends": "Node"})
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["script", "create", "/tmp/proj/hero.gd", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch, ["script", "create", "/tmp/proj/hero.gd", "--json"], stdout=stdout
     )
 
     assert result.exit_code == 0
@@ -91,10 +88,8 @@ def test_script_create_content_passes_verbatim_source(monkeypatch):
             "created_dirs": [],
         }
     )
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "create",
@@ -103,6 +98,7 @@ def test_script_create_content_passes_verbatim_source(monkeypatch):
             "extends RefCounted\n",
             "--json",
         ],
+        stdout=stdout,
     )
 
     assert result.exit_code == 0
@@ -121,12 +117,8 @@ def test_script_create_content_passes_verbatim_source(monkeypatch):
 def test_script_create_content_and_extends_are_mutually_exclusive(monkeypatch):
     # Verbatim content is not templated, so a base class has nowhere to go;
     # supplying both is a usage error (exit 2), never a silent precedence rule.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(CREATE_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "create",
@@ -137,6 +129,7 @@ def test_script_create_content_and_extends_are_mutually_exclusive(monkeypatch):
             "Node2D",
             "--json",
         ],
+        stdout=sentinel(CREATE_RESULT),
     )
 
     assert result.exit_code == 2
@@ -253,12 +246,8 @@ def test_script_set_line_range_dispatches_start_end_and_content(monkeypatch):
     # line-range mode: --start-line/--end-line + --content ride through; the
     # search-replace params pass as null. The CLI stamps the explicit `mode`
     # discriminator the op dispatches on (issue #133).
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "set",
@@ -271,6 +260,7 @@ def test_script_set_line_range_dispatches_start_end_and_content(monkeypatch):
             "extends Node2D",
             "--json",
         ],
+        stdout=sentinel(SET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -294,12 +284,8 @@ def test_script_set_full_overwrite_dispatches_content_only(monkeypatch):
     # full mode: --content with no --start-line overwrites the whole file; every
     # other mode param passes as null. The CLI stamps the explicit `mode`
     # discriminator the op dispatches on (issue #133).
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "set",
@@ -308,6 +294,7 @@ def test_script_set_full_overwrite_dispatches_content_only(monkeypatch):
             "extends Node\n",
             "--json",
         ],
+        stdout=sentinel(SET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -336,11 +323,11 @@ def _assert_set_usage_error(fake, result):
 
 def test_script_set_no_flags_is_a_usage_error(monkeypatch):
     # No edit mode at all is a usage error: set always needs exactly one mode.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["script", "set", "/tmp/proj/hero.gd", "--json"],
+        stdout=sentinel(SET_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["script", "set", "/tmp/proj/hero.gd", "--json"])
 
     _assert_set_usage_error(fake, result)
 
@@ -348,24 +335,20 @@ def test_script_set_no_flags_is_a_usage_error(monkeypatch):
 def test_script_set_search_without_replace_is_a_usage_error(monkeypatch):
     # --search requires --replace (and vice versa) — a half-specified
     # search-replace is a usage error, never a silent default.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "set", "/tmp/proj/hero.gd", "--search", "Node", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["script", "set", "/tmp/proj/hero.gd", "--search", "Node", "--json"],
+        stdout=sentinel(SET_RESULT),
     )
 
     _assert_set_usage_error(fake, result)
 
 
 def test_script_set_replace_without_search_is_a_usage_error(monkeypatch):
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "set", "/tmp/proj/hero.gd", "--replace", "Node2D", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["script", "set", "/tmp/proj/hero.gd", "--replace", "Node2D", "--json"],
+        stdout=sentinel(SET_RESULT),
     )
 
     _assert_set_usage_error(fake, result)
@@ -374,12 +357,8 @@ def test_script_set_replace_without_search_is_a_usage_error(monkeypatch):
 def test_script_set_search_replace_and_content_are_mutually_exclusive(monkeypatch):
     # Mixing search-replace with a line-range/full param (--content) is a usage
     # error: the modes are mutually exclusive.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "set",
@@ -392,6 +371,7 @@ def test_script_set_search_replace_and_content_are_mutually_exclusive(monkeypatc
             "x",
             "--json",
         ],
+        stdout=sentinel(SET_RESULT),
     )
 
     _assert_set_usage_error(fake, result)
@@ -541,13 +521,10 @@ def test_script_validate_refuses_a_script_outside_the_resolved_project(
     # and names both sides so the reader sees which one is wrong.
     proj = minimal_project(tmp_path / "game")
     outsider = tmp_path / "elsewhere" / "deck.gd"
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         ["script", "validate", str(outsider), "--project", str(proj), "--json"],
+        stdout=sentinel({}),
     )
 
     assert result.exit_code == 4
@@ -579,12 +556,8 @@ def test_script_validate_refusal_is_identical_on_the_params_json_path(
     # paths share — not in the argv body, which --params-json bypasses.
     proj = minimal_project(tmp_path / "game")
     outsider = tmp_path / "elsewhere" / "deck.gd"
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "validate",
@@ -594,6 +567,7 @@ def test_script_validate_refusal_is_identical_on_the_params_json_path(
             str(proj),
             "--json",
         ],
+        stdout=sentinel({}),
     )
 
     assert_operation_error(result, "target_outside_project")
@@ -626,19 +600,14 @@ def test_script_validate_refuses_a_res_dotdot_escape_the_same_as_the_absolute_sp
     proj = minimal_project(tmp_path / "game")
     outsider = tmp_path / "outside.gd"  # one directory above the project root
 
-    fake_abs = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
-    )
-    result_abs = CliRunner().invoke(
-        app,
+    result_abs, fake_abs = invoke_cli(
+        monkeypatch,
         ["script", "validate", str(outsider), "--project", str(proj), "--json"],
+        stdout=sentinel({}),
     )
 
-    fake_res = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
-    )
-    result_res = CliRunner().invoke(
-        app,
+    result_res, fake_res = invoke_cli(
+        monkeypatch,
         [
             "script",
             "validate",
@@ -647,6 +616,7 @@ def test_script_validate_refuses_a_res_dotdot_escape_the_same_as_the_absolute_sp
             str(proj),
             "--json",
         ],
+        stdout=sentinel({}),
     )
 
     error_abs = json.loads(result_abs.stdout)["error"]
@@ -668,13 +638,10 @@ def test_script_validate_reports_the_resolved_project_root(monkeypatch, tmp_path
     # re-deriving gda's resolution.
     proj = minimal_project(tmp_path / "game")
     script = proj / "deck.gd"
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=_validate_sentinel(_ok(str(script))), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", str(script), "--project", str(proj), "--json"]
+        ["script", "validate", str(script), "--project", str(proj), "--json"],
+        stdout=_validate_sentinel(_ok(str(script))),
     )
 
     assert result.exit_code == 0
@@ -690,15 +657,10 @@ def test_script_validate_reports_a_null_project_root_when_projectless(
     # gda's choosing — so any res:// dependency error is not to be trusted.
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("GDA_PROJECT", raising=False)
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(_ok("/tmp/proj/ok.gd")), stderr="", exit_code=0
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", "/tmp/proj/ok.gd", "--json"]
+        ["script", "validate", "/tmp/proj/ok.gd", "--json"],
+        stdout=_validate_sentinel(_ok("/tmp/proj/ok.gd")),
     )
 
     assert result.exit_code == 0
@@ -716,16 +678,10 @@ def test_script_validate_does_not_refuse_a_res_path(monkeypatch, tmp_path):
     # lexically escapes the namespace, e.g. `res://../outside.gd`, is refused —
     # see test_script_validate_refuses_a_res_dotdot_escape_the_same_as_the_absolute_spelling.
     proj = minimal_project(tmp_path / "game")
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(_ok("res://deck.gd")), stderr="", exit_code=0
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app,
         ["script", "validate", "res://deck.gd", "--project", str(proj), "--json"],
+        stdout=_validate_sentinel(_ok("res://deck.gd")),
     )
 
     assert result.exit_code == 0
@@ -743,12 +699,10 @@ def test_script_validate_does_not_refuse_a_colon_bearing_path_as_virtual(
     # containment entirely and let the engine open the outside file).
     proj = minimal_project(tmp_path / "game")
     odd = tmp_path / "outside:" / "deck.gd"
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", str(odd), "--project", str(proj), "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["script", "validate", str(odd), "--project", str(proj), "--json"],
+        stdout=sentinel({}),
     )
 
     assert_operation_error(result, "target_outside_project")
@@ -764,12 +718,8 @@ def test_script_validate_refuses_a_target_a_nested_project_owns(monkeypatch, tmp
     # instead and names the owner to pass.
     outer = minimal_project(tmp_path / "outer")
     inner = minimal_project(tmp_path / "outer/inner")
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "validate",
@@ -778,6 +728,7 @@ def test_script_validate_refuses_a_target_a_nested_project_owns(monkeypatch, tmp
             str(outer),
             "--json",
         ],
+        stdout=sentinel({}),
     )
 
     assert result.exit_code == 4
@@ -802,10 +753,8 @@ def test_script_validate_names_a_res_target_s_real_location(monkeypatch, tmp_pat
     # in the human message and in the typed evidence alike.
     outer = minimal_project(tmp_path / "outer")
     inner = minimal_project(tmp_path / "outer/inner")
-    inject_runner(monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, _ = invoke_cli(
+        monkeypatch,
         [
             "script",
             "validate",
@@ -814,6 +763,7 @@ def test_script_validate_names_a_res_target_s_real_location(monkeypatch, tmp_pat
             str(outer),
             "--json",
         ],
+        stdout=sentinel({}),
     )
 
     error = json.loads(result.stdout)["error"]
@@ -833,11 +783,11 @@ def test_script_validate_refuses_a_projectless_target_that_has_an_owner(
     workspace = tmp_path / "workspace"
     game = minimal_project(workspace / "game")
     monkeypatch.chdir(workspace)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["script", "validate", "game/main.gd", "--json"],
+        stdout=sentinel({}),
     )
-
-    result = CliRunner().invoke(app, ["script", "validate", "game/main.gd", "--json"])
 
     assert result.exit_code == 4
     error = json.loads(result.stdout)["error"]
@@ -860,12 +810,11 @@ def test_script_validate_still_validates_a_standalone_script_projectless(
     # refusal for the files it exists to serve.
     monkeypatch.chdir(tmp_path)
     (tmp_path / "scratch.gd").write_text("extends Node\n", encoding="utf-8")
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=_validate_sentinel(_ok("scratch.gd")), stderr="", exit_code=0),
+        ["script", "validate", "scratch.gd", "--json"],
+        stdout=_validate_sentinel(_ok("scratch.gd")),
     )
-
-    result = CliRunner().invoke(app, ["script", "validate", "scratch.gd", "--json"])
 
     assert result.exit_code == 0, result.stdout
     assert json.loads(result.stdout)["project_root"] is None
@@ -887,13 +836,10 @@ def test_script_validate_accepts_a_relative_target_from_an_ancestor_cwd(
     # relatively. The engine anchors `deck.gd` at `--path game`, and the README
     # promises exactly that, so gda must not judge it against its own cwd.
     proj = _ancestor_cwd_project(monkeypatch, tmp_path)
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=_validate_sentinel(_ok("deck.gd")), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", "deck.gd", "--project", "game", "--json"]
+        ["script", "validate", "deck.gd", "--project", "game", "--json"],
+        stdout=_validate_sentinel(_ok("deck.gd")),
     )
 
     assert result.exit_code == 0, result.stdout
@@ -910,13 +856,8 @@ def test_script_validate_relative_target_parity_on_the_params_json_path(
 ):
     # ADR-0015 parity for the same shape: --params-json must anchor identically.
     proj = _ancestor_cwd_project(monkeypatch, tmp_path)
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=_validate_sentinel(_ok("deck.gd")), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "script",
             "validate",
@@ -926,6 +867,7 @@ def test_script_validate_relative_target_parity_on_the_params_json_path(
             "game",
             "--json",
         ],
+        stdout=_validate_sentinel(_ok("deck.gd")),
     )
 
     assert result.exit_code == 0, result.stdout
@@ -941,12 +883,8 @@ def test_script_validate_still_refuses_a_relative_target_that_climbs_out(
     # Anchoring at the project is not a blanket accept: a relative path that
     # climbs out of the project with `..` is still outside, from either spelling.
     _ancestor_cwd_project(monkeypatch, tmp_path)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "validate",
@@ -955,6 +893,7 @@ def test_script_validate_still_refuses_a_relative_target_that_climbs_out(
             "game",
             "--json",
         ],
+        stdout=sentinel({}),
     )
 
     assert_operation_error(result, "target_outside_project")
@@ -996,12 +935,10 @@ def test_script_validate_invalid_script_is_success_with_parsed_diagnostics(monke
 def test_script_set_start_line_without_content_is_a_usage_error(monkeypatch):
     # --start-line/--end-line require --content: a line range with no replacement
     # text is a usage error.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "set", "/tmp/proj/hero.gd", "--start-line", "2", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["script", "set", "/tmp/proj/hero.gd", "--start-line", "2", "--json"],
+        stdout=sentinel(SET_RESULT),
     )
 
     _assert_set_usage_error(fake, result)
@@ -1010,12 +947,8 @@ def test_script_set_start_line_without_content_is_a_usage_error(monkeypatch):
 def test_script_set_end_line_without_start_line_is_a_usage_error(monkeypatch):
     # --end-line alone (with --content) is a usage error: end without a start has
     # no anchor.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "set",
@@ -1026,6 +959,7 @@ def test_script_set_end_line_without_start_line_is_a_usage_error(monkeypatch):
             "x",
             "--json",
         ],
+        stdout=sentinel(SET_RESULT),
     )
 
     _assert_set_usage_error(fake, result)
@@ -1036,14 +970,11 @@ def test_script_set_end_line_without_start_line_is_a_usage_error(monkeypatch):
 
 def test_script_validate_human_output_valid(monkeypatch):
     # Without --json, a valid result renders a one-line 'valid <path>'.
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(_ok("/tmp/proj/ok.gd")), stderr="", exit_code=0
-        ),
+        ["script", "validate", "/tmp/proj/ok.gd"],
+        stdout=_validate_sentinel(_ok("/tmp/proj/ok.gd")),
     )
-
-    result = CliRunner().invoke(app, ["script", "validate", "/tmp/proj/ok.gd"])
 
     assert result.exit_code == 0
     assert result.stdout.strip() == "valid /tmp/proj/ok.gd"
@@ -1057,16 +988,12 @@ def test_script_validate_human_output_invalid_lists_diagnostics(monkeypatch):
         "SCRIPT ERROR: Parse Error: the message.\n"
         "          at: GDScript::reload (/tmp/proj/broken.gd:3)\n"
     )
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(_broken("/tmp/proj/broken.gd", "Parse error.")),
-            stderr=stderr,
-            exit_code=0,
-        ),
+        ["script", "validate", "/tmp/proj/broken.gd"],
+        stdout=_validate_sentinel(_broken("/tmp/proj/broken.gd", "Parse error.")),
+        stderr=stderr,
     )
-
-    result = CliRunner().invoke(app, ["script", "validate", "/tmp/proj/broken.gd"])
 
     assert result.exit_code == 0
     assert "invalid /tmp/proj/broken.gd" in result.stdout
@@ -1082,17 +1009,10 @@ def test_script_validate_human_output_invalid_leads_with_the_project_root(
     # artefact of that one mistake, so the cause must not sit under the cascade.
     proj = minimal_project(tmp_path / "game")
     script = proj / "broken.gd"
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(_broken(str(script), "Parse error.")),
-            stderr="",
-            exit_code=0,
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", str(script), "--project", str(proj)]
+        ["script", "validate", str(script), "--project", str(proj)],
+        stdout=_validate_sentinel(_broken(str(script), "Parse error.")),
     )
 
     assert result.exit_code == 0
@@ -1109,16 +1029,11 @@ def test_script_validate_human_output_names_projectless_explicitly(
     # res:// dependency error.
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("GDA_PROJECT", raising=False)
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(_broken("/tmp/proj/broken.gd", "Parse error.")),
-            stderr="",
-            exit_code=0,
-        ),
+        ["script", "validate", "/tmp/proj/broken.gd"],
+        stdout=_validate_sentinel(_broken("/tmp/proj/broken.gd", "Parse error.")),
     )
-
-    result = CliRunner().invoke(app, ["script", "validate", "/tmp/proj/broken.gd"])
 
     assert result.exit_code == 0
     assert "  project: (none resolved: projectless)" in result.stdout
@@ -1132,12 +1047,8 @@ def test_script_attach_human_output(monkeypatch):
         "script": "/tmp/proj/hero.gd",
         "class_name": "Hero",
     }
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, _ = invoke_cli(
+        monkeypatch,
         [
             "script",
             "attach",
@@ -1147,6 +1058,7 @@ def test_script_attach_human_output(monkeypatch):
             "--script",
             "/tmp/proj/hero.gd",
         ],
+        stdout=sentinel(payload),
     )
 
     assert result.exit_code == 0
@@ -1159,12 +1071,10 @@ def test_script_attach_human_output(monkeypatch):
 def test_script_set_human_output_renders_metadata(monkeypatch):
     # Without --json, set reuses the shared script-metadata renderer.
     payload = {"path": "/tmp/proj/hero.gd", "class_name": "Hero", "extends": "Node2D"}
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "set", "/tmp/proj/hero.gd", "--content", "x"]
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["script", "set", "/tmp/proj/hero.gd", "--content", "x"],
+        stdout=sentinel(payload),
     )
 
     assert result.exit_code == 0
@@ -1198,19 +1108,8 @@ def _broken(path: str, error: str = "Parse error") -> dict:
 def test_script_validate_batch_reaches_the_engine_once_with_every_path(monkeypatch):
     # The #663 core: repeated PATH arguments become ONE op call carrying the whole
     # batch, so six related scripts cost one engine launch instead of six.
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(
-                _ok("/tmp/proj/a.gd"), _ok("/tmp/proj/b.gd"), _ok("/tmp/proj/c.gd")
-            ),
-            stderr="",
-            exit_code=0,
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "script",
             "validate",
@@ -1219,6 +1118,9 @@ def test_script_validate_batch_reaches_the_engine_once_with_every_path(monkeypat
             "/tmp/proj/c.gd",
             "--json",
         ],
+        stdout=_validate_sentinel(
+            _ok("/tmp/proj/a.gd"), _ok("/tmp/proj/b.gd"), _ok("/tmp/proj/c.gd")
+        ),
     )
 
     assert result.exit_code == 0
@@ -1245,17 +1147,10 @@ def test_script_validate_batch_aggregate_is_false_when_any_script_is_invalid(
 ):
     # The aggregate verdict: false when ANY file is invalid, and the command still
     # exits 0 — an invalid script is a successful validation, the existing contract.
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(_ok("/tmp/proj/a.gd"), _broken("/tmp/proj/b.gd")),
-            stderr="",
-            exit_code=0,
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", "/tmp/proj/a.gd", "/tmp/proj/b.gd", "--json"]
+        ["script", "validate", "/tmp/proj/a.gd", "/tmp/proj/b.gd", "--json"],
+        stdout=_validate_sentinel(_ok("/tmp/proj/a.gd"), _broken("/tmp/proj/b.gd")),
     )
 
     assert result.exit_code == 0
@@ -1278,21 +1173,8 @@ def test_script_validate_batch_attributes_diagnostics_to_their_own_script(monkey
         "SCRIPT ERROR: Parse Error: bad c\n"
         "   at: GDScript::reload (/tmp/proj/c.gd:7)\n"
     )
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(
-                _ok("/tmp/proj/a.gd"),
-                _broken("/tmp/proj/b.gd"),
-                _broken("/tmp/proj/c.gd"),
-            ),
-            stderr=stderr,
-            exit_code=0,
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "script",
             "validate",
@@ -1301,6 +1183,12 @@ def test_script_validate_batch_attributes_diagnostics_to_their_own_script(monkey
             "/tmp/proj/c.gd",
             "--json",
         ],
+        stdout=_validate_sentinel(
+            _ok("/tmp/proj/a.gd"),
+            _broken("/tmp/proj/b.gd"),
+            _broken("/tmp/proj/c.gd"),
+        ),
+        stderr=stderr,
     )
 
     assert result.exit_code == 0
@@ -1317,17 +1205,10 @@ def test_script_validate_batch_attributes_diagnostics_to_their_own_script(monkey
 def test_script_validate_keeps_a_duplicate_path_as_its_own_entry(monkeypatch):
     # gda never silently drops an input: a path given twice is validated twice and
     # reported twice, so entry i always corresponds to argument i.
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(_ok("/tmp/proj/a.gd"), _ok("/tmp/proj/a.gd")),
-            stderr="",
-            exit_code=0,
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", "/tmp/proj/a.gd", "/tmp/proj/a.gd", "--json"]
+        ["script", "validate", "/tmp/proj/a.gd", "/tmp/proj/a.gd", "--json"],
+        stdout=_validate_sentinel(_ok("/tmp/proj/a.gd"), _ok("/tmp/proj/a.gd")),
     )
 
     assert result.exit_code == 0
@@ -1344,12 +1225,8 @@ def test_script_validate_refuses_a_batch_whose_second_path_is_outside_the_projec
     proj = minimal_project(tmp_path / "game")
     inside = proj / "deck.gd"
     outsider = tmp_path / "elsewhere" / "card.gd"
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "validate",
@@ -1359,6 +1236,7 @@ def test_script_validate_refuses_a_batch_whose_second_path_is_outside_the_projec
             str(proj),
             "--json",
         ],
+        stdout=sentinel({}),
     )
 
     assert result.exit_code == 4
@@ -1371,16 +1249,11 @@ def test_script_validate_refuses_a_batch_whose_second_path_is_outside_the_projec
 def test_script_validate_all_asks_the_engine_for_every_project_script(monkeypatch):
     # Project mode: `--all` carries no paths — the engine enumerates the project's
     # res:// tree itself and reports the same result shape.
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(_ok("res://a.gd"), _ok("res://b.gd")),
-            stderr="",
-            exit_code=0,
-        ),
+        ["script", "validate", "--all", "--json"],
+        stdout=_validate_sentinel(_ok("res://a.gd"), _ok("res://b.gd")),
     )
-
-    result = CliRunner().invoke(app, ["script", "validate", "--all", "--json"])
 
     assert result.exit_code == 0
     assert fake.calls == [("script-validate", {"paths": [], "all_scripts": True})]
@@ -1388,12 +1261,10 @@ def test_script_validate_all_asks_the_engine_for_every_project_script(monkeypatc
 
 
 def test_script_validate_all_with_paths_is_a_usage_error(monkeypatch):
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", "--all", "/tmp/proj/a.gd", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["script", "validate", "--all", "/tmp/proj/a.gd", "--json"],
+        stdout=sentinel({}),
     )
 
     assert result.exit_code == 2
@@ -1401,11 +1272,9 @@ def test_script_validate_all_with_paths_is_a_usage_error(monkeypatch):
 
 
 def test_script_validate_without_paths_or_all_is_a_usage_error(monkeypatch):
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch, ["script", "validate", "--json"], stdout=sentinel({})
     )
-
-    result = CliRunner().invoke(app, ["script", "validate", "--json"])
 
     assert result.exit_code == 2
     assert fake.calls == []
@@ -1414,12 +1283,8 @@ def test_script_validate_without_paths_or_all_is_a_usage_error(monkeypatch):
 def test_script_validate_params_json_refuses_an_empty_batch(monkeypatch):
     # ADR-0015 parity: the rule lives on the model, so the JSON route reports it as
     # the structured invalid_params rather than as a usage error.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "validate",
@@ -1427,6 +1292,7 @@ def test_script_validate_params_json_refuses_an_empty_batch(monkeypatch):
             json.dumps({"paths": []}),
             "--json",
         ],
+        stdout=sentinel({}),
     )
 
     assert_operation_error(result, "invalid_params")
@@ -1434,12 +1300,8 @@ def test_script_validate_params_json_refuses_an_empty_batch(monkeypatch):
 
 
 def test_script_validate_params_json_refuses_paths_together_with_all(monkeypatch):
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "validate",
@@ -1447,6 +1309,7 @@ def test_script_validate_params_json_refuses_paths_together_with_all(monkeypatch
             json.dumps({"paths": ["/tmp/proj/a.gd"], "all_scripts": True}),
             "--json",
         ],
+        stdout=sentinel({}),
     )
 
     assert_operation_error(result, "invalid_params")
@@ -1460,17 +1323,11 @@ def test_script_validate_batch_human_output_leads_with_the_aggregate(monkeypatch
         "SCRIPT ERROR: Parse Error: bad b\n"
         "   at: GDScript::reload (/tmp/proj/b.gd:3)\n"
     )
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(_ok("/tmp/proj/a.gd"), _broken("/tmp/proj/b.gd")),
-            stderr=stderr,
-            exit_code=0,
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", "/tmp/proj/a.gd", "/tmp/proj/b.gd"]
+        ["script", "validate", "/tmp/proj/a.gd", "/tmp/proj/b.gd"],
+        stdout=_validate_sentinel(_ok("/tmp/proj/a.gd"), _broken("/tmp/proj/b.gd")),
+        stderr=stderr,
     )
 
     assert result.exit_code == 0
@@ -1554,19 +1411,11 @@ def test_script_validate_attribution_is_dropped_when_the_stream_desynchronizes(
         "   at: GDScript::reload (/tmp/proj/b.gd:4)\n"
         "gda: validating: /tmp/proj/unexpected.gd\n"
     )
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(
-                _broken("/tmp/proj/a.gd"), _broken("/tmp/proj/b.gd")
-            ),
-            stderr=stderr,
-            exit_code=0,
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", "/tmp/proj/a.gd", "/tmp/proj/b.gd", "--json"]
+        ["script", "validate", "/tmp/proj/a.gd", "/tmp/proj/b.gd", "--json"],
+        stdout=_validate_sentinel(_broken("/tmp/proj/a.gd"), _broken("/tmp/proj/b.gd")),
+        stderr=stderr,
     )
 
     assert result.exit_code == 0
@@ -1591,17 +1440,11 @@ def test_script_validate_attributes_diagnostics_over_a_crlf_stream(monkeypatch):
         "SCRIPT ERROR: Parse Error: bad token\r\n"
         "   at: GDScript::reload (/tmp/proj/broken.gd:3)\r\n"
     )
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(_broken("/tmp/proj/broken.gd")),
-            stderr=stderr,
-            exit_code=0,
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", "/tmp/proj/broken.gd", "--json"]
+        ["script", "validate", "/tmp/proj/broken.gd", "--json"],
+        stdout=_validate_sentinel(_broken("/tmp/proj/broken.gd")),
+        stderr=stderr,
     )
 
     assert result.exit_code == 0

--- a/tests/test_script_commands.py
+++ b/tests/test_script_commands.py
@@ -22,22 +22,22 @@ from tests.support import (
     SCRIPT_GET_RESULT as GET_RESULT,
     SCRIPT_LIST_RESULT as LIST_RESULT,
     SCRIPT_SET_RESULT as SET_RESULT,
-    FakeRunner,
+    assert_operation_error,
     inject_runner,
+    invoke_cli,
+    minimal_project,
+    recording_runner,
     sentinel,
 )
 
 
 def test_script_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
     # Engine banner noise around the sentinel, diagnostics on stderr (ADR-0002).
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(CREATE_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         ["script", "create", "/tmp/proj/hero.gd", "--extends", "Node2D", "--json"],
+        stdout=sentinel(CREATE_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -147,10 +147,11 @@ def test_script_create_content_and_extends_are_mutually_exclusive(monkeypatch):
 def test_script_get_json_emits_source_and_metadata_and_exit_zero(monkeypatch):
     # script get is the verifier (issue #110): it reads a script's source back
     # as raw text with its class_name/extends, so a create round-trips.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(GET_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(app, ["script", "get", "/tmp/proj/hero.gd", "--json"])
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["script", "get", "/tmp/proj/hero.gd", "--json"],
+        stdout=sentinel(GET_RESULT),
+    )
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -167,12 +168,11 @@ def test_script_list_json_enumerates_project_scripts_and_exit_zero(
     # script list enumerates the resolved project's .gd files (issue #117): each
     # entry carries its res:// path plus the class_name/extends parsed cheaply
     # from the script's raw source.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(LIST_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["script", "list", "--project", str(tmp_path), "--json"]
+    minimal_project(tmp_path)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["script", "list", "--project", str(tmp_path), "--json"],
+        stdout=sentinel(LIST_RESULT),
     )
 
     assert result.exit_code == 0
@@ -192,23 +192,17 @@ def test_script_list_json_enumerates_project_scripts_and_exit_zero(
 def test_script_list_passes_resolved_project_to_the_runner(monkeypatch, tmp_path):
     # script list enumerates res:// in the resolved project, so --project must
     # reach the runner (which hands it to the engine as --path, issue #32).
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    seen: dict = {}
-
-    def record(binary, project):
-        seen["project"] = project
-        return FakeRunner(
-            RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
-        )
-
-    monkeypatch.setattr("gda.dispatch.make_runner", record)
+    minimal_project(tmp_path)
+    projects = recording_runner(
+        monkeypatch, RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(
         app, ["script", "list", "--project", str(tmp_path), "--json"]
     )
 
     assert result.exit_code == 0
-    assert seen["project"] == tmp_path
+    assert projects[0] == tmp_path
 
 
 def test_script_set_search_replace_dispatches_search_and_replace(monkeypatch):
@@ -217,13 +211,8 @@ def test_script_set_search_replace_dispatches_search_and_replace(monkeypatch):
     # the edit mode once and stamps the explicit `mode` discriminator the op
     # dispatches on (issue #133). The result re-parses the written source's
     # class_name/extends, so set round-trips through get.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(SET_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "set",
@@ -234,6 +223,8 @@ def test_script_set_search_replace_dispatches_search_and_replace(monkeypatch):
             "Node2D",
             "--json",
         ],
+        stdout=sentinel(SET_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -419,13 +410,8 @@ def test_script_attach_dispatches_scene_node_and_script(monkeypatch):
     # script attach (issue #118) binds a .gd to a node in a scene: the scene
     # path, the node path, and the script path ride through as the typed params;
     # the result echoes the attached script's class_name.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(ATTACH_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "attach",
@@ -436,6 +422,8 @@ def test_script_attach_dispatches_scene_node_and_script(monkeypatch):
             "/tmp/proj/hero.gd",
             "--json",
         ],
+        stdout=sentinel(ATTACH_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -471,11 +459,8 @@ def test_script_attach_reports_the_displaced_script(monkeypatch):
         "class_name": None,
         "replaced_script": "res://old.gd",
     }
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(payload)
-    inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, _ = invoke_cli(
+        monkeypatch,
         [
             "script",
             "attach",
@@ -486,6 +471,7 @@ def test_script_attach_reports_the_displaced_script(monkeypatch):
             "/tmp/proj/new.gd",
             "--json",
         ],
+        stdout=sentinel(payload),
     )
 
     assert result.exit_code == 0
@@ -517,13 +503,10 @@ def test_script_validate_valid_script_reports_valid_true_no_diagnostics(monkeypa
     # reporting valid=true, no error_string, and no diagnostics. A single path is a
     # batch of one (#663), so the verdict sits in the one `scripts` entry and the
     # top-level `valid` is that entry's own.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + _validate_sentinel(
-        _ok("/tmp/proj/ok.gd")
-    )
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", "/tmp/proj/ok.gd", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["script", "validate", "/tmp/proj/ok.gd", "--json"],
+        stdout=_validate_sentinel(_ok("/tmp/proj/ok.gd")),
     )
 
     assert result.exit_code == 0
@@ -548,14 +531,6 @@ def test_script_validate_help_mentions_valid_false_success_result():
 # --- project context: the refusal and the reported root (#658) ----------------
 
 
-def _project(tmp_path, name: str):
-    """A directory Godot counts as a project (it holds the marker)."""
-    proj = tmp_path / name
-    proj.mkdir(parents=True, exist_ok=True)
-    (proj / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return proj
-
-
 def test_script_validate_refuses_a_script_outside_the_resolved_project(
     monkeypatch, tmp_path
 ):
@@ -564,7 +539,7 @@ def test_script_validate_refuses_a_script_outside_the_resolved_project(
     # reports a cascade of false missing-file and derived type errors. gda refuses
     # instead — BEFORE the engine runs, which is what `fake.calls == []` pins —
     # and names both sides so the reader sees which one is wrong.
-    proj = _project(tmp_path, "game")
+    proj = minimal_project(tmp_path / "game")
     outsider = tmp_path / "elsewhere" / "deck.gd"
     fake = inject_runner(
         monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
@@ -602,7 +577,7 @@ def test_script_validate_refusal_is_identical_on_the_params_json_path(
     # ADR-0015 parity: --params-json builds the same model and must reach the same
     # refusal. The check lives on the command's recipe — the one hook both input
     # paths share — not in the argv body, which --params-json bypasses.
-    proj = _project(tmp_path, "game")
+    proj = minimal_project(tmp_path / "game")
     outsider = tmp_path / "elsewhere" / "deck.gd"
     fake = inject_runner(
         monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
@@ -621,8 +596,7 @@ def test_script_validate_refusal_is_identical_on_the_params_json_path(
         ],
     )
 
-    assert result.exit_code == 4
-    assert json.loads(result.stdout)["error"]["code"] == "target_outside_project"
+    assert_operation_error(result, "target_outside_project")
     assert fake.calls == []
 
 
@@ -649,7 +623,7 @@ def test_script_validate_refuses_a_res_dotdot_escape_the_same_as_the_absolute_sp
     # one test — not two separate ones — is deliberate: it is exactly the
     # invariant that broke (same file, same command, opposite verdicts), so a
     # future change that fixes one spelling without the other fails HERE.
-    proj = _project(tmp_path, "game")
+    proj = minimal_project(tmp_path / "game")
     outsider = tmp_path / "outside.gd"  # one directory above the project root
 
     fake_abs = inject_runner(
@@ -692,7 +666,7 @@ def test_script_validate_reports_the_resolved_project_root(monkeypatch, tmp_path
     # The result names the root its res:// dependencies resolved against, so a
     # reader can tell a real compile error from a wrong-project one without
     # re-deriving gda's resolution.
-    proj = _project(tmp_path, "game")
+    proj = minimal_project(tmp_path / "game")
     script = proj / "deck.gd"
     inject_runner(
         monkeypatch,
@@ -741,7 +715,7 @@ def test_script_validate_does_not_refuse_a_res_path(monkeypatch, tmp_path):
     # refused. That is no longer true of every res:// spelling (#762): one that
     # lexically escapes the namespace, e.g. `res://../outside.gd`, is refused —
     # see test_script_validate_refuses_a_res_dotdot_escape_the_same_as_the_absolute_spelling.
-    proj = _project(tmp_path, "game")
+    proj = minimal_project(tmp_path / "game")
     fake = inject_runner(
         monkeypatch,
         RunResult(
@@ -767,7 +741,7 @@ def test_script_validate_does_not_refuse_a_colon_bearing_path_as_virtual(
     # an ordinary filesystem path — and this one is outside the project, so it is
     # refused rather than waved through as engine-virtual (which skipped
     # containment entirely and let the engine open the outside file).
-    proj = _project(tmp_path, "game")
+    proj = minimal_project(tmp_path / "game")
     odd = tmp_path / "outside:" / "deck.gd"
     fake = inject_runner(
         monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
@@ -777,8 +751,7 @@ def test_script_validate_does_not_refuse_a_colon_bearing_path_as_virtual(
         app, ["script", "validate", str(odd), "--project", str(proj), "--json"]
     )
 
-    assert result.exit_code == 4
-    assert json.loads(result.stdout)["error"]["code"] == "target_outside_project"
+    assert_operation_error(result, "target_outside_project")
     assert fake.calls == []
 
 
@@ -789,8 +762,8 @@ def test_script_validate_refuses_a_target_a_nested_project_owns(monkeypatch, tmp
     # -file errors for a file that is perfectly valid in its own project, and only
     # `project_root` hinted why. ADR-0006's 2026-08-31 amendment (#697) refuses
     # instead and names the owner to pass.
-    outer = _project(tmp_path, "outer")
-    inner = _project(tmp_path, "outer/inner")
+    outer = minimal_project(tmp_path / "outer")
+    inner = minimal_project(tmp_path / "outer/inner")
     fake = inject_runner(
         monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
     )
@@ -827,8 +800,8 @@ def test_script_validate_names_a_res_target_s_real_location(monkeypatch, tmp_pat
     # anchoring made `Path("res://inner/main.gd")` the RELATIVE `res:/inner/main.gd`
     # and reported `<project>/res:/inner/main.gd`, a directory that does not exist —
     # in the human message and in the typed evidence alike.
-    outer = _project(tmp_path, "outer")
-    inner = _project(tmp_path, "outer/inner")
+    outer = minimal_project(tmp_path / "outer")
+    inner = minimal_project(tmp_path / "outer/inner")
     inject_runner(monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -858,7 +831,7 @@ def test_script_validate_refuses_a_projectless_target_that_has_an_owner(
     # projectless engine, where its res:// references resolved against nothing and
     # produced the same cascade with `project_root: null` as the only clue.
     workspace = tmp_path / "workspace"
-    game = _project(workspace, "game")
+    game = minimal_project(workspace / "game")
     monkeypatch.chdir(workspace)
     fake = inject_runner(
         monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
@@ -901,7 +874,7 @@ def test_script_validate_still_validates_a_standalone_script_projectless(
 
 def _ancestor_cwd_project(monkeypatch, tmp_path):
     """A project one level below the cwd, with a script in it (the #658 A shape)."""
-    proj = _project(tmp_path, "game")
+    proj = minimal_project(tmp_path / "game")
     monkeypatch.chdir(tmp_path)
     return proj
 
@@ -984,8 +957,7 @@ def test_script_validate_still_refuses_a_relative_target_that_climbs_out(
         ],
     )
 
-    assert result.exit_code == 4
-    assert json.loads(result.stdout)["error"]["code"] == "target_outside_project"
+    assert_operation_error(result, "target_outside_project")
     assert fake.calls == []
 
 
@@ -999,15 +971,11 @@ def test_script_validate_invalid_script_is_success_with_parsed_diagnostics(monke
         'value after "=".\n'
         "          at: GDScript::reload (/tmp/proj/broken.gd:3)\n"
     )
-    stdout = "Godot Engine v4.6.3.stable.official\n" + _validate_sentinel(
-        _broken("/tmp/proj/broken.gd", "Parse error.")
-    )
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr=stderr, exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", "/tmp/proj/broken.gd", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["script", "validate", "/tmp/proj/broken.gd", "--json"],
+        stdout=_validate_sentinel(_broken("/tmp/proj/broken.gd", "Parse error.")),
+        stderr=stderr,
     )
 
     assert result.exit_code == 0
@@ -1112,7 +1080,7 @@ def test_script_validate_human_output_invalid_leads_with_the_project_root(
     # An invalid verdict prints the project it was compiled against BEFORE the
     # diagnostics (#658): when the root is wrong every line below it is an
     # artefact of that one mistake, so the cause must not sit under the cascade.
-    proj = _project(tmp_path, "game")
+    proj = minimal_project(tmp_path / "game")
     script = proj / "broken.gd"
     inject_runner(
         monkeypatch,
@@ -1373,7 +1341,7 @@ def test_script_validate_refuses_a_batch_whose_second_path_is_outside_the_projec
     # ADR-0006's one resolved project applies to EVERY path in the batch: a batch
     # that spans projects is refused before the engine runs, reusing #658's refusal
     # rather than compiling the outsider against the wrong root.
-    proj = _project(tmp_path, "game")
+    proj = minimal_project(tmp_path / "game")
     inside = proj / "deck.gd"
     outsider = tmp_path / "elsewhere" / "card.gd"
     fake = inject_runner(
@@ -1461,8 +1429,7 @@ def test_script_validate_params_json_refuses_an_empty_batch(monkeypatch):
         ],
     )
 
-    assert result.exit_code == 4
-    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+    assert_operation_error(result, "invalid_params")
     assert fake.calls == []
 
 
@@ -1482,8 +1449,7 @@ def test_script_validate_params_json_refuses_paths_together_with_all(monkeypatch
         ],
     )
 
-    assert result.exit_code == 4
-    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+    assert_operation_error(result, "invalid_params")
     assert fake.calls == []
 
 

--- a/tests/test_script_errors.py
+++ b/tests/test_script_errors.py
@@ -8,147 +8,95 @@ mode without parsing prose. The script group reuses the existing file-level
 codes rather than minting parallel ones.
 """
 
-import json
-
-from typer.testing import CliRunner
-
-from gda.cli import app
-from gda.runner import RunResult
-from tests.support import error_sentinel, inject_runner
+from tests.support import assert_operation_error, operation_error_invoker
 
 
-def _invoke_script_create(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: script-create\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, ["script", "create", "/x/hero.gd", "--json"])
+_script_create = operation_error_invoker(
+    ["script", "create", "/x/hero.gd", "--json"],
+    "script-create",
+)
 
 
-def _invoke_script_get(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: script-get\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, ["script", "get", "/x/hero.gd", "--json"])
+_script_get = operation_error_invoker(
+    ["script", "get", "/x/hero.gd", "--json"],
+    "script-get",
+)
 
 
-def _invoke_script_list(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: script-list\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, ["script", "list", "--json"])
+_script_list = operation_error_invoker(
+    ["script", "list", "--json"],
+    "script-list",
+)
 
 
-def _invoke_script_delete(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: script-delete\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, ["script", "delete", "/x/hero.gd", "--json"])
+_script_delete = operation_error_invoker(
+    ["script", "delete", "/x/hero.gd", "--json"],
+    "script-delete",
+)
 
 
 def test_script_create_collision_reuses_stable_already_exists_code(monkeypatch):
     # No-clobber: a create whose target already exists reuses the registered
     # already_exists code (the same one scene create uses), leaving the file
     # untouched — the script group mints no parallel collision code.
-    result = _invoke_script_create(
+    result = _script_create(
         monkeypatch, "already_exists", "script target already exists: /x/hero.gd"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "already_exists"
-    assert "/x/hero.gd" in err["message"]
     # The raw stderr still rides along as diagnostics (ADR-0002).
-    assert err["diagnostics"] == "gda: running operation: script-create\n"
+    assert_operation_error(
+        result,
+        "already_exists",
+        "/x/hero.gd",
+        diagnostics="gda: running operation: script-create\n",
+    )
 
 
 def test_script_create_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
     # A target that is not a .gd script is an invalid path param — reuse the
     # registered invalid_path code rather than a focused per-group code.
-    result = _invoke_script_create(
+    result = _script_create(
         monkeypatch,
         "invalid_path",
         "script path must end in .gd: /x/hero.txt",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "invalid_path"
-    assert ".gd" in err["message"]
+    assert_operation_error(result, "invalid_path", ".gd")
 
 
 def test_script_create_missing_path_reuses_stable_invalid_path_code(monkeypatch):
-    result = _invoke_script_create(
-        monkeypatch, "invalid_path", "missing required param: path"
-    )
+    result = _script_create(monkeypatch, "invalid_path", "missing required param: path")
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "invalid_path"
+    assert_operation_error(result, "invalid_path")
 
 
 def test_script_create_unwritable_target_reuses_stable_save_failed_code(monkeypatch):
-    result = _invoke_script_create(
+    result = _script_create(
         monkeypatch, "save_failed", "failed to save script to /x/hero.gd"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "save_failed"
-    assert "/x/hero.gd" in err["message"]
+    assert_operation_error(result, "save_failed", "/x/hero.gd")
 
 
 def test_script_get_missing_file_reuses_stable_path_not_found_code(monkeypatch):
     # A script that does not exist reuses the registered path_not_found code
     # (now generalized in the registry from scene-specific to any file), so an
     # agent branches on the missing-file mode without a new code.
-    result = _invoke_script_get(
+    result = _script_get(
         monkeypatch, "path_not_found", "script file does not exist: /x/hero.gd"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/hero.gd" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/hero.gd")
 
 
 def test_script_get_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
-    result = _invoke_script_get(
+    result = _script_get(
         monkeypatch,
         "invalid_path",
         "script path must end in .gd: /x/notes.txt",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "invalid_path"
-    assert ".gd" in err["message"]
+    assert_operation_error(result, "invalid_path", ".gd")
 
 
 def test_script_list_without_project_reuses_stable_project_not_found_code(monkeypatch):
@@ -156,46 +104,34 @@ def test_script_list_without_project_reuses_stable_project_not_found_code(monkey
     # (issue #117): with no resolvable project, the operation reuses the
     # registered project_not_found code (the same one scene list uses) so an
     # agent knows to pass --project rather than retry.
-    result = _invoke_script_list(
+    result = _script_list(
         monkeypatch,
         "project_not_found",
         "script list requires a Godot project; none was resolved — pass --project",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "project_not_found"
-    assert "--project" in err["message"]
+    assert_operation_error(result, "project_not_found", "--project")
 
 
 def test_script_delete_missing_file_reuses_stable_path_not_found_code(monkeypatch):
     # A script that does not exist reuses the registered path_not_found code (the
     # same one script get uses), so an agent branches on the missing-file mode
     # without a new code.
-    result = _invoke_script_delete(
+    result = _script_delete(
         monkeypatch, "path_not_found", "script file does not exist: /x/hero.gd"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/hero.gd" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/hero.gd")
 
 
 def test_script_delete_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
     # delete only removes a .gd script, so a non-.gd target is refused with the
     # registered invalid_path code — the same addressing boundary create/get use.
-    result = _invoke_script_delete(
+    result = _script_delete(
         monkeypatch, "invalid_path", "script path must end in .gd: /x/notes.txt"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "invalid_path"
-    assert ".gd" in err["message"]
+    assert_operation_error(result, "invalid_path", ".gd")
 
 
 def test_script_delete_unlink_failure_reuses_stable_delete_failed_code(monkeypatch):
@@ -203,49 +139,35 @@ def test_script_delete_unlink_failure_reuses_stable_delete_failed_code(monkeypat
     # read-only filesystem, a permission boundary): this maps to the stable
     # delete_failed code (the same one scene delete uses) so an agent can tell
     # "deletion was blocked" apart from other failures.
-    result = _invoke_script_delete(
+    result = _script_delete(
         monkeypatch,
         "delete_failed",
         "failed to delete script /x/hero.gd: Permission denied",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "delete_failed"
-    assert "/x/hero.gd" in err["message"]
+    assert_operation_error(result, "delete_failed", "/x/hero.gd")
 
 
-def _invoke_script_set(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: script-set\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app,
-        ["script", "set", "/x/hero.gd", "--search", "a", "--replace", "b", "--json"],
-    )
+_script_set = operation_error_invoker(
+    ["script", "set", "/x/hero.gd", "--search", "a", "--replace", "b", "--json"],
+    "script-set",
+)
 
 
 def test_script_set_no_search_match_maps_to_stable_no_search_match_code(monkeypatch):
     # search-replace mode (issue #118): a search string the source does not
     # contain is a new no_search_match code, so an agent learns the edit landed
     # nowhere (and the file was left untouched) rather than parsing prose.
-    result = _invoke_script_set(
+    result = _script_set(
         monkeypatch, "no_search_match", 'search string not found in script: "xyzzy"'
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "no_search_match"
-    assert "xyzzy" in err["message"]
-    assert err["diagnostics"] == "gda: running operation: script-set\n"
+    assert_operation_error(
+        result,
+        "no_search_match",
+        "xyzzy",
+        diagnostics="gda: running operation: script-set\n",
+    )
 
 
 def test_script_set_invalid_line_range_maps_to_stable_invalid_line_range_code(
@@ -254,84 +176,62 @@ def test_script_set_invalid_line_range_maps_to_stable_invalid_line_range_code(
     # line-range mode: a range outside the script's bounds (or end before start)
     # is a new invalid_line_range code, distinct from no_search_match, so an
     # agent knows the line numbers — not the search string — are the problem.
-    result = _invoke_script_set(
+    result = _script_set(
         monkeypatch,
         "invalid_line_range",
         "line range 5..9 is outside the script's bounds (1..3) or ends before it starts",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "invalid_line_range"
-    assert "1..3" in err["message"]
+    assert_operation_error(result, "invalid_line_range", "1..3")
 
 
 def test_script_set_missing_file_reuses_stable_path_not_found_code(monkeypatch):
     # set edits an existing script; a missing target is path_not_found (the same
     # one get/delete use), never a silent create.
-    result = _invoke_script_set(
+    result = _script_set(
         monkeypatch, "path_not_found", "script file does not exist: /x/hero.gd"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/hero.gd" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/hero.gd")
 
 
 def test_script_set_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
-    result = _invoke_script_set(
+    result = _script_set(
         monkeypatch, "invalid_path", "script path must end in .gd: /x/notes.txt"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "invalid_path"
-    assert ".gd" in err["message"]
+    assert_operation_error(result, "invalid_path", ".gd")
 
 
-def _invoke_script_attach(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: script-attach\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app,
-        [
-            "script",
-            "attach",
-            "/x/main.tscn",
-            "--node",
-            "Hero",
-            "--script",
-            "/x/hero.gd",
-            "--json",
-        ],
-    )
+_script_attach = operation_error_invoker(
+    [
+        "script",
+        "attach",
+        "/x/main.tscn",
+        "--node",
+        "Hero",
+        "--script",
+        "/x/hero.gd",
+        "--json",
+    ],
+    "script-attach",
+)
 
 
 def test_script_attach_missing_script_reuses_stable_path_not_found_code(monkeypatch):
     # attach binds an existing script; a missing .gd is path_not_found (the same
     # one script get uses) so an agent knows the script file, not the scene, is
     # the thing that's missing.
-    result = _invoke_script_attach(
+    result = _script_attach(
         monkeypatch, "path_not_found", "script file does not exist: /x/hero.gd"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/hero.gd" in err["message"]
-    assert err["diagnostics"] == "gda: running operation: script-attach\n"
+    assert_operation_error(
+        result,
+        "path_not_found",
+        "/x/hero.gd",
+        diagnostics="gda: running operation: script-attach\n",
+    )
 
 
 def test_script_attach_wrong_script_extension_reuses_stable_invalid_path_code(
@@ -339,60 +239,44 @@ def test_script_attach_wrong_script_extension_reuses_stable_invalid_path_code(
 ):
     # A non-.gd script target is refused with invalid_path — the same addressing
     # boundary the rest of the script group uses.
-    result = _invoke_script_attach(
+    result = _script_attach(
         monkeypatch, "invalid_path", "script path must end in .gd: /x/notes.txt"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "invalid_path"
-    assert ".gd" in err["message"]
+    assert_operation_error(result, "invalid_path", ".gd")
 
 
 def test_script_attach_missing_node_reuses_stable_node_not_found_code(monkeypatch):
     # The scene loaded but the node path resolves to nothing — node_not_found
     # (the same one node get/set use), distinct from the file-level path_not_found.
-    result = _invoke_script_attach(
+    result = _script_attach(
         monkeypatch, "node_not_found", "node not found in scene: Hero"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "node_not_found"
-    assert "Hero" in err["message"]
+    assert_operation_error(result, "node_not_found", "Hero")
 
 
 def test_script_attach_missing_scene_reuses_stable_path_not_found_code(monkeypatch):
     # The scene-file-level failure reuses the registered scene code; attach
     # introduces no parallel code for the same mode.
-    result = _invoke_script_attach(
+    result = _script_attach(
         monkeypatch, "path_not_found", "scene file does not exist: /x/main.tscn"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/main.tscn" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/main.tscn")
 
 
 def test_script_attach_unloadable_resource_reuses_stable_invalid_path_code(monkeypatch):
     # A .gd that cannot even be loaded AS A RESOURCE (a genuine load failure, not
     # a compile error — load returns non-null for a non-compiling script) is the
     # defensive invalid_path branch, naming the path.
-    result = _invoke_script_attach(
+    result = _script_attach(
         monkeypatch,
         "invalid_path",
         "file could not be loaded as a GDScript resource: /x/hero.gd",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "invalid_path"
-    assert "/x/hero.gd" in err["message"]
+    assert_operation_error(result, "invalid_path", "/x/hero.gd")
 
 
 def test_script_attach_non_compiling_script_uses_script_compile_failed_code(
@@ -402,17 +286,13 @@ def test_script_attach_non_compiling_script_uses_script_compile_failed_code(
     # silently rejects it from set_script, so attach refuses with the focused
     # script_compile_failed code rather than report a phantom success over a
     # scene with nothing attached.
-    result = _invoke_script_attach(
+    result = _script_attach(
         monkeypatch,
         "script_compile_failed",
         "script does not compile, so it cannot be attached: /x/hero.gd",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "script_compile_failed"
-    assert "/x/hero.gd" in err["message"]
+    assert_operation_error(result, "script_compile_failed", "/x/hero.gd")
 
 
 def test_script_attach_incompatible_type_uses_incompatible_script_type_code(
@@ -423,56 +303,41 @@ def test_script_attach_incompatible_type_uses_incompatible_script_type_code(
     # a different reason than a compile error — attach reports the distinct
     # incompatible_script_type code so the agent fixes the node/script pairing
     # rather than chasing a non-existent syntax error.
-    result = _invoke_script_attach(
+    result = _script_attach(
         monkeypatch,
         "incompatible_script_type",
         "script extends Node3D, which is incompatible with node Hero of type Node2D",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "incompatible_script_type"
-    assert "Node3D" in err["message"]
+    err = assert_operation_error(result, "incompatible_script_type", "Node3D")
     assert "Node2D" in err["message"]
 
 
-def _invoke_script_validate(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: script-validate\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, ["script", "validate", "/x/hero.gd", "--json"])
+_script_validate = operation_error_invoker(
+    ["script", "validate", "/x/hero.gd", "--json"],
+    "script-validate",
+)
 
 
 def test_script_validate_missing_file_reuses_stable_path_not_found_code(monkeypatch):
     # validate only op-fails (non-zero) for op errors. A missing file is
     # path_not_found (the same one get/set use); an INVALID script is NOT a
     # failure — it is a successful op reporting valid=false (covered in S3 success).
-    result = _invoke_script_validate(
+    result = _script_validate(
         monkeypatch, "path_not_found", "script file does not exist: /x/hero.gd"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/hero.gd" in err["message"]
-    assert err["diagnostics"] == "gda: running operation: script-validate\n"
+    assert_operation_error(
+        result,
+        "path_not_found",
+        "/x/hero.gd",
+        diagnostics="gda: running operation: script-validate\n",
+    )
 
 
 def test_script_validate_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
-    result = _invoke_script_validate(
+    result = _script_validate(
         monkeypatch, "invalid_path", "script path must end in .gd: /x/notes.txt"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "invalid_path"
-    assert ".gd" in err["message"]
+    assert_operation_error(result, "invalid_path", ".gd")

--- a/tests/test_script_run_commands.py
+++ b/tests/test_script_run_commands.py
@@ -15,13 +15,13 @@ SAME recipe (ADR-0015), not the wrong runner.
 """
 
 import json
-from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import RunResult
+from tests.support import assert_operation_error, minimal_project
 
 
 def _patch_launch(monkeypatch, result: RunResult) -> list:
@@ -41,13 +41,8 @@ def _patch_launch(monkeypatch, result: RunResult) -> list:
     return calls
 
 
-def _project(tmp_path: Path) -> Path:
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
-
-
 def test_clean_run_emits_the_passthrough_result(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="hi\n", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -83,7 +78,7 @@ def test_non_zero_script_exit_is_success_process_exits_zero(monkeypatch, tmp_pat
     # THE CRUX at the CLI boundary: a script quit(1) is a SUCCESS — the JSON carries
     # exit_status=1 but the gda PROCESS exits 0 (not an error envelope). This is the
     # one command where success != zero exit_status.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(monkeypatch, RunResult(stdout="fail\n", stderr="", exit_code=1))
 
     result = CliRunner().invoke(
@@ -105,7 +100,7 @@ def test_strict_makes_the_process_exit_the_registered_operation_code(
     # the JSON — the process exits 4, the registered operation code. Not 1: the
     # child's own status is never propagated verbatim, or a script's quit(3) would
     # alias EXIT_VERSION and a quit(124) the runner's timeout.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(monkeypatch, RunResult(stdout="fail\n", stderr="", exit_code=1))
 
     result = CliRunner().invoke(
@@ -121,16 +116,13 @@ def test_strict_makes_the_process_exit_the_registered_operation_code(
         ],
     )
 
-    assert result.exit_code == 4, result.stdout + result.stderr
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "script_failed"
-    assert err["category"] == "operation"
+    assert_operation_error(result, "script_failed")
 
 
 def test_strict_is_reachable_through_params_json(monkeypatch, tmp_path):
     # --strict is a params field, not an argv-only flag (ADR-0015), so gda-mcp and
     # any JSON caller can opt in exactly as argv does.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=2))
 
     result = CliRunner().invoke(
@@ -146,14 +138,13 @@ def test_strict_is_reachable_through_params_json(monkeypatch, tmp_path):
         ],
     )
 
-    assert result.exit_code == 4, result.stdout + result.stderr
-    assert json.loads(result.stdout)["error"]["code"] == "script_failed"
+    assert_operation_error(result, "script_failed")
 
 
 def test_params_json_drives_the_same_recipe(monkeypatch, tmp_path):
     # --params-json (ADR-0015) must drive the SAME recipe — a regression guard that
     # the generic dispatch hook does not route script run through the wrong runner.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="ok\n", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -179,7 +170,7 @@ def test_both_path_forms_are_accepted_at_the_cli(monkeypatch, tmp_path, form):
     # AC of #675 at the CLI boundary: ONE script-path representation now serves both
     # `script validate` and `script run`. Whichever form the caller types, the launch
     # gets the canonical res:// address and the result reports it back.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="ok\n", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -197,7 +188,7 @@ def test_params_json_accepts_the_project_relative_form_too(monkeypatch, tmp_path
     # ADR-0015: the argv and --params-json paths must agree on the new form as well,
     # since the acceptance rides on the model's shared NormalizedPath plus the one
     # operation-side lift — not on argv-only handling.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="ok\n", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -240,7 +231,7 @@ def test_a_non_project_scoped_path_emits_invalid_path_envelope(
     # reached the engine and came back a phantom exit-0 success before this guard.
     # These are ADDRESS-FORM refusals; the upward escapes moved to the shared
     # containment code below (#763).
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -263,7 +254,7 @@ def test_an_escaping_path_emits_the_shared_containment_code(
     # one containment answer instead of a per-command spelling. It stays a
     # pre-launch refusal, and it names no resolved root, because this whole path
     # edge is decided ahead of the projectless check (ADR-0031).
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -271,9 +262,7 @@ def test_an_escaping_path_emits_the_shared_containment_code(
         ["script", "run", script, "--project", str(project), "--json"],
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "target_outside_project"
+    err = assert_operation_error(result, "target_outside_project")
     assert "evidence" not in err
     assert not calls, "no engine launch on an escaping path"
 
@@ -282,7 +271,7 @@ def test_a_tilde_path_is_refused_as_the_absolute_path_it_means(monkeypatch, tmp_
     # The shared NormalizedPath is what makes this honest (#675): `~/logic.gd` expands
     # to an absolute path and is refused as one, instead of being lifted into a
     # nonsense `res://~/logic.gd` naming a directory called `~` inside the project.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -365,7 +354,7 @@ def test_an_unexpandable_tilde_keeps_the_structured_refusal(
     # Both channels because they FAIL DIFFERENTLY: --params-json wraps model
     # construction (it would have reported invalid_params), while the argv body builds
     # the model directly and had nothing to catch the raise at all.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
     tilde = "~nosuchuser_gda_test/x.gd"
     argv = ["script", "run"]
@@ -375,10 +364,7 @@ def test_an_unexpandable_tilde_keeps_the_structured_refusal(
 
     result = CliRunner().invoke(app, [*argv, "--project", str(project), "--json"])
 
-    assert result.exit_code == 4, result.stdout + (result.stderr or "")
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "invalid_path"
-    assert err["category"] == "operation"
+    err = assert_operation_error(result, "invalid_path")
     # The message names the path the caller gave, tilde intact.
     assert tilde in err["message"]
     assert not calls, "no engine launch on an invalid path"
@@ -391,7 +377,7 @@ def test_an_unexpandable_tilde_keeps_the_structured_refusal(
 
 
 def test_timeout_reaches_the_launch_from_argv(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -418,7 +404,7 @@ def test_timeout_reaches_the_launch_from_argv(monkeypatch, tmp_path):
 def test_timeout_and_marker_reach_the_launch_through_params_json(monkeypatch, tmp_path):
     # ADR-0015: both are params fields, so a JSON/MCP caller opts in exactly as argv
     # does — a fixed ceiling with no JSON route would leave gda-mcp on the old defect.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -460,7 +446,7 @@ def test_a_non_positive_timeout_is_a_usage_error_not_a_launch(
     # A zero or negative ceiling would end every run instantly. It is refused before
     # any spawn — as a usage error on argv, where Click's exit 2 is the ergonomic
     # answer, mirroring how `script set` handles a contradictory edit.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -489,7 +475,7 @@ def test_a_non_positive_timeout_is_structured_through_params_json(
     # The same rule on the JSON path surfaces as the structured `invalid_params`
     # envelope rather than a Click usage error, because the model enforces it
     # (ADR-0015) — one rule, two idiomatic reports.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -515,7 +501,7 @@ def test_an_empty_completion_marker_is_refused(monkeypatch, tmp_path):
     # An empty marker would match every line, disarming the abort while looking
     # declared — the same class of mistake as an empty --godot, so it is refused
     # rather than silently ignored.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -545,7 +531,7 @@ def test_a_non_finite_timeout_is_refused_on_argv(monkeypatch, tmp_path, value):
     # exact opposite of what the option is for, and reached by an ordinary CLI string
     # because Click parses these through float(). `nan` fails the same way, comparing
     # false against everything. `1e400` overflows to inf without ever spelling it.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -576,7 +562,7 @@ def test_a_non_finite_timeout_is_refused_through_params_json(
     # decoder accepts the `Infinity`/`NaN` extensions, and a plain overflowing literal
     # needs no extension at all. Enforced by the shared params model, so it surfaces as
     # the structured `invalid_params` envelope (ADR-0015).
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -603,7 +589,7 @@ def test_a_blank_completion_marker_is_refused_on_argv(monkeypatch, tmp_path, mar
     # The marker is compared as a stripped whole LINE, so a blank one would equal every
     # blank line the run prints and arm the abort on nothing. Refused rather than
     # silently ignored — the same treatment an empty --godot gets.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -629,7 +615,7 @@ def test_a_blank_completion_marker_is_refused_on_argv(monkeypatch, tmp_path, mar
 def test_a_blank_completion_marker_is_refused_through_params_json(
     monkeypatch, tmp_path
 ):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(

--- a/tests/test_script_run_operation.py
+++ b/tests/test_script_run_operation.py
@@ -55,6 +55,7 @@ from gda.execution import ExecutionKind
 from gda.models import TerminationPhase
 from gda.exit_codes import EXIT_NOT_FOUND, EXIT_OPERATION, EXIT_TIMEOUT
 from gda.runner import LaunchFailure, LaunchWatch, RunResult
+from tests.support import minimal_project
 
 PROJECT = Path("/tmp/project")
 # The canonical entry the ABORTED_STDERR fixture names, so attribution matches.
@@ -397,8 +398,8 @@ def test_a_script_a_nested_project_owns_is_refused_before_any_launch(tmp_path):
     outer = tmp_path / "outer"
     inner = outer / "inner"
     inner.mkdir(parents=True)
-    (outer / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    (inner / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(outer)
+    minimal_project(inner)
 
     outcome, launch = _run(
         RunResult(stdout="", stderr="", exit_code=0),
@@ -420,7 +421,7 @@ def test_a_script_the_resolved_project_owns_still_launches(tmp_path):
     # owner and refusing every correct invocation.
     project = tmp_path / "game"
     (project / "tests").mkdir(parents=True)
-    (project / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(project)
 
     outcome, launch = _run(
         RunResult(stdout="ok\n", stderr="", exit_code=0),


### PR DESCRIPTION
Closes #816

## What changed

The unit-tier command tests each carried their own copy of the same invocation
ritual. `tests/support.py` now owns it, and the modules state only what they are
testing.

**New in `tests/support.py`**

| Interface | What it owns |
| --- | --- |
| `ENGINE_BANNER` | The line a real engine run writes before anything a command cares about. |
| `invoke_cli(monkeypatch, argv, *, stdout, stderr, exit_code, banner, stdin)` | The banner, the runner injection, the `CliRunner` call. Returns the result and the fake it injected. |
| `invoke_operation_error(monkeypatch, argv, code, message, operation)` | Its failure twin: an ADR-0002 operation-error envelope plus the runner's stderr notice. |
| `operation_error_invoker(argv, operation)` | Binds one command to the invoker; `argv` may be a builder where a command's argv varies per test. |
| `assert_operation_error(result, code, needle, diagnostics)` | The one place the operation-failure contract is spelled. Returns the parsed error. |
| `minimal_project(directory)` | The `project.godot` that makes a directory a project (ADR-0006). |
| `recording_runner(monkeypatch, result)` | The runner seam that records the resolved `--project`, one entry per runner built. |
| `FakeProc` | One `Popen` stand-in: `poll()` answers `returncode`, the pid is gda's own. |
| `server_with_session(tmp_path, log_file, alive)` | A `DaemonServer` holding a stand-in session, for the log-backed live reads. |

**Removed from the modules**

- 24 `_invoke_*` helpers across six error-test modules, replaced by 26 one-line
  bindings and 19 direct calls. The bindings drop the `_invoke_` prefix, because
  what remains is the command, not an invoker.
- 112 inline operation-error assertion blocks, plus the two divergent named
  helpers (10 more call sites): 122 assertions, one helper. The resource-uid
  helper's hard-coded diagnostics line is now an explicit argument at each of its
  five call sites.
- **Every headless invocation ritual in the unit tier.** 147 functions built the
  runner injection and the `CliRunner` call by hand; 4 do now, and each says why
  (see the exemptions below). With them go every hand-typed banner literal outside
  the parser tests, where the line carries the engine's URL suffix and IS the input
  under test.
- 18 `_project` builders, 2 more rewritten to delegate, and 39 inline
  `config_version=5` writes.
- Four `_FakeProc` / `_Proc` classes in three shapes, and two copies of the
  log-backed server fixture.
- Five `record(binary, project)` closures plus the info-command list variant, and
  ten hand-rolled `FakeRunner` + `make_runner` monkeypatch pairs.

## Ritual count

Functions containing both `inject_runner(` and `CliRunner().invoke(`, over every
non-e2e module:

| | Count |
| --- | --- |
| Base `f80f31e5` | 147 |
| Head | **4** (all exempt, see below) |

Two keywords were needed to reach that: `banner=False` (one call site) and
`stdin` (one call site). Both are documented on `invoke_cli`.

## Exemptions — the four that keep the ritual

Each stages a `RunResult` whose **launch failure** is the input under test, and a
launch failure is not one of the three canned streams the invoker stages. A
comment at each site says so.

| Module | Test |
| --- | --- |
| `test_human_failure_output` | `test_a_human_invocation_gets_the_lines_and_never_the_envelope` |
| `test_human_failure_output` | `test_the_same_failure_under_json_is_the_envelope_and_nothing_else` |
| `test_human_failure_output` | `test_a_capped_diagnostics_failure_keeps_the_full_stderr_tee` |
| `test_scene_errors` | `test_scene_create_missing_binary_maps_to_environment_error` |

One more site uses `invoke_cli` but opts out of the banner —
`test_scene_errors::test_scene_get_broken_sentinel_maps_to_parse_error`, whose
staged frame carries no result sentinel and is the subject. Its literal is
restored to the base's `"no sentinel here\n"`, so that fixture is byte-identical
to the base again.

Not in scope, and not counted: `test_info_errors` stages the classifier's own raw
runs through an aliased import — every fixture there (a missing sentinel, a
malformed one, a signal death, a launch failure) is the input under test.
`test_parser` and `test_launch` do not touch the runner seam at all.

## Fixture normalization — the banner

Migrated staged runs now carry the engine banner, as a real run does. No
assertion reads it; nothing else about the staged runs changed. Staged runs that
gained it, module → count:

| Module | Count | | Module | Count |
| --- | --- | --- | --- | --- |
| `test_script_commands` | 43 | | `test_resource_commands` | 6 |
| `test_project_commands` | 23 | | `test_project_analysis_commands` | 5 |
| `test_params_json` | 15 | | `test_json_flag_acceptance` | 3 |
| `test_asset_file_commands` | 13 | | `test_node_commands` | 3 |
| `test_scene_validate_commands` | 9 | | `test_scene_commands` | 3 |
| `test_scene_errors` | 8 | | `test_project_analysis_errors` | 3 |
| `test_human_failure_output` | 2 | | `test_export_commands` | 1 |
| `test_human_output` | 1 | | `test_export_run_commands` | 1 |

**139 source sites in total** — staged-run constructions counted at their source site, so a helper that stages once for many tests counts once and a loop counts once per site (an instrumented per-nodeid count is higher for that reason). Five remain bannerless: the four exemptions and the
one `banner=False`. In `test_scene_errors` (8) and `test_project_analysis_errors`
(3) the staged run also gained the runner's `gda: running operation…` stderr
notice, because those fixtures had an empty stderr; everywhere else stderr is
unchanged. Measured by walking the AST of both checkouts, not by reading the
diff.

## Line counts

| | Before | After | Delta |
| --- | --- | --- | --- |
| `tests/` overall | | | **-1060** (1954 added, 3014 removed) |
| test modules alone | | | -1274 |
| `tests/support.py` | 1079 | 1293 | +214 |

## Definition of Done

| Gate | Command | Result |
| --- | --- | --- |
| Lint | `uv run --frozen ruff check .` | All checks passed |
| Format | `uv run --frozen ruff format --check .` | 492 files already formatted |
| Types | `uv run --frozen pyright` (bare, src + tests + scripts) | 0 errors, 0 warnings |
| Coverage guard | `pytest --collect-only -q -p no:cacheprovider -m "not e2e"`, sorted, head vs base `f80f31e5` | 2,429 IDs both sides; `diff` printed nothing, `cmp` reports identical |
| Unit tier | `uv run --frozen pytest -m "not e2e" -q -p no:cacheprovider` | 2,429 passed in 44.70s |
| Import health | `uv run --frozen pytest --collect-only -q -p no:cacheprovider` | 3,075 collected, 0 errors |
| Real engine | `uv run --frozen pytest -q -p no:cacheprovider tests/test_e2e_info.py` | 4 passed in 3.32s (Godot 4.6.3) |

Surface diff: none — tests only.

## Notes for the reviewer

- **No test added, removed, renamed or reparametrized.** The collected ID list is
  byte-identical to the base.
- **One strengthening, and it is a no-op.** `assert_operation_error` asserts the
  `operation` category; some inline blocks asserted only the code. Exit 4 and that
  category are the same fact — in `ERROR_CODE_BY_CODE`, every code with exit 4 is
  operation-category and every operation-category code exits 4 — so the block
  already asserted it through the exit code it kept.
- **Why the error modules bind rather than pass argv per call.** Inlining argv and
  the operation name at the 90 call sites would have grown them past the line
  limit and added roughly 270 lines, turning a deletion into a wash. The binding
  keeps every call site as it was and leaves the ritual in exactly one place.
- **Kept local, on purpose:**
  - `test_daemon_lifecycle_payload`'s project builder — its payload reports the
    application NAME, so it needs a different `project.godot`, not the shared
    minimum plus a second write of the same path (a docstring now says so);
  - `test_project::_make_project` and `test_res_containment_consistency`'s
    `project` fixture — byte-identical to `minimal_project`, but both spell the
    filename through the product constant `PROJECT_MARKER`, and those two modules
    are what tests project-marker resolution itself. Sharing a builder that
    hard-codes the name would remove the constant from the test that exists to
    exercise it;
  - the harness-install and export-run-operation project writes — different file
    contents (an autoload section, an application name), not copies of the shared
    builder;
  - the `params-json` blocks that assert `exit_code != 0` — the shared assertion
    helper asserts exit 4, which those call sites deliberately do not;
  - the `script run` two-result comparison and the `script validate` evidence
    block, whose assertions do not fit one call.
- **Possible follow-up, deliberately out of this round:** 129 functions do the
  same two-statement ritual against the LIVE seam (`inject_live_runner` +
  `CliRunner`), in the input (47), screen (31), game (23), perf (13), logger (6),
  diag (4), daemon-wait-ready (4) and live-contract-guard (1) modules. A live twin
  of `invoke_cli` would collapse them the same way; it is a separate change with a
  separate blast radius.
