### PR TITLE
refactor(tests): one deep gda invoker for the e2e tier (#817)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,6 +87,32 @@ def project_godot(name: str = "gda-e2e-fixture", extra: str = "") -> str:
 # logging-disable rationale lives in exactly one place.
 PROJECT_GODOT = project_godot()
 
+# The live tier's scaffold: a project that names a main scene, and the two main
+# scenes its modules run. A live module needs a game to launch, so `daemon`,
+# `game`, `input`, `screen`, `perf`, `diag`, `logger`, `mcp_live` and the harness
+# install tests each carried a copy of this pair; the copies are one edit away
+# from disagreeing about what "the live fixture project" is, so they live here
+# beside the builder that makes them. A module whose scene is its own subject
+# (the coloured rect `screen` captures, the reference graph `project analysis`
+# walks) keeps that scene local — it is not a copy of anything.
+LIVE_PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
+
+# A main scene with a child node, for a live module that addresses a node path.
+LIVE_MAIN_TSCN = (
+    "[gd_scene format=3]\n\n"
+    '[node name="Main" type="Node2D"]\n\n'
+    '[node name="Player" type="Node2D" parent="."]\n'
+)
+
+# A main scene that runs `res://main.gd`, for a live module whose subject is what
+# the running game PRINTS (the session log, the runtime errors read back).
+SCRIPTED_MAIN_TSCN = (
+    "[gd_scene load_steps=2 format=3]\n\n"
+    '[ext_resource type="Script" path="res://main.gd" id="1"]\n\n'
+    '[node name="Main" type="Node2D"]\n'
+    'script = ExtResource("1")\n'
+)
+
 
 @pytest.fixture
 def godot_project(tmp_path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,12 +88,15 @@ def project_godot(name: str = "gda-e2e-fixture", extra: str = "") -> str:
 PROJECT_GODOT = project_godot()
 
 # The live tier's scaffold: a project that names a main scene, and the two main
-# scenes its modules run. A live module needs a game to launch, so `daemon`,
-# `game`, `input`, `screen`, `perf`, `diag`, `logger`, `mcp_live` and the harness
-# install tests each carried a copy of this pair; the copies are one edit away
-# from disagreeing about what "the live fixture project" is, so they live here
-# beside the builder that makes them. A module whose scene is its own subject
-# (the coloured rect `screen` captures, the reference graph `project analysis`
+# scenes its modules run. A live module needs a game to launch, so the eleven
+# that launch one (`daemon`, `game`, `input`, `screen`, `perf`, `diag`, `logger`,
+# `mcp_live`, `live_number_transport`, `write_value_fidelity` and the harness
+# install tests) take the project from here; `daemon`, `perf` and `mcp_live`
+# take the node-path scene, `diag` and `logger` the scripted one. The copies
+# they carried were one edit away from disagreeing about what "the live fixture
+# project" is, so they live here beside the builder that makes them. A module
+# whose scene is its own subject (the coloured rect `screen` captures, the bare
+# root the harness-install gate watches, the reference graph `project analysis`
 # walks) keeps that scene local — it is not a copy of anything.
 LIVE_PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
 

--- a/tests/support.py
+++ b/tests/support.py
@@ -17,12 +17,13 @@ import re
 import subprocess
 import sys
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from typer.testing import CliRunner, Result
 
+from gda.binary import resolve_godot_binary
 from gda.cli import app
 from gda.runner import RunResult
 
@@ -108,11 +109,184 @@ def assert_no_pydantic_dump(message: str) -> None:
 GDA_CMD = [sys.executable, "-m", "gda"]
 
 
-def templates_installed(gda, preset: str = "Linux/X11") -> bool:
+# The Godot binary the e2e tier drives, resolved ONCE for the whole tier by the
+# same precedence gda itself uses (``--godot`` > ``$GDA_GODOT`` > the RULES.md
+# default). Every e2e module used to resolve its own copy; one constant keeps the
+# path a test passes as ``--godot`` and the path ``conftest`` gates the tier on
+# from drifting apart.
+GODOT = resolve_godot_binary()
+
+# What one `gda` e2e spawn waits before the test calls it wedged. Long enough for
+# a real engine to boot, import and answer on a loaded machine; short enough that
+# a wedged engine fails one test instead of hanging the whole tier. A call that
+# legitimately needs longer states its own bound; no spawn goes unbounded.
+DEFAULT_TIMEOUT = 90.0
+
+
+class Gda:
+    """The e2e tier's one out-of-process ``gda`` invoker.
+
+    Every e2e spawn goes through here, so the tier has ONE adapter over the
+    ``[sys.executable, "-m", "gda"]`` seam (:data:`GDA_CMD`, #299) instead of a
+    per-module copy of :func:`subprocess.run`. Out of process is the point: the
+    e2e tier proves the shipped CLI, not an in-process Typer call.
+
+    An instance BINDS what a module repeats — the project, the engine, the child
+    environment, the working directory, the timeout, and whether ``--json`` is
+    baked in — and exposes three forms over that binding:
+
+    * calling it runs the command and returns the raw
+      :class:`subprocess.CompletedProcess`, for a test that reads an exit code,
+      a stream, or a failure of any category;
+    * :meth:`json` asserts the run succeeded and returns the parsed result;
+    * :meth:`error` asserts the ADR-0002 operation-failure envelope for one
+      :term:`Gda error code` and returns the parsed error.
+
+    ``project=None`` builds the project-less form the commands that resolve no
+    project need (``gda version``, ``gda info --godot``, the "no project"
+    refusals); ``godot=None`` drops ``--godot`` for the few tests that spell the
+    engine themselves or read it from ``$GDA_GODOT``.
+
+    Bound options are appended AFTER the command's own argv, in the
+    ``--project``, ``--godot``, ``--json`` order, because a few tests read a
+    target relative to the working directory and the placement of the target
+    among the options is part of what they exercise.
+    """
+
+    def __init__(
+        self,
+        project: Path | str | None = None,
+        *,
+        godot: Path | str | None = GODOT,
+        json_output: bool = False,
+        env: Mapping[str, str] | None = None,
+        extra_env: Mapping[str, str] | None = None,
+        cwd: Path | str | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> None:
+        tail: list[str] = []
+        if project is not None:
+            tail += ["--project", str(project)]
+        if godot is not None:
+            tail += ["--godot", str(godot)]
+        if json_output:
+            tail.append("--json")
+        self._tail = tail
+        self._json_output = json_output
+        self._env = env
+        self._extra_env = extra_env
+        self._cwd = cwd
+        self._timeout = timeout
+
+    def __call__(
+        self,
+        *args: str,
+        cwd: Path | str | None = None,
+        timeout: float | None = None,
+        extra_env: Mapping[str, str] | None = None,
+        stdin: str | None = None,
+        retry: bool = False,
+    ) -> "subprocess.CompletedProcess[str]":
+        """Run ``gda <args>`` and return the finished process.
+
+        ``cwd``, ``timeout`` and ``extra_env`` override the binding for this one
+        call; ``stdin`` is the text the CLI reads from standard input (the
+        ``--params-json -`` channel). ``retry`` re-runs once on a transient
+        ``engine_crashed`` — a shared-``user://`` log race under parallel e2e,
+        not a gda bug (#180) — so a happy path does not flake on it.
+        """
+        argv = [*GDA_CMD, *args, *self._tail]
+        cwd = self._cwd if cwd is None else cwd
+        proc = self._spawn(
+            argv,
+            cwd=cwd,
+            timeout=self._timeout if timeout is None else timeout,
+            extra_env=extra_env,
+            stdin=stdin,
+        )
+        if retry and proc.returncode != 0 and _run_error_code(proc) == "engine_crashed":
+            proc = self._spawn(
+                argv,
+                cwd=cwd,
+                timeout=self._timeout if timeout is None else timeout,
+                extra_env=extra_env,
+                stdin=stdin,
+            )
+        return proc
+
+    def json(self, *args: str, **overrides) -> dict:
+        """Run ``gda <args> --json``, assert it succeeded, and return the result."""
+        proc = self(*self._with_json(args), **overrides)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        return json.loads(proc.stdout)
+
+    def error(self, *args: str, code: str, **overrides) -> dict:
+        """Run ``gda <args> --json`` and assert it failed the operation with ``code``."""
+        return assert_operation_error(self(*self._with_json(args), **overrides), code)
+
+    def _with_json(self, args: tuple[str, ...]) -> tuple[str, ...]:
+        """``args`` guaranteed to ask for JSON, which both parsing forms need."""
+        if self._json_output or "--json" in args:
+            return args
+        return (*args, "--json")
+
+    def _spawn(
+        self,
+        argv: list[str],
+        *,
+        cwd: Path | str | None,
+        timeout: float,
+        extra_env: Mapping[str, str] | None,
+        stdin: str | None,
+    ) -> "subprocess.CompletedProcess[str]":
+        extra = {**(self._extra_env or {}), **(extra_env or {})}
+        if self._env is not None:
+            env = {**self._env, **extra}
+        else:
+            env = {**os.environ, **extra} if extra else None
+        return subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=None if cwd is None else str(cwd),
+            timeout=timeout,
+            input=stdin,
+        )
+
+
+def _run_error_code(proc: "subprocess.CompletedProcess[str]") -> str | None:
+    """The ``Gda error code`` a finished run reported, or ``None`` if it reported none."""
+    try:
+        return json.loads(proc.stdout)["error"]["code"]
+    except (ValueError, KeyError, TypeError):
+        return None
+
+
+def import_project(project: Path | str, *, timeout: float = 180.0) -> None:
+    """Run the engine's headless import pass over ``project``, and assert it passed.
+
+    The precondition several e2e scenarios need: a ``class_name`` registers in
+    ``.godot/global_script_class_list.cfg``, and a UID resolves through the UID
+    cache, only after a project scan — the step a CI pipeline runs before using
+    either. The engine's exit code is asserted here, so an import that failed
+    surfaces as itself rather than as a confusing later assertion about a class
+    name that was never registered.
+    """
+    imported = subprocess.run(
+        [str(GODOT), "--headless", "--path", str(project), "--import"],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    assert imported.returncode == 0, imported.stdout + imported.stderr
+
+
+def templates_installed(gda: Gda, preset: str = "Linux/X11") -> bool:
     """Whether the running engine has export templates, via ``gda export get``.
 
-    ``gda`` is a bound ``gda <args> --json`` callable (e.g. the e2e tests'
-    ``_gda_project``). The single source of truth for the e2e template-presence
+    ``gda`` is a project-bound :class:`Gda`. The single source of truth for the
+    e2e template-presence
     policy, shared by the export-run happy-path skip and the harness template-gate
     behavioural proof (#301). ``preset`` only needs to NAME a preset that exists in
     the project so ``export get`` succeeds; the verdict itself is preset-independent
@@ -121,9 +295,7 @@ def templates_installed(gda, preset: str = "Linux/X11") -> bool:
     version dir present but the host platform's file missing still sees ``True`` and
     must tolerate the export failing later.
     """
-    got = gda("export", "get", "--preset", preset, "--json")
-    assert got.returncode == 0, got.stdout + got.stderr
-    return json.loads(got.stdout)["templates_installed"]
+    return gda.json("export", "get", "--preset", preset)["templates_installed"]
 
 
 class FakeRunner:
@@ -339,7 +511,10 @@ def operation_error_invoker(
 
 
 def assert_operation_error(
-    result: Result, code: str, needle: str | None = None, diagnostics: str | None = None
+    result: "Result | subprocess.CompletedProcess[str]",
+    code: str,
+    needle: str | None = None,
+    diagnostics: str | None = None,
 ) -> dict:
     """Assert ``result`` is the operation-category failure for ``code``, and return it.
 
@@ -350,9 +525,23 @@ def assert_operation_error(
     asserts the raw stderr the envelope carries, and is always passed EXPLICITLY —
     a module that checks it says so at the call site rather than inheriting it.
     Returns the parsed error, so a caller asserts anything further on it.
+
+    Both tiers' invocation results are read: a Typer ``Result`` from an in-process
+    CLI call, and a finished ``CompletedProcess`` from an e2e :class:`Gda` spawn
+    (which is where :meth:`Gda.error` lands). The contract asserted is the same
+    envelope either way; only where the exit code sits, and how much of the run to
+    quote when the assertion fails, differ.
     """
-    assert result.exit_code == 4, result.stdout
-    err = json.loads(result.stdout)["error"]
+    if isinstance(result, subprocess.CompletedProcess):
+        exit_code, stdout, evidence = (
+            result.returncode,
+            result.stdout,
+            result.stdout + result.stderr,
+        )
+    else:
+        exit_code, stdout, evidence = result.exit_code, result.stdout, result.stdout
+    assert exit_code == 4, evidence
+    err = json.loads(stdout)["error"]
     assert err["category"] == "operation"
     assert err["code"] == code
     if needle is not None:

--- a/tests/support.py
+++ b/tests/support.py
@@ -194,6 +194,11 @@ class Gda:
         ``--params-json -`` channel). ``retry`` re-runs once on a transient
         ``engine_crashed`` — a shared-``user://`` log race under parallel e2e,
         not a gda bug (#180) — so a happy path does not flake on it.
+
+        ``extra_env`` reaches the ENGINE too: the CLI passes no ``env=`` to its
+        own Godot subprocess, so the engine inherits whatever gda was given —
+        the channel the production-inert ``GDA_TEST_PERTURB_BEFORE_SAVE`` test
+        seam rides on (issue #226).
         """
         argv = [*GDA_CMD, *args, *self._tail]
         cwd = self._cwd if cwd is None else cwd

--- a/tests/support.py
+++ b/tests/support.py
@@ -268,7 +268,9 @@ def _run_error_code(proc: "subprocess.CompletedProcess[str]") -> str | None:
         return None
 
 
-def import_project(project: Path | str, *, timeout: float = 180.0) -> None:
+def import_project(
+    project: Path | str, *, timeout: float = 180.0
+) -> "subprocess.CompletedProcess[str]":
     """Run the engine's headless import pass over ``project``, and assert it passed.
 
     The precondition several e2e scenarios need: a ``class_name`` registers in
@@ -276,7 +278,8 @@ def import_project(project: Path | str, *, timeout: float = 180.0) -> None:
     cache, only after a project scan — the step a CI pipeline runs before using
     either. The engine's exit code is asserted here, so an import that failed
     surfaces as itself rather than as a confusing later assertion about a class
-    name that was never registered.
+    name that was never registered. The finished process is returned for the
+    caller that reads what the pass printed.
     """
     imported = subprocess.run(
         [str(GODOT), "--headless", "--path", str(project), "--import"],
@@ -285,6 +288,7 @@ def import_project(project: Path | str, *, timeout: float = 180.0) -> None:
         timeout=timeout,
     )
     assert imported.returncode == 0, imported.stdout + imported.stderr
+    return imported
 
 
 def templates_installed(gda: Gda, preset: str = "Linux/X11") -> bool:

--- a/tests/test_e2e_asset_file.py
+++ b/tests/test_e2e_asset_file.py
@@ -12,25 +12,9 @@ import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
+from tests.support import GODOT, Gda
 
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
-
-
-def _gda(*args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT)], capture_output=True, text=True
-    )
-
-
-def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
-    assert proc.returncode == 4, proc.stdout + proc.stderr
-    err = json.loads(proc.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == code
-    return err
+gda = Gda()
 
 
 # --- shader create → get → set round-trip ----------------------------------
@@ -43,7 +27,7 @@ def test_shader_create_default_template_then_get_round_trip(godot_project):
     # write.
     shader_path = godot_project / "wave.gdshader"
 
-    created = _gda("shader", "create", str(shader_path), "--json")
+    created = gda("shader", "create", str(shader_path), "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     data = json.loads(created.stdout)
@@ -51,7 +35,7 @@ def test_shader_create_default_template_then_get_round_trip(godot_project):
     assert data["shader_type"] == "canvas_item"
     assert shader_path.exists()
 
-    got = _gda("shader", "get", str(shader_path), "--json")
+    got = gda("shader", "get", str(shader_path), "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     got_data = json.loads(got.stdout)
@@ -65,14 +49,14 @@ def test_shader_create_default_template_then_get_round_trip(godot_project):
 def test_shader_create_with_type_parameterizes_the_template(godot_project):
     shader_path = godot_project / "world.gdshader"
 
-    created = _gda(
+    created = gda(
         "shader", "create", str(shader_path), "--shader-type", "spatial", "--json"
     )
 
     assert created.returncode == 0, created.stdout + created.stderr
     assert json.loads(created.stdout)["shader_type"] == "spatial"
 
-    got = _gda("shader", "get", str(shader_path), "--json")
+    got = gda("shader", "get", str(shader_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["shader_type"] == "spatial"
 
@@ -89,12 +73,12 @@ def test_shader_create_with_content_round_trips_verbatim_source(godot_project):
         "}\n"
     )
 
-    created = _gda("shader", "create", str(shader_path), "--content", source, "--json")
+    created = gda("shader", "create", str(shader_path), "--content", source, "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     assert json.loads(created.stdout)["shader_type"] == "canvas_item"
 
-    got = _gda("shader", "get", str(shader_path), "--json")
+    got = gda("shader", "get", str(shader_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["source"] == source
 
@@ -105,9 +89,9 @@ def test_shader_set_search_replace_round_trips_through_get(godot_project):
     # reused script-set interface, issue #115): edit the shader_type and read it
     # back changed.
     shader_path = godot_project / "edit.gdshader"
-    _gda("shader", "create", str(shader_path), "--json")
+    gda("shader", "create", str(shader_path), "--json")
 
-    edited = _gda(
+    edited = gda(
         "shader",
         "set",
         str(shader_path),
@@ -121,7 +105,7 @@ def test_shader_set_search_replace_round_trips_through_get(godot_project):
     assert edited.returncode == 0, edited.stdout + edited.stderr
     assert json.loads(edited.stdout)["shader_type"] == "spatial"
 
-    got = _gda("shader", "get", str(shader_path), "--json")
+    got = gda("shader", "get", str(shader_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["source"] == "shader_type spatial;\n"
 
@@ -129,13 +113,13 @@ def test_shader_set_search_replace_round_trips_through_get(godot_project):
 @pytest.mark.e2e
 def test_shader_set_full_overwrite_round_trips_through_get(godot_project):
     shader_path = godot_project / "full.gdshader"
-    _gda("shader", "create", str(shader_path), "--json")
+    gda("shader", "create", str(shader_path), "--json")
     new_source = "shader_type particles;\n"
 
-    edited = _gda("shader", "set", str(shader_path), "--content", new_source, "--json")
+    edited = gda("shader", "set", str(shader_path), "--content", new_source, "--json")
 
     assert edited.returncode == 0, edited.stdout + edited.stderr
-    got = _gda("shader", "get", str(shader_path), "--json")
+    got = gda("shader", "get", str(shader_path), "--json")
     assert json.loads(got.stdout)["source"] == new_source
 
 
@@ -145,36 +129,40 @@ def test_shader_set_full_overwrite_round_trips_through_get(godot_project):
 @pytest.mark.e2e
 def test_shader_create_no_clobber_existing_file(godot_project):
     shader_path = godot_project / "once.gdshader"
-    assert _gda("shader", "create", str(shader_path), "--json").returncode == 0
+    assert gda("shader", "create", str(shader_path), "--json").returncode == 0
     before = shader_path.read_text(encoding="utf-8")
 
-    again = _gda(
+    gda.error(
         "shader",
         "create",
         str(shader_path),
         "--content",
         "shader_type spatial;\n",
         "--json",
+        code="already_exists",
     )
-
-    _assert_operation_error(again, "already_exists")
     # The original file is untouched — no-clobber.
     assert shader_path.read_text(encoding="utf-8") == before
 
 
 @pytest.mark.e2e
 def test_shader_get_missing_file_is_path_not_found(godot_project):
-    missing = _gda("shader", "get", str(godot_project / "nope.gdshader"), "--json")
-    _assert_operation_error(missing, "path_not_found")
+    gda.error(
+        "shader",
+        "get",
+        str(godot_project / "nope.gdshader"),
+        "--json",
+        code="path_not_found",
+    )
 
 
 @pytest.mark.e2e
 def test_shader_set_no_search_match_leaves_file_untouched(godot_project):
     shader_path = godot_project / "nomatch.gdshader"
-    _gda("shader", "create", str(shader_path), "--json")
+    gda("shader", "create", str(shader_path), "--json")
     before = shader_path.read_text(encoding="utf-8")
 
-    edited = _gda(
+    gda.error(
         "shader",
         "set",
         str(shader_path),
@@ -183,18 +171,17 @@ def test_shader_set_no_search_match_leaves_file_untouched(godot_project):
         "--replace",
         "z",
         "--json",
+        code="no_search_match",
     )
-
-    _assert_operation_error(edited, "no_search_match")
     assert shader_path.read_text(encoding="utf-8") == before
 
 
 @pytest.mark.e2e
 def test_shader_set_invalid_line_range_is_invalid_line_range(godot_project):
     shader_path = godot_project / "range.gdshader"
-    _gda("shader", "create", str(shader_path), "--json")
+    gda("shader", "create", str(shader_path), "--json")
 
-    edited = _gda(
+    gda.error(
         "shader",
         "set",
         str(shader_path),
@@ -205,9 +192,8 @@ def test_shader_set_invalid_line_range_is_invalid_line_range(godot_project):
         "--content",
         "x",
         "--json",
+        code="invalid_line_range",
     )
-
-    _assert_operation_error(edited, "invalid_line_range")
 
 
 # --- theme create: a genuinely LOADABLE .tres ------------------------------
@@ -220,7 +206,7 @@ def test_theme_create_produces_a_loadable_tres(godot_project):
     # assert the loaded resource is a Theme — the structured-level proof.
     theme_path = godot_project / "ui.tres"
 
-    created = _gda("theme", "create", str(theme_path), "--json")
+    created = gda("theme", "create", str(theme_path), "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     data = json.loads(created.stdout)
@@ -236,17 +222,16 @@ def test_theme_create_produces_a_loadable_tres(godot_project):
 @pytest.mark.e2e
 def test_theme_create_no_clobber_existing_file(godot_project):
     theme_path = godot_project / "dup.tres"
-    assert _gda("theme", "create", str(theme_path), "--json").returncode == 0
+    assert gda("theme", "create", str(theme_path), "--json").returncode == 0
 
-    again = _gda("theme", "create", str(theme_path), "--json")
-
-    _assert_operation_error(again, "already_exists")
+    gda.error("theme", "create", str(theme_path), "--json", code="already_exists")
 
 
 @pytest.mark.e2e
 def test_theme_create_wrong_extension_is_invalid_path(godot_project):
-    bad = _gda("theme", "create", str(godot_project / "ui.txt"), "--json")
-    _assert_operation_error(bad, "invalid_path")
+    gda.error(
+        "theme", "create", str(godot_project / "ui.txt"), "--json", code="invalid_path"
+    )
 
 
 def _load_resource_class(resource_path) -> str:
@@ -270,6 +255,7 @@ def _load_resource_class(resource_path) -> str:
         [str(GODOT), "--headless", "--script", str(probe)],
         capture_output=True,
         text=True,
+        timeout=120,
     )
     out = proc.stdout
     start = out.find("<<<CLASS>>>") + len("<<<CLASS>>>")

--- a/tests/test_e2e_classname_resolution.py
+++ b/tests/test_e2e_classname_resolution.py
@@ -29,16 +29,12 @@ when the cache misses. These tests exercise the change through the REAL engine
 """
 
 import json
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
+from tests.support import Gda, assert_operation_error, import_project
 
 from .conftest import project_godot
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
 
 # Built through ``project_godot`` so e2e file logging stays disabled (issue #180).
 CLASSNAME_RES_PROJECT_GODOT = project_godot(name="gda-classname-res-fixture")
@@ -66,35 +62,6 @@ func taunt() -> void:
 """
 
 
-def _gda(project, *args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-        capture_output=True,
-        text=True,
-    )
-
-
-def _import_project(project) -> None:
-    # An editor/import scan is what populates .godot/global_script_class_cache.cfg
-    # (tier 2). Scenario (b) runs it; scenarios (a), (c), (d) deliberately do NOT,
-    # so the resolver must fall through to the static scan (tier 3).
-    imported = subprocess.run(
-        [str(GODOT), "--headless", "--path", str(project), "--import"],
-        capture_output=True,
-        text=True,
-        timeout=120,
-    )
-    assert imported.returncode == 0, imported.stdout + imported.stderr
-
-
-def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
-    assert proc.returncode == 4, proc.stdout + proc.stderr
-    err = json.loads(proc.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == code
-    return err
-
-
 @pytest.fixture
 def uncached_project(tmp_path):
     """An editor-never-opened project (NO .godot/) with project-local classes."""
@@ -119,8 +86,7 @@ def test_resource_create_resolves_project_class_name_without_editor_cache(
     assert not (uncached_project / ".godot").exists()
     resource_path = uncached_project / "panda.tres"
 
-    created = _gda(
-        uncached_project,
+    created = Gda(uncached_project)(
         "resource",
         "create",
         str(resource_path),
@@ -144,8 +110,7 @@ def test_node_add_resolves_project_class_name_without_editor_cache(uncached_proj
     # node add resolves a project-local class_name Node via the static scan.
     assert not (uncached_project / ".godot").exists()
     scene_path = uncached_project / "main.tscn"
-    created = _gda(
-        uncached_project,
+    created = Gda(uncached_project)(
         "scene",
         "create",
         str(scene_path),
@@ -155,8 +120,8 @@ def test_node_add_resolves_project_class_name_without_editor_cache(uncached_proj
     )
     assert created.returncode == 0, created.stdout + created.stderr
 
-    added = _gda(
-        uncached_project, "node", "add", str(scene_path), "--type", "Hero", "--json"
+    added = Gda(uncached_project)(
+        "node", "add", str(scene_path), "--type", "Hero", "--json"
     )
 
     assert added.returncode == 0, added.stdout + added.stderr
@@ -175,7 +140,7 @@ def test_find_references_resolves_project_class_name_without_editor_cache(
     # no more "not a res:// path or a registered class_name" for a real class.
     assert not (uncached_project / ".godot").exists()
 
-    proc = _gda(uncached_project, "project", "find-references", "Hero", "--json")
+    proc = Gda(uncached_project)("project", "find-references", "Hero", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     data = json.loads(proc.stdout)
@@ -192,12 +157,14 @@ def test_find_references_resolves_project_class_name_without_editor_cache(
 def test_editor_opened_project_resolves_via_cache_unchanged(uncached_project):
     # With a populated .godot/ cache (tier 2), resolution is unchanged — the
     # static-scan fallback is unobservable for an editor-opened project.
-    _import_project(uncached_project)
+    # An editor/import scan is what populates .godot/global_script_class_cache.cfg
+    # (tier 2). Only this scenario runs it; (a), (c) and (d) deliberately do NOT,
+    # so the resolver must fall through to the static scan (tier 3).
+    import_project(uncached_project)
     assert (uncached_project / ".godot").exists()
     resource_path = uncached_project / "panda_cached.tres"
 
-    created = _gda(
-        uncached_project,
+    created = Gda(uncached_project)(
         "resource",
         "create",
         str(resource_path),
@@ -244,8 +211,7 @@ def _assert_ambiguous(err: dict) -> None:
 
 @pytest.mark.e2e
 def test_resource_create_ambiguous_class_name(ambiguous_project):
-    created = _gda(
-        ambiguous_project,
+    created = Gda(ambiguous_project)(
         "resource",
         "create",
         str(ambiguous_project / "x.tres"),
@@ -253,7 +219,7 @@ def test_resource_create_ambiguous_class_name(ambiguous_project):
         "Dup",
         "--json",
     )
-    _assert_ambiguous(_assert_operation_error(created, "ambiguous_class_name"))
+    _assert_ambiguous(assert_operation_error(created, "ambiguous_class_name"))
     # Nothing was written for the rejected type.
     assert not (ambiguous_project / "x.tres").exists()
 
@@ -261,8 +227,7 @@ def test_resource_create_ambiguous_class_name(ambiguous_project):
 @pytest.mark.e2e
 def test_node_add_ambiguous_class_name(ambiguous_project):
     scene_path = ambiguous_project / "main.tscn"
-    created = _gda(
-        ambiguous_project,
+    created = Gda(ambiguous_project)(
         "scene",
         "create",
         str(scene_path),
@@ -272,18 +237,18 @@ def test_node_add_ambiguous_class_name(ambiguous_project):
     )
     assert created.returncode == 0, created.stdout + created.stderr
 
-    added = _gda(
-        ambiguous_project, "node", "add", str(scene_path), "--type", "Dup", "--json"
+    added = Gda(ambiguous_project)(
+        "node", "add", str(scene_path), "--type", "Dup", "--json"
     )
 
-    _assert_ambiguous(_assert_operation_error(added, "ambiguous_class_name"))
+    _assert_ambiguous(assert_operation_error(added, "ambiguous_class_name"))
 
 
 @pytest.mark.e2e
 def test_find_references_ambiguous_class_name(ambiguous_project):
-    proc = _gda(ambiguous_project, "project", "find-references", "Dup", "--json")
+    proc = Gda(ambiguous_project)("project", "find-references", "Dup", "--json")
 
-    _assert_ambiguous(_assert_operation_error(proc, "ambiguous_class_name"))
+    _assert_ambiguous(assert_operation_error(proc, "ambiguous_class_name"))
 
 
 # --- (d) unknown type: actionable message, no editor-cache implication -------
@@ -291,17 +256,15 @@ def test_find_references_ambiguous_class_name(ambiguous_project):
 
 @pytest.mark.e2e
 def test_resource_create_unknown_type_message_is_actionable(uncached_project):
-    created = _gda(
-        uncached_project,
+    err = Gda(uncached_project).error(
         "resource",
         "create",
         str(uncached_project / "nope.tres"),
         "--type",
         "Nope",
         "--json",
+        code="invalid_resource_type",
     )
-
-    err = _assert_operation_error(created, "invalid_resource_type")
     msg = err["message"]
     assert "Nope" in msg
     # The actionable cause: the class is not declared in a .gd (a misspelling).
@@ -315,8 +278,7 @@ def test_resource_create_unknown_type_message_is_actionable(uncached_project):
 @pytest.mark.e2e
 def test_node_add_unknown_type_message_is_actionable(uncached_project):
     scene_path = uncached_project / "main.tscn"
-    created = _gda(
-        uncached_project,
+    created = Gda(uncached_project)(
         "scene",
         "create",
         str(scene_path),
@@ -326,11 +288,15 @@ def test_node_add_unknown_type_message_is_actionable(uncached_project):
     )
     assert created.returncode == 0, created.stdout + created.stderr
 
-    added = _gda(
-        uncached_project, "node", "add", str(scene_path), "--type", "Nope", "--json"
+    err = Gda(uncached_project).error(
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Nope",
+        "--json",
+        code="invalid_node_type",
     )
-
-    err = _assert_operation_error(added, "invalid_node_type")
     msg = err["message"]
     assert "Nope" in msg
     assert "no .gd script declares class_name Nope" in msg
@@ -350,8 +316,7 @@ def test_resource_create_project_class_emits_no_engine_error(uncached_project):
     # probe, so the static-scan resolution is silent.
     assert not (uncached_project / ".godot").exists()
 
-    created = _gda(
-        uncached_project,
+    created = Gda(uncached_project)(
         "resource",
         "create",
         str(uncached_project / "quiet.tres"),
@@ -368,8 +333,7 @@ def test_resource_create_project_class_emits_no_engine_error(uncached_project):
 def test_node_add_project_class_emits_no_engine_error(uncached_project):
     assert not (uncached_project / ".godot").exists()
     scene_path = uncached_project / "main.tscn"
-    created = _gda(
-        uncached_project,
+    created = Gda(uncached_project)(
         "scene",
         "create",
         str(scene_path),
@@ -379,8 +343,8 @@ def test_node_add_project_class_emits_no_engine_error(uncached_project):
     )
     assert created.returncode == 0, created.stdout + created.stderr
 
-    added = _gda(
-        uncached_project, "node", "add", str(scene_path), "--type", "Hero", "--json"
+    added = Gda(uncached_project)(
+        "node", "add", str(scene_path), "--type", "Hero", "--json"
     )
 
     assert added.returncode == 0, added.stdout + added.stderr
@@ -393,8 +357,7 @@ def test_ambiguous_class_name_carries_no_cannot_get_class(ambiguous_project):
     # of UNRELATED error envelopes on the fallback path — an ambiguous_class_name
     # failure carried "Cannot get class 'Dup'", pointing away from the real
     # cause. Neither the envelope's diagnostics nor stderr embeds it now.
-    created = _gda(
-        ambiguous_project,
+    created = Gda(ambiguous_project)(
         "resource",
         "create",
         str(ambiguous_project / "x.tres"),
@@ -403,7 +366,7 @@ def test_ambiguous_class_name_carries_no_cannot_get_class(ambiguous_project):
         "--json",
     )
 
-    err = _assert_operation_error(created, "ambiguous_class_name")
+    err = assert_operation_error(created, "ambiguous_class_name")
     assert "Cannot get class" not in err.get("diagnostics", "")
     assert "Cannot get class" not in created.stderr
 
@@ -414,8 +377,7 @@ def test_builtin_classes_resolve_unchanged_and_silent(uncached_project):
     # built-in Resource (Gradient) still resolve on the ClassDB tier exactly as
     # before — never reaching the class_name resolver — and stay silent.
     scene_path = uncached_project / "builtin.tscn"
-    created = _gda(
-        uncached_project,
+    created = Gda(uncached_project)(
         "scene",
         "create",
         str(scene_path),
@@ -426,16 +388,15 @@ def test_builtin_classes_resolve_unchanged_and_silent(uncached_project):
     assert created.returncode == 0, created.stdout + created.stderr
     assert "ERROR:" not in created.stderr, created.stderr
 
-    added = _gda(
-        uncached_project, "node", "add", str(scene_path), "--type", "Sprite2D", "--json"
+    added = Gda(uncached_project)(
+        "node", "add", str(scene_path), "--type", "Sprite2D", "--json"
     )
     assert added.returncode == 0, added.stdout + added.stderr
     assert json.loads(added.stdout)["type"] == "Sprite2D"
     assert "ERROR:" not in added.stderr, added.stderr
 
     resource_path = uncached_project / "builtin.tres"
-    res = _gda(
-        uncached_project,
+    res = Gda(uncached_project)(
         "resource",
         "create",
         str(resource_path),

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -23,7 +23,6 @@ import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
 from gda.harness.install import (
     HARNESS_FILE,
     HARNESS_RES_DIR,
@@ -31,22 +30,13 @@ from gda.harness.install import (
     installed_harness_version,
 )
 
-from tests.support import GDA_CMD, assert_windowed_ok
+from tests.support import Gda, assert_windowed_ok, import_project
 
-from .conftest import project_godot
-
-GODOT = resolve_godot_binary()
+from .conftest import LIVE_MAIN_TSCN, LIVE_PROJECT_GODOT
 
 # A main scene so the launched session has a runtime SceneTree to read; a Player
 # Node2D child carries a Vector2 storage property (position) for the game get/set
 # round trip (#220). File logging stays disabled via project_godot (issue #180).
-MAIN_TSCN = (
-    "[gd_scene format=3]\n\n"
-    '[node name="Main" type="Node2D"]\n\n'
-    '[node name="Player" type="Node2D" parent="."]\n'
-)
-PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
-
 RECT_MAIN_TSCN = (
     "[gd_scene format=3]\n\n"
     '[node name="Main" type="Control"]\n\n'
@@ -74,29 +64,12 @@ pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"
 
 @pytest.mark.e2e
 def test_daemon_serves_a_real_runtime_tree(tmp_path, daemon_runtime_dir):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
 
     # XDG_RUNTIME_DIR is set short by the daemon_runtime_dir fixture; the spawned
     # daemon inherits it through the subprocess environment.
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -125,26 +98,9 @@ def test_wait_ready_makes_a_first_diag_errors_serve(tmp_path, daemon_runtime_dir
     # no warm-up live op, no sleep loop. Without the wait, the first
     # `diag errors` reports engine_session_not_running by design (it must never
     # be the thing that launches the project's code, ADR-0022).
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -187,27 +143,10 @@ def test_daemon_serves_game_get_set_round_trip(tmp_path, daemon_runtime_dir):
     # The #220 DoD: a real daemon → engine session → `game set` mutates a runtime
     # property, applied at a frame boundary, and `game get` observes the change —
     # State consistency (ADR-0020) end-to-end through the real harness over UDS.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -251,9 +190,9 @@ def test_daemon_game_rect_reads_free_positioned_control_rect(
 ):
     # #419: `game rect` reads rendered viewport-space geometry, not storage
     # properties, so a free-positioned Control reports get_global_rect().
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(RECT_MAIN_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -277,9 +216,9 @@ def test_daemon_game_set_control_position_updates_offsets_preserving_size(
 ):
     # #464: live `game set` mirrors headless `node set` for Control.position by
     # applying an actionable offset write while preserving the current size.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(CONTROL_POSITION_MAIN_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -321,9 +260,9 @@ def test_daemon_game_set_container_managed_control_position_names_offset_alterna
 ):
     # A Container owns direct-child layout; `game set position` reports an
     # actionable live error instead of claiming a write the next layout pass owns.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(RECT_MAIN_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -354,9 +293,9 @@ def test_daemon_game_rect_reads_container_managed_child_rect(
 ):
     # #419: container-managed Controls have layout output even when a storage
     # property read is the wrong surface. `game rect` returns the rendered rect.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(RECT_MAIN_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -388,9 +327,9 @@ def test_daemon_game_rect_reads_container_managed_child_rect(
 def test_daemon_game_rect_rejects_non_control_node(tmp_path, daemon_runtime_dir):
     # #419: the command is intentionally Control-specific; a live node that
     # exists but is not a Control gets a typed LIVE error.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -458,10 +397,10 @@ def test_daemon_game_get_projects_compound_values_with_live_fallback(
     # JSON object, while a Node-valued property — a non-whitelisted runtime
     # Object — stays the str() fallback (the whitelist keeps the shared
     # projection safe against projecting a whole live scene tree).
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(PROJECTION_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(PROJECTION_PLAYER_GD, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -489,10 +428,10 @@ def test_daemon_game_get_reads_explicit_plain_script_dictionary_variable(
 ):
     # #422: a plain non-exported script variable is addressable when explicitly
     # named, but it remains outside the unfiltered storage-property listing.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(SCRIPT_VARIABLE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(SCRIPT_VARIABLE_PLAYER_GD, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -521,10 +460,10 @@ def test_daemon_game_set_mutates_explicit_plain_script_dictionary_variable(
 ):
     # #422: script-variable writes are live-session state seeding only. A later
     # read in the same session observes the mutation; nothing is persisted.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(SCRIPT_VARIABLE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(SCRIPT_VARIABLE_PLAYER_GD, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -581,10 +520,10 @@ def test_daemon_game_set_preserves_json_container_integer_and_float_types(
 ):
     # #427 live-side parity: the mirrored harness coercion must preserve JSON
     # integer vs float values in the same session state that game get observes.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(SCRIPT_VARIABLE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(SCRIPT_VARIABLE_PLAYER_GD, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -621,10 +560,10 @@ def test_daemon_game_set_preserves_json_container_integer_and_float_types(
 def test_daemon_game_get_unknown_explicit_script_variable_reports_unknown_property(
     tmp_path, daemon_runtime_dir
 ):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(SCRIPT_VARIABLE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(SCRIPT_VARIABLE_PLAYER_GD, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -645,10 +584,10 @@ def test_daemon_game_get_unknown_explicit_script_variable_reports_unknown_proper
 def test_daemon_game_set_uncoercible_script_variable_reports_target_type(
     tmp_path, daemon_runtime_dir
 ):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(SCRIPT_VARIABLE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(SCRIPT_VARIABLE_PLAYER_GD, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -678,12 +617,12 @@ def test_daemon_game_set_uncoercible_script_variable_reports_target_type(
 def test_daemon_game_set_readonly_script_variable_reports_unverified_observed_value(
     tmp_path, daemon_runtime_dir
 ):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(SCRIPT_VARIABLE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(
         READONLY_SCRIPT_VARIABLE_PLAYER_GD, encoding="utf-8"
     )
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -720,12 +659,12 @@ def test_daemon_game_set_readonly_script_variable_reports_unverified_observed_va
 def test_daemon_game_set_edge_trigger_reports_unverified_then_side_effect_is_readable(
     tmp_path, daemon_runtime_dir
 ):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(SCRIPT_VARIABLE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(
         EDGE_TRIGGER_SCRIPT_VARIABLE_PLAYER_GD, encoding="utf-8"
     )
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -758,35 +697,6 @@ def test_daemon_game_set_edge_trigger_reports_unverified_then_side_effect_is_rea
         run("daemon", "stop")
 
 
-def _gda(tmp_path, env, timeout=90):
-    """A `gda <args> --project <tmp> --godot <GODOT> --json` subprocess helper.
-
-    ``timeout`` defaults to 90s (the value every existing call site relied on
-    implicitly); a windowed session is heavier to launch, so callers that start
-    one pass a larger value (e.g. ``timeout=120``, matching the windowed e2e
-    tests elsewhere) instead of hand-rolling a near-duplicate of this helper.
-    """
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=timeout,
-        )
-
-    return run
-
-
 @pytest.mark.e2e
 def test_daemon_start_re_syncs_harness_after_a_version_bump(
     tmp_path, daemon_runtime_dir
@@ -797,9 +707,9 @@ def test_daemon_start_re_syncs_harness_after_a_version_bump(
     # stale value, stop the daemon, and start again. The second start must detect
     # the mismatch and re-materialize (harness_synced True), syncing the on-disk
     # version back to HARNESS_VERSION.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
+    run = Gda(tmp_path, json_output=True)
     harness = tmp_path / HARNESS_RES_DIR / HARNESS_FILE
 
     try:
@@ -837,9 +747,9 @@ def test_daemon_install_then_uninstall_is_paired_and_idempotent(
     # #225 D2: a real start installs the harness; with the daemon stopped,
     # `daemon uninstall` removes BOTH the [autoload] entry and the files (paired),
     # and a second uninstall is an idempotent no-op success.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
+    run = Gda(tmp_path, json_output=True)
     harness = tmp_path / HARNESS_RES_DIR / HARNESS_FILE
 
     try:
@@ -888,8 +798,8 @@ def test_daemon_round_trip_restores_the_project_it_started_from(
     # harness, its sidecar and `addons/` are deliberately NOT ignored, so any residue
     # shows up.
     project_godot = tmp_path / "project.godot"
-    project_godot.write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    project_godot.write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / ".gitignore").write_text(".godot/\n", encoding="utf-8")
     before = project_godot.read_bytes()
 
@@ -909,7 +819,7 @@ def test_daemon_round_trip_restores_the_project_it_started_from(
     assert committed.returncode == 0, committed.stdout + committed.stderr
     assert git("status", "--porcelain").stdout == ""  # a clean baseline to diff against
 
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
     harness = tmp_path / HARNESS_RES_DIR / HARNESS_FILE
 
     try:
@@ -934,12 +844,7 @@ def test_daemon_round_trip_restores_the_project_it_started_from(
 
         # Now let the ENGINE scan the project, the way a human opening the editor on
         # it does. This is what writes the .uid sidecar next to the installed harness.
-        imported = subprocess.run(
-            [str(GODOT), "--headless", "--path", str(tmp_path), "--import"],
-            capture_output=True,
-            text=True,
-            timeout=180,
-        )
+        imported = import_project(tmp_path)
         sidecar = harness.with_name(f"{HARNESS_FILE}.uid")
         assert sidecar.exists(), (
             "the engine did not write the .uid sidecar, so the removal assertions "
@@ -986,9 +891,9 @@ def test_daemon_uninstall_is_refused_while_running(tmp_path, daemon_runtime_dir)
     # #225 D2: uninstall is refused while a daemon is running — it would yank the
     # harness autoload out from under the live engine session. The CLI surfaces the
     # daemon_running error at the LIVE exit (6), and the install is untouched.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
+    run = Gda(tmp_path, json_output=True)
     harness = tmp_path / HARNESS_RES_DIR / HARNESS_FILE
 
     try:
@@ -1011,9 +916,9 @@ def test_daemon_status_surfaces_the_windowed_display_mode(tmp_path, daemon_runti
     # `windowed` null (clean, hang-free fallback); a default start -> false; a
     # `--windowed` start -> true. The daemon records the mode at start; no engine
     # session is launched here (lazy launch, ADR-0017), so this needs no display.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
+    run = Gda(tmp_path, json_output=True)
 
     # No daemon running yet: running False, windowed null.
     before = json.loads(run("daemon", "status").stdout)
@@ -1063,11 +968,11 @@ def test_daemon_start_scene_runs_the_chosen_scene_not_main(
     # scene B — `game tree` reports B's root (not Main's), proving the engine received
     # `--scene` (before `--path`) — and `project.godot`'s `main_scene` is UNCHANGED
     # (no mutation, F6-equivalent). With scenes A (main) + B present.
-    project_text = PROJECT_GODOT
+    project_text = LIVE_PROJECT_GODOT
     (tmp_path / "project.godot").write_text(project_text, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "B.tscn").write_text(B_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start", "--scene", "res://B.tscn")
@@ -1096,9 +1001,9 @@ def test_daemon_start_nonexistent_scene_is_typed_live_scene_not_found(
     # (LIVE exit 6) on the first live op — NEVER a silent fall back to main_scene.
     # Detected at launch by the harness (the loaded scene != the requested selector),
     # surfaced when the lazy launch is triggered by `game tree`.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start", "--scene", "res://does_not_exist.tscn")
@@ -1119,9 +1024,9 @@ def test_daemon_start_nonexistent_uid_is_typed_not_silent_main_scene(
     # to main_scene. Launch-time harness verification catches this — the loaded scene
     # (main) != the requested uid — and surfaces a typed `live_scene_not_found`, NOT a
     # silent success on main_scene.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start", "--scene", "uid://doesnotexist000")
@@ -1141,10 +1046,10 @@ def test_daemon_start_scene_against_a_running_daemon_is_a_typed_refusal(
     # #278 review finding 3: `--scene` only takes effect at daemon START. Against a
     # daemon that is already running it is a typed `daemon_already_running` refusal,
     # NOT a silent no-op that quietly ignores the chosen scene.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "B.tscn").write_text(B_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         assert run("daemon", "start").returncode == 0
@@ -1164,11 +1069,11 @@ def test_scene_verified_once_at_launch_survives_deleting_the_file(
     # live session bound to scene B keeps serving B after B.tscn is deleted on disk —
     # the running game does not reload disk edits (ADR-0017/0020 session-bound state),
     # so a later `game tree` STILL reports B, not `live_scene_not_found`.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
     b_scene = tmp_path / "B.tscn"
     b_scene.write_text(B_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         assert run("daemon", "start", "--scene", "res://B.tscn").returncode == 0
@@ -1244,10 +1149,10 @@ def test_daemon_serves_live_ops_while_scenetree_paused(tmp_path, daemon_runtime_
     # everywhere a daemon e2e runs — including CI's display-less godot-e2e job; the
     # `screen capture` leg needs a real DisplayServer and lives in the windowed-gated
     # test below instead.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(PAUSE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(PAUSE_PLAYER_GD, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     def ticker_ticks() -> int:
         got = run("game", "get", "/root/Main/Ticker", "--property", "ticks")
@@ -1331,10 +1236,10 @@ def test_daemon_serves_screen_capture_while_scenetree_paused(
 
     require_windowed_host()
 
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(PAUSE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(PAUSE_PLAYER_GD, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ}, timeout=120)
+    run = Gda(tmp_path, json_output=True, timeout=120)
 
     def ticker_ticks() -> int:
         got = run("game", "get", "/root/Main/Ticker", "--property", "ticks")

--- a/tests/test_e2e_diag.py
+++ b/tests/test_e2e_diag.py
@@ -20,17 +20,13 @@ serially in review.
 
 import json
 import os
-import subprocess
 import time
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
+from tests.support import Gda
 
-from .conftest import project_godot
-
-GODOT = resolve_godot_binary()
+from .conftest import LIVE_PROJECT_GODOT, SCRIPTED_MAIN_TSCN
 
 # A main scene whose root script emits a KNOWN runtime error and a KNOWN print
 # line at `_ready`, so the daemon's Session log captures both for `diag` to read
@@ -43,14 +39,6 @@ func _ready() -> void:
 	print("known line")
 	push_error("known error")
 """
-
-MAIN_TSCN = (
-    "[gd_scene load_steps=2 format=3]\n\n"
-    '[ext_resource type="Script" path="res://main.gd" id="1"]\n\n'
-    '[node name="Main" type="Node2D"]\n'
-    'script = ExtResource("1")\n'
-)
-PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
 
 # A main scene whose `_ready` calls a chain a() -> b() that triggers a runtime
 # GDScript error (calling a method on a null), so the engine emits a `GDScript
@@ -77,28 +65,11 @@ pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"
 def test_diag_reads_back_a_known_runtime_error_and_log_line(
     tmp_path, daemon_runtime_dir
 ):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(SCRIPTED_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "main.gd").write_text(MAIN_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     # Correct lifecycle (ADR-0022): `gda diag` OBSERVES an already-launched session
     # — it does NOT create one. So the session must be launched by a NON-diagnostic
@@ -152,28 +123,11 @@ def test_diag_reads_back_a_multi_frame_callstack(tmp_path, daemon_runtime_dir):
     # — not just the top `file:line`. Same lifecycle as the sibling test: a
     # NON-diag live op (`game tree`) launches + warms the session, THEN diag
     # observes the daemon-owned Session log.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(SCRIPTED_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "main.gd").write_text(CALLSTACK_MAIN_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     def poll_errors(needle, timeout=15.0):
         deadline = time.monotonic() + timeout

--- a/tests/test_e2e_export.py
+++ b/tests/test_e2e_export.py
@@ -13,14 +13,10 @@ not a fixed value.
 """
 
 import json
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
+from tests.support import Gda
 
 # Two presets in the canonical format Godot writes export_presets.cfg: a
 # runnable Linux preset and a non-runnable Web preset, each with its sibling
@@ -64,38 +60,11 @@ def _expected_templates_version() -> str:
     re-adding the ``.0`` patch — fail RED here, instead of silently making the
     template-gate e2e skip (templates_installed would go False on a .0 engine).
     """
-    info = subprocess.run(
-        [*GDA_CMD, "info", "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-    )
-    assert info.returncode == 0, info.stdout + info.stderr
-    v = json.loads(info.stdout)
+    v = Gda().json("info")
     base = f"{v['major']}.{v['minor']}"
     if v["patch"]:
         base += f".{v['patch']}"
     return f"{base}.{v['status']}"
-
-
-def _gda_project(project):
-    """A ``gda`` bound to ``--project`` for res:// resolution of the cfg."""
-
-    def gda(*args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-            capture_output=True,
-            text=True,
-        )
-
-    return gda
-
-
-def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
-    assert proc.returncode == 4, proc.stdout + proc.stderr
-    err = json.loads(proc.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == code
-    return err
 
 
 @pytest.mark.e2e
@@ -106,7 +75,7 @@ def test_export_list_enumerates_presets_from_export_presets_cfg(godot_project):
     (godot_project / "export_presets.cfg").write_text(
         EXPORT_PRESETS_CFG, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     listed = gda("export", "list", "--json")
 
@@ -126,7 +95,7 @@ def test_export_list_empty_cfg_is_an_empty_listing(godot_project):
     # An export_presets.cfg that defines no presets is a valid, empty listing —
     # not an error (distinct from no cfg at all).
     (godot_project / "export_presets.cfg").write_text("", encoding="utf-8")
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     listed = gda("export", "list", "--json")
 
@@ -140,11 +109,9 @@ def test_export_list_no_cfg_yields_export_presets_not_found(godot_project):
     # export list refuses with the structured export_presets_not_found code rather
     # than a misleading empty listing, so an agent knows the project defines no
     # presets.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
-    listed = gda("export", "list", "--json")
-
-    err = _assert_operation_error(listed, "export_presets_not_found")
+    err = gda.error("export", "list", "--json", code="export_presets_not_found")
     assert "export_presets.cfg" in err["message"]
 
 
@@ -153,14 +120,9 @@ def test_export_list_without_project_yields_project_not_found(tmp_path):
     # export list reads export_presets.cfg in a project, so it cannot run
     # projectless: run from a non-project directory with no --project, it refuses
     # with project_not_found rather than returning a misleading empty listing.
-    listed = subprocess.run(
-        [*GDA_CMD, "export", "list", "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-        cwd=str(tmp_path),
+    err = Gda().error(
+        "export", "list", "--json", cwd=tmp_path, code="project_not_found"
     )
-
-    err = _assert_operation_error(listed, "project_not_found")
     assert "--project" in err["message"]
 
 
@@ -173,7 +135,7 @@ def test_export_get_reports_preset_details_and_template_status(godot_project):
     (godot_project / "export_presets.cfg").write_text(
         EXPORT_PRESETS_CFG, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     got = gda("export", "get", "--preset", "Web", "--json")
 
@@ -200,7 +162,7 @@ def test_export_get_reports_export_path_of_a_preset_with_one(godot_project):
     (godot_project / "export_presets.cfg").write_text(
         EXPORT_PRESETS_CFG, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     got = gda("export", "get", "--preset", "Linux/X11", "--json")
 
@@ -218,11 +180,11 @@ def test_export_get_unknown_preset_yields_export_preset_not_found(godot_project)
     (godot_project / "export_presets.cfg").write_text(
         EXPORT_PRESETS_CFG, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
-    got = gda("export", "get", "--preset", "Nope", "--json")
-
-    err = _assert_operation_error(got, "export_preset_not_found")
+    err = gda.error(
+        "export", "get", "--preset", "Nope", "--json", code="export_preset_not_found"
+    )
     assert "Nope" in err["message"]
 
 
@@ -230,9 +192,9 @@ def test_export_get_unknown_preset_yields_export_preset_not_found(godot_project)
 def test_export_get_no_cfg_yields_export_presets_not_found(godot_project):
     # export get over a project with no export_presets.cfg reports the same
     # export_presets_not_found mode as export list — there is nothing to address.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
-    got = gda("export", "get", "--preset", "Web", "--json")
-
-    err = _assert_operation_error(got, "export_presets_not_found")
+    err = gda.error(
+        "export", "get", "--preset", "Web", "--json", code="export_presets_not_found"
+    )
     assert "export_presets.cfg" in err["message"]

--- a/tests/test_e2e_export_run.py
+++ b/tests/test_e2e_export_run.py
@@ -30,23 +30,19 @@ unconditionally.
 
 import json
 import os
-import subprocess
 import sys
 import zipfile
 from pathlib import Path
 
 import pytest
 
-from gda.binary import resolve_godot_binary
 from gda.harness.install import (
     HARNESS_AUTOLOAD_NAME,
     HARNESS_FILE,
     HARNESS_RES_DIR,
     install_harness,
 )
-from tests.support import GDA_CMD, templates_installed
-
-GODOT = resolve_godot_binary()
+from tests.support import Gda, templates_installed
 
 # A runnable Linux preset writing to build/game.x86_64, plus a non-runnable
 # preset with NO export_path (to exercise export_path_unset). Sibling `.options`
@@ -84,19 +80,6 @@ binary_format/embed_pck=false
 """
 
 
-def _gda_project(project):
-    """A ``gda`` bound to ``--godot`` + ``--project`` for the real engine."""
-
-    def gda(*args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-            capture_output=True,
-            text=True,
-        )
-
-    return gda
-
-
 @pytest.mark.e2e
 def test_export_run_unknown_preset_reuses_export_get_error(godot_project):
     # export run resolves the preset via export get first, so an unknown preset is
@@ -105,7 +88,7 @@ def test_export_run_unknown_preset_reuses_export_get_error(godot_project):
     (godot_project / "export_presets.cfg").write_text(
         EXPORT_PRESETS_CFG, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     run = gda("export", "run", "--preset", "Nope", "--json")
 
@@ -123,7 +106,7 @@ def test_export_run_unset_path_yields_export_path_unset(godot_project):
     (godot_project / "export_presets.cfg").write_text(
         EXPORT_PRESETS_CFG, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     run = gda("export", "run", "--preset", "NoPath", "--json")
 
@@ -158,7 +141,7 @@ def test_export_run_writes_to_configured_export_path(godot_project):
     )
     configured_rel = "build/game.x86_64"
     artifact = godot_project / configured_rel
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     run = gda("export", "run", "--preset", "Linux/X11", "--json")
 
@@ -211,7 +194,7 @@ def test_export_run_pack_writes_pck_without_templates(godot_project):
     )
     artifact = godot_project / "dist" / "packed.pck"
     configured = godot_project / "build/game.x86_64"
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     run = gda(
         "export",
@@ -257,26 +240,17 @@ def test_export_run_pack_accepts_a_relative_project(godot_project):
 
     # Drive gda from the project's PARENT with a RELATIVE --project (the failing
     # case) — NOT the absolute path _gda_project passes.
-    run = subprocess.run(
-        [
-            *GDA_CMD,
-            "export",
-            "run",
-            "--preset",
-            "Linux/X11",
-            "--mode",
-            "pack",
-            "--output",
-            str(artifact),
-            "--json",
-            "--godot",
-            str(GODOT),
-            "--project",
-            godot_project.name,  # RELATIVE; resolved against the cwd below
-        ],
-        capture_output=True,
-        text=True,
-        cwd=str(godot_project.parent),
+    run = Gda(godot_project.name)(  # RELATIVE project; resolved against the cwd
+        "export",
+        "run",
+        "--preset",
+        "Linux/X11",
+        "--mode",
+        "pack",
+        "--output",
+        str(artifact),
+        "--json",
+        cwd=godot_project.parent,
     )
 
     # No skip: pack must RUN to completion regardless of template presence. Before
@@ -314,7 +288,7 @@ def test_export_run_pack_omits_installed_harness_and_restores_it(godot_project):
     assert HARNESS_AUTOLOAD_NAME in project_godot.read_text(encoding="utf-8")
 
     artifact = godot_project / "dist" / "packed.zip"
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     run = gda(
         "export",
@@ -380,22 +354,13 @@ def test_export_run_without_templates_yields_export_templates_missing(
     empty_data = tmp_path / "empty-xdg"
     empty_data.mkdir()
 
-    run = subprocess.run(
-        [
-            *GDA_CMD,
-            "export",
-            "run",
-            "--preset",
-            "Linux/X11",
-            "--json",
-            "--godot",
-            str(GODOT),
-            "--project",
-            str(godot_project),
-        ],
-        capture_output=True,
-        text=True,
-        env={**os.environ, "XDG_DATA_HOME": str(empty_data)},
+    run = Gda(godot_project)(
+        "export",
+        "run",
+        "--preset",
+        "Linux/X11",
+        "--json",
+        extra_env={"XDG_DATA_HOME": str(empty_data)},
     )
 
     assert run.returncode == 4, run.stdout + run.stderr
@@ -444,7 +409,7 @@ def test_templates_installed_is_true_when_host_templates_are_on_disk(godot_proje
     (godot_project / "export_presets.cfg").write_text(
         EXPORT_PRESETS_CFG, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     # templates_installed is preset-independent (it only checks the version dir
     # exists), so any real preset works; the on-disk check above is the source of truth.

--- a/tests/test_e2e_export_run.py
+++ b/tests/test_e2e_export_run.py
@@ -239,7 +239,7 @@ def test_export_run_pack_accepts_a_relative_project(godot_project):
     artifact = godot_project / "dist" / "packed.pck"
 
     # Drive gda from the project's PARENT with a RELATIVE --project (the failing
-    # case) — NOT the absolute path _gda_project passes.
+    # case) — NOT the absolute path a project-bound invoker passes.
     run = Gda(godot_project.name)(  # RELATIVE project; resolved against the cwd
         "export",
         "run",

--- a/tests/test_e2e_game.py
+++ b/tests/test_e2e_game.py
@@ -9,45 +9,14 @@ RULES.md DoD the fake-runner command tests do not count toward this gate.
 """
 
 import json
-import os
-import subprocess
 import time
 
 import pytest
 
 from gda.exit_codes import EXIT_LIVE
+from tests.support import Gda
 
-from tests.support import GDA_CMD
-
-
-def _gda_runner(project, timeout: int = 90):
-    """One project/Godot-aware `gda` invoker for this module's live e2es (#749 review).
-
-    The protocol arguments, environment and timeout were repeated per test and
-    could drift; this is the single place they live.
-    """
-    from gda.binary import resolve_godot_binary
-
-    godot = resolve_godot_binary()
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(project),
-                "--godot",
-                str(godot),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env={**os.environ},
-            timeout=timeout,
-        )
-
-    return run
+from .conftest import LIVE_PROJECT_GODOT
 
 
 @pytest.mark.e2e
@@ -55,12 +24,8 @@ def test_game_tree_without_a_daemon_reports_daemon_not_running(tmp_path):
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
 
     # An empty runtime dir so discovery finds no daemon for this fresh project.
-    env = {**os.environ, "XDG_RUNTIME_DIR": str(tmp_path / "run")}
-    proc = subprocess.run(
-        [*GDA_CMD, "game", "tree", "--project", str(tmp_path), "--json"],
-        capture_output=True,
-        text=True,
-        env=env,
+    proc = Gda(tmp_path, godot=None)(
+        "game", "tree", "--json", extra_env={"XDG_RUNTIME_DIR": str(tmp_path / "run")}
     )
 
     assert proc.returncode == EXIT_LIVE, proc.stdout + proc.stderr
@@ -106,15 +71,11 @@ def test_game_get_projects_a_path_less_texture_with_optional_digest(
     # under object_string, NO resource_path key — with digest null by default;
     # with --texture-digest, two same-class textures with different content
     # get different digests and same-content textures the same one.
-    from .conftest import project_godot
-
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(TEXTURE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(TEXTURE_PLAYER_GD, encoding="utf-8")
 
-    run = _gda_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True)
 
     def texture_value(prop, *extra):
         got = run("game", "get", "/root/Main/Player", "--property", prop, *extra)
@@ -285,17 +246,13 @@ CALL_MAIN_TSCN = (
 def test_game_call_serves_declared_methods_and_refuses_the_rest(
     tmp_path, daemon_runtime_dir
 ):
-    from .conftest import project_godot
-
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(CALL_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "call_base.gd").write_text(CALL_BASE_GD, encoding="utf-8")
     (tmp_path / "call_child.gd").write_text(CALL_CHILD_GD, encoding="utf-8")
     (tmp_path / "call_main.gd").write_text(CALL_MAIN_GD, encoding="utf-8")
 
-    run = _gda_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True)
 
     def call(node, method, *extra):
         return run("game", "call", node, "--method", method, *extra)
@@ -383,11 +340,7 @@ def test_declaring_gda_callable_in_both_base_and_subclass_is_an_engine_parse_err
     # GDScript forbids redeclaring a base class's constant, so an opted-in chain
     # has at most one declaration owner. The failure is loud — the script does
     # not load — never a silently wrong allowlist.
-    from .conftest import project_godot
-
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "call_base.gd").write_text(CALL_BASE_GD, encoding="utf-8")
     (tmp_path / "call_main.gd").write_text(
         'extends "res://call_base.gd"\n\n'
@@ -404,7 +357,7 @@ def test_declaring_gda_callable_in_both_base_and_subclass_is_an_engine_parse_err
         encoding="utf-8",
     )
 
-    run = _gda_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True)
 
     try:
         assert run("daemon", "start").returncode == 0
@@ -434,17 +387,13 @@ def test_game_call_refuses_arguments_the_engine_would_not_convert(
     # (and polluting the Session log). Every refusal below was a false success at
     # the reviewed head; every acceptance below is a conversion the engine really
     # performs, so the gate mirrors the engine rather than over-refusing.
-    from .conftest import project_godot
-
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(CALL_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "call_base.gd").write_text(CALL_BASE_GD, encoding="utf-8")
     (tmp_path / "call_child.gd").write_text(CALL_CHILD_GD, encoding="utf-8")
     (tmp_path / "call_main.gd").write_text(CALL_MAIN_GD, encoding="utf-8")
 
-    run = _gda_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True)
 
     def call(method, args):
         return run("game", "call", "/root/Main", "--method", method, "--args", args)
@@ -496,17 +445,13 @@ def test_game_call_non_finite_args_never_reach_the_session(
     # the daemon retired the channel — the NEXT call relaunched the session and
     # its runtime state was gone. The refusal now happens in the params model,
     # before the wire: fast, typed, and the session identity is untouched.
-    from .conftest import project_godot
-
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(CALL_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "call_base.gd").write_text(CALL_BASE_GD, encoding="utf-8")
     (tmp_path / "call_child.gd").write_text(CALL_CHILD_GD, encoding="utf-8")
     (tmp_path / "call_main.gd").write_text(CALL_MAIN_GD, encoding="utf-8")
 
-    run = _gda_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True)
 
     try:
         assert run("daemon", "start").returncode == 0
@@ -566,17 +511,13 @@ def test_game_call_argument_gate_agrees_with_the_engine(tmp_path, daemon_runtime
     # oracle is the engine itself: `probe_direct` performs the call inside the
     # game and reports whether the method body RAN. gda must call exactly when
     # the engine would, so the table can never drift silently again.
-    from .conftest import project_godot
-
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(CALL_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "call_base.gd").write_text(CALL_BASE_GD, encoding="utf-8")
     (tmp_path / "call_child.gd").write_text(CALL_CHILD_GD, encoding="utf-8")
     (tmp_path / "call_main.gd").write_text(CALL_MAIN_GD, encoding="utf-8")
 
-    run = _gda_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True)
 
     # (method, JSON arguments) pairs spanning every retained live source-to-target
     # conversion edge, plus identity and refusal boundaries. Empty Arrays isolate
@@ -672,17 +613,14 @@ def test_game_call_refuses_integers_the_wire_cannot_carry(tmp_path, daemon_runti
     # to …984 instead of …986; 1.2e29 arrived as -2). The bound is now refused at
     # the input boundary; the largest exact value still goes through unchanged.
     from gda.commands.game import MAX_EXACT_JSON_INT
-    from .conftest import project_godot
 
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(CALL_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "call_base.gd").write_text(CALL_BASE_GD, encoding="utf-8")
     (tmp_path / "call_child.gd").write_text(CALL_CHILD_GD, encoding="utf-8")
     (tmp_path / "call_main.gd").write_text(CALL_MAIN_GD, encoding="utf-8")
 
-    run = _gda_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True)
 
     try:
         assert run("daemon", "start").returncode == 0
@@ -749,17 +687,13 @@ def test_game_call_refuses_integers_the_wire_cannot_carry(tmp_path, daemon_runti
 @pytest.mark.e2e
 def test_game_call_preserves_large_finite_float_arguments(tmp_path, daemon_runtime_dir):
     """The live wire preserves high-range finite binary64 arguments."""
-    from .conftest import project_godot
-
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(CALL_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "call_base.gd").write_text(CALL_BASE_GD, encoding="utf-8")
     (tmp_path / "call_child.gd").write_text(CALL_CHILD_GD, encoding="utf-8")
     (tmp_path / "call_main.gd").write_text(CALL_MAIN_GD, encoding="utf-8")
 
-    run = _gda_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True)
 
     try:
         assert run("daemon", "start").returncode == 0

--- a/tests/test_e2e_harness_install.py
+++ b/tests/test_e2e_harness_install.py
@@ -39,7 +39,6 @@ from typing import NamedTuple
 
 import pytest
 
-from gda.binary import resolve_godot_binary
 from gda.daemon.protocol import read_frame
 from gda.harness.install import (
     HARNESS_AUTOLOAD_NAME,
@@ -48,16 +47,13 @@ from gda.harness.install import (
     install_harness,
 )
 
-from tests.support import GDA_CMD, templates_installed
+from tests.support import GODOT, Gda, templates_installed
 
-from .conftest import project_godot
-
-GODOT = resolve_godot_binary()
+from .conftest import LIVE_PROJECT_GODOT, project_godot
 
 # A trivial main scene so a normal (non-`--script`) boot runs the autoload's
 # `_ready`; file logging stays disabled via project_godot (issue #180).
 MAIN_TSCN = '[gd_scene format=3]\n\n[node name="Main" type="Node"]\n'
-PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
 
 # The harness only connects when a `gda-daemon` marker is present in the user args
 # (StreamPeerUDS.connect_to_host). An inert boot opens nothing, so none of these
@@ -79,7 +75,7 @@ def _assert_inert_boot(out: str, returncode: int) -> None:
 
 @pytest.mark.e2e
 def test_installed_harness_boots_inert_in_a_real_engine(tmp_path):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
 
     result = install_harness(tmp_path)
@@ -110,7 +106,7 @@ def test_exported_pck_with_harness_runs_inert(tmp_path):
     # harness is genuinely IN the pack, then RUN that .pck with no `gda-daemon`
     # marker — the packed GdaHarness autoload must boot clean and open nothing (the
     # exact failure ADR-0018 guards: a dangling/active autoload in an exported game).
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
     install_harness(tmp_path)
 
@@ -368,14 +364,7 @@ def test_template_feature_gates_the_harness_only_in_exported_builds(
     (tmp_path / "export_presets.cfg").write_text(target.presets_cfg, encoding="utf-8")
     install_harness(tmp_path)
 
-    def gda(*args):  # bound `gda export get` for the templates-presence gate
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(tmp_path)],
-            capture_output=True,
-            text=True,
-        )
-
-    if not templates_installed(gda, preset=target.preset):
+    if not templates_installed(Gda(tmp_path), preset=target.preset):
         pytest.skip(
             f"export templates for the running engine + {target.preset!r} are not "
             "installed; the template-gate BEHAVIOURAL proof cannot export a template "
@@ -481,15 +470,10 @@ def test_daemon_install_leaves_a_project_a_real_engine_boots_inert(tmp_path):
     # same way the fast install tests' does — the autoload loads, and stays inert with
     # no daemon marker. Driven through a REAL `gda` subprocess (no daemon involved),
     # so the recipe, the JSON receipt and the engine's verdict are all exercised.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
 
-    installed = subprocess.run(
-        [*GDA_CMD, "daemon", "install", "--project", str(tmp_path), "--json"],
-        capture_output=True,
-        text=True,
-        timeout=60,
-    )
+    installed = Gda(tmp_path, godot=None, timeout=60)("daemon", "install", "--json")
 
     assert installed.returncode == 0, installed.stdout + installed.stderr
     receipt = json.loads(installed.stdout)
@@ -510,12 +494,7 @@ def test_daemon_install_leaves_a_project_a_real_engine_boots_inert(tmp_path):
     _assert_inert_boot(proc.stdout + proc.stderr, proc.returncode)
 
     # And `gda daemon uninstall` reverses it, so the pair is symmetric end to end.
-    removed = subprocess.run(
-        [*GDA_CMD, "daemon", "uninstall", "--project", str(tmp_path), "--json"],
-        capture_output=True,
-        text=True,
-        timeout=60,
-    )
+    removed = Gda(tmp_path, godot=None, timeout=60)("daemon", "uninstall", "--json")
     assert removed.returncode == 0, removed.stdout + removed.stderr
     assert json.loads(removed.stdout)["removed"] is True
     assert not (tmp_path / "addons" / "gda_harness").exists()

--- a/tests/test_e2e_headless_number_reads.py
+++ b/tests/test_e2e_headless_number_reads.py
@@ -21,11 +21,8 @@ claims anything about it.
 
 import json
 import math
-import subprocess
 
 import pytest
-
-from gda.binary import resolve_godot_binary
 
 from tests.live_number_corpus import (
     LIVE_NUMBER_CORPUS,
@@ -34,9 +31,7 @@ from tests.live_number_corpus import (
     tally_outcome,
     value_bits,
 )
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
+from tests.support import Gda
 
 # One exported float per corpus row plus the whole corpus as a packed array, so
 # the scalar arm of the value projection and its element-wise arm are both read
@@ -84,33 +79,12 @@ PROBE_TSCN = (
 )
 
 
-def _gda(project):
-    """A bound ``gda <args> --project <p> --godot <g> --json`` runner."""
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(project),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=180,
-        )
-
-    return run
-
-
 def _probe_project(project):
     """Write the probe scene into ``project`` and return its bound runner."""
     (project / "numbers.gd").write_text(_probe_source(), encoding="utf-8")
     (project / "numbers.tscn").write_text(PROBE_TSCN, encoding="utf-8")
-    return _gda(project)
+    # 180s: a read of the whole corpus boots the engine on every row.
+    return Gda(project, json_output=True, timeout=180)
 
 
 def _exports_by_name(run) -> dict:
@@ -221,7 +195,7 @@ def test_a_project_setting_round_trips_through_set_and_get(godot_project):
     from both — while `project.godot` held the value the caller sent. These are the
     two literals #771 quotes, and they are the round-trip the catalog promises.
     """
-    run = _gda(godot_project)
+    run = Gda(godot_project, json_output=True, timeout=180)
     setting = "physics/2d/default_gravity"
 
     for literal, expected in (

--- a/tests/test_e2e_info.py
+++ b/tests/test_e2e_info.py
@@ -7,23 +7,19 @@ supported version (>= 4.4) per ADR-0003.
 """
 
 import json
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
+from tests.support import Gda
 
-GODOT = resolve_godot_binary()
+from .conftest import project_godot
+
+gda = Gda()
 
 
 @pytest.mark.e2e
 def test_gda_info_json_against_real_godot():
-    proc = subprocess.run(
-        [*GDA_CMD, "info", "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-    )
+    proc = gda("info", "--json")
 
     assert proc.returncode == 0, proc.stderr
     # stdout is a single valid JSON object.
@@ -41,11 +37,7 @@ def test_gda_info_missing_binary_yields_structured_error_end_to_end():
     # against a binary that cannot launch. No installed engine required — the
     # point is that the path does NOT exist. The runner synthesizes exit 127,
     # the CLI emits a structured JSON error on stdout.
-    proc = subprocess.run(
-        [*GDA_CMD, "info", "--godot", "/nonexistent/Godot", "--json"],
-        capture_output=True,
-        text=True,
-    )
+    proc = Gda(godot="/nonexistent/Godot")("info", "--json")
 
     assert proc.returncode == 127
     err = json.loads(proc.stdout)["error"]
@@ -62,14 +54,10 @@ def test_gda_info_accepts_a_project_and_still_reports_the_engine(tmp_path):
     # (ADR-0006), not that the flag is parsed and dropped. Against a REAL engine: the
     # version comes back unchanged, so the uniform argv costs nothing.
     (tmp_path / "project.godot").write_text(
-        'config_version=5\n\n[application]\n\nconfig/name="probe"\n', encoding="utf-8"
+        project_godot(name="probe"), encoding="utf-8"
     )
 
-    proc = subprocess.run(
-        [*GDA_CMD, "info", "--project", str(tmp_path), "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-    )
+    proc = Gda(tmp_path)("info", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     data = json.loads(proc.stdout)
@@ -77,22 +65,14 @@ def test_gda_info_accepts_a_project_and_still_reports_the_engine(tmp_path):
 
     # And it is the SAME answer as the projectless probe — the project does not
     # change what `info` reports.
-    projectless = subprocess.run(
-        [*GDA_CMD, "info", "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-    )
+    projectless = gda("info", "--json")
     assert json.loads(projectless.stdout) == data
 
 
 @pytest.mark.e2e
 def test_gda_info_refuses_a_project_that_is_not_one(tmp_path):
     # Validated, not merely accepted — through the real CLI, before any engine runs.
-    proc = subprocess.run(
-        [*GDA_CMD, "info", "--project", str(tmp_path), "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-    )
+    proc = Gda(tmp_path)("info", "--json")
 
     assert proc.returncode == 4, proc.stdout + proc.stderr
     assert json.loads(proc.stdout)["error"]["code"] == "project_not_found"

--- a/tests/test_e2e_input.py
+++ b/tests/test_e2e_input.py
@@ -14,16 +14,12 @@ project_godot (#180).
 
 import json
 import os
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD, assert_windowed_ok
+from tests.support import Gda, assert_windowed_ok
 
-from .conftest import project_godot
-
-GODOT = resolve_godot_binary()
+from .conftest import LIVE_PROJECT_GODOT, project_godot
 
 # A Player whose `_input` moves it right on KEY_RIGHT — so an injected key event
 # rides the game's real input flow into `_input` and mutates `position.x`, observed
@@ -130,7 +126,6 @@ PHYSICS_ACTION_PLAYER_GD = (
     "\t\tposition.x += SPEED * delta\n"
 )
 
-PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
 
 # A project.godot whose [input] section declares `move_right` so the running
 # InputMap has the action `input action move_right` drives (InputMap.has_action).
@@ -230,28 +225,11 @@ def test_daemon_serves_input_key_observed_via_game_get(tmp_path, daemon_runtime_
     # The #221 DoD: a real daemon -> engine session -> `input key Right` pushes a key
     # event into the running game, whose `_input` moves the Player, observed via
     # `game get` — end-to-end through the real harness over UDS (ADR-0020).
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(KEY_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(KEY_PLAYER_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     try:
         assert run("daemon", "start").returncode == 0
@@ -293,28 +271,11 @@ def test_daemon_serves_input_mouse_click_observed_via_game_get(
     # InputEventMouseButton through the real `push_input` viewport path into the
     # running game's `_input`, which snaps the Player to the click position —
     # observed via `game get` (ADR-0020).
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MOUSE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(MOUSE_PLAYER_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     try:
         assert run("daemon", "start").returncode == 0
@@ -355,28 +316,11 @@ def test_mouse_input_reports_event_position_when_tracked_mouse_position_is_stale
     # #462: in the default daemon session, Godot accepts the injected event position
     # but does not expose a reliable seam for updating the engine-tracked mouse
     # position. Pin that limitation so the documented workaround remains true.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(TRACKED_MOUSE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(TRACKED_MOUSE_PLAYER_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     def player_property(name: str):
         got = run("game", "get", "/root/Main/Player", "--property", name)
@@ -422,28 +366,11 @@ def test_input_sequence_drags_mouse_with_held_button_mask(tmp_path, daemon_runti
     # #461: a press -> move(s) -> release gesture stays inside one `input sequence`
     # RPC. The game reads event.position and event.button_mask, not tracked mouse
     # position, because #462 documents the tracked-position limitation.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(DRAG_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(DRAG_PLAYER_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     def player_property(name: str):
         got = run("game", "get", "/root/Main/Player", "--property", name)
@@ -486,24 +413,7 @@ def test_daemon_serves_input_action_observed_via_game_get(tmp_path, daemon_runti
     (tmp_path / "main.tscn").write_text(ACTION_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(ACTION_PLAYER_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     try:
         assert run("daemon", "start").returncode == 0
@@ -549,28 +459,11 @@ def test_add_input_action_makes_the_action_immediately_driveable(
     # action exists only because add-input-action persisted it. Ordering matters:
     # the InputMap loads from project.godot at engine launch, so the headless add
     # runs BEFORE `daemon start`.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(ACTION_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(ACTION_PLAYER_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     # Register the action headlessly FIRST — before any engine session exists.
     added = run("project", "add-input-action", "move_right", "--key", "Right")
@@ -613,28 +506,11 @@ def test_daemon_serves_input_sequence_across_frames(tmp_path, daemon_runtime_dir
     # multi-frame base (#223), returned as ONE blocking result. Three Right presses at
     # frames 0/1/2 each move the Player by 10, so position.x advances by 30 over the
     # window — observed via game get.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(KEY_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(KEY_PLAYER_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     events = json.dumps(
         [
@@ -688,24 +564,7 @@ def test_input_sequence_physics_frame_hold_matches_predicted_displacement(
     (tmp_path / "main.tscn").write_text(ACTION_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(PHYSICS_ACTION_PLAYER_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     hold_frames = 12
     physics_fps = 60
@@ -767,28 +626,11 @@ def test_input_action_unknown_action_reports_live_unknown_action(
 ):
     # An action absent from the running InputMap is the typed harness op-error,
     # relayed through the daemon (exit-0 sentinel) and mapped by classify_live.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(KEY_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(KEY_PLAYER_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     from gda.exit_codes import EXIT_LIVE
 
@@ -803,23 +645,14 @@ def test_input_action_unknown_action_reports_live_unknown_action(
 
 
 def _button_project(tmp_path):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(BUTTON_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "ui.gd").write_text(BUTTON_UI_GD, encoding="utf-8")
 
 
-def _gda_json(tmp_path, env, *args):
-    return subprocess.run(
-        [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
-        capture_output=True,
-        text=True,
-        env=env,
-        timeout=90,
-    )
-
-
-def _property_value(tmp_path, env, node, name):
-    got = _gda_json(tmp_path, env, "game", "get", node, "--property", name)
+def _property_value(gda, node, name):
+    """One property's projected value, read live off the running game."""
+    got = gda("game", "get", node, "--property", name)
     assert got.returncode == 0, got.stdout + got.stderr
     return next(p for p in json.loads(got.stdout)["properties"] if p["name"] == name)[
         "value"
@@ -835,12 +668,12 @@ def test_mouse_click_performs_the_complete_activation_gesture(
     # press that leaves the button held down forever. Repeated clicks keep
     # activating, because each gesture releases what it pressed.
     _button_project(tmp_path)
-    env = {**os.environ}
+    gda = Gda(tmp_path, json_output=True)
 
     try:
-        assert _gda_json(tmp_path, env, "daemon", "start").returncode == 0
+        assert gda("daemon", "start").returncode == 0
 
-        first = _gda_json(tmp_path, env, "input", "mouse-click", "50", "20")
+        first = gda("input", "mouse-click", "50", "20")
         assert first.returncode == 0, first.stdout + first.stderr
         doc = json.loads(first.stdout)
         # The structured gesture evidence: the three phases at their frames.
@@ -851,18 +684,18 @@ def test_mouse_click_performs_the_complete_activation_gesture(
         ]
 
         # The Button observed the COMPLETE activation: down, up, and `pressed`.
-        assert _property_value(tmp_path, env, "/root/Main", "pressed_count") == 1
-        assert _property_value(tmp_path, env, "/root/Main", "down_count") == 1
-        assert _property_value(tmp_path, env, "/root/Main", "up_count") == 1
+        assert _property_value(gda, "/root/Main", "pressed_count") == 1
+        assert _property_value(gda, "/root/Main", "down_count") == 1
+        assert _property_value(gda, "/root/Main", "up_count") == 1
         # The gesture included the initial move (GDA-DF-004's "initial move").
-        assert _property_value(tmp_path, env, "/root/Main", "motion_seen") is True
+        assert _property_value(gda, "/root/Main", "motion_seen") is True
 
-        second = _gda_json(tmp_path, env, "input", "mouse-click", "50", "20")
+        second = gda("input", "mouse-click", "50", "20")
         assert second.returncode == 0, second.stdout + second.stderr
-        assert _property_value(tmp_path, env, "/root/Main", "pressed_count") == 2
-        assert _property_value(tmp_path, env, "/root/Main", "up_count") == 2
+        assert _property_value(gda, "/root/Main", "pressed_count") == 2
+        assert _property_value(gda, "/root/Main", "up_count") == 2
     finally:
-        _gda_json(tmp_path, env, "daemon", "stop")
+        gda("daemon", "stop")
 
 
 @pytest.mark.e2e
@@ -872,23 +705,19 @@ def test_two_clicks_leave_diag_errors_empty(tmp_path, daemon_runtime_dir):
     # EMPTY — not merely free of one known message — so a consumer can use an
     # empty result as clean runtime evidence after a multi-click playtest.
     _button_project(tmp_path)
-    env = {**os.environ}
+    gda = Gda(tmp_path, json_output=True)
 
     try:
-        assert _gda_json(tmp_path, env, "daemon", "start").returncode == 0
+        assert gda("daemon", "start").returncode == 0
 
-        assert (
-            _gda_json(tmp_path, env, "input", "mouse-click", "50", "20").returncode == 0
-        )
-        assert (
-            _gda_json(tmp_path, env, "input", "mouse-click", "50", "20").returncode == 0
-        )
+        assert gda("input", "mouse-click", "50", "20").returncode == 0
+        assert gda("input", "mouse-click", "50", "20").returncode == 0
 
-        diag = _gda_json(tmp_path, env, "diag", "errors")
+        diag = gda("diag", "errors")
         assert diag.returncode == 0, diag.stdout + diag.stderr
         assert json.loads(diag.stdout)["errors"] == []
     finally:
-        _gda_json(tmp_path, env, "daemon", "stop")
+        gda("daemon", "stop")
 
 
 @pytest.mark.e2e
@@ -901,18 +730,18 @@ def test_two_windowed_clicks_leave_diag_errors_empty(tmp_path, daemon_runtime_di
     # (tests.support.require_windowed_host); a capability refusal skips, a
     # confined run fails loudly (#345/#667).
     _button_project(tmp_path)
-    env = {**os.environ}
+    gda = Gda(tmp_path, json_output=True)
 
     try:
-        assert_windowed_ok(_gda_json(tmp_path, env, "daemon", "start", "--windowed"))
+        assert_windowed_ok(gda("daemon", "start", "--windowed"))
 
-        assert_windowed_ok(_gda_json(tmp_path, env, "input", "mouse-click", "50", "20"))
-        assert_windowed_ok(_gda_json(tmp_path, env, "input", "mouse-click", "50", "20"))
+        assert_windowed_ok(gda("input", "mouse-click", "50", "20"))
+        assert_windowed_ok(gda("input", "mouse-click", "50", "20"))
 
-        diag = assert_windowed_ok(_gda_json(tmp_path, env, "diag", "errors"))
+        diag = assert_windowed_ok(gda("diag", "errors"))
         assert json.loads(diag.stdout)["errors"] == []
     finally:
-        _gda_json(tmp_path, env, "daemon", "stop")
+        gda("daemon", "stop")
 
 
 @pytest.mark.e2e
@@ -921,14 +750,12 @@ def test_sequence_mouse_click_event_activates_a_button(tmp_path, daemon_runtime_
     # (#652): the harness pushes the press and the release on the same frame,
     # which fully activates a default Button.
     _button_project(tmp_path)
-    env = {**os.environ}
+    gda = Gda(tmp_path, json_output=True)
 
     try:
-        assert _gda_json(tmp_path, env, "daemon", "start").returncode == 0
+        assert gda("daemon", "start").returncode == 0
 
-        injected = _gda_json(
-            tmp_path,
-            env,
+        injected = gda(
             "input",
             "sequence",
             "--events",
@@ -936,10 +763,10 @@ def test_sequence_mouse_click_event_activates_a_button(tmp_path, daemon_runtime_
         )
         assert injected.returncode == 0, injected.stdout + injected.stderr
 
-        assert _property_value(tmp_path, env, "/root/Main", "pressed_count") == 1
-        assert _property_value(tmp_path, env, "/root/Main", "up_count") == 1
+        assert _property_value(gda, "/root/Main", "pressed_count") == 1
+        assert _property_value(gda, "/root/Main", "up_count") == 1
     finally:
-        _gda_json(tmp_path, env, "daemon", "stop")
+        gda("daemon", "stop")
 
 
 @pytest.mark.e2e
@@ -949,15 +776,15 @@ def test_tap_advances_a_focus_driven_ui_exactly_once_repeatably(
     # The #652 tap DoD (GDA-DF-034): one key tap advances a focus-driven UI
     # exactly ONE step, and does so repeatably — the press and the release land
     # on separate process frames, and only the press navigates.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(FOCUS_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "ui.gd").write_text(FOCUS_UI_GD, encoding="utf-8")
-    env = {**os.environ}
+    gda = Gda(tmp_path, json_output=True)
 
     try:
-        assert _gda_json(tmp_path, env, "daemon", "start").returncode == 0
+        assert gda("daemon", "start").returncode == 0
 
-        first = _gda_json(tmp_path, env, "input", "tap", "--key", "Down")
+        first = gda("input", "tap", "--key", "Down")
         assert first.returncode == 0, first.stdout + first.stderr
         doc = json.loads(first.stdout)
         assert doc["phases"] == [
@@ -968,14 +795,14 @@ def test_tap_advances_a_focus_driven_ui_exactly_once_repeatably(
         assert doc["focus_before"] == "/root/Main/A", doc
         assert doc["focus_after"] == "/root/Main/B", doc
 
-        second = _gda_json(tmp_path, env, "input", "tap", "--key", "Down")
+        second = gda("input", "tap", "--key", "Down")
         assert second.returncode == 0, second.stdout + second.stderr
         doc = json.loads(second.stdout)
         # Repeatably: the next tap advances exactly one more step, B -> C.
         assert doc["focus_before"] == "/root/Main/B", doc
         assert doc["focus_after"] == "/root/Main/C", doc
     finally:
-        _gda_json(tmp_path, env, "daemon", "stop")
+        gda("daemon", "stop")
 
 
 @pytest.mark.e2e
@@ -988,27 +815,27 @@ def test_tap_action_produces_exactly_one_press_and_release_edge(
     (tmp_path / "project.godot").write_text(ACTION_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(ACTION_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(TAP_ACTION_PLAYER_GD, encoding="utf-8")
-    env = {**os.environ}
+    gda = Gda(tmp_path, json_output=True)
 
     try:
-        assert _gda_json(tmp_path, env, "daemon", "start").returncode == 0
+        assert gda("daemon", "start").returncode == 0
 
-        first = _gda_json(tmp_path, env, "input", "tap", "--action", "move_right")
+        first = gda("input", "tap", "--action", "move_right")
         assert first.returncode == 0, first.stdout + first.stderr
         doc = json.loads(first.stdout)
         assert doc["action"] == "move_right"
         assert doc["key"] is None
 
         node = "/root/Main/Player"
-        assert _property_value(tmp_path, env, node, "pressed_edges") == 1
-        assert _property_value(tmp_path, env, node, "released_edges") == 1
+        assert _property_value(gda, node, "pressed_edges") == 1
+        assert _property_value(gda, node, "released_edges") == 1
 
-        second = _gda_json(tmp_path, env, "input", "tap", "--action", "move_right")
+        second = gda("input", "tap", "--action", "move_right")
         assert second.returncode == 0, second.stdout + second.stderr
-        assert _property_value(tmp_path, env, node, "pressed_edges") == 2
-        assert _property_value(tmp_path, env, node, "released_edges") == 2
+        assert _property_value(gda, node, "pressed_edges") == 2
+        assert _property_value(gda, node, "released_edges") == 2
     finally:
-        _gda_json(tmp_path, env, "daemon", "stop")
+        gda("daemon", "stop")
 
 
 @pytest.mark.e2e
@@ -1018,12 +845,12 @@ def test_input_key_without_a_daemon_reports_daemon_not_running(tmp_path):
 
     from gda.exit_codes import EXIT_LIVE
 
-    env = {**os.environ, "XDG_RUNTIME_DIR": str(tmp_path / "run")}
-    proc = subprocess.run(
-        [*GDA_CMD, "input", "key", "Right", "--project", str(tmp_path), "--json"],
-        capture_output=True,
-        text=True,
-        env=env,
+    proc = Gda(tmp_path, godot=None)(
+        "input",
+        "key",
+        "Right",
+        "--json",
+        extra_env={"XDG_RUNTIME_DIR": str(tmp_path / "run")},
     )
 
     assert proc.returncode == EXIT_LIVE, proc.stdout + proc.stderr

--- a/tests/test_e2e_launch_timeout.py
+++ b/tests/test_e2e_launch_timeout.py
@@ -32,21 +32,17 @@ CLI arm would have to spend a real minute or ten. ``resource import`` does expos
 """
 
 import json
-import subprocess
 import time
 from pathlib import Path
 
 import pytest
 
-from gda.binary import resolve_godot_binary
 from gda.commands.export import ExportRunMode, classify_export_run
 from gda.errors import Failure, classify_run
 from gda.export_runner import SubprocessExportRunner
 from gda.models import EngineVersion
 from gda.runner import SubprocessGodotRunner
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
+from tests.support import GODOT, Gda
 
 # The ceiling every arm gives its wedged engine. Long enough for a real Godot to
 # boot and print, short enough that three arms plus gda's terminate grace stay
@@ -221,22 +217,13 @@ def test_a_wedged_import_pass_reports_what_the_engine_printed(tmp_path):
     (project / "icon.png").write_bytes(b"\x89PNG not really an image")
 
     started = time.monotonic()
-    run = subprocess.run(
-        [
-            *GDA_CMD,
-            "resource",
-            "import",
-            "res://icon.png",
-            "--timeout",
-            str(CEILING_SECONDS),
-            "--project",
-            str(project),
-            "--godot",
-            str(GODOT),
-            "--json",
-        ],
-        capture_output=True,
-        text=True,
+    run = Gda(project)(
+        "resource",
+        "import",
+        "res://icon.png",
+        "--timeout",
+        str(CEILING_SECONDS),
+        "--json",
     )
     elapsed = time.monotonic() - started
 

--- a/tests/test_e2e_launch_timeout.py
+++ b/tests/test_e2e_launch_timeout.py
@@ -42,6 +42,7 @@ from gda.errors import Failure, classify_run
 from gda.export_runner import SubprocessExportRunner
 from gda.models import EngineVersion
 from gda.runner import SubprocessGodotRunner
+from tests.conftest import project_godot
 from tests.support import GODOT, Gda
 
 # The ceiling every arm gives its wedged engine. Long enough for a real Godot to
@@ -91,17 +92,12 @@ script="plugin.gd"
 
 def _wedged_project(tmp_path: Path, *, autoload: bool, plugin: bool) -> Path:
     """A project whose engine startup never finishes on the requested path(s)."""
-    sections = [
-        "config_version=5\n\n[application]\n\n",
-        'config/name="t714"\n\n',
-        # The e2e file-logging policy (#180): no launch here writes a shared
-        # user://logs/godot.log, so concurrent runs cannot contend over it.
-        "[debug]\n\nfile_logging/enable_file_logging=false\n"
-        "file_logging/enable_file_logging.pc=false\n\n",
-    ]
+    # Built through the one e2e builder so the file-logging policy (#180) is
+    # inherited, not re-spelled: every launch here boots a real engine.
+    sections = []
     if autoload:
         (tmp_path / "wedge.gd").write_text(BLOCKING_AUTOLOAD_GD, encoding="utf-8")
-        sections.append('[autoload]\n\nWedge="*res://wedge.gd"\n\n')
+        sections.append('[autoload]\n\nWedge="*res://wedge.gd"\n')
     if plugin:
         addon = tmp_path / "addons" / "wedge"
         addon.mkdir(parents=True)
@@ -111,7 +107,9 @@ def _wedged_project(tmp_path: Path, *, autoload: bool, plugin: bool) -> Path:
             "[editor_plugins]\n\n"
             'enabled=PackedStringArray("res://addons/wedge/plugin.cfg")\n'
         )
-    (tmp_path / "project.godot").write_text("".join(sections), encoding="utf-8")
+    (tmp_path / "project.godot").write_text(
+        project_godot(name="t714", extra="\n".join(sections)), encoding="utf-8"
+    )
     return tmp_path
 
 

--- a/tests/test_e2e_live_number_transport.py
+++ b/tests/test_e2e_live_number_transport.py
@@ -20,11 +20,9 @@ flatten must be REFUSED instead of quietly arriving as ``0.0``.
 import json
 import math
 import struct
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
 from gda.live_numbers import wire_flattens_to_zero
 
 from tests.live_number_corpus import (
@@ -35,9 +33,9 @@ from tests.live_number_corpus import (
     tally_outcome,
     value_bits,
 )
-from tests.support import GDA_CMD, panel_text
+from tests.support import Gda, panel_text
 
-GODOT = resolve_godot_binary()
+from .conftest import LIVE_PROJECT_GODOT
 
 _PROBE_BODY = """\
 func _hex(v: float) -> String:
@@ -104,24 +102,7 @@ def _ulp_gap(sent: float, arrived: float) -> int:
 def _engine_rows(project) -> dict[str, tuple[str, str, str]]:
     """Run the probe through `gda script run` and index its lines by value bits."""
     (project / "probe.gd").write_text(_probe_source(), encoding="utf-8")
-    run = subprocess.run(
-        [
-            *GDA_CMD,
-            "script",
-            "run",
-            "res://probe.gd",
-            "--project",
-            str(project),
-            "--godot",
-            str(GODOT),
-            "--json",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=180,
-    )
-    assert run.returncode == 0, run.stdout + run.stderr
-    result = json.loads(run.stdout)
+    result = Gda(project, timeout=180).json("script", "run", "res://probe.gd")
     assert result["exit_status"] == 0, result
 
     rows: dict[str, tuple[str, str, str]] = {}
@@ -237,40 +218,16 @@ NUMBERS_MAIN_TSCN = (
 )
 
 
-def _live_runner(project):
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(project),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
-
-    return run
-
-
 @pytest.mark.e2e
 def test_live_reads_carry_small_and_many_digit_floats_exactly(
     tmp_path, daemon_runtime_dir
 ):
     """`game get` reports the value the running game holds, bit for bit."""
-    from .conftest import project_godot
-
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(NUMBERS_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "numbers_main.gd").write_text(NUMBERS_MAIN_GD, encoding="utf-8")
 
-    run = _live_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     try:
         assert run("daemon", "start").returncode == 0
 
@@ -308,15 +265,11 @@ def test_live_call_refuses_an_argument_the_wire_would_flatten(
     tmp_path, daemon_runtime_dir
 ):
     """A value the parser cannot carry is refused, not silently delivered as 0.0."""
-    from .conftest import project_godot
-
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(NUMBERS_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "numbers_main.gd").write_text(NUMBERS_MAIN_GD, encoding="utf-8")
 
-    run = _live_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     try:
         assert run("daemon", "start").returncode == 0
 
@@ -386,15 +339,11 @@ def test_every_live_ingress_refuses_a_flattening_value_against_a_real_daemon(
     event the same way. Each is driven here through a real daemon and a real
     engine session, so a guard that only existed in a unit test could not pass.
     """
-    from .conftest import project_godot
-
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(NUMBERS_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "numbers_main.gd").write_text(NUMBERS_MAIN_GD, encoding="utf-8")
 
-    run = _live_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     try:
         assert run("daemon", "start").returncode == 0
         before = json.loads(run("daemon", "status").stdout)["session_id"]

--- a/tests/test_e2e_logger.py
+++ b/tests/test_e2e_logger.py
@@ -30,12 +30,9 @@ import time
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
+from tests.support import GODOT, Gda
 
-from .conftest import project_godot
-
-GODOT = resolve_godot_binary()
+from .conftest import LIVE_PROJECT_GODOT, SCRIPTED_MAIN_TSCN
 
 # A main scene whose root script emits a KNOWN print line, a KNOWN warning, and a
 # KNOWN error at `_ready`, so the daemon's Session log captures all three for
@@ -58,14 +55,6 @@ func _ready() -> void:
 	push_error("known error")
 """
 
-MAIN_TSCN = (
-    "[gd_scene load_steps=2 format=3]\n\n"
-    '[ext_resource type="Script" path="res://main.gd" id="1"]\n\n'
-    '[node name="Main" type="Node2D"]\n'
-    'script = ExtResource("1")\n'
-)
-PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
-
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
 
@@ -73,28 +62,11 @@ pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"
 def test_logger_tail_reads_back_structured_records_and_raw_lines(
     tmp_path, daemon_runtime_dir
 ):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(SCRIPTED_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "main.gd").write_text(MAIN_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     def poll_records(extra_args, needle, timeout=15.0):
         # The session is already launched + warmed by `game tree`; this short poll
@@ -218,8 +190,8 @@ def test_gda_log_is_inert_outside_a_daemon_launched_session(tmp_path):
     # calls GdaHarness.gda_log(...), and assert the sentinel is absent.
     from gda.harness.install import install_harness
 
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(SCRIPTED_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "main.gd").write_text(PLAIN_MAIN_GD, encoding="utf-8")
     install_harness(
         tmp_path

--- a/tests/test_e2e_mcp_live.py
+++ b/tests/test_e2e_mcp_live.py
@@ -34,32 +34,21 @@ import anyio
 import pytest
 from mcp import Client
 
-from gda.binary import GODOT_BIN_ENV, resolve_godot_binary
+from gda.binary import GODOT_BIN_ENV
 from gda.mcp.project_context import GDA_PROJECT_ENV
 from gda.mcp.runner import SubprocessGdaRunner
 from gda.mcp.server import build_server
+from tests.support import GODOT
 
-from .conftest import project_godot
+from .conftest import LIVE_MAIN_TSCN, LIVE_PROJECT_GODOT
 from .mcp_support import tool_text
-
-GODOT = resolve_godot_binary()
-
-# Reuse test_e2e_daemon's scaffold: a main scene so the launched session has a
-# runtime SceneTree to read; a Player child mirrors the daemon e2e fixture. File
-# logging stays disabled via project_godot (issue #180).
-MAIN_TSCN = (
-    "[gd_scene format=3]\n\n"
-    '[node name="Main" type="Node2D"]\n\n'
-    '[node name="Player" type="Node2D" parent="."]\n'
-)
-PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
 
 def _scaffold_project(tmp_path):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
 
 
 def _pin_env(monkeypatch, project):

--- a/tests/test_e2e_mcp_project_context.py
+++ b/tests/test_e2e_mcp_project_context.py
@@ -20,11 +20,10 @@ from mcp import Client
 from mcp.types import ListRootsResult, Root
 from pydantic import FileUrl
 
-from gda.binary import GODOT_BIN_ENV, resolve_godot_binary
+from gda.binary import GODOT_BIN_ENV
 from gda.mcp.runner import SubprocessGdaRunner
 from gda.mcp.server import build_server
-
-GODOT = resolve_godot_binary()
+from tests.support import GODOT
 
 
 def _call_tool(server, name, arguments, *, roots=None):

--- a/tests/test_e2e_mcp_stdio.py
+++ b/tests/test_e2e_mcp_stdio.py
@@ -22,9 +22,8 @@ import pytest
 from mcp import Client, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
-from gda.binary import GODOT_BIN_ENV, resolve_godot_binary
-
-GODOT = resolve_godot_binary()
+from gda.binary import GODOT_BIN_ENV
+from tests.support import GODOT
 
 
 def _server_params() -> StdioServerParameters:

--- a/tests/test_e2e_mcp_tracer.py
+++ b/tests/test_e2e_mcp_tracer.py
@@ -12,11 +12,10 @@ import anyio
 import pytest
 from mcp import Client
 
-from gda.binary import GODOT_BIN_ENV, resolve_godot_binary
+from gda.binary import GODOT_BIN_ENV
 from gda.mcp.runner import SubprocessGdaRunner
 from gda.mcp.server import build_server
-
-GODOT = resolve_godot_binary()
+from tests.support import GODOT
 
 
 @pytest.mark.e2e

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -7,50 +7,13 @@ verification of ``node add``'s effect.
 """
 
 import json
-import os
 import re
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
+from tests.support import Gda, import_project
 
-GODOT = resolve_godot_binary()
-
-
-def _gda(*args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT)], capture_output=True, text=True
-    )
-
-
-def _gda_env(extra_env: dict, *args: str) -> subprocess.CompletedProcess:
-    """``_gda`` with extra env vars in the child's environment.
-
-    The CLI passes no ``env=`` to its Godot subprocess, so the engine inherits
-    this environment — the channel the production-inert
-    ``GDA_TEST_PERTURB_BEFORE_SAVE`` test seam rides on (issue #226).
-    """
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-        env={**os.environ, **extra_env},
-    )
-
-
-def _gda_project(project):
-    """``gda`` bound to ``--project`` so ``res://`` ext_resources resolve."""
-
-    def gda(*args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-            capture_output=True,
-            text=True,
-        )
-
-    return gda
+gda = Gda()
 
 
 def _no_gda_temp_siblings(project) -> bool:
@@ -59,14 +22,12 @@ def _no_gda_temp_siblings(project) -> bool:
 
 
 def _create_scene(scene_path) -> None:
-    created = _gda(
-        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
-    )
+    created = gda("scene", "create", str(scene_path), "--root-type", "Node2D", "--json")
     assert created.returncode == 0, created.stdout + created.stderr
 
 
 def _root_children(scene_path) -> list[dict]:
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
     assert listed.returncode == 0, listed.stdout + listed.stderr
     return json.loads(listed.stdout)["root"]["children"]
 
@@ -80,7 +41,7 @@ def test_node_add_then_list_round_trip(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(scene_path),
@@ -99,7 +60,7 @@ def test_node_add_then_list_round_trip(godot_project):
     assert data["name"] == "Hero"
     assert data["type"] == "Sprite2D"
 
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
 
     assert listed.returncode == 0, listed.stdout + listed.stderr
     tree = json.loads(listed.stdout)
@@ -119,7 +80,7 @@ def test_node_add_index_inserts_at_zero_based_sibling_position(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     for name in ("HP", "MP", "EXP"):
-        added = _gda(
+        added = gda(
             "node",
             "add",
             str(scene_path),
@@ -131,7 +92,7 @@ def test_node_add_index_inserts_at_zero_based_sibling_position(godot_project):
         )
         assert added.returncode == 0, added.stdout + added.stderr
 
-    inserted = _gda(
+    inserted = gda(
         "node",
         "add",
         str(scene_path),
@@ -158,7 +119,7 @@ def test_node_add_under_nested_parent_path(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    first = _gda(
+    first = gda(
         "node",
         "add",
         str(scene_path),
@@ -170,7 +131,7 @@ def test_node_add_under_nested_parent_path(godot_project):
     )
     assert first.returncode == 0, first.stdout + first.stderr
 
-    second = _gda(
+    second = gda(
         "node",
         "add",
         str(scene_path),
@@ -188,7 +149,7 @@ def test_node_add_under_nested_parent_path(godot_project):
     assert data["path"] == "Hero/Hitbox"
     assert data["type"] == "Area2D"
 
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
 
     assert listed.returncode == 0, listed.stdout + listed.stderr
     hero = json.loads(listed.stdout)["root"]["children"][0]
@@ -205,7 +166,7 @@ def test_node_add_preserves_existing_ext_resource_ids_on_scene_repack(godot_proj
     # string helper: node add exercises the shared _load_for_mutation ->
     # _repack_and_save tail, then script attach proves a newly introduced resource
     # still receives a fresh non-colliding id.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     scene_path = godot_project / "main.tscn"
     (godot_project / "hero.gd").write_text("extends Node2D\n", encoding="utf-8")
     (godot_project / "enemy.gd").write_text("extends Node2D\n", encoding="utf-8")
@@ -282,7 +243,7 @@ def test_node_add_preserves_first_id_when_duplicate_ext_resource_path_is_canonic
     # ResourceSaver canonicalizes duplicate ext_resources for the same path down to
     # one entry. gda should keep the first old id for that canonical path instead of
     # accepting a new random id.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     scene_path = godot_project / "main.tscn"
     (godot_project / "hero.gd").write_text("extends Node2D\n", encoding="utf-8")
     scene_path.write_text(
@@ -327,7 +288,7 @@ def test_node_add_default_name_is_the_type_name(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    added = _gda("node", "add", str(scene_path), "--type", "Sprite2D", "--json")
+    added = gda("node", "add", str(scene_path), "--type", "Sprite2D", "--json")
 
     assert added.returncode == 0, added.stdout + added.stderr
     data = json.loads(added.stdout)
@@ -346,7 +307,7 @@ def test_node_add_builtin_type_reports_null_script_class(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(scene_path),
@@ -370,7 +331,7 @@ def test_node_add_instance_preserves_existing_ext_resource_ids(godot_project):
     # pre-existing ext_resource id (and the ExtResource("...") references
     # pointing at them) byte-identical, while the newly introduced PackedScene
     # ext_resource receives a fresh non-colliding id.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     (godot_project / "hero.gd").write_text("extends Node2D\n", encoding="utf-8")
     (godot_project / "hud.tscn").write_text(
         "\n".join(
@@ -422,7 +383,7 @@ def test_node_add_instance_composes_a_scene_and_round_trips(godot_project):
     # instance=ExtResource(...) node entry, exactly what the editor writes),
     # and the composed scene must LOAD: node get instantiates the host, so it
     # proves the engine resolves the instanced child to its real root class.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     (godot_project / "hud.tscn").write_text(
         "\n".join(
             [
@@ -511,30 +472,26 @@ def test_node_add_instance_composes_a_scene_and_round_trips(godot_project):
     assert _no_gda_temp_siblings(godot_project)
 
 
-def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
-    assert proc.returncode == 4, proc.stdout + proc.stderr
-    err = json.loads(proc.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == code
-    return err
-
-
 @pytest.mark.e2e
 def test_node_add_instance_missing_scene_yields_missing_dependency(godot_project):
     # The #392/#396 dependency precedent applied to composition (#399): a
     # missing instanced-scene path is a structured missing_dependency naming
     # the path — never a silent or prose-only failure — and the host file
     # stays untouched.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    added = gda(
-        "node", "add", "res://main.tscn", "--instance", "res://ghost.tscn", "--json"
+    err = gda.error(
+        "node",
+        "add",
+        "res://main.tscn",
+        "--instance",
+        "res://ghost.tscn",
+        "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(added, "missing_dependency")
     assert "res://ghost.tscn" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -548,7 +505,7 @@ def test_node_add_instance_with_broken_dependency_yields_missing_dependency(
     # scene) is a dependency-shaped failure, not a "wrong kind of file" one:
     # missing_dependency naming the instance path the caller passed (engine
     # diagnostics name the nested culprit), never not_a_scene.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     (godot_project / "hud.tscn").write_text(
         "\n".join(
             [
@@ -568,11 +525,15 @@ def test_node_add_instance_with_broken_dependency_yields_missing_dependency(
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    added = gda(
-        "node", "add", "res://main.tscn", "--instance", "res://hud.tscn", "--json"
+    err = gda.error(
+        "node",
+        "add",
+        "res://main.tscn",
+        "--instance",
+        "res://hud.tscn",
+        "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(added, "missing_dependency")
     assert "res://hud.tscn" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -582,17 +543,21 @@ def test_node_add_instance_non_scene_file_yields_not_a_scene(godot_project):
     # --instance must reference a PackedScene: a file that exists but loads as
     # something else (a script here) is refused with not_a_scene, naming the
     # offending path.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     (godot_project / "hero.gd").write_text("extends Node2D\n", encoding="utf-8")
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    added = gda(
-        "node", "add", "res://main.tscn", "--instance", "res://hero.gd", "--json"
+    err = gda.error(
+        "node",
+        "add",
+        "res://main.tscn",
+        "--instance",
+        "res://hero.gd",
+        "--json",
+        code="not_a_scene",
     )
-
-    err = _assert_operation_error(added, "not_a_scene")
     assert "res://hero.gd" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -603,16 +568,20 @@ def test_node_add_instance_of_the_host_itself_yields_cyclic_target(godot_project
     # never finish loading. The direct cycle is refused up front with the
     # registered cyclic_target code, leaving the file untouched (deeper A→B→A
     # cycles remain the engine's load-time problem, out of gda's guard).
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    added = gda(
-        "node", "add", "res://main.tscn", "--instance", "res://main.tscn", "--json"
+    err = gda.error(
+        "node",
+        "add",
+        "res://main.tscn",
+        "--instance",
+        "res://main.tscn",
+        "--json",
+        code="cyclic_target",
     )
-
-    err = _assert_operation_error(added, "cyclic_target")
     assert "res://main.tscn" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -621,9 +590,15 @@ def test_node_add_instance_of_the_host_itself_yields_cyclic_target(godot_project
 def test_node_add_to_missing_scene_yields_path_not_found(godot_project):
     missing = godot_project / "missing.tscn"
 
-    added = _gda("node", "add", str(missing), "--type", "Sprite2D", "--json")
-
-    err = _assert_operation_error(added, "path_not_found")
+    err = gda.error(
+        "node",
+        "add",
+        str(missing),
+        "--type",
+        "Sprite2D",
+        "--json",
+        code="path_not_found",
+    )
     assert str(missing) in err["message"]
 
 
@@ -635,7 +610,7 @@ def test_node_add_bad_parent_yields_parent_not_found_and_leaves_file_unchanged(
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -644,9 +619,8 @@ def test_node_add_bad_parent_yields_parent_not_found_and_leaves_file_unchanged(
         "--parent",
         "Bogus/Path",
         "--json",
+        code="parent_not_found",
     )
-
-    err = _assert_operation_error(added, "parent_not_found")
     assert "Bogus/Path" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -657,7 +631,7 @@ def _scene_with_nested_children(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     for name, parent in (("A", "."), ("B", "A")):
-        added = _gda(
+        added = gda(
             "node",
             "add",
             str(scene_path),
@@ -684,7 +658,7 @@ def test_node_add_parent_path_escaping_or_absolute_stays_rejected(godot_project,
     scene_path = _scene_with_nested_children(godot_project)
     before = scene_path.read_text(encoding="utf-8")
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -695,9 +669,8 @@ def test_node_add_parent_path_escaping_or_absolute_stays_rejected(godot_project,
         "--parent",
         form,
         "--json",
+        code="parent_not_found",
     )
-
-    err = _assert_operation_error(added, "parent_not_found")
     assert form in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -717,7 +690,7 @@ def test_node_add_rejects_non_canonical_parent_path(godot_project, form):
     scene_path = _scene_with_nested_children(godot_project)
     before = scene_path.read_text(encoding="utf-8")
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -728,9 +701,8 @@ def test_node_add_rejects_non_canonical_parent_path(godot_project, form):
         "--parent",
         form,
         "--json",
+        code="parent_not_found",
     )
-
-    err = _assert_operation_error(added, "parent_not_found")
     assert form in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -741,7 +713,7 @@ def test_node_add_explicit_dot_parent_addresses_the_root(godot_project):
     # form node list reports for the root, and the CLI's --parent default.
     scene_path = _scene_with_nested_children(godot_project)
 
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(scene_path),
@@ -762,7 +734,7 @@ def test_node_add_explicit_dot_parent_addresses_the_root(godot_project):
 def test_node_add_name_collision_yields_duplicate_node_name(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    first = _gda(
+    first = gda(
         "node",
         "add",
         str(scene_path),
@@ -775,7 +747,7 @@ def test_node_add_name_collision_yields_duplicate_node_name(godot_project):
     assert first.returncode == 0, first.stdout + first.stderr
     before = scene_path.read_text(encoding="utf-8")
 
-    again = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -784,9 +756,8 @@ def test_node_add_name_collision_yields_duplicate_node_name(godot_project):
         "--name",
         "Hero",
         "--json",
+        code="duplicate_node_name",
     )
-
-    err = _assert_operation_error(again, "duplicate_node_name")
     assert "Hero" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -802,7 +773,7 @@ def test_node_add_invalid_index_yields_invalid_child_index_and_leaves_file_uncha
     # them, and child_count+1 is out of range.
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    first = _gda(
+    first = gda(
         "node",
         "add",
         str(scene_path),
@@ -815,7 +786,7 @@ def test_node_add_invalid_index_yields_invalid_child_index_and_leaves_file_uncha
     assert first.returncode == 0, first.stdout + first.stderr
     before = scene_path.read_text(encoding="utf-8")
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -826,9 +797,8 @@ def test_node_add_invalid_index_yields_invalid_child_index_and_leaves_file_uncha
         "--index",
         index,
         "--json",
+        code="invalid_child_index",
     )
-
-    err = _assert_operation_error(added, "invalid_child_index")
     assert index in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -846,11 +816,11 @@ def test_node_add_collision_with_internal_child_yields_duplicate_node_name(
     # correct on Godot 4.6.3: get_node_or_null resolves through the engine's
     # child-name map, which includes internal children.
     scene_path = godot_project / "ui.tscn"
-    created = _gda(
+    created = gda(
         "scene", "create", str(scene_path), "--root-type", "Control", "--json"
     )
     assert created.returncode == 0, created.stdout + created.stderr
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(scene_path),
@@ -863,7 +833,7 @@ def test_node_add_collision_with_internal_child_yields_duplicate_node_name(
     assert added.returncode == 0, added.stdout + added.stderr
     before = scene_path.read_text(encoding="utf-8")
 
-    colliding = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -874,9 +844,8 @@ def test_node_add_collision_with_internal_child_yields_duplicate_node_name(
         "--parent",
         "Scroll",
         "--json",
+        code="duplicate_node_name",
     )
-
-    err = _assert_operation_error(colliding, "duplicate_node_name")
     assert "_h_scroll" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -887,9 +856,15 @@ def test_node_add_unknown_type_yields_invalid_node_type(godot_project):
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    added = _gda("node", "add", str(scene_path), "--type", "NotAClass", "--json")
-
-    err = _assert_operation_error(added, "invalid_node_type")
+    err = gda.error(
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "NotAClass",
+        "--json",
+        code="invalid_node_type",
+    )
     assert "NotAClass" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -899,7 +874,7 @@ def test_node_add_rejects_name_godot_would_rewrite(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -908,9 +883,8 @@ def test_node_add_rejects_name_godot_would_rewrite(godot_project):
         "--name",
         "Bad%Name",
         "--json",
+        code="invalid_node_name",
     )
-
-    err = _assert_operation_error(added, "invalid_node_name")
     assert "Bad%Name" in err["message"]
 
 
@@ -919,7 +893,7 @@ def test_node_add_rejects_name_godot_would_rewrite(godot_project):
 
 def _get_property(scene_path, node: str, name: str):
     """Read one property dict (by name) off a node via `gda node get --json`."""
-    got = _gda("node", "get", str(scene_path), "--node", node, "--json")
+    got = gda("node", "get", str(scene_path), "--node", node, "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     for prop in json.loads(got.stdout)["properties"]:
         if prop["name"] == name:
@@ -934,7 +908,7 @@ def test_node_get_reports_typed_properties(godot_project):
     # declared Godot type, and value in the JSON projection.
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(scene_path),
@@ -946,7 +920,7 @@ def test_node_get_reports_typed_properties(godot_project):
     )
     assert added.returncode == 0, added.stdout + added.stderr
 
-    got = _gda("node", "get", str(scene_path), "--node", "Hero", "--json")
+    got = gda("node", "get", str(scene_path), "--node", "Hero", "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     data = json.loads(got.stdout)
@@ -967,7 +941,7 @@ def test_node_get_addresses_the_root_with_dot(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    got = _gda("node", "get", str(scene_path), "--node", ".", "--json")
+    got = gda("node", "get", str(scene_path), "--node", ".", "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     data = json.loads(got.stdout)
@@ -979,9 +953,15 @@ def test_node_get_missing_node_yields_node_not_found(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    got = _gda("node", "get", str(scene_path), "--node", "Bogus", "--json")
-
-    err = _assert_operation_error(got, "node_not_found")
+    err = gda.error(
+        "node",
+        "get",
+        str(scene_path),
+        "--node",
+        "Bogus",
+        "--json",
+        code="node_not_found",
+    )
     assert "Bogus" in err["message"]
 
 
@@ -1006,11 +986,11 @@ def test_node_set_coerces_and_round_trips_via_get(
     # rules documented in the command catalog.
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    _gda(
+    gda(
         "node", "add", str(scene_path), "--type", "Sprite2D", "--name", "Hero", "--json"
     )
 
-    was_set = _gda(
+    was_set = gda(
         "node",
         "set",
         str(scene_path),
@@ -1047,7 +1027,7 @@ def test_node_set_control_position_updates_offsets_preserving_size(godot_project
         encoding="utf-8",
     )
 
-    was_set = _gda(
+    was_set = gda(
         "node",
         "set",
         str(scene_path),
@@ -1098,7 +1078,7 @@ def test_node_set_container_managed_control_position_names_offset_alternatives(
     )
     before = scene_path.read_text(encoding="utf-8")
 
-    was_set = _gda(
+    err = gda.error(
         "node",
         "set",
         str(scene_path),
@@ -1109,9 +1089,8 @@ def test_node_set_container_managed_control_position_names_offset_alternatives(
         "--value",
         "20,30",
         "--json",
+        code="unknown_property",
     )
-
-    err = _assert_operation_error(was_set, "unknown_property")
     for name in ("offset_left", "offset_top", "offset_right", "offset_bottom"):
         assert name in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
@@ -1135,7 +1114,7 @@ def test_node_set_coerces_json_dictionary_and_array_via_get(godot_project):
         'script = ExtResource("1")\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     stats_set = gda(
         "node",
@@ -1206,7 +1185,7 @@ def test_node_set_preserves_json_container_integer_and_float_types(godot_project
         'script = ExtResource("1")\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     was_set = gda(
         "node",
@@ -1257,7 +1236,7 @@ def test_node_set_typed_dictionary_coerces_entries_to_declared_value_type(
         'script = ExtResource("1")\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     was_set = gda(
         "node",
@@ -1306,7 +1285,7 @@ def test_node_set_typed_array_coerces_elements_to_declared_element_type(
         'script = ExtResource("1")\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     was_set = gda(
         "node",
@@ -1342,12 +1321,12 @@ def test_node_set_unknown_property_yields_unknown_property_and_leaves_file_uncha
 ):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    _gda(
+    gda(
         "node", "add", str(scene_path), "--type", "Sprite2D", "--name", "Hero", "--json"
     )
     before = scene_path.read_text(encoding="utf-8")
 
-    was_set = _gda(
+    err = gda.error(
         "node",
         "set",
         str(scene_path),
@@ -1358,9 +1337,8 @@ def test_node_set_unknown_property_yields_unknown_property_and_leaves_file_uncha
         "--value",
         "1",
         "--json",
+        code="unknown_property",
     )
-
-    err = _assert_operation_error(was_set, "unknown_property")
     assert "no_such_prop" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -1374,12 +1352,12 @@ def test_node_set_uncoercible_value_yields_uncoercible_value_and_leaves_file_unc
     # the scene file is left untouched.
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    _gda(
+    gda(
         "node", "add", str(scene_path), "--type", "Sprite2D", "--name", "Hero", "--json"
     )
     before = scene_path.read_text(encoding="utf-8")
 
-    was_set = _gda(
+    err = gda.error(
         "node",
         "set",
         str(scene_path),
@@ -1390,9 +1368,8 @@ def test_node_set_uncoercible_value_yields_uncoercible_value_and_leaves_file_unc
         "--value",
         "not_a_vector",
         "--json",
+        code="uncoercible_value",
     )
-
-    err = _assert_operation_error(was_set, "uncoercible_value")
     assert "Vector2" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -1403,7 +1380,7 @@ def test_node_set_missing_node_yields_node_not_found(godot_project):
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    was_set = _gda(
+    err = gda.error(
         "node",
         "set",
         str(scene_path),
@@ -1414,9 +1391,8 @@ def test_node_set_missing_node_yields_node_not_found(godot_project):
         "--value",
         "1,2",
         "--json",
+        code="node_not_found",
     )
-
-    err = _assert_operation_error(was_set, "node_not_found")
     assert "Bogus" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -1431,7 +1407,7 @@ def test_node_set_refuses_scene_whose_sub_scene_cannot_resolve(godot_project):
     (godot_project / "gone.tscn").unlink(missing_ok=True)
     before = parent.read_text(encoding="utf-8")
 
-    was_set = _gda(
+    err = gda.error(
         "node",
         "set",
         str(parent),
@@ -1444,9 +1420,8 @@ def test_node_set_refuses_scene_whose_sub_scene_cannot_resolve(godot_project):
         "--project",
         str(godot_project),
         "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(was_set, "missing_dependency")
     assert "ChildInstance" in err["message"]
     assert parent.read_text(encoding="utf-8") == before
 
@@ -1462,7 +1437,7 @@ def test_node_list_reports_all_siblings_at_one_level_in_tree_order(godot_project
     _create_scene(scene_path)
     siblings = [("A", "Node2D"), ("B", "Sprite2D"), ("C", "Area2D")]
     for name, node_type in siblings:
-        added = _gda(
+        added = gda(
             "node",
             "add",
             str(scene_path),
@@ -1474,7 +1449,7 @@ def test_node_list_reports_all_siblings_at_one_level_in_tree_order(godot_project
         )
         assert added.returncode == 0, added.stdout + added.stderr
 
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
 
     assert listed.returncode == 0, listed.stdout + listed.stderr
     children = json.loads(listed.stdout)["root"]["children"]
@@ -1490,9 +1465,7 @@ def test_node_list_reports_all_siblings_at_one_level_in_tree_order(godot_project
 def test_node_list_missing_scene_yields_path_not_found(godot_project):
     missing = godot_project / "missing.tscn"
 
-    listed = _gda("node", "list", str(missing), "--json")
-
-    err = _assert_operation_error(listed, "path_not_found")
+    err = gda.error("node", "list", str(missing), "--json", code="path_not_found")
     assert str(missing) in err["message"]
 
 
@@ -1501,9 +1474,7 @@ def test_node_list_non_scene_file_yields_not_a_scene(godot_project):
     notes = godot_project / "notes.txt"
     notes.write_text("not a scene\n", encoding="utf-8")
 
-    listed = _gda("node", "list", str(notes), "--json")
-
-    _assert_operation_error(listed, "not_a_scene")
+    gda.error("node", "list", str(notes), "--json", code="not_a_scene")
 
 
 # A legal editable-children fixture, in the engine's own serialization (issue
@@ -1598,7 +1569,7 @@ def test_node_add_preserves_editable_instance_overrides(godot_project):
     # the editable instance. Verified to hold on Godot 4.6.3.
     parent = _write_instance_fixture(godot_project)
 
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(parent),
@@ -1638,7 +1609,7 @@ def test_node_add_preserves_preexisting_plain_instance_stub(godot_project):
     # gain a class `type=` attribute.
     parent = _write_plain_instance_fixture(godot_project)
 
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(parent),
@@ -1671,7 +1642,7 @@ def test_node_add_does_not_promote_instance_baseline_to_host_override(godot_proj
     # serialize them into the host scene.
     parent = _write_plain_instance_fixture(godot_project, instance_override="")
 
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(parent),
@@ -1705,11 +1676,17 @@ def test_node_add_without_project_context_refuses_rather_than_drops_instances(
     parent = _write_instance_fixture(godot_project)
     before = parent.read_text(encoding="utf-8")
 
-    added = _gda(
-        "node", "add", str(parent), "--type", "Marker2D", "--name", "M", "--json"
+    err = gda.error(
+        "node",
+        "add",
+        str(parent),
+        "--type",
+        "Marker2D",
+        "--name",
+        "M",
+        "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(added, "missing_dependency")
     assert "ChildInstance" in err["message"]
     assert parent.read_text(encoding="utf-8") == before
 
@@ -1725,7 +1702,7 @@ def test_node_add_refuses_scene_whose_sub_scene_cannot_resolve(godot_project):
     (godot_project / "gone.tscn").unlink(missing_ok=True)
     before = parent.read_text(encoding="utf-8")
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(parent),
@@ -1736,9 +1713,8 @@ def test_node_add_refuses_scene_whose_sub_scene_cannot_resolve(godot_project):
         "--project",
         str(godot_project),
         "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(added, "missing_dependency")
     assert "ChildInstance" in err["message"]
     assert parent.read_text(encoding="utf-8") == before
 
@@ -1750,7 +1726,7 @@ def test_node_add_refuses_scene_whose_attached_script_preloads_missing_asset(
     # A scene mutation must not report clean success when an already-attached
     # script has a now-missing preload target. The structured error names the
     # missing res:// path and the scene remains byte-identical.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1808,7 +1784,7 @@ def test_node_add_refuses_scene_whose_attached_script_preloads_missing_asset(
     )
     assert "uid=" in script_line_before
 
-    added = gda(
+    err = gda.error(
         "node",
         "add",
         "res://main.tscn",
@@ -1817,9 +1793,8 @@ def test_node_add_refuses_scene_whose_attached_script_preloads_missing_asset(
         "--name",
         "M",
         "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(added, "missing_dependency")
     assert "res://enemy_projectile.tscn" in err["message"]
     assert "res://enemy.gd" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
@@ -1849,7 +1824,7 @@ def test_node_add_refuses_scene_that_instantiates_to_null(godot_project):
     )
     before = parent.read_text(encoding="utf-8")
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(parent),
@@ -1860,9 +1835,8 @@ def test_node_add_refuses_scene_that_instantiates_to_null(godot_project):
         "--project",
         str(godot_project),
         "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(added, "missing_dependency")
     assert str(parent) in err["message"]
     assert parent.read_text(encoding="utf-8") == before
 
@@ -1890,7 +1864,7 @@ def test_node_add_refuses_scene_whose_declared_class_is_substituted(godot_projec
     scene_path.write_text(MISSING_CLASS_TSCN, encoding="utf-8")
     before = scene_path.read_text(encoding="utf-8")
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -1899,9 +1873,8 @@ def test_node_add_refuses_scene_whose_declared_class_is_substituted(godot_projec
         "--name",
         "M",
         "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(added, "missing_dependency")
     assert "Widget (declared TotallyMissingClass, materialized" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -1912,18 +1885,6 @@ extends Node2D
 """
 
 
-def _import_project(project) -> None:
-    # class_name registration lives in .godot/global_script_class_list.cfg,
-    # which only a project scan produces — run the engine's headless import
-    # step the way a CI pipeline would before using script classes.
-    imported = subprocess.run(
-        [str(GODOT), "--headless", "--path", str(project), "--import"],
-        capture_output=True,
-        text=True,
-    )
-    assert imported.returncode == 0, imported.stdout + imported.stderr
-
-
 @pytest.mark.e2e
 def test_node_add_by_class_name_attaches_the_script(godot_project):
     # The second half of --type's contract (issue #53): a class_name registered
@@ -1932,11 +1893,11 @@ def test_node_add_by_class_name_attaches_the_script(godot_project):
     # script_class, so an agent can assert the script attach without reading
     # the .tscn.
     (godot_project / "hero.gd").write_text(HERO_GD, encoding="utf-8")
-    _import_project(godot_project)
+    import_project(godot_project)
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(scene_path),
@@ -1954,7 +1915,7 @@ def test_node_add_by_class_name_attaches_the_script(godot_project):
     assert data["type"] == "Node2D"
     assert data["script_class"] == "Hero"
 
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
 
     assert listed.returncode == 0, listed.stdout + listed.stderr
     hero = json.loads(listed.stdout)["root"]["children"][0]
@@ -1972,7 +1933,7 @@ def test_node_add_by_unregistered_class_name_yields_invalid_node_type(godot_proj
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -1981,9 +1942,8 @@ def test_node_add_by_unregistered_class_name_yields_invalid_node_type(godot_proj
         "--project",
         str(godot_project),
         "--json",
+        code="invalid_node_type",
     )
-
-    err = _assert_operation_error(added, "invalid_node_type")
     assert "Hero" in err["message"]
 
 
@@ -2006,13 +1966,13 @@ def test_node_add_by_registered_but_broken_class_name_names_the_script(godot_pro
     # distinct uninstantiable_script code naming the script, with the scene
     # file left unchanged.
     (godot_project / "hero.gd").write_text(HERO_GD, encoding="utf-8")
-    _import_project(godot_project)
+    import_project(godot_project)
     (godot_project / "hero.gd").write_text(BROKEN_HERO_GD, encoding="utf-8")
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -2021,9 +1981,8 @@ def test_node_add_by_registered_but_broken_class_name_names_the_script(godot_pro
         "--project",
         str(godot_project),
         "--json",
+        code="uninstantiable_script",
     )
-
-    err = _assert_operation_error(added, "uninstantiable_script")
     assert "Hero" in err["message"]
     assert "hero.gd" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
@@ -2044,12 +2003,12 @@ def test_node_add_by_non_node_class_name_yields_invalid_node_type(godot_project)
     # invalid_node_type (not uninstantiable_script), with a message naming the
     # script and the real cause rather than "not a registered class_name".
     (godot_project / "loot.gd").write_text(LOOT_GD, encoding="utf-8")
-    _import_project(godot_project)
+    import_project(godot_project)
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -2058,9 +2017,8 @@ def test_node_add_by_non_node_class_name_yields_invalid_node_type(godot_project)
         "--project",
         str(godot_project),
         "--json",
+        code="invalid_node_type",
     )
-
-    err = _assert_operation_error(added, "invalid_node_type")
     assert "Loot" in err["message"]
     assert "not a Node-derived script" in err["message"]
     assert "loot.gd" in err["message"]
@@ -2088,12 +2046,12 @@ def test_node_add_by_class_name_whose_init_requires_args_names_the_constructor(
     # script.new() cannot construct it. Same misdiagnosis risk as the broken
     # script: the type IS registered, the constructor is the problem.
     (godot_project / "hero.gd").write_text(NEEDS_ARGS_HERO_GD, encoding="utf-8")
-    _import_project(godot_project)
+    import_project(godot_project)
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -2102,9 +2060,8 @@ def test_node_add_by_class_name_whose_init_requires_args_names_the_constructor(
         "--project",
         str(godot_project),
         "--json",
+        code="uninstantiable_script",
     )
-
-    err = _assert_operation_error(added, "uninstantiable_script")
     assert "Hero" in err["message"]
     assert "hero.gd" in err["message"]
     assert "_init" in err["message"]
@@ -2120,15 +2077,15 @@ def test_node_remove_deletes_node_and_subtree_round_trip(godot_project):
     # and its whole subtree, verified through a fresh node list — the deletion
     # is on disk, not just in the reporting process. A sibling is untouched.
     scene_path = _scene_with_nested_children(godot_project)  # root -> A -> B
-    _gda("node", "add", str(scene_path), "--type", "Node2D", "--name", "C", "--json")
+    gda("node", "add", str(scene_path), "--type", "Node2D", "--name", "C", "--json")
 
-    removed = _gda("node", "remove", str(scene_path), "--node", "A", "--json")
+    removed = gda("node", "remove", str(scene_path), "--node", "A", "--json")
 
     assert removed.returncode == 0, removed.stdout + removed.stderr
     data = json.loads(removed.stdout)
     assert (data["path"], data["name"], data["type"]) == ("A", "A", "Node2D")
 
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
     assert listed.returncode == 0, listed.stdout + listed.stderr
     children = json.loads(listed.stdout)["root"]["children"]
     names = {child["name"] for child in children}
@@ -2141,12 +2098,12 @@ def test_node_remove_nested_node_leaves_ancestors(godot_project):
     # Removing a descendant deletes only its subtree; its parent survives.
     scene_path = _scene_with_nested_children(godot_project)  # root -> A -> B
 
-    removed = _gda("node", "remove", str(scene_path), "--node", "A/B", "--json")
+    removed = gda("node", "remove", str(scene_path), "--node", "A/B", "--json")
 
     assert removed.returncode == 0, removed.stdout + removed.stderr
     assert json.loads(removed.stdout)["path"] == "A/B"
 
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
     a = json.loads(listed.stdout)["root"]["children"][0]
     assert a["name"] == "A"
     assert a["children"] == []
@@ -2158,9 +2115,15 @@ def test_node_remove_missing_node_yields_node_not_found(godot_project):
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    removed = _gda("node", "remove", str(scene_path), "--node", "Bogus", "--json")
-
-    err = _assert_operation_error(removed, "node_not_found")
+    err = gda.error(
+        "node",
+        "remove",
+        str(scene_path),
+        "--node",
+        "Bogus",
+        "--json",
+        code="node_not_found",
+    )
     assert "Bogus" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -2174,7 +2137,7 @@ def _scene_with_emitter_and_receiver(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     for node_type, name in (("Timer", "Emitter"), ("Node2D", "Receiver")):
-        added = _gda(
+        added = gda(
             "node",
             "add",
             str(scene_path),
@@ -2204,7 +2167,7 @@ def test_node_connect_signal_records_a_connection_that_round_trips(godot_project
     # mutation is on disk (a re-read shows it), not just in the reporting process.
     scene_path = _scene_with_emitter_and_receiver(godot_project)
 
-    connected = _gda(
+    connected = gda(
         "node",
         "connect-signal",
         str(scene_path),
@@ -2239,7 +2202,7 @@ def test_node_connect_signal_allows_a_not_yet_defined_target_method(godot_projec
     # authored afterward. The connection is recorded with the dangling method.
     scene_path = _scene_with_emitter_and_receiver(godot_project)
 
-    connected = _gda(
+    connected = gda(
         "node",
         "connect-signal",
         str(scene_path),
@@ -2269,7 +2232,7 @@ def test_node_connect_signal_unknown_signal_yields_signal_not_found(godot_projec
     scene_path = _scene_with_emitter_and_receiver(godot_project)
     before = scene_path.read_text(encoding="utf-8")
 
-    connected = _gda(
+    err = gda.error(
         "node",
         "connect-signal",
         str(scene_path),
@@ -2282,9 +2245,8 @@ def test_node_connect_signal_unknown_signal_yields_signal_not_found(godot_projec
         "--method",
         "on_timeout",
         "--json",
+        code="signal_not_found",
     )
-
-    err = _assert_operation_error(connected, "signal_not_found")
     assert "no_such_signal" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -2295,7 +2257,7 @@ def test_node_connect_signal_already_connected_yields_already_connected(godot_pr
     # rather than a noisy engine failure or a silent re-apply; the file is
     # unchanged after the second attempt.
     scene_path = _scene_with_emitter_and_receiver(godot_project)
-    first = _gda(
+    first = gda(
         "node",
         "connect-signal",
         str(scene_path),
@@ -2312,7 +2274,7 @@ def test_node_connect_signal_already_connected_yields_already_connected(godot_pr
     assert first.returncode == 0, first.stdout + first.stderr
     before = scene_path.read_text(encoding="utf-8")
 
-    again = _gda(
+    err = gda.error(
         "node",
         "connect-signal",
         str(scene_path),
@@ -2325,9 +2287,8 @@ def test_node_connect_signal_already_connected_yields_already_connected(godot_pr
         "--method",
         "on_timeout",
         "--json",
+        code="already_connected",
     )
-
-    err = _assert_operation_error(again, "already_connected")
     assert "Receiver.on_timeout" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -2337,7 +2298,7 @@ def test_node_connect_signal_missing_source_node_yields_node_not_found(godot_pro
     scene_path = _scene_with_emitter_and_receiver(godot_project)
     before = scene_path.read_text(encoding="utf-8")
 
-    connected = _gda(
+    err = gda.error(
         "node",
         "connect-signal",
         str(scene_path),
@@ -2350,9 +2311,8 @@ def test_node_connect_signal_missing_source_node_yields_node_not_found(godot_pro
         "--method",
         "on_timeout",
         "--json",
+        code="node_not_found",
     )
-
-    err = _assert_operation_error(connected, "node_not_found")
     assert "source" in err["message"]
     assert "Bogus" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
@@ -2368,9 +2328,15 @@ def test_node_remove_root_yields_cannot_target_root(godot_project):
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    removed = _gda("node", "remove", str(scene_path), "--node", ".", "--json")
-
-    _assert_operation_error(removed, "cannot_target_root")
+    gda.error(
+        "node",
+        "remove",
+        str(scene_path),
+        "--node",
+        ".",
+        "--json",
+        code="cannot_target_root",
+    )
     assert scene_path.read_text(encoding="utf-8") == before
 
 
@@ -2384,11 +2350,11 @@ def test_node_duplicate_copies_node_under_same_parent_with_fresh_name(godot_proj
     # is reported — verified through a fresh node list. The source survives.
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    _gda(
+    gda(
         "node", "add", str(scene_path), "--type", "Sprite2D", "--name", "Hero", "--json"
     )
 
-    duplicated = _gda("node", "duplicate", str(scene_path), "--node", "Hero", "--json")
+    duplicated = gda("node", "duplicate", str(scene_path), "--node", "Hero", "--json")
 
     assert duplicated.returncode == 0, duplicated.stdout + duplicated.stderr
     data = json.loads(duplicated.stdout)
@@ -2400,7 +2366,7 @@ def test_node_duplicate_copies_node_under_same_parent_with_fresh_name(godot_proj
     assert "/" not in data["path"]
     assert data["path"] == data["name"]
 
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
     children = json.loads(listed.stdout)["root"]["children"]
     names = sorted(child["name"] for child in children)
     # Both the source and its fresh-named copy are present as siblings.
@@ -2415,8 +2381,8 @@ def test_node_duplicate_copies_the_whole_subtree(godot_project):
     # copy must carry an equivalent child under the new node path.
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    _gda("node", "add", str(scene_path), "--type", "Node2D", "--name", "Hero", "--json")
-    _gda(
+    gda("node", "add", str(scene_path), "--type", "Node2D", "--name", "Hero", "--json")
+    gda(
         "node",
         "add",
         str(scene_path),
@@ -2429,11 +2395,11 @@ def test_node_duplicate_copies_the_whole_subtree(godot_project):
         "--json",
     )
 
-    duplicated = _gda("node", "duplicate", str(scene_path), "--node", "Hero", "--json")
+    duplicated = gda("node", "duplicate", str(scene_path), "--node", "Hero", "--json")
     assert duplicated.returncode == 0, duplicated.stdout + duplicated.stderr
     new_name = json.loads(duplicated.stdout)["name"]
 
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
     by_name = {c["name"]: c for c in json.loads(listed.stdout)["root"]["children"]}
     copy = by_name[new_name]
     # The copied subtree carries the child, re-pathed under the new parent.
@@ -2448,7 +2414,7 @@ def test_node_duplicate_nested_node_lands_under_its_own_parent(godot_project):
     # node path shares the source's parent prefix.
     scene_path = _scene_with_nested_children(godot_project)  # root -> A -> B
 
-    duplicated = _gda("node", "duplicate", str(scene_path), "--node", "A/B", "--json")
+    duplicated = gda("node", "duplicate", str(scene_path), "--node", "A/B", "--json")
 
     assert duplicated.returncode == 0, duplicated.stdout + duplicated.stderr
     data = json.loads(duplicated.stdout)
@@ -2464,9 +2430,15 @@ def test_node_duplicate_missing_node_yields_node_not_found(godot_project):
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    duplicated = _gda("node", "duplicate", str(scene_path), "--node", "Bogus", "--json")
-
-    err = _assert_operation_error(duplicated, "node_not_found")
+    err = gda.error(
+        "node",
+        "duplicate",
+        str(scene_path),
+        "--node",
+        "Bogus",
+        "--json",
+        code="node_not_found",
+    )
     assert "Bogus" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -2479,9 +2451,15 @@ def test_node_duplicate_root_yields_cannot_target_root(godot_project):
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    duplicated = _gda("node", "duplicate", str(scene_path), "--node", ".", "--json")
-
-    _assert_operation_error(duplicated, "cannot_target_root")
+    gda.error(
+        "node",
+        "duplicate",
+        str(scene_path),
+        "--node",
+        ".",
+        "--json",
+        code="cannot_target_root",
+    )
     assert scene_path.read_text(encoding="utf-8") == before
 
 
@@ -2495,8 +2473,8 @@ def test_node_move_reparents_node_and_subtree_round_trip(godot_project):
     # list: the moved node now sits under the target, carrying its child.
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    _gda("node", "add", str(scene_path), "--type", "Node2D", "--name", "Hero", "--json")
-    _gda(
+    gda("node", "add", str(scene_path), "--type", "Node2D", "--name", "Hero", "--json")
+    gda(
         "node",
         "add",
         str(scene_path),
@@ -2508,7 +2486,7 @@ def test_node_move_reparents_node_and_subtree_round_trip(godot_project):
         "Hero",
         "--json",
     )
-    _gda(
+    gda(
         "node",
         "add",
         str(scene_path),
@@ -2519,7 +2497,7 @@ def test_node_move_reparents_node_and_subtree_round_trip(godot_project):
         "--json",
     )
 
-    moved = _gda(
+    moved = gda(
         "node", "move", str(scene_path), "--node", "Hero", "--to", "Enemies", "--json"
     )
 
@@ -2529,7 +2507,7 @@ def test_node_move_reparents_node_and_subtree_round_trip(godot_project):
     assert data["new_parent"] == "Enemies"
     assert data["path"] == "Enemies/Hero"
 
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
     by_name = {c["name"]: c for c in json.loads(listed.stdout)["root"]["children"]}
     # Hero is no longer a direct child of the root; it sits under Enemies, with
     # its subtree intact.
@@ -2555,7 +2533,7 @@ def test_node_move_index_places_reparented_node_in_destination_order(godot_proje
         ("Slime", "Enemies"),
         ("Bat", "Enemies"),
     ):
-        added = _gda(
+        added = gda(
             "node",
             "add",
             str(scene_path),
@@ -2569,7 +2547,7 @@ def test_node_move_index_places_reparented_node_in_destination_order(godot_proje
         )
         assert added.returncode == 0, added.stdout + added.stderr
 
-    moved = _gda(
+    moved = gda(
         "node",
         "move",
         str(scene_path),
@@ -2599,16 +2577,14 @@ def test_node_move_to_root_reparents_under_the_root(godot_project):
     # up to be a direct child of the scene root.
     scene_path = _scene_with_nested_children(godot_project)  # root -> A -> B
 
-    moved = _gda(
-        "node", "move", str(scene_path), "--node", "A/B", "--to", ".", "--json"
-    )
+    moved = gda("node", "move", str(scene_path), "--node", "A/B", "--to", ".", "--json")
 
     assert moved.returncode == 0, moved.stdout + moved.stderr
     data = json.loads(moved.stdout)
     assert data["new_parent"] == "."
     assert data["path"] == "B"
 
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
     names = {c["name"] for c in json.loads(listed.stdout)["root"]["children"]}
     assert names == {"A", "B"}
 
@@ -2621,7 +2597,7 @@ def test_node_move_index_reorders_same_parent_without_rebuilding_node(godot_proj
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     for name in ("HP", "MP", "EXP"):
-        added = _gda(
+        added = gda(
             "node",
             "add",
             str(scene_path),
@@ -2632,7 +2608,7 @@ def test_node_move_index_reorders_same_parent_without_rebuilding_node(godot_proj
             "--json",
         )
         assert added.returncode == 0, added.stdout + added.stderr
-    set_text = _gda(
+    set_text = gda(
         "node",
         "set",
         str(scene_path),
@@ -2645,7 +2621,7 @@ def test_node_move_index_reorders_same_parent_without_rebuilding_node(godot_proj
         "--json",
     )
     assert set_text.returncode == 0, set_text.stdout + set_text.stderr
-    child = _gda(
+    child = gda(
         "node",
         "add",
         str(scene_path),
@@ -2659,7 +2635,7 @@ def test_node_move_index_reorders_same_parent_without_rebuilding_node(godot_proj
     )
     assert child.returncode == 0, child.stdout + child.stderr
 
-    moved = _gda(
+    moved = gda(
         "node",
         "move",
         str(scene_path),
@@ -2678,7 +2654,7 @@ def test_node_move_index_reorders_same_parent_without_rebuilding_node(godot_proj
     assert [child["name"] for child in root_children] == ["HP", "EXP", "MP"]
     exp = root_children[1]
     assert exp["children"][0]["path"] == "EXP/Icon"
-    got = _gda("node", "get", str(scene_path), "--node", "EXP", "--json")
+    got = gda("node", "get", str(scene_path), "--node", "EXP", "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     properties = {
         prop["name"]: prop["value"] for prop in json.loads(got.stdout)["properties"]
@@ -2695,7 +2671,7 @@ def test_node_move_invalid_index_yields_invalid_child_index_and_leaves_file_unch
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     for name in ("HP", "MP", "EXP"):
-        added = _gda(
+        added = gda(
             "node",
             "add",
             str(scene_path),
@@ -2708,7 +2684,7 @@ def test_node_move_invalid_index_yields_invalid_child_index_and_leaves_file_unch
         assert added.returncode == 0, added.stdout + added.stderr
     before = scene_path.read_text(encoding="utf-8")
 
-    moved = _gda(
+    err = gda.error(
         "node",
         "move",
         str(scene_path),
@@ -2719,9 +2695,8 @@ def test_node_move_invalid_index_yields_invalid_child_index_and_leaves_file_unch
         "--index",
         "3",
         "--json",
+        code="invalid_child_index",
     )
-
-    err = _assert_operation_error(moved, "invalid_child_index")
     assert "3" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -2734,11 +2709,17 @@ def test_node_move_under_own_descendant_yields_cyclic_target(godot_project):
     scene_path = _scene_with_nested_children(godot_project)  # root -> A -> B
     before = scene_path.read_text(encoding="utf-8")
 
-    moved = _gda(
-        "node", "move", str(scene_path), "--node", "A", "--to", "A/B", "--json"
+    err = gda.error(
+        "node",
+        "move",
+        str(scene_path),
+        "--node",
+        "A",
+        "--to",
+        "A/B",
+        "--json",
+        code="cyclic_target",
     )
-
-    err = _assert_operation_error(moved, "cyclic_target")
     assert "A/B" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -2750,9 +2731,17 @@ def test_node_move_under_itself_yields_cyclic_target(godot_project):
     scene_path = _scene_with_nested_children(godot_project)  # root -> A -> B
     before = scene_path.read_text(encoding="utf-8")
 
-    moved = _gda("node", "move", str(scene_path), "--node", "A", "--to", "A", "--json")
-
-    _assert_operation_error(moved, "cyclic_target")
+    gda.error(
+        "node",
+        "move",
+        str(scene_path),
+        "--node",
+        "A",
+        "--to",
+        "A",
+        "--json",
+        code="cyclic_target",
+    )
     assert scene_path.read_text(encoding="utf-8") == before
 
 
@@ -2763,11 +2752,17 @@ def test_node_move_to_missing_parent_yields_parent_not_found(godot_project):
     scene_path = _scene_with_nested_children(godot_project)  # root -> A -> B
     before = scene_path.read_text(encoding="utf-8")
 
-    moved = _gda(
-        "node", "move", str(scene_path), "--node", "A/B", "--to", "Bogus", "--json"
+    err = gda.error(
+        "node",
+        "move",
+        str(scene_path),
+        "--node",
+        "A/B",
+        "--to",
+        "Bogus",
+        "--json",
+        code="parent_not_found",
     )
-
-    err = _assert_operation_error(moved, "parent_not_found")
     assert "Bogus" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -2781,8 +2776,8 @@ def test_node_move_name_collision_at_destination_yields_duplicate_node_name(
     # node add reports), leaving the file untouched.
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    _gda("node", "add", str(scene_path), "--type", "Node2D", "--name", "Hero", "--json")
-    _gda(
+    gda("node", "add", str(scene_path), "--type", "Node2D", "--name", "Hero", "--json")
+    gda(
         "node",
         "add",
         str(scene_path),
@@ -2792,7 +2787,7 @@ def test_node_move_name_collision_at_destination_yields_duplicate_node_name(
         "Enemies",
         "--json",
     )
-    _gda(
+    gda(
         "node",
         "add",
         str(scene_path),
@@ -2806,11 +2801,17 @@ def test_node_move_name_collision_at_destination_yields_duplicate_node_name(
     )
     before = scene_path.read_text(encoding="utf-8")
 
-    moved = _gda(
-        "node", "move", str(scene_path), "--node", "Hero", "--to", "Enemies", "--json"
+    err = gda.error(
+        "node",
+        "move",
+        str(scene_path),
+        "--node",
+        "Hero",
+        "--to",
+        "Enemies",
+        "--json",
+        code="duplicate_node_name",
     )
-
-    err = _assert_operation_error(moved, "duplicate_node_name")
     assert "Hero" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -2819,7 +2820,7 @@ def test_node_move_name_collision_at_destination_yields_duplicate_node_name(
 def test_node_connect_signal_missing_target_node_yields_node_not_found(godot_project):
     scene_path = _scene_with_emitter_and_receiver(godot_project)
 
-    connected = _gda(
+    err = gda.error(
         "node",
         "connect-signal",
         str(scene_path),
@@ -2832,9 +2833,8 @@ def test_node_connect_signal_missing_target_node_yields_node_not_found(godot_pro
         "--method",
         "on_timeout",
         "--json",
+        code="node_not_found",
     )
-
-    err = _assert_operation_error(connected, "node_not_found")
     assert "target" in err["message"]
     assert "Bogus" in err["message"]
 
@@ -2844,7 +2844,7 @@ def test_node_disconnect_signal_removes_an_existing_connection(godot_project):
     # disconnect-signal removes a connection connect-signal recorded; the round-
     # trip read shows the [connection] is gone from the saved file.
     scene_path = _scene_with_emitter_and_receiver(godot_project)
-    connected = _gda(
+    connected = gda(
         "node",
         "connect-signal",
         str(scene_path),
@@ -2861,7 +2861,7 @@ def test_node_disconnect_signal_removes_an_existing_connection(godot_project):
     assert connected.returncode == 0, connected.stdout + connected.stderr
     assert _connection_lines(scene_path)  # the connection is there first
 
-    disconnected = _gda(
+    disconnected = gda(
         "node",
         "disconnect-signal",
         str(scene_path),
@@ -2892,7 +2892,7 @@ def test_node_disconnect_signal_absent_connection_yields_connection_not_found(
     scene_path = _scene_with_emitter_and_receiver(godot_project)
     before = scene_path.read_text(encoding="utf-8")
 
-    disconnected = _gda(
+    err = gda.error(
         "node",
         "disconnect-signal",
         str(scene_path),
@@ -2905,9 +2905,8 @@ def test_node_disconnect_signal_absent_connection_yields_connection_not_found(
         "--method",
         "on_timeout",
         "--json",
+        code="connection_not_found",
     )
-
-    err = _assert_operation_error(disconnected, "connection_not_found")
     assert "Emitter.timeout" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -2917,11 +2916,17 @@ def test_node_move_missing_node_yields_node_not_found(godot_project):
     scene_path = _scene_with_nested_children(godot_project)
     before = scene_path.read_text(encoding="utf-8")
 
-    moved = _gda(
-        "node", "move", str(scene_path), "--node", "Bogus", "--to", ".", "--json"
+    err = gda.error(
+        "node",
+        "move",
+        str(scene_path),
+        "--node",
+        "Bogus",
+        "--to",
+        ".",
+        "--json",
+        code="node_not_found",
     )
-
-    err = _assert_operation_error(moved, "node_not_found")
     assert "Bogus" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -2934,7 +2939,7 @@ def test_node_disconnect_signal_missing_signal_yields_signal_not_found(godot_pro
     scene_path = _scene_with_emitter_and_receiver(godot_project)
     before = scene_path.read_text(encoding="utf-8")
 
-    disconnected = _gda(
+    err = gda.error(
         "node",
         "disconnect-signal",
         str(scene_path),
@@ -2947,9 +2952,8 @@ def test_node_disconnect_signal_missing_signal_yields_signal_not_found(godot_pro
         "--method",
         "on_timeout",
         "--json",
+        code="signal_not_found",
     )
-
-    err = _assert_operation_error(disconnected, "signal_not_found")
     assert "no_such_signal" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -2961,9 +2965,17 @@ def test_node_move_root_yields_cannot_target_root(godot_project):
     scene_path = _scene_with_nested_children(godot_project)
     before = scene_path.read_text(encoding="utf-8")
 
-    moved = _gda("node", "move", str(scene_path), "--node", ".", "--to", "A", "--json")
-
-    _assert_operation_error(moved, "cannot_target_root")
+    gda.error(
+        "node",
+        "move",
+        str(scene_path),
+        "--node",
+        ".",
+        "--to",
+        "A",
+        "--json",
+        code="cannot_target_root",
+    )
     assert scene_path.read_text(encoding="utf-8") == before
 
 
@@ -2977,13 +2989,13 @@ def test_node_move_to_current_parent_is_a_noop_preserving_sibling_order(godot_pr
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     for name in ("A", "B", "C"):
-        added = _gda(
+        added = gda(
             "node", "add", str(scene_path), "--type", "Node2D", "--name", name, "--json"
         )
         assert added.returncode == 0, added.stdout + added.stderr
     before = scene_path.read_text(encoding="utf-8")
 
-    moved = _gda("node", "move", str(scene_path), "--node", "A", "--to", ".", "--json")
+    moved = gda("node", "move", str(scene_path), "--node", "A", "--to", ".", "--json")
 
     assert moved.returncode == 0, moved.stdout + moved.stderr
     assert scene_path.read_text(encoding="utf-8") == before
@@ -2992,7 +3004,7 @@ def test_node_move_to_current_parent_is_a_noop_preserving_sibling_order(godot_pr
     assert data["new_parent"] == "."
     assert data["path"] == "A"
 
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
     assert listed.returncode == 0, listed.stdout + listed.stderr
     order = [c["name"] for c in json.loads(listed.stdout)["root"]["children"]]
     # Sibling order is preserved: A was not shuffled to the end.
@@ -3010,7 +3022,7 @@ def test_node_move_preserves_editable_instance_overrides(godot_project):
     # Verified empirically against Godot 4.6.3.
     parent = _write_instance_fixture(godot_project)
     # A destination parent to reparent the instance under.
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(parent),
@@ -3024,7 +3036,7 @@ def test_node_move_preserves_editable_instance_overrides(godot_project):
     )
     assert added.returncode == 0, added.stdout + added.stderr
 
-    moved = _gda(
+    moved = gda(
         "node",
         "move",
         str(parent),
@@ -3059,7 +3071,7 @@ def test_node_move_preserves_editable_instance_overrides(godot_project):
 def test_node_connect_signal_to_missing_scene_yields_path_not_found(godot_project):
     missing = godot_project / "missing.tscn"
 
-    connected = _gda(
+    err = gda.error(
         "node",
         "connect-signal",
         str(missing),
@@ -3072,9 +3084,8 @@ def test_node_connect_signal_to_missing_scene_yields_path_not_found(godot_projec
         "--method",
         "on_timeout",
         "--json",
+        code="path_not_found",
     )
-
-    err = _assert_operation_error(connected, "path_not_found")
     assert str(missing) in err["message"]
 
 
@@ -3085,7 +3096,7 @@ def test_node_add_leaves_no_temp_file_on_success(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(scene_path),
@@ -3115,8 +3126,7 @@ def test_node_add_with_external_edit_in_window_yields_file_changed_externally(
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    added = _gda_env(
-        {"GDA_TEST_PERTURB_BEFORE_SAVE": "1"},
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -3125,15 +3135,15 @@ def test_node_add_with_external_edit_in_window_yields_file_changed_externally(
         "--name",
         "Hero",
         "--json",
+        extra_env={"GDA_TEST_PERTURB_BEFORE_SAVE": "1"},
+        code="file_changed_externally",
     )
-
-    err = _assert_operation_error(added, "file_changed_externally")
     assert str(scene_path) in err["message"]
 
     # The mutation did NOT land: a fresh list shows no "Hero" child. (The seam
     # perturbs the file by one byte, so we assert the EFFECT — the node is absent —
     # not byte-identical content.)
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
     assert listed.returncode == 0, listed.stdout + listed.stderr
     tree = json.loads(listed.stdout)
     child_names = [c["name"] for c in tree["root"]["children"]]
@@ -3159,8 +3169,7 @@ def test_node_add_with_external_edit_during_instantiate_yields_file_changed_exte
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    added = _gda_env(
-        {"GDA_TEST_PERTURB_AFTER_LOAD": "1"},
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -3169,13 +3178,13 @@ def test_node_add_with_external_edit_during_instantiate_yields_file_changed_exte
         "--name",
         "Hero",
         "--json",
+        extra_env={"GDA_TEST_PERTURB_AFTER_LOAD": "1"},
+        code="file_changed_externally",
     )
-
-    err = _assert_operation_error(added, "file_changed_externally")
     assert str(scene_path) in err["message"]
 
     # The mutation did NOT land despite the edit landing in the earlier window.
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
     assert listed.returncode == 0, listed.stdout + listed.stderr
     child_names = [c["name"] for c in json.loads(listed.stdout)["root"]["children"]]
     assert "Hero" not in child_names, child_names
@@ -3212,7 +3221,7 @@ def test_node_get_projects_a_path_less_texture_headless(godot_project):
         encoding="utf-8",
     )
 
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     got = gda("node", "get", "res://main.tscn", "--node", ".", "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
@@ -3253,7 +3262,7 @@ def test_node_get_keeps_non_res_pathed_textures_on_the_string_fallback(godot_pro
         encoding="utf-8",
     )
 
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     got = gda("node", "get", "res://main.tscn", "--node", ".", "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
@@ -3294,7 +3303,7 @@ def test_inline_projection_drops_a_storage_property_named_object_string(
         encoding="utf-8",
     )
 
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     got = gda("node", "get", "res://main.tscn", "--node", ".", "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
@@ -3342,13 +3351,19 @@ def test_node_add_refuses_a_broken_script_behind_a_type_decoy(godot_project):
         encoding="utf-8",
     )
     before = (godot_project / "main.tscn").read_text(encoding="utf-8")
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
-    added = gda(
-        "node", "add", "res://main.tscn", "--type", "Marker2D", "--name", "M", "--json"
+    err = gda.error(
+        "node",
+        "add",
+        "res://main.tscn",
+        "--type",
+        "Marker2D",
+        "--name",
+        "M",
+        "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(added, "missing_dependency")
     assert "res://enemy_projectile.tscn" in err["message"]
     assert (godot_project / "main.tscn").read_text(encoding="utf-8") == before
 
@@ -3369,9 +3384,9 @@ def test_node_add_refuses_a_broken_script_declared_by_a_relative_path(godot_proj
         encoding="utf-8",
     )
     before = (godot_project / "scenes" / "main.tscn").read_text(encoding="utf-8")
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
-    added = gda(
+    err = gda.error(
         "node",
         "add",
         "res://scenes/main.tscn",
@@ -3380,9 +3395,8 @@ def test_node_add_refuses_a_broken_script_declared_by_a_relative_path(godot_proj
         "--name",
         "M",
         "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(added, "missing_dependency")
     assert "res://enemy_projectile.tscn" in err["message"]
     assert (godot_project / "scenes" / "main.tscn").read_text(
         encoding="utf-8"
@@ -3402,7 +3416,7 @@ def test_node_add_does_not_read_a_script_prefixed_property_as_a_binding(godot_pr
         'script_owner = ExtResource("1_enemy")\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     added = gda(
         "node", "add", "res://main.tscn", "--type", "Marker2D", "--name", "M", "--json"

--- a/tests/test_e2e_object_property.py
+++ b/tests/test_e2e_object_property.py
@@ -19,52 +19,10 @@ the generic ``uncoercible_value``), leaving the target file untouched.
 """
 
 import json
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
-
-
-def _gda_project(project):
-    """A ``gda`` bound to ``--godot`` and ``--project`` so ``res://`` resolves."""
-
-    def gda(*args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-            capture_output=True,
-            text=True,
-        )
-
-    return gda
-
-
-def _import_project(project) -> None:
-    """Run a one-shot headless import so the project's class_name list is written.
-
-    A script ``class_name`` only registers in
-    ``.godot/global_script_class_list.cfg`` after a project scan — the realistic
-    precondition for resolving ``Player`` / ``PlayerConfig`` by class_name
-    (mirrors the node/resource class_name e2e tests).
-    """
-    imported = subprocess.run(
-        [str(GODOT), "--headless", "--path", str(project), "--import"],
-        capture_output=True,
-        text=True,
-        timeout=120,
-    )
-    assert imported.returncode == 0, imported.stdout + imported.stderr
-
-
-def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
-    assert proc.returncode == 4, proc.stdout + proc.stderr
-    err = json.loads(proc.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == code
-    return err
+from tests.support import Gda, import_project
 
 
 def _scene_with_collision_shape(gda, project):
@@ -117,7 +75,7 @@ def test_node_set_object_property_wires_ext_resource_end_to_end(godot_project):
     # workflow wires CollisionShape2D.shape to an existing RectangleShape2D by its
     # res:// path, and the saved scene reloads with the resource attached as an
     # EXTERNAL reference (ext_resource), never inlined.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     scene_path = _scene_with_collision_shape(gda, godot_project)
     _box_shape(gda, godot_project)
 
@@ -174,7 +132,7 @@ def test_resource_set_object_property_wires_ext_resource(godot_project):
     # The resource-on-resource half (ADR-0033): resource set assigns an existing
     # Gradient to GradientTexture1D.gradient (an engine-class-typed Object property)
     # by res:// path, saved as an ext_resource on the .tres.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     tex = gda(
         "resource", "create", "res://tex.tres", "--type", "GradientTexture1D", "--json"
     )
@@ -225,13 +183,13 @@ def test_node_set_object_type_mismatch_yields_resource_type_mismatch(godot_proje
     # A res:// resource whose type is incompatible with the property's expected
     # engine class is a DISTINCT resource_type_mismatch — not uncoercible_value —
     # naming both the actual and the expected class; the scene is left untouched.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     scene_path = _scene_with_collision_shape(gda, godot_project)
     grad = gda("resource", "create", "res://grad.tres", "--type", "Gradient", "--json")
     assert grad.returncode == 0, grad.stdout + grad.stderr
     before = scene_path.read_text(encoding="utf-8")
 
-    was_set = gda(
+    err = gda.error(
         "node",
         "set",
         "res://main.tscn",
@@ -242,9 +200,8 @@ def test_node_set_object_type_mismatch_yields_resource_type_mismatch(godot_proje
         "--value",
         "res://grad.tres",
         "--json",
+        code="resource_type_mismatch",
     )
-
-    err = _assert_operation_error(was_set, "resource_type_mismatch")
     assert "Gradient" in err["message"]
     assert "Shape2D" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
@@ -255,11 +212,11 @@ def test_node_set_object_non_res_value_yields_expected_resource_path(godot_proje
     # A non-res:// value for an Object-typed property is a DISTINCT
     # expected_resource_path (a comma-form scalar that would coerce for a Vector2 is
     # NOT accepted here) — not uncoercible_value; the scene is left untouched.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     scene_path = _scene_with_collision_shape(gda, godot_project)
     before = scene_path.read_text(encoding="utf-8")
 
-    was_set = gda(
+    err = gda.error(
         "node",
         "set",
         "res://main.tscn",
@@ -270,9 +227,8 @@ def test_node_set_object_non_res_value_yields_expected_resource_path(godot_proje
         "--value",
         "32,64",
         "--json",
+        code="expected_resource_path",
     )
-
-    err = _assert_operation_error(was_set, "expected_resource_path")
     assert "res://" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -281,11 +237,11 @@ def test_node_set_object_non_res_value_yields_expected_resource_path(godot_proje
 def test_node_set_object_missing_resource_yields_not_a_resource(godot_project):
     # A res:// value that does not load as a Resource (here: no such path) is a
     # DISTINCT not_a_resource — not uncoercible_value; the scene is left untouched.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     scene_path = _scene_with_collision_shape(gda, godot_project)
     before = scene_path.read_text(encoding="utf-8")
 
-    was_set = gda(
+    err = gda.error(
         "node",
         "set",
         "res://main.tscn",
@@ -296,9 +252,8 @@ def test_node_set_object_missing_resource_yields_not_a_resource(godot_project):
         "--value",
         "res://nope.tres",
         "--json",
+        code="not_a_resource",
     )
-
-    err = _assert_operation_error(was_set, "not_a_resource")
     assert "res://nope.tres" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -308,12 +263,12 @@ def test_node_set_non_resource_file_yields_not_a_resource(godot_project):
     # A res:// path that exists but is NOT a resource (a plain text file) also fails
     # not_a_resource — the failure is "does not load as a Resource", not merely
     # "missing path".
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     scene_path = _scene_with_collision_shape(gda, godot_project)
     (godot_project / "notes.txt").write_text("not a resource\n", encoding="utf-8")
     before = scene_path.read_text(encoding="utf-8")
 
-    was_set = gda(
+    err = gda.error(
         "node",
         "set",
         "res://main.tscn",
@@ -324,9 +279,8 @@ def test_node_set_non_resource_file_yields_not_a_resource(godot_project):
         "--value",
         "res://notes.txt",
         "--json",
+        code="not_a_resource",
     )
-
-    err = _assert_operation_error(was_set, "not_a_resource")
     assert "res://notes.txt" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -337,12 +291,12 @@ def test_node_set_script_property_yields_use_script_attach(godot_project):
     # `script attach` (#118) — the one authoritative script-binding path. Setting it
     # returns an ACTIONABLE structured error naming `script attach`, never a second
     # attach entry; the scene is left untouched.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     scene_path = _scene_with_collision_shape(gda, godot_project)
     (godot_project / "foo.gd").write_text("extends Node2D\n", encoding="utf-8")
     before = scene_path.read_text(encoding="utf-8")
 
-    was_set = gda(
+    err = gda.error(
         "node",
         "set",
         "res://main.tscn",
@@ -353,9 +307,8 @@ def test_node_set_script_property_yields_use_script_attach(godot_project):
         "--value",
         "res://foo.gd",
         "--json",
+        code="use_script_attach",
     )
-
-    err = _assert_operation_error(was_set, "use_script_attach")
     assert "script attach" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -365,7 +318,7 @@ def test_node_set_value_typed_coercion_is_unchanged(godot_project):
     # Regression: the Object branch must not disturb value-typed coercion — a
     # Vector2 property still coerces from the comma form and round-trips as a JSON
     # number pair (the #55 contract, unchanged by ADR-0033).
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     _scene_with_collision_shape(gda, godot_project)
 
     was_set = gda(
@@ -416,10 +369,13 @@ def test_node_set_script_class_name_typed_property_is_deferred(godot_project):
     # never a misleading resource_type_mismatch — naming the class and the deferral,
     # and leaves the scene untouched. Pins the deferred branch as a checked-in
     # contract (the code is public ABI), dispatching through operations.gd.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     (godot_project / "player_config.gd").write_text(PLAYER_CONFIG_GD, encoding="utf-8")
     (godot_project / "player.gd").write_text(PLAYER_GD, encoding="utf-8")
-    _import_project(godot_project)
+    # A script ``class_name`` only registers in the project's global class list
+    # after a project scan — the realistic precondition for resolving ``Player`` /
+    # ``PlayerConfig`` by class_name.
+    import_project(godot_project)
 
     created = gda(
         "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -443,7 +399,7 @@ def test_node_set_script_class_name_typed_property_is_deferred(godot_project):
     assert cfg.returncode == 0, cfg.stdout + cfg.stderr
     before = (godot_project / "main.tscn").read_text(encoding="utf-8")
 
-    was_set = gda(
+    err = gda.error(
         "node",
         "set",
         "res://main.tscn",
@@ -454,8 +410,7 @@ def test_node_set_script_class_name_typed_property_is_deferred(godot_project):
         "--value",
         "res://cfg.tres",
         "--json",
+        code="unsupported_property_type",
     )
-
-    err = _assert_operation_error(was_set, "unsupported_property_type")
     assert "PlayerConfig" in err["message"]
     assert (godot_project / "main.tscn").read_text(encoding="utf-8") == before

--- a/tests/test_e2e_op_robustness.py
+++ b/tests/test_e2e_op_robustness.py
@@ -13,13 +13,11 @@ import time
 
 import pytest
 
-from gda.binary import resolve_godot_binary
 from gda.errors import Failure, classify_run
 from gda.models import EngineVersion
 from gda.parser import parse_result
 from gda.runner import OPERATIONS_GD, RunResult, SubprocessGodotRunner
-
-GODOT = resolve_godot_binary()
+from tests.support import GODOT
 
 
 @pytest.mark.e2e

--- a/tests/test_e2e_params_json.py
+++ b/tests/test_e2e_params_json.py
@@ -8,15 +8,12 @@ toward this gate.
 """
 
 import json
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
+from tests.support import Gda
 
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
+gda = Gda()
 
 
 @pytest.mark.e2e
@@ -24,20 +21,7 @@ def test_scene_create_via_params_json_creates_the_scene(godot_project):
     scene_path = godot_project / "main.tscn"
     params = json.dumps({"path": str(scene_path), "root_type": "Node2D"})
 
-    created = subprocess.run(
-        [
-            *GDA_CMD,
-            "scene",
-            "create",
-            "--params-json",
-            params,
-            "--json",
-            "--godot",
-            str(GODOT),
-        ],
-        capture_output=True,
-        text=True,
-    )
+    created = gda("scene", "create", "--params-json", params, "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     data = json.loads(created.stdout)
@@ -48,11 +32,7 @@ def test_scene_create_via_params_json_creates_the_scene(godot_project):
     assert scene_path.exists()
 
     # And reads back through the engine — the file is loadable, not just present.
-    got = subprocess.run(
-        [*GDA_CMD, "scene", "get", str(scene_path), "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-    )
+    got = gda("scene", "get", str(scene_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["root"]["type"] == "Node2D"
 
@@ -63,21 +43,7 @@ def test_scene_create_via_params_json_stdin_creates_the_scene(godot_project):
     scene_path = godot_project / "fromstdin.tscn"
     params = json.dumps({"path": str(scene_path), "root_type": "Node2D"})
 
-    created = subprocess.run(
-        [
-            *GDA_CMD,
-            "scene",
-            "create",
-            "--params-json",
-            "-",
-            "--json",
-            "--godot",
-            str(GODOT),
-        ],
-        input=params,
-        capture_output=True,
-        text=True,
-    )
+    created = gda("scene", "create", "--params-json", "-", "--json", stdin=params)
 
     assert created.returncode == 0, created.stdout + created.stderr
     assert json.loads(created.stdout)["root_name"] == "fromstdin"

--- a/tests/test_e2e_perf.py
+++ b/tests/test_e2e_perf.py
@@ -11,28 +11,16 @@ Run e2e SERIALLY; not a fresh empty HOME (Godot first-run). The
 
 import json
 import os
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
+from tests.support import Gda
 
-from tests.support import GDA_CMD
-
-from .conftest import project_godot
-
-GODOT = resolve_godot_binary()
+from .conftest import LIVE_MAIN_TSCN, LIVE_PROJECT_GODOT
 
 # A main scene with a Player Node2D so the launched session has a runtime
 # SceneTree to monitor; Player.position is a Vector2 storage property the property
 # timeline samples each frame. File logging stays disabled via project_godot (#180).
-MAIN_TSCN = (
-    "[gd_scene format=3]\n\n"
-    '[node name="Main" type="Node2D"]\n\n'
-    '[node name="Player" type="Node2D" parent="."]\n'
-)
-PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
-
 # A Player that DECLARES a custom signal and emits it once per _process frame with
 # a single int argument (a monotonically increasing tick). The signal e2e watches
 # this signal over a window and asserts the recorded emissions — exercising the
@@ -60,27 +48,10 @@ pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"
 def test_daemon_serves_a_live_perf_snapshot(tmp_path, daemon_runtime_dir):
     # `perf monitors`: a real daemon -> engine session -> the running game's live
     # Performance counters, snapshotted in one frame (frame-coherent, ADR-0020).
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -105,27 +76,10 @@ def test_daemon_serves_a_property_timeline_over_a_window(tmp_path, daemon_runtim
     # `perf monitor --property --frames N`: the time-windowed multi-frame base
     # (#223) collects one sample per frame across the engine session and returns
     # the whole N-sample timeline in a single blocking call (ADR-0017 one-shot RPC).
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -162,28 +116,11 @@ def test_daemon_serves_a_signal_timeline_over_a_window(tmp_path, daemon_runtime_
     # disconnects on finalize. The Player emits `ticked(n)` once per _process frame,
     # so a window of N frames records emissions carrying the int tick arg — the real
     # get_signal_list / connect / record / disconnect path (#239).
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(SIGNAL_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(SIGNAL_PLAYER_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -230,27 +167,10 @@ def test_perf_monitor_missing_node_reports_live_perf_node_not_found(
 ):
     # A path that resolves to no running node is the typed harness op-error,
     # relayed through the daemon (exit-0 sentinel) and mapped by classify_live.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     try:
         assert run("daemon", "start").returncode == 0
@@ -279,12 +199,11 @@ def test_perf_monitors_without_a_daemon_reports_daemon_not_running(tmp_path):
 
     from gda.exit_codes import EXIT_LIVE
 
-    env = {**os.environ, "XDG_RUNTIME_DIR": str(tmp_path / "run")}
-    proc = subprocess.run(
-        [*GDA_CMD, "perf", "monitors", "--project", str(tmp_path), "--json"],
-        capture_output=True,
-        text=True,
-        env=env,
+    proc = Gda(tmp_path, godot=None)(
+        "perf",
+        "monitors",
+        "--json",
+        extra_env={"XDG_RUNTIME_DIR": str(tmp_path / "run")},
     )
 
     assert proc.returncode == EXIT_LIVE, proc.stdout + proc.stderr
@@ -305,8 +224,8 @@ def test_perf_monitors_window_collects_bounded_stats_and_verdicts(
     # 1e6) with one that must fail (fps min 1e6), so `passed` is
     # deterministically false while the command still exits 0 (the verdict is
     # data). The plain snapshot is asserted afterwards on the SAME surface.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
     budget = tmp_path / "budget.json"
     budget.write_text(
         '{"node_count": {"stat": "max", "max": 1000000},'
@@ -314,24 +233,7 @@ def test_perf_monitors_window_collects_bounded_stats_and_verdicts(
         encoding="utf-8",
     )
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     try:
         assert run("daemon", "start").returncode == 0

--- a/tests/test_e2e_project.py
+++ b/tests/test_e2e_project.py
@@ -12,24 +12,12 @@ the e2e fixture has none, so that surface is exercised as a no-op here.
 """
 
 import json
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
+from tests.support import Gda
 
 from .conftest import project_godot
-
-GODOT = resolve_godot_binary()
-
-
-def _gda(project, *args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [*GDA_CMD, *args, "--project", str(project), "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-    )
 
 
 # An [input] action holding a real InputEventKey Object literal — the exact
@@ -51,7 +39,7 @@ INPUT_ACTION_SECTION = (
 
 @pytest.mark.e2e
 def test_project_info_reports_metadata(godot_project):
-    info = _gda(godot_project, "project", "info", "--json")
+    info = Gda(godot_project)("project", "info", "--json")
 
     assert info.returncode == 0, info.stdout + info.stderr
     data = json.loads(info.stdout)
@@ -69,7 +57,7 @@ def test_project_info_reports_metadata(godot_project):
 
 @pytest.mark.e2e
 def test_project_get_reads_a_setting_as_typed_json(godot_project):
-    got = _gda(godot_project, "project", "get", "application/config/name", "--json")
+    got = Gda(godot_project)("project", "get", "application/config/name", "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     data = json.loads(got.stdout)
@@ -88,7 +76,7 @@ def test_project_get_input_action_projects_a_structured_dictionary(godot_project
         project_godot(extra=INPUT_ACTION_SECTION), encoding="utf-8"
     )
 
-    got = _gda(godot_project, "project", "get", "input/fire", "--json")
+    got = Gda(godot_project)("project", "get", "input/fire", "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     data = json.loads(got.stdout)
@@ -119,7 +107,7 @@ def test_project_get_packed_string_array_setting_projects_a_json_list(godot_proj
         encoding="utf-8",
     )
 
-    got = _gda(godot_project, "project", "get", "gda/tags", "--json")
+    got = Gda(godot_project)("project", "get", "gda/tags", "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     data = json.loads(got.stdout)
@@ -132,8 +120,7 @@ def test_project_set_coerces_persists_and_round_trips_via_get(godot_project):
     # The CLI value is a STRING; the operation coerces it to the setting's declared
     # int type, saves project.godot, and the result reports the coerced int (#55
     # coercion reused). A second get reads it back from the saved file.
-    was_set = _gda(
-        godot_project,
+    was_set = Gda(godot_project)(
         "project",
         "set",
         "display/window/size/viewport_width",
@@ -150,14 +137,14 @@ def test_project_set_coerces_persists_and_round_trips_via_get(godot_project):
     assert set_data["value"] == 1920
 
     # Round-trip: a fresh process reads the persisted value back from project.godot.
-    got = _gda(
-        godot_project, "project", "get", "display/window/size/viewport_width", "--json"
+    got = Gda(godot_project)(
+        "project", "get", "display/window/size/viewport_width", "--json"
     )
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["value"] == 1920
 
     # And project info reflects the saved viewport width.
-    info = _gda(godot_project, "project", "info", "--json")
+    info = Gda(godot_project)("project", "info", "--json")
     assert info.returncode == 0, info.stdout + info.stderr
     assert json.loads(info.stdout)["viewport_width"] == 1920
 
@@ -172,8 +159,7 @@ def test_project_set_preserves_json_container_integer_and_float_types(godot_proj
         encoding="utf-8",
     )
 
-    was_set = _gda(
-        godot_project,
+    was_set = Gda(godot_project)(
         "project",
         "set",
         "gda/stats",
@@ -189,7 +175,7 @@ def test_project_set_preserves_json_container_integer_and_float_types(godot_proj
     assert type(set_value["items"][0]) is int
     assert type(set_value["items"][1]) is float
 
-    got = _gda(godot_project, "project", "get", "gda/stats", "--json")
+    got = Gda(godot_project)("project", "get", "gda/stats", "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     got_value = json.loads(got.stdout)["value"]
     assert type(got_value["a"]) is int
@@ -201,8 +187,7 @@ def test_project_set_preserves_json_container_integer_and_float_types(godot_proj
 @pytest.mark.e2e
 def test_project_set_string_setting_round_trips(godot_project):
     # A String-typed setting takes the CLI value verbatim and round-trips.
-    was_set = _gda(
-        godot_project,
+    was_set = Gda(godot_project)(
         "project",
         "set",
         "application/config/name",
@@ -213,7 +198,7 @@ def test_project_set_string_setting_round_trips(godot_project):
     assert was_set.returncode == 0, was_set.stdout + was_set.stderr
     assert json.loads(was_set.stdout)["value"] == "Renamed Game"
 
-    got = _gda(godot_project, "project", "get", "application/config/name", "--json")
+    got = Gda(godot_project)("project", "get", "application/config/name", "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["value"] == "Renamed Game"
 
@@ -223,7 +208,7 @@ def test_project_list_bare_reports_only_customized_settings(godot_project):
     # A bare list reports only the settings the fixture's project.godot actually
     # writes (customized), each as {setting, type, value, is_default} with
     # is_default false — NOT the hundreds of engine built-in defaults.
-    listed = _gda(godot_project, "project", "list", "--json")
+    listed = Gda(godot_project)("project", "list", "--json")
 
     assert listed.returncode == 0, listed.stdout + listed.stderr
     settings = json.loads(listed.stdout)["settings"]
@@ -248,7 +233,7 @@ def test_project_list_all_includes_engine_defaults(godot_project):
     # --all widens the listing to the engine's built-in defaults too, so a setting
     # the project never customized appears, flagged is_default true, alongside the
     # customized ones (is_default false).
-    listed = _gda(godot_project, "project", "list", "--all", "--json")
+    listed = Gda(godot_project)("project", "list", "--all", "--json")
 
     assert listed.returncode == 0, listed.stdout + listed.stderr
     settings = json.loads(listed.stdout)["settings"]
@@ -273,8 +258,7 @@ def test_project_list_all_includes_engine_defaults(godot_project):
 def test_project_list_section_filters_to_a_prefix_and_composes_with_all(godot_project):
     # --section restricts to keys under a section/ prefix; with --all it scopes the
     # engine defaults to that section too.
-    listed = _gda(
-        godot_project,
+    listed = Gda(godot_project)(
         "project",
         "list",
         "--all",
@@ -299,7 +283,7 @@ def test_project_list_section_filters_to_a_prefix_and_composes_with_all(godot_pr
 def test_project_list_entry_round_trips_through_project_get(godot_project):
     # A listed entry reports the SAME {type, value} projection project get reports
     # for that key — so an agent can list to discover, then get to read one.
-    listed = _gda(godot_project, "project", "list", "--all", "--json")
+    listed = Gda(godot_project)("project", "list", "--all", "--json")
     assert listed.returncode == 0, listed.stdout + listed.stderr
     entry = next(
         e
@@ -307,8 +291,8 @@ def test_project_list_entry_round_trips_through_project_get(godot_project):
         if e["setting"] == "display/window/size/viewport_width"
     )
 
-    got = _gda(
-        godot_project, "project", "get", "display/window/size/viewport_width", "--json"
+    got = Gda(godot_project)(
+        "project", "get", "display/window/size/viewport_width", "--json"
     )
     assert got.returncode == 0, got.stdout + got.stderr
     got_data = json.loads(got.stdout)
@@ -321,12 +305,7 @@ def test_project_list_without_project_is_a_clean_error():
     # Projectless: ProjectSettings would report only the engine's bare defaults,
     # not the agent's project, so it is refused with project_not_found (exit 4),
     # consistent with the rest of the project group.
-    proc = subprocess.run(
-        [*GDA_CMD, "project", "list", "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-        cwd="/tmp",
-    )
+    proc = Gda()("project", "list", "--json", cwd="/tmp")
 
     assert proc.returncode == 4
     err = json.loads(proc.stdout)["error"]
@@ -335,7 +314,7 @@ def test_project_list_without_project_is_a_clean_error():
 
 @pytest.mark.e2e
 def test_project_get_unknown_setting_is_a_clean_error(godot_project):
-    got = _gda(godot_project, "project", "get", "application/bogus/key", "--json")
+    got = Gda(godot_project)("project", "get", "application/bogus/key", "--json")
 
     assert got.returncode == 4
     err = json.loads(got.stdout)["error"]
@@ -348,8 +327,7 @@ def test_project_get_unknown_setting_is_a_clean_error(godot_project):
 def test_project_set_uncoercible_value_is_a_clean_error(godot_project):
     # An int setting cannot take a non-numeric string — uncoercible_value (#55),
     # exit 4, project.godot left untouched.
-    bad = _gda(
-        godot_project,
+    bad = Gda(godot_project)(
         "project",
         "set",
         "display/window/size/viewport_width",
@@ -364,8 +342,8 @@ def test_project_set_uncoercible_value_is_a_clean_error(godot_project):
     assert err["code"] == "uncoercible_value"
 
     # The file was untouched: a subsequent get still returns the original value.
-    got = _gda(
-        godot_project, "project", "get", "display/window/size/viewport_width", "--json"
+    got = Gda(godot_project)(
+        "project", "get", "display/window/size/viewport_width", "--json"
     )
     assert got.returncode == 0, got.stdout + got.stderr
 
@@ -375,8 +353,7 @@ def test_project_add_autoload_registers_persists_and_round_trips(godot_project):
     # A real script to autoload must exist in the project (path_not_found otherwise).
     (godot_project / "global.gd").write_text("extends Node\n", encoding="utf-8")
 
-    added = _gda(
-        godot_project,
+    added = Gda(godot_project)(
         "project",
         "add-autoload",
         "Global",
@@ -391,7 +368,7 @@ def test_project_add_autoload_registers_persists_and_round_trips(godot_project):
     assert add_data["path"] == "*res://global.gd"
 
     # Round-trip: a fresh process reads the autoload back from project.godot via get.
-    got = _gda(godot_project, "project", "get", "autoload/Global", "--json")
+    got = Gda(godot_project)("project", "get", "autoload/Global", "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     got_data = json.loads(got.stdout)
     assert got_data["setting"] == "autoload/Global"
@@ -401,18 +378,18 @@ def test_project_add_autoload_registers_persists_and_round_trips(godot_project):
 @pytest.mark.e2e
 def test_project_remove_autoload_unregisters_and_round_trips(godot_project):
     (godot_project / "global.gd").write_text("extends Node\n", encoding="utf-8")
-    added = _gda(
-        godot_project, "project", "add-autoload", "Global", "res://global.gd", "--json"
+    added = Gda(godot_project)(
+        "project", "add-autoload", "Global", "res://global.gd", "--json"
     )
     assert added.returncode == 0, added.stdout + added.stderr
 
-    removed = _gda(godot_project, "project", "remove-autoload", "Global", "--json")
+    removed = Gda(godot_project)("project", "remove-autoload", "Global", "--json")
     assert removed.returncode == 0, removed.stdout + removed.stderr
     assert json.loads(removed.stdout) == {"name": "Global"}
 
     # Round-trip: the autoload is gone from project.godot — a fresh get reports it
     # as an unknown setting, exit 4.
-    got = _gda(godot_project, "project", "get", "autoload/Global", "--json")
+    got = Gda(godot_project)("project", "get", "autoload/Global", "--json")
     assert got.returncode == 4, got.stdout + got.stderr
     assert json.loads(got.stdout)["error"]["code"] == "unknown_setting"
 
@@ -420,13 +397,13 @@ def test_project_remove_autoload_unregisters_and_round_trips(godot_project):
 @pytest.mark.e2e
 def test_project_add_autoload_duplicate_name_is_a_clean_error(godot_project):
     (godot_project / "global.gd").write_text("extends Node\n", encoding="utf-8")
-    first = _gda(
-        godot_project, "project", "add-autoload", "Global", "res://global.gd", "--json"
+    first = Gda(godot_project)(
+        "project", "add-autoload", "Global", "res://global.gd", "--json"
     )
     assert first.returncode == 0, first.stdout + first.stderr
 
-    dup = _gda(
-        godot_project, "project", "add-autoload", "Global", "res://global.gd", "--json"
+    dup = Gda(godot_project)(
+        "project", "add-autoload", "Global", "res://global.gd", "--json"
     )
     assert dup.returncode == 4
     err = json.loads(dup.stdout)["error"]
@@ -434,7 +411,7 @@ def test_project_add_autoload_duplicate_name_is_a_clean_error(godot_project):
     assert err["code"] == "already_exists"
 
     # The original registration is untouched: a get still reads it back.
-    got = _gda(godot_project, "project", "get", "autoload/Global", "--json")
+    got = Gda(godot_project)("project", "get", "autoload/Global", "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["value"] == "*res://global.gd"
 
@@ -442,8 +419,7 @@ def test_project_add_autoload_duplicate_name_is_a_clean_error(godot_project):
 @pytest.mark.e2e
 def test_project_add_autoload_missing_target_is_a_clean_error(godot_project):
     # The target script/scene does not exist — path_not_found, exit 4, nothing saved.
-    bad = _gda(
-        godot_project,
+    bad = Gda(godot_project)(
         "project",
         "add-autoload",
         "Global",
@@ -457,14 +433,14 @@ def test_project_add_autoload_missing_target_is_a_clean_error(godot_project):
     assert err["code"] == "path_not_found"
 
     # Nothing was registered: a get reports the autoload as unknown.
-    got = _gda(godot_project, "project", "get", "autoload/Global", "--json")
+    got = Gda(godot_project)("project", "get", "autoload/Global", "--json")
     assert got.returncode == 4
     assert json.loads(got.stdout)["error"]["code"] == "unknown_setting"
 
 
 @pytest.mark.e2e
 def test_project_remove_autoload_unknown_name_is_a_clean_error(godot_project):
-    bad = _gda(godot_project, "project", "remove-autoload", "Nonexistent", "--json")
+    bad = Gda(godot_project)("project", "remove-autoload", "Nonexistent", "--json")
 
     assert bad.returncode == 4
     err = json.loads(bad.stdout)["error"]
@@ -491,8 +467,7 @@ def test_project_add_input_action_persists_var_to_str_form_and_reports_keycodes(
     # section with real Object(InputEventKey, ...) literals (issue #380). The
     # stored-value SHAPE via `project get` is deliberately NOT asserted here (the
     # read-side projection of a compound setting is #381, independent).
-    added = _gda(
-        godot_project,
+    added = Gda(godot_project)(
         "project",
         "add-input-action",
         "jump",
@@ -531,8 +506,7 @@ def test_project_add_input_action_persists_var_to_str_form_and_reports_keycodes(
 def test_project_add_input_action_physical_binds_physical_keycode(godot_project):
     # --physical binds the keyboard POSITION: the persisted event carries the
     # keycode in physical_keycode, and the layout keycode stays unset (0).
-    added = _gda(
-        godot_project,
+    added = Gda(godot_project)(
         "project",
         "add-input-action",
         "move_up",
@@ -557,14 +531,14 @@ def test_project_add_input_action_physical_binds_physical_keycode(godot_project)
 
 @pytest.mark.e2e
 def test_project_add_input_action_duplicate_name_is_a_clean_error(godot_project):
-    first = _gda(
-        godot_project, "project", "add-input-action", "fire", "--key", "F", "--json"
+    first = Gda(godot_project)(
+        "project", "add-input-action", "fire", "--key", "F", "--json"
     )
     assert first.returncode == 0, first.stdout + first.stderr
     before = _normalized_project_godot(godot_project)
 
-    dup = _gda(
-        godot_project, "project", "add-input-action", "fire", "--key", "J", "--json"
+    dup = Gda(godot_project)(
+        "project", "add-input-action", "fire", "--key", "J", "--json"
     )
     assert dup.returncode == 4
     err = json.loads(dup.stdout)["error"]
@@ -577,8 +551,7 @@ def test_project_add_input_action_duplicate_name_is_a_clean_error(godot_project)
 
 @pytest.mark.e2e
 def test_project_add_input_action_unknown_key_is_a_clean_error(godot_project):
-    bad = _gda(
-        godot_project,
+    bad = Gda(godot_project)(
         "project",
         "add-input-action",
         "jump",
@@ -599,12 +572,12 @@ def test_project_add_input_action_unknown_key_is_a_clean_error(godot_project):
 
 @pytest.mark.e2e
 def test_project_remove_input_action_unregisters_and_persists(godot_project):
-    added = _gda(
-        godot_project, "project", "add-input-action", "jump", "--key", "J", "--json"
+    added = Gda(godot_project)(
+        "project", "add-input-action", "jump", "--key", "J", "--json"
     )
     assert added.returncode == 0, added.stdout + added.stderr
 
-    removed = _gda(godot_project, "project", "remove-input-action", "jump", "--json")
+    removed = Gda(godot_project)("project", "remove-input-action", "jump", "--json")
     assert removed.returncode == 0, removed.stdout + removed.stderr
     assert json.loads(removed.stdout) == {"name": "jump"}
 
@@ -616,7 +589,7 @@ def test_project_remove_input_action_unregisters_and_persists(godot_project):
 
 @pytest.mark.e2e
 def test_project_remove_input_action_unknown_name_is_a_clean_error(godot_project):
-    bad = _gda(godot_project, "project", "remove-input-action", "nonexistent", "--json")
+    bad = Gda(godot_project)("project", "remove-input-action", "nonexistent", "--json")
 
     assert bad.returncode == 4
     err = json.loads(bad.stdout)["error"]
@@ -629,12 +602,7 @@ def test_project_remove_input_action_unknown_name_is_a_clean_error(godot_project
 def test_project_info_without_project_is_a_clean_error():
     # Projectless: ProjectSettings would report only the engine's bare defaults,
     # not the agent's project, so it is refused with project_not_found.
-    proc = subprocess.run(
-        [*GDA_CMD, "project", "info", "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-        cwd="/tmp",
-    )
+    proc = Gda()("project", "info", "--json", cwd="/tmp")
 
     assert proc.returncode == 4
     err = json.loads(proc.stdout)["error"]

--- a/tests/test_e2e_project_analysis.py
+++ b/tests/test_e2e_project_analysis.py
@@ -14,16 +14,12 @@ acceptance criterion: the same reference graph backs both).
 """
 
 import json
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
+from tests.support import Gda, import_project
 
 from .conftest import project_godot
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
 
 
 # A project.godot with an autoload, a main scene, and an enabled editor plugin —
@@ -140,17 +136,9 @@ def refgraph_project(tmp_path):
     return tmp_path
 
 
-def _gda(project, *args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-        capture_output=True,
-        text=True,
-    )
-
-
 @pytest.mark.e2e
 def test_dependencies_maps_each_scene_to_its_ext_resources(refgraph_project):
-    proc = _gda(refgraph_project, "project", "dependencies", "--json")
+    proc = Gda(refgraph_project)("project", "dependencies", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     data = json.loads(proc.stdout)
@@ -169,8 +157,8 @@ def test_dependencies_maps_each_scene_to_its_ext_resources(refgraph_project):
 
 @pytest.mark.e2e
 def test_find_references_to_a_script_finds_every_referencing_site(refgraph_project):
-    proc = _gda(
-        refgraph_project, "project", "find-references", "res://util.gd", "--json"
+    proc = Gda(refgraph_project)(
+        "project", "find-references", "res://util.gd", "--json"
     )
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
@@ -183,8 +171,8 @@ def test_find_references_to_a_script_finds_every_referencing_site(refgraph_proje
 
 @pytest.mark.e2e
 def test_find_references_to_a_scene_finds_the_ext_resource(refgraph_project):
-    proc = _gda(
-        refgraph_project, "project", "find-references", "res://hero.tscn", "--json"
+    proc = Gda(refgraph_project)(
+        "project", "find-references", "res://hero.tscn", "--json"
     )
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
@@ -197,8 +185,8 @@ def test_find_references_to_a_scene_finds_the_ext_resource(refgraph_project):
 def test_find_references_to_the_main_scene_includes_the_project_level_reference(
     refgraph_project,
 ):
-    proc = _gda(
-        refgraph_project, "project", "find-references", "res://main.tscn", "--json"
+    proc = Gda(refgraph_project)(
+        "project", "find-references", "res://main.tscn", "--json"
     )
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
@@ -209,8 +197,8 @@ def test_find_references_to_the_main_scene_includes_the_project_level_reference(
 
 @pytest.mark.e2e
 def test_find_references_to_an_unreferenced_resource_is_empty(refgraph_project):
-    proc = _gda(
-        refgraph_project, "project", "find-references", "res://orphan.tres", "--json"
+    proc = Gda(refgraph_project)(
+        "project", "find-references", "res://orphan.tres", "--json"
     )
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
@@ -221,7 +209,7 @@ def test_find_references_to_an_unreferenced_resource_is_empty(refgraph_project):
 def test_find_unused_resources_reports_the_orphan_and_is_consistent_with_find_references(
     refgraph_project,
 ):
-    proc = _gda(refgraph_project, "project", "find-unused-resources", "--json")
+    proc = Gda(refgraph_project)("project", "find-unused-resources", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     unused = json.loads(proc.stdout)["unused"]
@@ -238,13 +226,13 @@ def test_find_unused_resources_reports_the_orphan_and_is_consistent_with_find_re
     # find-references for it returns empty, and a referenced one returns non-empty.
     for path in unused:
         refs = json.loads(
-            _gda(refgraph_project, "project", "find-references", path, "--json").stdout
+            Gda(refgraph_project)("project", "find-references", path, "--json").stdout
         )["references"]
         assert refs == [], f"{path} reported unused but has references {refs}"
 
     hero_refs = json.loads(
-        _gda(
-            refgraph_project, "project", "find-references", "res://hero.tscn", "--json"
+        Gda(refgraph_project)(
+            "project", "find-references", "res://hero.tscn", "--json"
         ).stdout
     )["references"]
     assert hero_refs != []  # referenced, hence not in unused
@@ -256,8 +244,8 @@ def test_find_references_skips_decoding_binary_artifacts(refgraph_project):
     # dispatch on extension BEFORE reading, so the binary is never UTF-8-decoded
     # — no engine "Unicode parsing error" on stderr (issue #378) — while the
     # references over the text formats stay byte-for-byte unchanged.
-    proc = _gda(
-        refgraph_project, "project", "find-references", "res://util.gd", "--json"
+    proc = Gda(refgraph_project)(
+        "project", "find-references", "res://util.gd", "--json"
     )
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
@@ -275,7 +263,7 @@ def test_find_unused_resources_skips_decoding_but_keeps_binary_graph_nodes(
     # for DECODING — they stay enumerated as graph nodes, so the unreferenced
     # binary asset (orphan.png) and the build artifact are still unused
     # candidates.
-    proc = _gda(refgraph_project, "project", "find-unused-resources", "--json")
+    proc = Gda(refgraph_project)("project", "find-unused-resources", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     assert "Unicode parsing error" not in proc.stderr, proc.stderr
@@ -286,7 +274,7 @@ def test_find_unused_resources_skips_decoding_but_keeps_binary_graph_nodes(
 
 @pytest.mark.e2e
 def test_statistics_reports_counts_autoloads_and_plugins(refgraph_project):
-    proc = _gda(refgraph_project, "project", "statistics", "--json")
+    proc = Gda(refgraph_project)("project", "statistics", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     data = json.loads(proc.stdout)
@@ -314,8 +302,8 @@ def test_statistics_reports_counts_autoloads_and_plugins(refgraph_project):
 def test_find_references_bad_target_is_invalid_target(refgraph_project):
     # A target that is neither a res:// path nor a registered class_name is a
     # structured invalid_target operation error (exit 4), not an empty result.
-    proc = _gda(
-        refgraph_project, "project", "find-references", "/abs/not/a/target", "--json"
+    proc = Gda(refgraph_project)(
+        "project", "find-references", "/abs/not/a/target", "--json"
     )
 
     assert proc.returncode == 4, proc.stdout + proc.stderr
@@ -370,18 +358,6 @@ func sigh() -> void:
 """
 
 
-def _import_project(project) -> None:
-    # class_name registration lives in the project's global class list, which only
-    # a project scan produces — run the engine's headless import step the way a CI
-    # pipeline would before resolving a find-references target by class_name.
-    imported = subprocess.run(
-        [str(GODOT), "--headless", "--path", str(project), "--import"],
-        capture_output=True,
-        text=True,
-    )
-    assert imported.returncode == 0, imported.stdout + imported.stderr
-
-
 @pytest.fixture
 def classname_project(tmp_path):
     """A project where a class is referenced only by its class_name token."""
@@ -390,7 +366,10 @@ def classname_project(tmp_path):
     (tmp_path / "villain.gd").write_text(VILLAIN_GD, encoding="utf-8")
     (tmp_path / "spawner.gd").write_text(SPAWNER_GD, encoding="utf-8")
     (tmp_path / "lonely.gd").write_text(LONELY_GD, encoding="utf-8")
-    _import_project(tmp_path)
+    # class_name registration lives in the project's global class list, which only
+    # a project scan produces — the precondition for resolving a find-references
+    # target by class_name.
+    import_project(tmp_path)
     return tmp_path
 
 
@@ -402,7 +381,7 @@ def test_find_references_to_a_class_name_excludes_its_own_declaration(
     # `var x: Hero` annotation, Hero.new()) but NEVER hero.gd's own
     # `class_name Hero` declaration line — that is the definition site, not a
     # reference (issue #116 review: false positive).
-    proc = _gda(classname_project, "project", "find-references", "Hero", "--json")
+    proc = Gda(classname_project)("project", "find-references", "Hero", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     data = json.loads(proc.stdout)
@@ -428,7 +407,7 @@ def test_find_references_to_a_class_name_excludes_its_own_declaration(
 def test_find_references_to_an_unreferenced_class_name_is_empty(classname_project):
     # A class declared via class_name that NOTHING consumes returns an empty
     # reference set — its own declaration line must not count as a reference.
-    proc = _gda(classname_project, "project", "find-references", "Lonely", "--json")
+    proc = Gda(classname_project)("project", "find-references", "Lonely", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     assert json.loads(proc.stdout)["references"] == []
@@ -453,7 +432,7 @@ def test_statistics_counts_binary_assets_as_files_but_not_lines(tmp_path):
         b"\x89PNG\r\n\x1a\n" + (b"\n" * 50) + b"\x00\xff\x10binary\n"
     )
 
-    proc = _gda(tmp_path, "project", "statistics", "--json")
+    proc = Gda(tmp_path)("project", "statistics", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     data = json.loads(proc.stdout)
@@ -475,12 +454,7 @@ def test_statistics_counts_binary_assets_as_files_but_not_lines(tmp_path):
 def test_dependencies_without_project_is_project_not_found(tmp_path):
     # Run projectless (no --project, cwd is not a project): the res:// scan has no
     # tree to walk, so it refuses with the registered project_not_found code.
-    proc = subprocess.run(
-        [*GDA_CMD, "project", "dependencies", "--godot", str(GODOT), "--json"],
-        capture_output=True,
-        text=True,
-        cwd=str(tmp_path),
-    )
+    proc = Gda()("project", "dependencies", "--json", cwd=tmp_path)
 
     assert proc.returncode == 4, proc.stdout + proc.stderr
     err = json.loads(proc.stdout)["error"]
@@ -540,9 +514,9 @@ def test_project_walks_agree_on_a_nested_dot_godot_directory(tmp_path):
         CACHED_THING_GD, encoding="utf-8"
     )
 
-    scene_proc = _gda(project, "scene", "list", "--json")
-    script_proc = _gda(project, "script", "list", "--json")
-    stats_proc = _gda(project, "project", "statistics", "--json")
+    scene_proc = Gda(project)("scene", "list", "--json")
+    script_proc = Gda(project)("script", "list", "--json")
+    stats_proc = Gda(project)("project", "statistics", "--json")
 
     assert scene_proc.returncode == 0, scene_proc.stdout + scene_proc.stderr
     assert script_proc.returncode == 0, script_proc.stdout + script_proc.stderr
@@ -566,14 +540,14 @@ def test_project_walks_agree_on_a_nested_dot_godot_directory(tmp_path):
 
     # The class_name index rides the resource walk, so node/resource creation
     # resolves the nested declaration `script list` reports...
-    added = _gda(
-        project, "node", "add", "res://top.tscn", "--type", "NestedThing", "--json"
+    added = Gda(project)(
+        "node", "add", "res://top.tscn", "--type", "NestedThing", "--json"
     )
     assert added.returncode == 0, added.stdout + added.stderr
     assert json.loads(added.stdout)["script_class"] == "NestedThing"
     # ...and still does not resolve one authored into the engine's own cache.
-    cached = _gda(
-        project, "node", "add", "res://top.tscn", "--type", "CachedThing", "--json"
+    cached = Gda(project)(
+        "node", "add", "res://top.tscn", "--type", "CachedThing", "--json"
     )
     assert cached.returncode == 4, cached.stdout + cached.stderr
     assert json.loads(cached.stdout)["error"]["code"] == "invalid_node_type"
@@ -582,11 +556,11 @@ def test_project_walks_agree_on_a_nested_dot_godot_directory(tmp_path):
     # add, which wrote an [ext_resource] to the nested script into
     # `res://top.tscn` — so the nested content is a real reference target here,
     # not just an enumerated path.
-    deps_proc = _gda(project, "project", "dependencies", "--json")
-    refs_proc = _gda(
-        project, "project", "find-references", "res://nested/.godot/hidden.gd", "--json"
+    deps_proc = Gda(project)("project", "dependencies", "--json")
+    refs_proc = Gda(project)(
+        "project", "find-references", "res://nested/.godot/hidden.gd", "--json"
     )
-    unused_proc = _gda(project, "project", "find-unused-resources", "--json")
+    unused_proc = Gda(project)("project", "find-unused-resources", "--json")
 
     assert deps_proc.returncode == 0, deps_proc.stdout + deps_proc.stderr
     assert refs_proc.returncode == 0, refs_proc.stdout + refs_proc.stderr
@@ -759,7 +733,7 @@ def alias_project(tmp_path):
 
 @pytest.mark.e2e
 def test_dependencies_keys_an_aliased_declaration_canonically(alias_project):
-    proc = _gda(alias_project, "project", "dependencies", "--json")
+    proc = Gda(alias_project)("project", "dependencies", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     by_source = {
@@ -796,11 +770,11 @@ def test_dependencies_keys_an_aliased_declaration_canonically(alias_project):
 def test_find_references_matches_an_aliased_declaration_from_a_canonical_query(
     alias_project,
 ):
-    scene = _gda(
-        alias_project, "project", "find-references", "res://leaf.tscn", "--json"
+    scene = Gda(alias_project)(
+        "project", "find-references", "res://leaf.tscn", "--json"
     )
-    script = _gda(
-        alias_project, "project", "find-references", "res://helper.gd", "--json"
+    script = Gda(alias_project)(
+        "project", "find-references", "res://helper.gd", "--json"
     )
 
     assert scene.returncode == 0, scene.stdout + scene.stderr
@@ -819,13 +793,12 @@ def test_find_references_matches_a_relative_declaration(alias_project):
     # the engine loads res://shared/deep.tscn, so a query for that path must find
     # the declaring site. Reported empty before the declaring file's directory was
     # used to anchor the spelling.
-    deep = _gda(
-        alias_project, "project", "find-references", "res://shared/deep.tscn", "--json"
+    deep = Gda(alias_project)(
+        "project", "find-references", "res://shared/deep.tscn", "--json"
     )
     # And the prefix-less relative form, declared `scenes/nested.tscn` from the
     # project root — a spelling with no `..` in it at all.
-    nested = _gda(
-        alias_project,
+    nested = Gda(alias_project)(
         "project",
         "find-references",
         "res://scenes/nested.tscn",
@@ -851,8 +824,7 @@ def test_find_references_matches_a_relative_declaration(alias_project):
 def test_find_references_matches_a_canonical_declaration_from_an_aliased_query(
     alias_project,
 ):
-    proc = _gda(
-        alias_project,
+    proc = Gda(alias_project)(
         "project",
         "find-references",
         "res://sub/../icon.png",
@@ -872,11 +844,11 @@ def test_find_references_matches_a_canonical_declaration_from_an_aliased_query(
 def test_find_references_matches_an_aliased_project_level_entry(alias_project):
     # project.godot is a harvest site too: its main scene and autoloads name a
     # resource by path the way an ext_resource line does.
-    main = _gda(
-        alias_project, "project", "find-references", "res://parent.tscn", "--json"
+    main = Gda(alias_project)(
+        "project", "find-references", "res://parent.tscn", "--json"
     )
-    autoload = _gda(
-        alias_project, "project", "find-references", "res://hud.tscn", "--json"
+    autoload = Gda(alias_project)(
+        "project", "find-references", "res://hud.tscn", "--json"
     )
 
     assert main.returncode == 0, main.stdout + main.stderr
@@ -891,7 +863,7 @@ def test_find_references_matches_an_aliased_project_level_entry(alias_project):
 
 @pytest.mark.e2e
 def test_find_unused_resources_never_lists_an_aliased_reference(alias_project):
-    proc = _gda(alias_project, "project", "find-unused-resources", "--json")
+    proc = Gda(alias_project)("project", "find-unused-resources", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     unused = json.loads(proc.stdout)["unused"]
@@ -915,7 +887,7 @@ def test_find_unused_resources_never_lists_an_aliased_reference(alias_project):
     # exactly "find-references returns empty".
     for path in unused:
         refs = json.loads(
-            _gda(alias_project, "project", "find-references", path, "--json").stdout
+            Gda(alias_project)("project", "find-references", path, "--json").stdout
         )["references"]
         assert refs == [], f"{path} reported unused but has references {refs}"
 
@@ -964,7 +936,7 @@ def one_reader_project(tmp_path):
 def test_dependencies_reads_the_named_path_attribute_not_a_substring(
     one_reader_project,
 ):
-    proc = _gda(one_reader_project, "project", "dependencies", "--json")
+    proc = Gda(one_reader_project)("project", "dependencies", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     by_source = {
@@ -981,11 +953,11 @@ def test_dependencies_reads_the_named_path_attribute_not_a_substring(
 def test_find_references_reads_the_named_path_attribute_not_a_substring(
     one_reader_project,
 ):
-    real = _gda(
-        one_reader_project, "project", "find-references", "res://real.png", "--json"
+    real = Gda(one_reader_project)(
+        "project", "find-references", "res://real.png", "--json"
     )
-    decoy = _gda(
-        one_reader_project, "project", "find-references", "res://decoy.png", "--json"
+    decoy = Gda(one_reader_project)(
+        "project", "find-references", "res://decoy.png", "--json"
     )
 
     assert real.returncode == 0, real.stdout + real.stderr
@@ -1006,7 +978,7 @@ def test_find_references_reads_the_named_path_attribute_not_a_substring(
 def test_find_unused_resources_agrees_with_the_named_path_attribute(
     one_reader_project,
 ):
-    proc = _gda(one_reader_project, "project", "find-unused-resources", "--json")
+    proc = Gda(one_reader_project)("project", "find-unused-resources", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     unused = json.loads(proc.stdout)["unused"]
@@ -1054,9 +1026,9 @@ def unknown_tag_project(tmp_path):
 def test_an_unknown_section_tag_is_not_an_ext_resource_declaration(
     unknown_tag_project,
 ):
-    deps = _gda(unknown_tag_project, "project", "dependencies", "--json")
-    ghost = _gda(
-        unknown_tag_project, "project", "find-references", "res://ghost.png", "--json"
+    deps = Gda(unknown_tag_project)("project", "dependencies", "--json")
+    ghost = Gda(unknown_tag_project)(
+        "project", "find-references", "res://ghost.png", "--json"
     )
 
     assert deps.returncode == 0, deps.stdout + deps.stderr
@@ -1108,8 +1080,8 @@ def pathless_decl_project(tmp_path):
 def test_find_references_does_not_match_a_directory_through_a_pathless_declaration(
     pathless_decl_project,
 ):
-    found = _gda(
-        pathless_decl_project, "project", "find-references", "res://scenes", "--json"
+    found = Gda(pathless_decl_project)(
+        "project", "find-references", "res://scenes", "--json"
     )
 
     assert found.returncode == 0, found.stdout + found.stderr

--- a/tests/test_e2e_project_walk.py
+++ b/tests/test_e2e_project_walk.py
@@ -27,16 +27,12 @@ universe is the engine's.
 """
 
 import json
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
+from tests.support import Gda
 
 from .conftest import project_godot
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
 
 PROJECT_GODOT = project_godot(name="gda-walk-fixture")
 
@@ -86,28 +82,14 @@ def walk_project(tmp_path):
     return tmp_path
 
 
-def _gda(project, *args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-        capture_output=True,
-        text=True,
-    )
-
-
-def _result(project, *args: str) -> dict:
-    proc = _gda(project, *args, "--json")
-    assert proc.returncode == 0, proc.stdout + proc.stderr
-    return json.loads(proc.stdout)
-
-
 @pytest.mark.e2e
 def test_the_listings_accept_an_extension_in_any_case_as_the_engine_does(walk_project):
     # AC2 (#764): the case-sensitivity drift is resolved case-INSENSITIVELY, on
     # both sides. `Level.TSCN` is a scene to the engine (it loads as a
     # PackedScene, reported below through root_type) so `scene list` reports it;
     # `Widget.GD` was already accepted by the script walk and stays accepted.
-    scenes = {s["path"]: s for s in _result(walk_project, "scene", "list")["scenes"]}
-    scripts = {s["path"] for s in _result(walk_project, "script", "list")["scripts"]}
+    scenes = {s["path"]: s for s in Gda(walk_project).json("scene", "list")["scenes"]}
+    scripts = {s["path"] for s in Gda(walk_project).json("script", "list")["scripts"]}
 
     assert set(scenes) == {"res://main.tscn", "res://Level.TSCN"}
     assert scripts == {"res://helper.gd", "res://Widget.GD"}
@@ -120,7 +102,7 @@ def test_the_listings_accept_an_extension_in_any_case_as_the_engine_does(walk_pr
     # classifies by a lowercased extension, so its counts match the listings.
     # Before this change it counted a scene `scene list` could not see (#712's
     # failure shape, on the acceptance test instead of the descent decision).
-    stats = _result(walk_project, "project", "statistics")
+    stats = Gda(walk_project).json("project", "statistics")
     assert stats["scene_count"] == len(scenes)
     assert stats["script_count"] == len(scripts)
 
@@ -131,7 +113,7 @@ def test_the_two_file_universes_survive_the_shared_traversal(walk_project):
     # file it reaches — including the `.import` sidecar and `project.godot` — while
     # the extension-filtered walk behind the reference graph excludes exactly
     # those, and still sees the leaf asset beside them.
-    stats = _result(walk_project, "project", "statistics")
+    stats = Gda(walk_project).json("project", "statistics")
     by_ext = {e["extension"]: e["files"] for e in stats["by_extension"]}
 
     assert by_ext.get("import") == 1, by_ext  # icon.png.import
@@ -140,10 +122,10 @@ def test_the_two_file_universes_survive_the_shared_traversal(walk_project):
 
     # The filtered universe: the sidecar and the project file are not resources,
     # so they are neither unused-resource candidates nor dependency sources...
-    unused = set(_result(walk_project, "project", "find-unused-resources")["unused"])
+    unused = set(Gda(walk_project).json("project", "find-unused-resources")["unused"])
     sources = {
         d["path"]
-        for d in _result(walk_project, "project", "dependencies")["dependencies"]
+        for d in Gda(walk_project).json("project", "dependencies")["dependencies"]
     }
     excluded = {"res://icon.png.import", "res://project.godot"}
     assert not (unused & excluded), unused
@@ -264,10 +246,9 @@ def _assert_class_name_unresolvable(project, *classes: str) -> None:
     The message half is asserted too, because it is the half that distinguishes
     "no script declares this" from every other ``invalid_node_type``.
     """
-    _result(project, "scene", "create", "res://host.tscn", "--root-type", "Node")
+    Gda(project).json("scene", "create", "res://host.tscn", "--root-type", "Node")
     for name in classes:
-        proc = _gda(
-            project,
+        proc = Gda(project)(
             "node",
             "add",
             "res://host.tscn",
@@ -292,12 +273,12 @@ def _walked_paths(project) -> set[str]:
     The policy is one decision, so the assertions are made against the union: a
     path admitted by any collector is a path the walk admitted.
     """
-    scripts = {s["path"] for s in _result(project, "script", "list")["scripts"]}
-    scenes = {s["path"] for s in _result(project, "scene", "list")["scenes"]}
+    scripts = {s["path"] for s in Gda(project).json("script", "list")["scripts"]}
+    scenes = {s["path"] for s in Gda(project).json("scene", "list")["scenes"]}
     sources = {
-        d["path"] for d in _result(project, "project", "dependencies")["dependencies"]
+        d["path"] for d in Gda(project).json("project", "dependencies")["dependencies"]
     }
-    unused = set(_result(project, "project", "find-unused-resources")["unused"])
+    unused = set(Gda(project).json("project", "find-unused-resources")["unused"])
     return scripts | scenes | sources | unused
 
 
@@ -324,7 +305,7 @@ def test_an_alias_cannot_re_admit_the_engine_cache(symlink_project):
 
     # `project statistics` counts over the unfiltered universe, so it is the
     # collector that would show the cache re-entering as a raw count.
-    stats = _result(symlink_project, "project", "statistics")
+    stats = Gda(symlink_project).json("project", "statistics")
     assert stats["script_count"] == 2, stats  # sub/leaf.gd and vendored/vendored.gd
     assert stats["scene_count"] == 1, stats  # vendored/vendored.tscn — nothing aliased
 
@@ -348,7 +329,9 @@ def test_a_symlink_cycle_terminates_without_fabricated_paths(symlink_project):
 
     # The termination is a rule, not a truncation: the counting collector agrees
     # with the listing rather than reporting the OS limit's leftovers.
-    scripts = [s["path"] for s in _result(symlink_project, "script", "list")["scripts"]]
+    scripts = [
+        s["path"] for s in Gda(symlink_project).json("script", "list")["scripts"]
+    ]
     assert scripts.count("res://sub/leaf.gd") == 1, scripts
 
 
@@ -367,11 +350,10 @@ def test_a_link_to_authored_content_is_still_walked(symlink_project):
     assert "res://vendored/vendored.gd" in walked, walked
     assert "res://vendored/vendored.tscn" in walked, walked
 
-    _result(
-        symlink_project, "scene", "create", "res://host.tscn", "--root-type", "Node"
+    Gda(symlink_project).json(
+        "scene", "create", "res://host.tscn", "--root-type", "Node"
     )
-    added = _result(
-        symlink_project,
+    added = Gda(symlink_project).json(
         "node",
         "add",
         "res://host.tscn",
@@ -495,7 +477,7 @@ def test_the_cache_stays_excluded_under_a_second_spelling_of_its_parent(
         "res://link1/deep_leaf.gd",
     } <= walked, walked
 
-    stats = _result(aliased_spelling_project, "project", "statistics")
+    stats = Gda(aliased_spelling_project).json("project", "statistics")
     assert stats["script_count"] == 3, stats
     assert stats["scene_count"] == 0, stats
 
@@ -514,7 +496,7 @@ def test_a_vendored_checkouts_own_cache_is_not_taken_for_the_projects(
     # `res://.godot`, which is_equivalent then confirmed against the project's own
     # cache — so a nested cache #712 decided to walk was silently hidden.
     scripts = {
-        s["path"] for s in _result(vendored_cache_project, "script", "list")["scripts"]
+        s["path"] for s in Gda(vendored_cache_project).json("script", "list")["scripts"]
     }
 
     assert "res://vendored/x/vendored_sample.gd" in scripts, scripts
@@ -546,7 +528,7 @@ def test_a_cache_alias_is_excluded_however_deep_below_the_cache_it_points(tmp_pa
     (deep / "deep_cache.gd").write_text(ROOT_CACHE_GD, encoding="utf-8")
     (project / "alias_deep").symlink_to(deep, target_is_directory=True)
 
-    scripts = {s["path"] for s in _result(project, "script", "list")["scripts"]}
+    scripts = {s["path"] for s in Gda(project).json("script", "list")["scripts"]}
     assert scripts == {"res://real.gd"}, scripts
     _assert_class_name_unresolvable(project, "RootCacheThing")
 
@@ -689,18 +671,19 @@ def test_the_listings_skip_a_nested_project_and_a_gdignore_directory(
 
     scripts = {
         s["path"]
-        for s in _result(skipped_directory_project, "script", "list")["scripts"]
+        for s in Gda(skipped_directory_project).json("script", "list")["scripts"]
     }
     assert scripts == {"res://outer.gd", "res://duplicate.gd"}, scripts
 
     scenes = {
-        s["path"] for s in _result(skipped_directory_project, "scene", "list")["scenes"]
+        s["path"]
+        for s in Gda(skipped_directory_project).json("scene", "list")["scenes"]
     }
     assert scenes == {"res://outer.tscn"}, scenes
 
     # The unfiltered universe is the one that counts a `project.godot` and the
     # `.gdignore` marker itself, so it is where a re-entry shows up as a raw count.
-    stats = _result(skipped_directory_project, "project", "statistics")
+    stats = Gda(skipped_directory_project).json("project", "statistics")
     by_ext = {e["extension"]: e["files"] for e in stats["by_extension"]}
     assert stats["script_count"] == 2, stats
     assert stats["scene_count"] == 1, stats
@@ -722,15 +705,14 @@ def test_validate_all_and_the_named_target_agree_on_a_nested_projects_script(
     # cascade — while NAMING that file is refused outright by ADR-0006's ownership
     # gate. The walk no longer reaches it, so `--all` reports only what the outer
     # project owns and the refusal stays the one true answer for the nested file.
-    validated = _result(skipped_directory_project, "script", "validate", "--all")
+    validated = Gda(skipped_directory_project).json("script", "validate", "--all")
     assert {s["path"] for s in validated["scripts"]} == {
         "res://outer.gd",
         "res://duplicate.gd",
     }, validated
     assert validated["valid"] is True, validated
 
-    proc = _gda(
-        skipped_directory_project,
+    proc = Gda(skipped_directory_project)(
         "script",
         "validate",
         "res://nested/inner.gd",
@@ -755,8 +737,7 @@ def test_the_class_name_index_follows_the_walk_out_of_a_skipped_directory(
     # ...and a duplicate that existed only because the walk entered the nested
     # project is no longer a duplicate, so a name that reported
     # `ambiguous_class_name` now resolves — to the outer project's declaration.
-    added = _result(
-        skipped_directory_project,
+    added = Gda(skipped_directory_project).json(
         "node",
         "add",
         "res://host.tscn",  # created by the helper above
@@ -772,13 +753,12 @@ def test_the_class_name_index_follows_the_walk_out_of_a_skipped_directory(
     # `find-references` shares the identical resolver, so it agrees: the outer
     # class is a resolvable target, the nested one is not a class at all.
     assert (
-        _result(skipped_directory_project, "project", "find-references", "OuterThing")[
+        Gda(skipped_directory_project).json("project", "find-references", "OuterThing")[
             "target"
         ]
         == "OuterThing"
     )
-    proc = _gda(
-        skipped_directory_project,
+    proc = Gda(skipped_directory_project)(
         "project",
         "find-references",
         "InnerThing",
@@ -798,8 +778,7 @@ def test_the_import_gap_listing_promises_nothing_in_a_skipped_directory(
     # scan skips both marked directories, so their stale sidecars were a promise of
     # work the pass never does. It listed res://ignored/pic.png and
     # res://nested/pic.png before.
-    predicted = _result(
-        skipped_directory_project,
+    predicted = Gda(skipped_directory_project).json(
         "resource",
         "import",
         "res://pic.png",
@@ -948,7 +927,7 @@ def test_an_engine_written_nested_cache_is_skipped_where_an_authored_one_is_walk
     # it is walked, as #712 and #760 decided.
     assert "res://vendored/real.gd" in walked, walked
 
-    stats = _result(marker_reach_project, "project", "statistics")
+    stats = Gda(marker_reach_project).json("project", "statistics")
     by_ext = {e["extension"]: e["files"] for e in stats["by_extension"]}
     assert "gdignore" not in by_ext, by_ext
 
@@ -956,8 +935,7 @@ def test_an_engine_written_nested_cache_is_skipped_where_an_authored_one_is_walk
     # it: the engine-written cache's declaration is gone from the index while the
     # authored one still resolves.
     _assert_class_name_unresolvable(marker_reach_project, "EngineCacheThing")
-    added = _result(
-        marker_reach_project,
+    added = Gda(marker_reach_project).json(
         "node",
         "add",
         "res://host.tscn",  # created by the helper above

--- a/tests/test_e2e_res_containment.py
+++ b/tests/test_e2e_res_containment.py
@@ -28,11 +28,10 @@ import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
 from tests.conftest import project_godot
-from tests.support import GDA_CMD
+from tests.support import GODOT, Gda
 
-GODOT = resolve_godot_binary()
+gda = Gda()
 
 INSIDE_GD = """\
 extends SceneTree
@@ -41,10 +40,6 @@ func _initialize() -> void:
 \tprint("ran")
 \tquit(0)
 """
-
-
-def _run_gda(*args: str) -> subprocess.CompletedProcess:
-    return subprocess.run([*GDA_CMD, *args], capture_output=True, text=True)
 
 
 def _code(proc: subprocess.CompletedProcess) -> "str | None":
@@ -108,36 +103,30 @@ def test_the_three_commands_agree_on_a_res_spelling(
     script = template.format(n="bar.gd", ext=".gd")
     asset = template.format(n="pic.png", ext=".png")
 
-    validate = _run_gda(
+    validate = gda(
         "script",
         "validate",
         script,
         "--project",
         project,
-        "--godot",
-        str(GODOT),
         "--json",
     )
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         script,
         "--project",
         project,
-        "--godot",
-        str(GODOT),
         "--timeout",
         "60",
         "--json",
     )
-    imported = _run_gda(
+    imported = gda(
         "resource",
         "import",
         asset,
         "--project",
         project,
-        "--godot",
-        str(GODOT),
         "--dry-run",
         "--json",
     )
@@ -253,14 +242,12 @@ def test_an_asset_a_nested_project_owns_is_refused_before_the_import_pass(tmp_pa
     (vendor / "pic.png").write_bytes(b"\x89PNG\r\n\x1a\n")
     (outer / "own.png").write_bytes(b"\x89PNG\r\n\x1a\n")
 
-    refused = _run_gda(
+    refused = gda(
         "resource",
         "import",
         "res://vendor/pic.png",
         "--project",
         str(outer),
-        "--godot",
-        str(GODOT),
         "--dry-run",
         "--json",
     )
@@ -269,14 +256,12 @@ def test_an_asset_a_nested_project_owns_is_refused_before_the_import_pass(tmp_pa
     assert error["code"] == "target_outside_project"
     assert error["evidence"]["owning_project"] == str(vendor.resolve())
 
-    accepted = _run_gda(
+    accepted = gda(
         "resource",
         "import",
         "res://own.png",
         "--project",
         str(outer),
-        "--godot",
-        str(GODOT),
         "--dry-run",
         "--json",
     )
@@ -303,14 +288,12 @@ def test_a_script_a_nested_project_owns_is_refused_instead_of_falsely_invalid(tm
     )
 
     # Against its OWN project the verdict is the true one, and stays reachable.
-    owned = _run_gda(
+    owned = gda(
         "script",
         "validate",
         str(inner / "main.gd"),
         "--project",
         str(inner),
-        "--godot",
-        str(GODOT),
         "--json",
     )
     assert owned.returncode == 0, owned.stdout + owned.stderr
@@ -318,14 +301,12 @@ def test_a_script_a_nested_project_owns_is_refused_instead_of_falsely_invalid(tm
 
     # Against the outer one it is refused before the engine runs, and the owner to
     # pass is named in the typed evidence.
-    refused = _run_gda(
+    refused = gda(
         "script",
         "validate",
         str(inner / "main.gd"),
         "--project",
         str(outer),
-        "--godot",
-        str(GODOT),
         "--json",
     )
     assert refused.returncode == 4, refused.stdout + refused.stderr
@@ -351,20 +332,7 @@ def test_a_projectless_call_on_an_owned_script_is_refused(tmp_path):
         'extends Node\n\nconst Dep := preload("res://local_dep.gd")\n', encoding="utf-8"
     )
 
-    refused = subprocess.run(
-        [
-            *GDA_CMD,
-            "script",
-            "validate",
-            "game/main.gd",
-            "--godot",
-            str(GODOT),
-            "--json",
-        ],
-        capture_output=True,
-        text=True,
-        cwd=str(workspace),
-    )
+    refused = gda("script", "validate", "game/main.gd", "--json", cwd=workspace)
 
     assert refused.returncode == 4, refused.stdout + refused.stderr
     error = json.loads(refused.stdout)["error"]
@@ -384,12 +352,7 @@ def test_a_standalone_script_is_still_validated_projectless(tmp_path):
         "extends Node\n\nfunc go() -> int:\n\treturn 1\n", encoding="utf-8"
     )
 
-    proc = subprocess.run(
-        [*GDA_CMD, "script", "validate", "scratch.gd", "--godot", str(GODOT), "--json"],
-        capture_output=True,
-        text=True,
-        cwd=str(tmp_path),
-    )
+    proc = gda("script", "validate", "scratch.gd", "--json", cwd=tmp_path)
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     data = json.loads(proc.stdout)
@@ -443,9 +406,7 @@ def test_the_refusal_states_a_reissue_that_actually_runs(
     # So this reads the two operands OUT of the message and runs them. Nothing here
     # knows the fixture's layout — if the sentence is wrong, the re-issue fails.
     outer = str(owned_target_project)
-    refused = _run_gda(
-        *head, spelling, "--project", outer, "--godot", str(GODOT), *extra, "--json"
-    )
+    refused = gda(*head, spelling, "--project", outer, *extra, "--json")
     assert refused.returncode == 4, refused.stdout + refused.stderr
     error = json.loads(refused.stdout)["error"]
     assert error["code"] == "target_outside_project"
@@ -453,13 +414,11 @@ def test_the_refusal_states_a_reissue_that_actually_runs(
     stated = REISSUE.search(error["message"])
     assert stated is not None, error["message"]
 
-    reissued = _run_gda(
+    reissued = gda(
         *head,
         stated["target"],
         "--project",
         stated["project"],
-        "--godot",
-        str(GODOT),
         *extra,
         "--json",
     )
@@ -468,13 +427,11 @@ def test_the_refusal_states_a_reissue_that_actually_runs(
     # And the half that says WHY the target had to be named beside the project:
     # the same re-issue with the caller's original spelling still fails, so the
     # sentence is not merely decorated with a value the caller already had.
-    stale = _run_gda(
+    stale = gda(
         *head,
         spelling,
         "--project",
         stated["project"],
-        "--godot",
-        str(GODOT),
         *extra,
         "--json",
     )
@@ -498,14 +455,12 @@ def test_the_stated_reissue_survives_a_link_spelled_owner(tmp_path):
     (pkg / "vend.gd").write_text(INSIDE_GD, encoding="utf-8")
     (outer / "addons" / "vendored").symlink_to(pkg, target_is_directory=True)
 
-    refused = _run_gda(
+    refused = gda(
         "script",
         "validate",
         "addons/vendored/vend.gd",
         "--project",
         str(outer),
-        "--godot",
-        str(GODOT),
         "--json",
     )
     assert refused.returncode == 4, refused.stdout + refused.stderr
@@ -513,14 +468,12 @@ def test_the_stated_reissue_survives_a_link_spelled_owner(tmp_path):
     assert stated is not None
     assert stated["target"] == "vend.gd"
 
-    reissued = _run_gda(
+    reissued = gda(
         "script",
         "validate",
         stated["target"],
         "--project",
         stated["project"],
-        "--godot",
-        str(GODOT),
         "--json",
     )
     assert reissued.returncode == 0, reissued.stdout + reissued.stderr

--- a/tests/test_e2e_resource.py
+++ b/tests/test_e2e_resource.py
@@ -23,16 +23,12 @@ modes, are exercised end to end.
 """
 
 import json
-import os
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
+from tests.support import Gda, import_project
 
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
+gda = Gda()
 
 # A plain custom Resource .tres. On import (without a .uid sidecar) it exists as
 # a resource but is NOT assigned a UID in the non-editor reverse cache, so it is
@@ -44,59 +40,12 @@ DATA_TRES = """\
 """
 
 
-def _gda(*args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT)], capture_output=True, text=True
-    )
-
-
-def _import_project(project) -> None:
-    """Run a one-shot headless import so the project's UID cache is written."""
-    subprocess.run(
-        [str(GODOT), "--headless", "--path", str(project), "--import"],
-        capture_output=True,
-        text=True,
-        timeout=120,
-    )
-
-
-def _gda_project(project):
-    """A ``gda`` bound to ``--godot`` and ``--project`` for res:// / UID resolution."""
-
-    def gda(*args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-            capture_output=True,
-            text=True,
-        )
-
-    return gda
-
-
-def _gda_env(extra_env: dict, *args: str) -> subprocess.CompletedProcess:
-    """``_gda`` with extra env vars in the child's environment (issue #226 seam)."""
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-        env={**os.environ, **extra_env},
-    )
-
-
-def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
-    assert proc.returncode == 4, proc.stdout + proc.stderr
-    err = json.loads(proc.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == code
-    return err
-
-
 @pytest.fixture
 def imported_project(godot_project):
     """A project fixture with a script (UID-cached) and a .tres (no cached UID)."""
     (godot_project / "hero.gd").write_text("extends Node\n", encoding="utf-8")
     (godot_project / "data.tres").write_text(DATA_TRES, encoding="utf-8")
-    _import_project(godot_project)
+    import_project(godot_project)
     return godot_project
 
 
@@ -107,7 +56,7 @@ def test_resource_create_then_get_round_trip(godot_project):
     # resource create wrote.
     resource_path = godot_project / "palette.tres"
 
-    created = _gda(
+    created = gda(
         "resource", "create", str(resource_path), "--type", "Gradient", "--json"
     )
 
@@ -119,7 +68,7 @@ def test_resource_create_then_get_round_trip(godot_project):
     # The written file is a real Godot .tres declaring the resource type.
     assert 'type="Gradient"' in resource_path.read_text(encoding="utf-8")
 
-    got = _gda("resource", "get", str(resource_path), "--json")
+    got = gda("resource", "get", str(resource_path), "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     got_data = json.loads(got.stdout)
@@ -140,12 +89,12 @@ def test_resource_get_projects_packed_arrays_as_json_lists(godot_project):
     # list of [r, g, b, a] lists (each Color element re-enters the projection) —
     # not the Variant str() dump.
     resource_path = godot_project / "palette.tres"
-    created = _gda(
+    created = gda(
         "resource", "create", str(resource_path), "--type", "Gradient", "--json"
     )
     assert created.returncode == 0, created.stdout + created.stderr
 
-    got = _gda("resource", "get", str(resource_path), "--json")
+    got = gda("resource", "get", str(resource_path), "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     by_name = {p["name"]: p for p in json.loads(got.stdout)["properties"]}
@@ -165,7 +114,7 @@ def test_resource_create_into_nested_dir_reports_created_dirs(godot_project):
     # outermost to innermost (mirrors scene/script create).
     resource_path = godot_project / "art" / "palettes" / "sunset.tres"
 
-    created = _gda(
+    created = gda(
         "resource", "create", str(resource_path), "--type", "Gradient", "--json"
     )
 
@@ -183,15 +132,21 @@ def test_resource_create_no_clobber_yields_already_exists(godot_project):
     # No-clobber: a create whose target already exists is refused with
     # already_exists, leaving the existing file untouched.
     resource_path = godot_project / "palette.tres"
-    first = _gda(
+    first = gda(
         "resource", "create", str(resource_path), "--type", "Gradient", "--json"
     )
     assert first.returncode == 0, first.stdout + first.stderr
     before = resource_path.read_text(encoding="utf-8")
 
-    second = _gda("resource", "create", str(resource_path), "--type", "Curve", "--json")
-
-    err = _assert_operation_error(second, "already_exists")
+    err = gda.error(
+        "resource",
+        "create",
+        str(resource_path),
+        "--type",
+        "Curve",
+        "--json",
+        code="already_exists",
+    )
     assert str(resource_path) in err["message"]
     # The original file is untouched — the clobber never happened.
     assert resource_path.read_text(encoding="utf-8") == before
@@ -201,11 +156,15 @@ def test_resource_create_no_clobber_yields_already_exists(godot_project):
 def test_resource_create_unknown_type_yields_invalid_resource_type(godot_project):
     resource_path = godot_project / "palette.tres"
 
-    created = _gda(
-        "resource", "create", str(resource_path), "--type", "Bogus", "--json"
+    err = gda.error(
+        "resource",
+        "create",
+        str(resource_path),
+        "--type",
+        "Bogus",
+        "--json",
+        code="invalid_resource_type",
     )
-
-    err = _assert_operation_error(created, "invalid_resource_type")
     assert "Bogus" in err["message"]
     # Nothing was written for the rejected type.
     assert not resource_path.exists()
@@ -217,11 +176,15 @@ def test_resource_create_non_resource_type_yields_invalid_resource_type(godot_pr
     # .tres, so it is refused with the same code as an unknown type.
     resource_path = godot_project / "thing.tres"
 
-    created = _gda(
-        "resource", "create", str(resource_path), "--type", "Node2D", "--json"
+    err = gda.error(
+        "resource",
+        "create",
+        str(resource_path),
+        "--type",
+        "Node2D",
+        "--json",
+        code="invalid_resource_type",
     )
-
-    err = _assert_operation_error(created, "invalid_resource_type")
     assert "Node2D" in err["message"]
     assert not resource_path.exists()
 
@@ -260,10 +223,10 @@ def test_resource_create_by_class_name_round_trips_typed_fields(godot_project):
     # back and reports the exported fields with their declared Godot types and
     # values — create → get IS the round-trip proof for a custom Resource type.
     (godot_project / "panda_stats.gd").write_text(PANDA_STATS_GD, encoding="utf-8")
-    _import_project(godot_project)
+    import_project(godot_project)
     resource_path = godot_project / "panda.tres"
 
-    created = _gda(
+    created = gda(
         "resource",
         "create",
         str(resource_path),
@@ -283,7 +246,7 @@ def test_resource_create_by_class_name_round_trips_typed_fields(godot_project):
     assert resource_path.exists()
     assert 'script_class="PandaStats"' in resource_path.read_text(encoding="utf-8")
 
-    got = _gda(
+    got = gda(
         "resource",
         "get",
         str(resource_path),
@@ -314,9 +277,9 @@ def test_resource_create_by_class_name_round_trips_a_set_via_get(godot_project):
     # persisted value — resource get IS the structured-level proof that set landed
     # on a custom Resource type.
     (godot_project / "panda_stats.gd").write_text(PANDA_STATS_GD, encoding="utf-8")
-    _import_project(godot_project)
+    import_project(godot_project)
     resource_path = godot_project / "panda.tres"
-    created = _gda(
+    created = gda(
         "resource",
         "create",
         str(resource_path),
@@ -328,7 +291,7 @@ def test_resource_create_by_class_name_round_trips_a_set_via_get(godot_project):
     )
     assert created.returncode == 0, created.stdout + created.stderr
 
-    was_set = _gda(
+    was_set = gda(
         "resource",
         "set",
         str(resource_path),
@@ -348,7 +311,7 @@ def test_resource_create_by_class_name_round_trips_a_set_via_get(godot_project):
     assert set_data["type"] == "float"
     assert set_data["value"] == 9.5
 
-    got = _gda(
+    got = gda(
         "resource",
         "get",
         str(resource_path),
@@ -373,9 +336,9 @@ def test_resource_set_preserves_json_container_integer_and_float_types(
     (godot_project / "drop_table_stats.gd").write_text(
         DROP_TABLE_STATS_GD, encoding="utf-8"
     )
-    _import_project(godot_project)
+    import_project(godot_project)
     resource_path = godot_project / "drop_table.tres"
-    created = _gda(
+    created = gda(
         "resource",
         "create",
         str(resource_path),
@@ -387,7 +350,7 @@ def test_resource_set_preserves_json_container_integer_and_float_types(
     )
     assert created.returncode == 0, created.stdout + created.stderr
 
-    was_set = _gda(
+    was_set = gda(
         "resource",
         "set",
         str(resource_path),
@@ -412,7 +375,7 @@ def test_resource_set_preserves_json_container_integer_and_float_types(
     assert '"a": 2.0' not in text
     assert '"b": 2.0' in text
 
-    got = _gda(
+    got = gda(
         "resource",
         "get",
         str(resource_path),
@@ -446,10 +409,10 @@ def test_resource_create_by_non_resource_class_name_yields_invalid_resource_type
     # invalid_resource_type (not uninstantiable_script), with a message naming
     # the script and the real cause rather than "not a registered class_name".
     (godot_project / "widget_node.gd").write_text(WIDGET_NODE_GD, encoding="utf-8")
-    _import_project(godot_project)
+    import_project(godot_project)
     resource_path = godot_project / "widget.tres"
 
-    created = _gda(
+    err = gda.error(
         "resource",
         "create",
         str(resource_path),
@@ -458,9 +421,8 @@ def test_resource_create_by_non_resource_class_name_yields_invalid_resource_type
         "--project",
         str(godot_project),
         "--json",
+        code="invalid_resource_type",
     )
-
-    err = _assert_operation_error(created, "invalid_resource_type")
     assert "WidgetNode" in err["message"]
     assert "not a Resource-derived script" in err["message"]
     assert "widget_node.gd" in err["message"]
@@ -494,11 +456,11 @@ def test_resource_create_by_registered_but_broken_class_name_names_the_script(
     # not the type name. The failure must surface as the distinct
     # uninstantiable_script code naming the script, with nothing written.
     (godot_project / "stats.gd").write_text(STATS_GD, encoding="utf-8")
-    _import_project(godot_project)
+    import_project(godot_project)
     (godot_project / "stats.gd").write_text(BROKEN_STATS_GD, encoding="utf-8")
     resource_path = godot_project / "stats.tres"
 
-    created = _gda(
+    err = gda.error(
         "resource",
         "create",
         str(resource_path),
@@ -507,9 +469,8 @@ def test_resource_create_by_registered_but_broken_class_name_names_the_script(
         "--project",
         str(godot_project),
         "--json",
+        code="uninstantiable_script",
     )
-
-    err = _assert_operation_error(created, "uninstantiable_script")
     assert "Stats" in err["message"]
     assert "stats.gd" in err["message"]
     assert not resource_path.exists()
@@ -541,16 +502,16 @@ def test_resource_create_over_existing_target_refuses_before_constructing(
     (godot_project / "needs_args_stats.gd").write_text(
         NEEDS_ARGS_STATS_GD, encoding="utf-8"
     )
-    _import_project(godot_project)
+    import_project(godot_project)
     resource_path = godot_project / "occupied.tres"
     # Occupy the target first with a plain built-in resource.
-    first = _gda(
+    first = gda(
         "resource", "create", str(resource_path), "--type", "Gradient", "--json"
     )
     assert first.returncode == 0, first.stdout + first.stderr
     before = resource_path.read_text(encoding="utf-8")
 
-    second = _gda(
+    err = gda.error(
         "resource",
         "create",
         str(resource_path),
@@ -559,9 +520,8 @@ def test_resource_create_over_existing_target_refuses_before_constructing(
         "--project",
         str(godot_project),
         "--json",
+        code="already_exists",
     )
-
-    err = _assert_operation_error(second, "already_exists")
     assert str(resource_path) in err["message"]
     # The existing file is untouched — no clobber — and, because the code is
     # already_exists rather than uninstantiable_script, the broken constructor
@@ -573,9 +533,15 @@ def test_resource_create_over_existing_target_refuses_before_constructing(
 def test_resource_create_non_tres_path_yields_invalid_path(godot_project):
     bad_path = godot_project / "palette.txt"
 
-    created = _gda("resource", "create", str(bad_path), "--type", "Gradient", "--json")
-
-    err = _assert_operation_error(created, "invalid_path")
+    err = gda.error(
+        "resource",
+        "create",
+        str(bad_path),
+        "--type",
+        "Gradient",
+        "--json",
+        code="invalid_path",
+    )
     assert ".tres" in err["message"]
     assert not bad_path.exists()
 
@@ -584,9 +550,7 @@ def test_resource_create_non_tres_path_yields_invalid_path(godot_project):
 def test_resource_get_missing_yields_path_not_found(godot_project):
     missing = godot_project / "nope.tres"
 
-    got = _gda("resource", "get", str(missing), "--json")
-
-    err = _assert_operation_error(got, "path_not_found")
+    err = gda.error("resource", "get", str(missing), "--json", code="path_not_found")
     assert str(missing) in err["message"]
 
 
@@ -595,9 +559,7 @@ def test_resource_get_non_tres_path_yields_invalid_path(godot_project):
     bad_path = godot_project / "palette.txt"
     bad_path.write_text("not a resource", encoding="utf-8")
 
-    got = _gda("resource", "get", str(bad_path), "--json")
-
-    err = _assert_operation_error(got, "invalid_path")
+    err = gda.error("resource", "get", str(bad_path), "--json", code="invalid_path")
     assert ".tres" in err["message"]
 
 
@@ -610,12 +572,12 @@ def test_resource_set_coerces_persists_and_round_trips_via_get(godot_project):
     # type, saves the .tres, and get reports the coerced value — resource get IS
     # the structured-level verification that set persisted.
     resource_path = godot_project / "palette.tres"
-    created = _gda(
+    created = gda(
         "resource", "create", str(resource_path), "--type", "Gradient", "--json"
     )
     assert created.returncode == 0, created.stdout + created.stderr
 
-    was_set = _gda(
+    was_set = gda(
         "resource",
         "set",
         str(resource_path),
@@ -634,7 +596,7 @@ def test_resource_set_coerces_persists_and_round_trips_via_get(godot_project):
     assert set_data["type"] == "int"
     assert set_data["value"] == 1
 
-    got = _gda("resource", "get", str(resource_path), "--json")
+    got = gda("resource", "get", str(resource_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     by_name = {p["name"]: p for p in json.loads(got.stdout)["properties"]}
     # Round-trip: get reports the value set persisted to the .tres.
@@ -645,9 +607,9 @@ def test_resource_set_coerces_persists_and_round_trips_via_get(godot_project):
 def test_resource_set_string_property_round_trips(godot_project):
     # A String property coerces trivially and round-trips through get.
     resource_path = godot_project / "palette.tres"
-    _gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
+    gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
 
-    was_set = _gda(
+    was_set = gda(
         "resource",
         "set",
         str(resource_path),
@@ -661,7 +623,7 @@ def test_resource_set_string_property_round_trips(godot_project):
     assert was_set.returncode == 0, was_set.stdout + was_set.stderr
     assert json.loads(was_set.stdout)["type"] == "String"
 
-    got = _gda("resource", "get", str(resource_path), "--json")
+    got = gda("resource", "get", str(resource_path), "--json")
     by_name = {p["name"]: p for p in json.loads(got.stdout)["properties"]}
     assert by_name["resource_name"]["value"] == "Sunset"
 
@@ -675,13 +637,12 @@ def test_resource_set_with_external_edit_in_window_yields_file_changed_externall
     # that window a blind save would clobber the external edit. The production-inert seam
     # (GDA_TEST_PERTURB_BEFORE_SAVE) simulates that edit, and the guard refuses.
     resource_path = godot_project / "palette.tres"
-    created = _gda(
+    created = gda(
         "resource", "create", str(resource_path), "--type", "Gradient", "--json"
     )
     assert created.returncode == 0, created.stdout + created.stderr
 
-    was_set = _gda_env(
-        {"GDA_TEST_PERTURB_BEFORE_SAVE": "1"},
+    err = gda.error(
         "resource",
         "set",
         str(resource_path),
@@ -690,13 +651,13 @@ def test_resource_set_with_external_edit_in_window_yields_file_changed_externall
         "--value",
         "Sunset",
         "--json",
+        extra_env={"GDA_TEST_PERTURB_BEFORE_SAVE": "1"},
+        code="file_changed_externally",
     )
-
-    err = _assert_operation_error(was_set, "file_changed_externally")
     assert str(resource_path) in err["message"]
 
     # The set did NOT land: resource_name is still empty (the default), not "Sunset".
-    got = _gda("resource", "get", str(resource_path), "--json")
+    got = gda("resource", "get", str(resource_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     by_name = {p["name"]: p for p in json.loads(got.stdout)["properties"]}
     assert by_name["resource_name"]["value"] != "Sunset"
@@ -708,9 +669,9 @@ def test_resource_set_unknown_property_is_a_clean_error(godot_project):
     # set edits an existing property; an unknown property is unknown_property,
     # never a silent create — the agent fixes the property name.
     resource_path = godot_project / "palette.tres"
-    _gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
+    gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
 
-    was_set = _gda(
+    err = gda.error(
         "resource",
         "set",
         str(resource_path),
@@ -719,9 +680,8 @@ def test_resource_set_unknown_property_is_a_clean_error(godot_project):
         "--value",
         "1",
         "--json",
+        code="unknown_property",
     )
-
-    err = _assert_operation_error(was_set, "unknown_property")
     assert "bogus_property" in err["message"]
 
 
@@ -730,10 +690,10 @@ def test_resource_set_uncoercible_value_is_a_clean_error(godot_project):
     # An int property cannot take a non-numeric string — uncoercible_value (#55),
     # the .tres left untouched.
     resource_path = godot_project / "palette.tres"
-    _gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
+    gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
     before = resource_path.read_text(encoding="utf-8")
 
-    was_set = _gda(
+    err = gda.error(
         "resource",
         "set",
         str(resource_path),
@@ -742,9 +702,8 @@ def test_resource_set_uncoercible_value_is_a_clean_error(godot_project):
         "--value",
         "not-a-number",
         "--json",
+        code="uncoercible_value",
     )
-
-    err = _assert_operation_error(was_set, "uncoercible_value")
     assert "not-a-number" in err["message"]
     # The file is untouched — the rejected coercion never wrote.
     assert resource_path.read_text(encoding="utf-8") == before
@@ -754,11 +713,17 @@ def test_resource_set_uncoercible_value_is_a_clean_error(godot_project):
 def test_resource_set_missing_yields_path_not_found(godot_project):
     missing = godot_project / "nope.tres"
 
-    was_set = _gda(
-        "resource", "set", str(missing), "--property", "x", "--value", "1", "--json"
+    err = gda.error(
+        "resource",
+        "set",
+        str(missing),
+        "--property",
+        "x",
+        "--value",
+        "1",
+        "--json",
+        code="path_not_found",
     )
-
-    err = _assert_operation_error(was_set, "path_not_found")
     assert str(missing) in err["message"]
 
 
@@ -767,13 +732,13 @@ def test_resource_delete_removes_file_and_round_trips_against_get(godot_project)
     # create → delete → get: delete removes the .tres and reports what was removed
     # (path + type); a subsequent get is now path_not_found, closing the lifecycle.
     resource_path = godot_project / "palette.tres"
-    created = _gda(
+    created = gda(
         "resource", "create", str(resource_path), "--type", "Gradient", "--json"
     )
     assert created.returncode == 0, created.stdout + created.stderr
     assert resource_path.exists()
 
-    deleted = _gda("resource", "delete", str(resource_path), "--json")
+    deleted = gda("resource", "delete", str(resource_path), "--json")
 
     assert deleted.returncode == 0, deleted.stdout + deleted.stderr
     del_data = json.loads(deleted.stdout)
@@ -783,17 +748,14 @@ def test_resource_delete_removes_file_and_round_trips_against_get(godot_project)
     assert not resource_path.exists()
 
     # Round-trip: get now reports path_not_found — the lifecycle's now-not-found.
-    got = _gda("resource", "get", str(resource_path), "--json")
-    _assert_operation_error(got, "path_not_found")
+    gda.error("resource", "get", str(resource_path), "--json", code="path_not_found")
 
 
 @pytest.mark.e2e
 def test_resource_delete_missing_yields_path_not_found(godot_project):
     missing = godot_project / "nope.tres"
 
-    deleted = _gda("resource", "delete", str(missing), "--json")
-
-    err = _assert_operation_error(deleted, "path_not_found")
+    err = gda.error("resource", "delete", str(missing), "--json", code="path_not_found")
     assert str(missing) in err["message"]
 
 
@@ -802,9 +764,7 @@ def test_resource_delete_non_tres_path_yields_invalid_path(godot_project):
     bad_path = godot_project / "palette.txt"
     bad_path.write_text("not a resource", encoding="utf-8")
 
-    deleted = _gda("resource", "delete", str(bad_path), "--json")
-
-    err = _assert_operation_error(deleted, "invalid_path")
+    err = gda.error("resource", "delete", str(bad_path), "--json", code="invalid_path")
     assert ".tres" in err["message"]
     # The non-.tres file is untouched — the rejected addressing never deleted.
     assert bad_path.exists()
@@ -816,7 +776,7 @@ def test_resource_uid_resolves_both_directions_round_trip(imported_project):
     # same path. This is the bidirectional contract: query a path, get its UID;
     # query that UID, get the path back — proving both directions read one
     # consistent cache.
-    gda = _gda_project(imported_project)
+    gda = Gda(imported_project)
 
     path_to_uid = gda("resource", "uid", "res://hero.gd", "--json")
     assert path_to_uid.returncode == 0, path_to_uid.stdout + path_to_uid.stderr
@@ -838,7 +798,7 @@ def test_resource_uid_resolves_both_directions_round_trip(imported_project):
 @pytest.mark.e2e
 def test_resource_uid_human_output_renders_uid_arrow_path(imported_project):
     # Without --json, a resolved mapping renders as `<uid> -> <path>`.
-    gda = _gda_project(imported_project)
+    gda = Gda(imported_project)
 
     proc = gda("resource", "uid", "res://hero.gd")
 
@@ -850,32 +810,26 @@ def test_resource_uid_human_output_renders_uid_arrow_path(imported_project):
 @pytest.mark.e2e
 def test_resource_uid_unknown_uid_is_unknown_uid(imported_project):
     # A syntactically valid uid:// not in the project's cache is unknown_uid.
-    gda = _gda_project(imported_project)
+    gda = Gda(imported_project)
 
-    proc = gda("resource", "uid", "uid://b00000000000b", "--json")
-
-    _assert_operation_error(proc, "unknown_uid")
+    gda.error("resource", "uid", "uid://b00000000000b", "--json", code="unknown_uid")
 
 
 @pytest.mark.e2e
 def test_resource_uid_invalid_uid_is_invalid_uid(imported_project):
     # A uid:// whose body holds illegal characters fails text_to_id (INVALID_ID),
     # reported as invalid_uid — distinct from a well-formed-but-unknown UID.
-    gda = _gda_project(imported_project)
+    gda = Gda(imported_project)
 
-    proc = gda("resource", "uid", "uid://<invalid>", "--json")
-
-    _assert_operation_error(proc, "invalid_uid")
+    gda.error("resource", "uid", "uid://<invalid>", "--json", code="invalid_uid")
 
 
 @pytest.mark.e2e
 def test_resource_uid_path_not_found_is_path_not_found(imported_project):
     # A res:// path naming no resource is path_not_found.
-    gda = _gda_project(imported_project)
+    gda = Gda(imported_project)
 
-    proc = gda("resource", "uid", "res://missing.tres", "--json")
-
-    _assert_operation_error(proc, "path_not_found")
+    gda.error("resource", "uid", "res://missing.tres", "--json", code="path_not_found")
 
 
 @pytest.mark.e2e
@@ -883,29 +837,15 @@ def test_resource_uid_path_without_uid_is_no_uid_assigned(imported_project):
     # A resource that exists but has no UID in the non-editor reverse cache is
     # no_uid_assigned — distinct from path_not_found (the file is there) and from
     # a UID-direction failure (the query was a path).
-    gda = _gda_project(imported_project)
+    gda = Gda(imported_project)
 
-    proc = gda("resource", "uid", "res://data.tres", "--json")
-
-    _assert_operation_error(proc, "no_uid_assigned")
+    gda.error("resource", "uid", "res://data.tres", "--json", code="no_uid_assigned")
 
 
 @pytest.mark.e2e
 def test_resource_uid_projectless_run_is_project_not_found():
     # Resolution queries the project's UID cache, so a projectless run is refused
     # with project_not_found rather than a misleading "no UID" answer.
-    proc = subprocess.run(
-        [
-            *GDA_CMD,
-            "resource",
-            "uid",
-            "uid://b00000000000b",
-            "--godot",
-            str(GODOT),
-            "--json",
-        ],
-        capture_output=True,
-        text=True,
+    gda.error(
+        "resource", "uid", "uid://b00000000000b", "--json", code="project_not_found"
     )
-
-    _assert_operation_error(proc, "project_not_found")

--- a/tests/test_e2e_resource_import.py
+++ b/tests/test_e2e_resource_import.py
@@ -12,16 +12,14 @@ import hashlib
 import json
 import os
 import struct
-import subprocess
 import zlib
 from pathlib import Path
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
+from tests.support import Gda, import_project
 
-GODOT = resolve_godot_binary()
+from .conftest import project_godot
 
 CHECK_GD = (
     "extends SceneTree\n"
@@ -49,11 +47,7 @@ def _png(path: Path, color: tuple[int, int, int]) -> None:
 
 def _project(tmp_path: Path) -> Path:
     (tmp_path / "project.godot").write_text(
-        "config_version=5\n\n[application]\n\n"
-        'config/name="t668"\n\n[debug]\n\n'
-        "file_logging/enable_file_logging=false\n"
-        "file_logging/enable_file_logging.pc=false\n",
-        encoding="utf-8",
+        project_godot(name="t668"), encoding="utf-8"
     )
     _png(tmp_path / "icon.png", (255, 0, 0))
     (tmp_path / "check.gd").write_text(CHECK_GD, encoding="utf-8")
@@ -63,33 +57,6 @@ def _project(tmp_path: Path) -> Path:
 def _receipt(project: Path, asset: str) -> Path:
     digest = hashlib.md5(f"res://{asset}".encode()).hexdigest()
     return project / ".godot" / "imported" / f"{Path(asset).name}-{digest}.md5"
-
-
-def _native_import(project: Path) -> subprocess.CompletedProcess:
-    """The engine's OWN import pass, no gda in between (native parity)."""
-    return subprocess.run(
-        [str(GODOT), "--headless", "--path", str(project), "--import"],
-        capture_output=True,
-        text=True,
-        timeout=180,
-    )
-
-
-def _gda(project: Path, *args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [
-            *GDA_CMD,
-            *args,
-            "--project",
-            str(project),
-            "--godot",
-            str(GODOT),
-            "--json",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=180,
-    )
 
 
 def _tree(project: Path) -> set[str]:
@@ -104,11 +71,12 @@ def test_import_heals_the_clean_worktree_preload_failure(tmp_path):
     # it succeeds — plus the dry run's zero-write inventory, the classified
     # created files, and the idempotent second run, all on the same project.
     project = _project(tmp_path)
+    gda = Gda(project, json_output=True, timeout=180)
 
     # AC1, the failing half: plain `script run` triggers no import pass, and
     # the clean-worktree load dies.
     before_run = _tree(project)
-    failing = _gda(project, "script", "run", "res://check.gd")
+    failing = gda("script", "run", "res://check.gd")
     assert failing.returncode == 0, failing.stdout + failing.stderr
     assert json.loads(failing.stdout)["exit_status"] == 1
     # `script run` added no import artifacts (the engine writes only its own
@@ -120,7 +88,7 @@ def test_import_heals_the_clean_worktree_preload_failure(tmp_path):
 
     # AC3: the dry run reports the inventory and writes NOTHING.
     before_dry = _tree(project)
-    dry = _gda(project, "resource", "import", "res://icon.png", "--dry-run")
+    dry = gda("resource", "import", "res://icon.png", "--dry-run")
     assert dry.returncode == 0, dry.stdout + dry.stderr
     dry_doc = json.loads(dry.stdout)
     assert dry_doc["dry_run"] is True
@@ -131,7 +99,7 @@ def test_import_heals_the_clean_worktree_preload_failure(tmp_path):
 
     # AC2 + AC4: the real run reports per-asset verdicts, the summary, and
     # every created file classified against the cache root.
-    imported = _gda(project, "resource", "import", "res://icon.png")
+    imported = gda("resource", "import", "res://icon.png")
     assert imported.returncode == 0, imported.stdout + imported.stderr
     doc = json.loads(imported.stdout)
     assert doc["engine_pass"] is True
@@ -151,14 +119,14 @@ def test_import_heals_the_clean_worktree_preload_failure(tmp_path):
     assert doc["summary"]["requested"] == 1
 
     # AC1, the healed half: the same preload now succeeds.
-    healed = _gda(project, "script", "run", "res://check.gd")
+    healed = gda("script", "run", "res://check.gd")
     assert healed.returncode == 0, healed.stdout + healed.stderr
     healed_doc = json.loads(healed.stdout)
     assert healed_doc["exit_status"] == 0
     assert "LOADED" in healed_doc["stdout"]
 
     # Idempotence: the second import is a cache hit and runs NO pass.
-    second = _gda(project, "resource", "import", "res://icon.png")
+    second = gda("resource", "import", "res://icon.png")
     second_doc = json.loads(second.stdout)
     assert second_doc["engine_pass"] is False
     assert second_doc["assets"][0]["status"] == "cached"
@@ -168,8 +136,9 @@ def test_import_heals_the_clean_worktree_preload_failure(tmp_path):
 @pytest.mark.e2e
 def test_a_script_is_engine_decided_not_importable(tmp_path):
     project = _project(tmp_path)
+    gda = Gda(project, json_output=True, timeout=180)
 
-    result = _gda(project, "resource", "import", "res://check.gd")
+    result = gda("resource", "import", "res://check.gd")
 
     assert result.returncode == 0, result.stdout + result.stderr
     doc = json.loads(result.stdout)
@@ -183,9 +152,10 @@ def test_engine_invalid_import_is_failed_not_imported(tmp_path):
     # .png — Godot writes a sidecar with valid=false and no dest_files. gda
     # must report `failed`, never a cache hit or a successful import.
     project = _project(tmp_path)
+    gda = Gda(project, json_output=True, timeout=180)
     (project / "broken.png").write_text("this is not a png", encoding="utf-8")
 
-    result = _gda(project, "resource", "import", "res://broken.png")
+    result = gda("resource", "import", "res://broken.png")
 
     assert result.returncode == 0, result.stdout + result.stderr
     doc = json.loads(result.stdout)
@@ -193,7 +163,7 @@ def test_engine_invalid_import_is_failed_not_imported(tmp_path):
     assert broken["status"] == "failed"
     assert doc["summary"]["failed"] == 1
     # And the verdict is stable: a second run still refuses to call it cached.
-    again = json.loads(_gda(project, "resource", "import", "res://broken.png").stdout)
+    again = json.loads(gda("resource", "import", "res://broken.png").stdout)
     assert again["assets"][0]["status"] == "failed"
 
 
@@ -205,22 +175,19 @@ def test_stale_source_reimports_and_dry_run_lists_project_gaps(tmp_path):
     # pinned: requesting only icon.png, the dry run's project-wide scan lists
     # other.png as something the pass would also import.
     project = _project(tmp_path)
+    gda = Gda(project, json_output=True, timeout=180)
     _png(project / "other.png", (0, 0, 255))
 
-    first = json.loads(_gda(project, "resource", "import", "res://icon.png").stdout)
+    first = json.loads(gda("resource", "import", "res://icon.png").stdout)
     assert first["assets"][0]["status"] == "imported"
 
     # Make icon.png stale (different content, same path).
     _png(project / "icon.png", (0, 255, 0))
-    dry = json.loads(
-        _gda(project, "resource", "import", "res://icon.png", "--dry-run").stdout
-    )
+    dry = json.loads(gda("resource", "import", "res://icon.png", "--dry-run").stdout)
     assert dry["assets"][0]["status"] == "stale"
     assert dry["engine_pass"] is True
 
-    re_imported = json.loads(
-        _gda(project, "resource", "import", "res://icon.png").stdout
-    )
+    re_imported = json.loads(gda("resource", "import", "res://icon.png").stdout)
     assert re_imported["assets"][0]["status"] == "imported"
 
     # The project-gap half: strip other.png's cache, request only icon.png.
@@ -229,9 +196,7 @@ def test_stale_source_reimports_and_dry_run_lists_project_gaps(tmp_path):
     other_sidecar = project / "other.png.import"
     assert other_sidecar.is_file()
     shutil.rmtree(project / ".godot")
-    dry2 = json.loads(
-        _gda(project, "resource", "import", "res://icon.png", "--dry-run").stdout
-    )
+    dry2 = json.loads(gda("resource", "import", "res://icon.png", "--dry-run").stdout)
     assert dry2["assets"][0]["status"] == "stale"
     assert "res://other.png" in dry2["pass_will_also_import"]
 
@@ -244,16 +209,17 @@ def test_alias_sidecar_and_invalid_skip_match_the_engine(tmp_path):
     # - an invalid sidecar is EXCLUDED from pass_will_also_import, and the
     #   pass leaves its bytes untouched (the engine skips failed imports).
     project = _project(tmp_path)
-    first = json.loads(_gda(project, "resource", "import", "res://icon.png").stdout)
+    gda = Gda(project, json_output=True, timeout=180)
+    first = json.loads(gda("resource", "import", "res://icon.png").stdout)
     assert first["assets"][0]["status"] == "imported"
 
     # The invalid neighbor FIRST (its first import runs a project-wide pass;
     # the alias must not exist yet or that pass would heal it prematurely).
     (project / "bad.png").write_text("not a png", encoding="utf-8")
     assert (
-        json.loads(_gda(project, "resource", "import", "res://bad.png").stdout)[
-            "assets"
-        ][0]["status"]
+        json.loads(gda("resource", "import", "res://bad.png").stdout)["assets"][0][
+            "status"
+        ]
         == "failed"
     )
     bad_sidecar_before = (project / "bad.png.import").read_bytes()
@@ -263,13 +229,11 @@ def test_alias_sidecar_and_invalid_skip_match_the_engine(tmp_path):
         (project / "icon.png.import").read_text(encoding="utf-8"), encoding="utf-8"
     )
 
-    dry = json.loads(
-        _gda(project, "resource", "import", "res://alias2.png", "--dry-run").stdout
-    )
+    dry = json.loads(gda("resource", "import", "res://alias2.png", "--dry-run").stdout)
     assert dry["assets"][0]["status"] == "stale"
     assert "res://bad.png" not in dry["pass_will_also_import"]
 
-    real = json.loads(_gda(project, "resource", "import", "res://alias2.png").stdout)
+    real = json.loads(gda("resource", "import", "res://alias2.png").stdout)
     assert real["assets"][0]["status"] == "imported"
     # The engine rewrote the alias's sidecar to its own source/dest paths.
     rewritten = (project / "alias2.png.import").read_text(encoding="utf-8")
@@ -288,7 +252,8 @@ def test_no_destination_sidecar_matches_the_engines_current_verdict(tmp_path):
     # sidecar untouched, and gda agrees: cached, no pass spent, never
     # settled to failed, excluded from the gap prediction.
     project = _project(tmp_path)
-    first = json.loads(_gda(project, "resource", "import", "res://icon.png").stdout)
+    gda = Gda(project, json_output=True, timeout=180)
+    first = json.loads(gda("resource", "import", "res://icon.png").stdout)
     assert first["assets"][0]["status"] == "imported"
 
     sidecar = project / "icon.png.import"
@@ -314,26 +279,22 @@ def test_no_destination_sidecar_matches_the_engines_current_verdict(tmp_path):
     # ...then prove the native verdict the test's name claims: the engine's
     # own pass reaches the full reimport test (the sidecar mtime changed)
     # and still leaves the mutated sidecar byte-identical.
-    native = _native_import(project)
-    assert native.returncode == 0, native.stderr
+    # The engine's OWN import pass, no gda in between (native parity).
+    import_project(project)
     assert sidecar.read_bytes() == mutated
 
-    dry = json.loads(
-        _gda(project, "resource", "import", "res://icon.png", "--dry-run").stdout
-    )
+    dry = json.loads(gda("resource", "import", "res://icon.png", "--dry-run").stdout)
     assert dry["assets"][0]["status"] == "cached"
     assert dry["engine_pass"] is False
 
-    real = json.loads(_gda(project, "resource", "import", "res://icon.png").stdout)
+    real = json.loads(gda("resource", "import", "res://icon.png").stdout)
     assert real["assets"][0]["status"] == "cached"
     assert real["engine_pass"] is False
     assert real["created"] == []
 
     # And a request for a NEW asset must not falsely predict this one.
     _png(project / "fresh.png", (1, 2, 3))
-    gap = json.loads(
-        _gda(project, "resource", "import", "res://fresh.png", "--dry-run").stdout
-    )
+    gap = json.loads(gda("resource", "import", "res://fresh.png", "--dry-run").stdout)
     assert "res://icon.png" not in gap["pass_will_also_import"]
 
 
@@ -344,7 +305,8 @@ def test_malformed_receipt_matches_the_engines_deliberate_skip(tmp_path):
     # loop" branch — no re-import, artifacts untouched. gda must agree:
     # invalid, no pass spent, settled failed without launching the engine.
     project = _project(tmp_path)
-    first = json.loads(_gda(project, "resource", "import", "res://icon.png").stdout)
+    gda = Gda(project, json_output=True, timeout=180)
+    first = json.loads(gda("resource", "import", "res://icon.png").stdout)
     assert first["assets"][0]["status"] == "imported"
 
     sidecar = project / "icon.png.import"
@@ -360,28 +322,24 @@ def test_malformed_receipt_matches_the_engines_deliberate_skip(tmp_path):
     sidecar_bytes = sidecar.read_bytes()
     dest_bytes = dest.read_bytes()
 
-    native = _native_import(project)
-    assert native.returncode == 0, native.stderr
+    # The engine's OWN import pass, no gda in between (native parity).
+    import_project(project)
     assert sidecar.read_bytes() == sidecar_bytes
     assert receipt.read_text(encoding="utf-8") == "source_md5=[\n"
     assert dest.read_bytes() == dest_bytes
 
-    dry = json.loads(
-        _gda(project, "resource", "import", "res://icon.png", "--dry-run").stdout
-    )
+    dry = json.loads(gda("resource", "import", "res://icon.png", "--dry-run").stdout)
     assert dry["assets"][0]["status"] == "invalid"
     assert dry["engine_pass"] is False
 
-    real = json.loads(_gda(project, "resource", "import", "res://icon.png").stdout)
+    real = json.loads(gda("resource", "import", "res://icon.png").stdout)
     assert real["assets"][0]["status"] == "failed"
     assert real["engine_pass"] is False
     assert real["created"] == []
 
     # And another asset's dry run must not predict the skipped one.
     _png(project / "fresh.png", (9, 9, 9))
-    gap = json.loads(
-        _gda(project, "resource", "import", "res://fresh.png", "--dry-run").stdout
-    )
+    gap = json.loads(gda("resource", "import", "res://fresh.png", "--dry-run").stdout)
     assert "res://icon.png" not in gap["pass_will_also_import"]
 
 
@@ -391,7 +349,8 @@ def test_duplicate_receipt_assignments_match_the_engines_last_value(tmp_path):
     # wrong source_md5 followed by the engine-written matching value is still
     # current, so gda must neither spend a pass nor predict neighbor work.
     project = _project(tmp_path)
-    first = json.loads(_gda(project, "resource", "import", "res://icon.png").stdout)
+    gda = Gda(project, json_output=True, timeout=180)
+    first = json.loads(gda("resource", "import", "res://icon.png").stdout)
     assert first["assets"][0]["status"] == "imported"
 
     sidecar = project / "icon.png.import"
@@ -410,22 +369,18 @@ def test_duplicate_receipt_assignments_match_the_engines_last_value(tmp_path):
     receipt_bytes = receipt.read_bytes()
     dest_bytes = dest.read_bytes()
 
-    native = _native_import(project)
-    assert native.returncode == 0, native.stderr
+    # The engine's OWN import pass, no gda in between (native parity).
+    import_project(project)
     assert sidecar.read_bytes() == sidecar_bytes
     assert receipt.read_bytes() == receipt_bytes
     assert dest.read_bytes() == dest_bytes
 
-    dry = json.loads(
-        _gda(project, "resource", "import", "res://icon.png", "--dry-run").stdout
-    )
+    dry = json.loads(gda("resource", "import", "res://icon.png", "--dry-run").stdout)
     assert dry["assets"][0]["status"] == "cached"
     assert dry["engine_pass"] is False
 
     _png(project / "fresh.png", (4, 5, 6))
-    gap = json.loads(
-        _gda(project, "resource", "import", "res://fresh.png", "--dry-run").stdout
-    )
+    gap = json.loads(gda("resource", "import", "res://fresh.png", "--dry-run").stdout)
     assert "res://icon.png" not in gap["pass_will_also_import"]
 
 
@@ -436,7 +391,8 @@ def test_lone_surrogate_receipt_matches_the_engines_deliberate_skip(tmp_path):
     # artifacts untouched — while json.loads would happily decode it. gda must
     # sit on the engine's side: invalid, no pass.
     project = _project(tmp_path)
-    first = json.loads(_gda(project, "resource", "import", "res://icon.png").stdout)
+    gda = Gda(project, json_output=True, timeout=180)
+    first = json.loads(gda("resource", "import", "res://icon.png").stdout)
     assert first["assets"][0]["status"] == "imported"
 
     sidecar = project / "icon.png.import"
@@ -448,19 +404,17 @@ def test_lone_surrogate_receipt_matches_the_engines_deliberate_skip(tmp_path):
     sidecar_bytes = sidecar.read_bytes()
     dest_bytes = dest.read_bytes()
 
-    native = _native_import(project)
-    assert native.returncode == 0, native.stderr
+    # The engine's OWN import pass, no gda in between (native parity).
+    import_project(project)
     assert sidecar.read_bytes() == sidecar_bytes
     assert receipt.read_text(encoding="utf-8") == 'source_md5="\\ud800"\n'
     assert dest.read_bytes() == dest_bytes
 
-    dry = json.loads(
-        _gda(project, "resource", "import", "res://icon.png", "--dry-run").stdout
-    )
+    dry = json.loads(gda("resource", "import", "res://icon.png", "--dry-run").stdout)
     assert dry["assets"][0]["status"] == "invalid"
     assert dry["engine_pass"] is False
 
-    real = json.loads(_gda(project, "resource", "import", "res://icon.png").stdout)
+    real = json.loads(gda("resource", "import", "res://icon.png").stdout)
     assert real["assets"][0]["status"] == "failed"
     assert real["engine_pass"] is False
     assert real["created"] == []

--- a/tests/test_e2e_scene.py
+++ b/tests/test_e2e_scene.py
@@ -8,20 +8,12 @@ structured-level verification of ``scene create``'s effect.
 
 import json
 import os
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
+from tests.support import Gda
 
-GODOT = resolve_godot_binary()
-
-
-def _gda(*args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT)], capture_output=True, text=True
-    )
+gda = Gda()
 
 
 @pytest.mark.e2e
@@ -30,12 +22,7 @@ def test_res_path_round_trip_against_the_project_fixture(godot_project):
     # project fixture, a res:// path resolves against it — proving the fixture
     # is actually handed to the engine (it previously never reached it). The
     # created scene lands inside the project and reads back through res://.
-    def gda(*args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(godot_project)],
-            capture_output=True,
-            text=True,
-        )
+    gda = Gda(godot_project)
 
     created = gda(
         "scene", "create", "res://hero.tscn", "--root-type", "Node2D", "--json"
@@ -53,9 +40,7 @@ def test_res_path_round_trip_against_the_project_fixture(godot_project):
 def test_scene_create_then_get_round_trip(godot_project):
     scene_path = godot_project / "main.tscn"
 
-    created = _gda(
-        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
-    )
+    created = gda("scene", "create", str(scene_path), "--root-type", "Node2D", "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     data = json.loads(created.stdout)
@@ -63,7 +48,7 @@ def test_scene_create_then_get_round_trip(godot_project):
     # The .tscn landed on disk inside the temp project.
     assert scene_path.exists()
 
-    got = _gda("scene", "get", str(scene_path), "--json")
+    got = gda("scene", "get", str(scene_path), "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     tree = json.loads(got.stdout)
@@ -82,7 +67,7 @@ def test_scene_path_containing_end_sentinel_round_trips(godot_project):
     # is not a legal node-name char, so it cannot be derived from this filename.
     scene_path = godot_project / "weird<<<GDA:END>>>name.tscn"
 
-    created = _gda(
+    created = gda(
         "scene",
         "create",
         str(scene_path),
@@ -96,7 +81,7 @@ def test_scene_path_containing_end_sentinel_round_trips(godot_project):
     assert created.returncode == 0, created.stdout + created.stderr
     assert json.loads(created.stdout)["path"] == str(scene_path)
 
-    got = _gda("scene", "get", str(scene_path), "--json")
+    got = gda("scene", "get", str(scene_path), "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     tree = json.loads(got.stdout)
@@ -108,9 +93,7 @@ def test_scene_path_containing_end_sentinel_round_trips(godot_project):
 def test_scene_create_creates_missing_parent_directories(godot_project):
     scene_path = godot_project / "levels" / "demo" / "main.tscn"
 
-    created = _gda(
-        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
-    )
+    created = gda("scene", "create", str(scene_path), "--root-type", "Node2D", "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     data = json.loads(created.stdout)
@@ -120,7 +103,7 @@ def test_scene_create_creates_missing_parent_directories(godot_project):
     ]
     assert scene_path.exists()
 
-    got = _gda("scene", "get", str(scene_path), "--json")
+    got = gda("scene", "get", str(scene_path), "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["root"]["name"] == "main"
@@ -130,22 +113,8 @@ def test_scene_create_creates_missing_parent_directories(godot_project):
 def test_scene_create_creates_relative_parent_directories_against_project(
     godot_project,
 ):
-    created = subprocess.run(
-        [
-            *GDA_CMD,
-            "scene",
-            "create",
-            "demo/main.tscn",
-            "--root-type",
-            "Node2D",
-            "--project",
-            str(godot_project),
-            "--godot",
-            str(GODOT),
-            "--json",
-        ],
-        capture_output=True,
-        text=True,
+    created = Gda(godot_project)(
+        "scene", "create", "demo/main.tscn", "--root-type", "Node2D", "--json"
     )
 
     assert created.returncode == 0, created.stdout + created.stderr
@@ -163,9 +132,7 @@ def test_scene_create_existing_path_yields_already_exists_without_overwriting(
     original = "not a scene\n"
     scene_path.write_text(original, encoding="utf-8")
 
-    created = _gda(
-        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
-    )
+    created = gda("scene", "create", str(scene_path), "--root-type", "Node2D", "--json")
 
     assert created.returncode == 4
     err = json.loads(created.stdout)["error"]
@@ -179,9 +146,7 @@ def test_scene_create_existing_path_yields_already_exists_without_overwriting(
 def test_scene_create_empty_root_name_yields_structured_error(godot_project):
     scene_path = godot_project / ".tscn"
 
-    created = _gda(
-        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
-    )
+    created = gda("scene", "create", str(scene_path), "--root-type", "Node2D", "--json")
 
     assert created.returncode == 4
     err = json.loads(created.stdout)["error"]
@@ -195,7 +160,7 @@ def test_scene_create_empty_root_name_yields_structured_error(godot_project):
 def test_scene_create_rejects_root_name_godot_would_rewrite(godot_project):
     scene_path = godot_project / "bad-name.tscn"
 
-    created = _gda(
+    created = gda(
         "scene",
         "create",
         str(scene_path),
@@ -220,7 +185,7 @@ def test_scene_create_rejects_dotted_default_root_name_but_allows_override(
 ):
     scene_path = godot_project / "level.v2.tscn"
 
-    rejected = _gda(
+    rejected = gda(
         "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
     )
 
@@ -230,7 +195,7 @@ def test_scene_create_rejects_dotted_default_root_name_but_allows_override(
     assert err["code"] == "invalid_root_name"
     assert not scene_path.exists()
 
-    created = _gda(
+    created = gda(
         "scene",
         "create",
         str(scene_path),
@@ -244,7 +209,7 @@ def test_scene_create_rejects_dotted_default_root_name_but_allows_override(
     assert created.returncode == 0, created.stdout + created.stderr
     assert json.loads(created.stdout)["root_name"] == "LevelV2"
 
-    got = _gda("scene", "get", str(scene_path), "--json")
+    got = gda("scene", "get", str(scene_path), "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["root"]["name"] == "LevelV2"
@@ -307,7 +272,7 @@ def test_scene_get_reports_nested_tree(godot_project):
     scene_path = godot_project / "nested.tscn"
     scene_path.write_text(NESTED_TSCN, encoding="utf-8")
 
-    got = _gda("scene", "get", str(scene_path), "--json")
+    got = gda("scene", "get", str(scene_path), "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     root = json.loads(got.stdout)["root"]
@@ -330,7 +295,7 @@ def test_scene_get_marks_instanced_child_and_resolves_its_root_type(godot_projec
     (godot_project / "main.tscn").write_text(
         HOST_WITH_INSTANCED_CHILD_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     got = gda("scene", "get", "res://main.tscn", "--json")
 
@@ -371,7 +336,7 @@ def test_scene_get_reads_the_instance_attribute_by_whole_name(godot_project):
     (godot_project / "main.tscn").write_text(
         HOST_WITH_DECOYED_INSTANCE_ATTR_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     got = gda("scene", "get", "res://main.tscn", "--json")
 
@@ -390,7 +355,7 @@ def test_scene_get_marks_missing_instanced_child_reference(godot_project):
     (godot_project / "main.tscn").write_text(
         HOST_WITH_MISSING_INSTANCED_CHILD_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     got = gda("scene", "get", "res://main.tscn", "--json")
 
@@ -410,7 +375,7 @@ def test_scene_get_missing_file_yields_structured_error_end_to_end(godot_project
     # operation exit code.
     missing = godot_project / "missing.tscn"
 
-    got = _gda("scene", "get", str(missing), "--json")
+    got = gda("scene", "get", str(missing), "--json")
 
     assert got.returncode == 4
     err = json.loads(got.stdout)["error"]
@@ -432,9 +397,7 @@ def test_scene_create_unwritable_directory_yields_structured_save_failed(godot_p
     target = locked / "main.tscn"
     locked.chmod(0o500)
     try:
-        created = _gda(
-            "scene", "create", str(target), "--root-type", "Node2D", "--json"
-        )
+        created = gda("scene", "create", str(target), "--root-type", "Node2D", "--json")
     finally:
         locked.chmod(0o700)
 
@@ -455,7 +418,7 @@ def test_scene_create_unknown_root_type_yields_structured_error_end_to_end(
 ):
     target = godot_project / "bogus.tscn"
 
-    created = _gda("scene", "create", str(target), "--root-type", "NotAClass", "--json")
+    created = gda("scene", "create", str(target), "--root-type", "NotAClass", "--json")
 
     assert created.returncode == 4
     err = json.loads(created.stdout)["error"]
@@ -464,26 +427,13 @@ def test_scene_create_unknown_root_type_yields_structured_error_end_to_end(
     assert not target.exists()
 
 
-def _gda_project(project):
-    """A ``_gda`` bound to ``--project`` for res:// enumeration/resolution."""
-
-    def gda(*args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-            capture_output=True,
-            text=True,
-        )
-
-    return gda
-
-
 @pytest.mark.e2e
 def test_scene_list_enumerates_created_scenes(godot_project):
     # scene list (issue #54) enumerates the project's .tscn scenes by walking
     # res://: two scenes created at different depths both appear, each with its
     # res:// path and the root name/type read from stored state. The listing IS
     # the structured-level verification of what scene create wrote.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     assert (
         gda(
@@ -520,7 +470,7 @@ def test_scene_list_marks_inherited_scene_root_and_resolves_its_type(godot_proje
     (godot_project / "inherited_hud.tscn").write_text(
         INHERITED_HUD_ROOT_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     listed = gda("scene", "list", "--json")
 
@@ -541,7 +491,7 @@ def test_scene_list_enumerates_dot_prefixed_scenes_but_skips_godot_cache(godot_p
     # dot-prefixed entry. The empty-project test already proves res://.godot does
     # not leak; this proves the skip is scoped to res://.godot, not "anything
     # starting with a dot".
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     assert (
         gda(
@@ -589,7 +539,7 @@ def test_scene_list_enumerates_dot_prefixed_scenes_but_skips_godot_cache(godot_p
 def test_scene_list_on_empty_project_is_an_empty_listing(godot_project):
     # A project with no scenes is a valid, empty listing — not an error (the
     # res://.godot import cache must not leak in as a phantom scene).
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     listed = gda("scene", "list", "--json")
 
@@ -602,12 +552,7 @@ def test_scene_list_without_project_yields_project_not_found(tmp_path):
     # scene list cannot enumerate res:// projectless: run from a non-project
     # directory with no --project, it must refuse with the structured
     # project_not_found code rather than return a misleading empty listing.
-    listed = subprocess.run(
-        [*GDA_CMD, "scene", "list", "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-        cwd=str(tmp_path),
-    )
+    listed = gda("scene", "list", "--json", cwd=tmp_path)
 
     assert listed.returncode == 4, listed.stdout + listed.stderr
     err = json.loads(listed.stdout)["error"]
@@ -621,7 +566,7 @@ def test_scene_delete_removes_a_scene_and_names_what_was_removed(godot_project):
     # scene delete (issue #54) removes a scene file and names the removed root.
     # The round-trip verifier: scene list before shows the scene, delete reports
     # the removed root's name/type, and scene list after no longer shows it.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -647,7 +592,7 @@ def test_scene_delete_removes_a_scene_and_names_what_was_removed(godot_project):
 def test_scene_delete_missing_file_yields_path_not_found(godot_project):
     missing = godot_project / "missing.tscn"
 
-    deleted = _gda("scene", "delete", str(missing), "--json")
+    deleted = gda("scene", "delete", str(missing), "--json")
 
     assert deleted.returncode == 4
     err = json.loads(deleted.stdout)["error"]
@@ -664,7 +609,7 @@ def test_scene_delete_refuses_non_scene_file_and_leaves_it_on_disk(godot_project
     notes = godot_project / "notes.txt"
     notes.write_text("not a scene\n", encoding="utf-8")
 
-    deleted = _gda("scene", "delete", str(notes), "--json")
+    deleted = gda("scene", "delete", str(notes), "--json")
 
     assert deleted.returncode == 4
     err = json.loads(deleted.stdout)["error"]

--- a/tests/test_e2e_scene_exports.py
+++ b/tests/test_e2e_scene_exports.py
@@ -12,29 +12,12 @@ The scene is built end-to-end with the real CLI: ``scene create`` →
 """
 
 import json
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
+from tests.support import Gda
 
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
-
-
-def _gda(*args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT)], capture_output=True, text=True
-    )
-
-
-def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
-    assert proc.returncode == 4, proc.stdout + proc.stderr
-    err = json.loads(proc.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == code
-    return err
+gda = Gda()
 
 
 # A script declaring a representative @export surface: a typed scalar with a
@@ -55,15 +38,13 @@ var not_exported: int = 7
 def _build_scene_with_exports(project) -> "tuple":
     """scene create → script create (exports) → script attach to the root."""
     scene_path = project / "main.tscn"
-    created = _gda(
-        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
-    )
+    created = gda("scene", "create", str(scene_path), "--root-type", "Node2D", "--json")
     assert created.returncode == 0, created.stdout + created.stderr
 
     script_path = project / "actor.gd"
     script_path.write_text(EXPORTING_SCRIPT, encoding="utf-8")
 
-    attached = _gda(
+    attached = gda(
         "script",
         "attach",
         str(scene_path),
@@ -87,7 +68,7 @@ def test_scene_get_exports_reports_declared_exports_per_node(godot_project):
     # typed JSON. A plain (non-@export) var is NOT reported.
     scene_path, _ = _build_scene_with_exports(godot_project)
 
-    got = _gda(
+    got = gda(
         "scene",
         "get-exports",
         str(scene_path),
@@ -131,12 +112,10 @@ def test_scene_get_exports_omits_nodes_without_declared_exports(godot_project):
     # not appear: get-exports lists only nodes that actually declare exports. A
     # bare scene (no scripts anywhere) is a valid, empty listing.
     scene_path = godot_project / "bare.tscn"
-    created = _gda(
-        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
-    )
+    created = gda("scene", "create", str(scene_path), "--root-type", "Node2D", "--json")
     assert created.returncode == 0, created.stdout + created.stderr
 
-    got = _gda(
+    got = gda(
         "scene",
         "get-exports",
         str(scene_path),
@@ -157,14 +136,12 @@ def test_scene_get_exports_reports_nested_node_by_path(godot_project):
     # afterwards. The root here carries no script, so only the child is listed —
     # which also pins that a scriptless node is omitted.
     scene_path = godot_project / "main.tscn"
-    created = _gda(
-        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
-    )
+    created = gda("scene", "create", str(scene_path), "--root-type", "Node2D", "--json")
     assert created.returncode == 0, created.stdout + created.stderr
     script_path = godot_project / "actor.gd"
     script_path.write_text(EXPORTING_SCRIPT, encoding="utf-8")
 
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(scene_path),
@@ -175,7 +152,7 @@ def test_scene_get_exports_reports_nested_node_by_path(godot_project):
         "--json",
     )
     assert added.returncode == 0, added.stdout + added.stderr
-    attached = _gda(
+    attached = gda(
         "script",
         "attach",
         str(scene_path),
@@ -189,7 +166,7 @@ def test_scene_get_exports_reports_nested_node_by_path(godot_project):
     )
     assert attached.returncode == 0, attached.stdout + attached.stderr
 
-    got = _gda(
+    got = gda(
         "scene",
         "get-exports",
         str(scene_path),
@@ -209,16 +186,15 @@ def test_scene_get_exports_reports_nested_node_by_path(godot_project):
 
 @pytest.mark.e2e
 def test_scene_get_exports_missing_file_yields_path_not_found(godot_project):
-    got = _gda(
+    err = gda.error(
         "scene",
         "get-exports",
         str(godot_project / "nope.tscn"),
         "--project",
         str(godot_project),
         "--json",
+        code="path_not_found",
     )
-
-    err = _assert_operation_error(got, "path_not_found")
     assert "nope.tscn" in err["message"]
 
 
@@ -229,13 +205,12 @@ def test_scene_get_exports_non_scene_file_yields_not_a_scene(godot_project):
     notes = godot_project / "notes.txt"
     notes.write_text("not a scene\n", encoding="utf-8")
 
-    got = _gda(
+    gda.error(
         "scene",
         "get-exports",
         str(notes),
         "--project",
         str(godot_project),
         "--json",
+        code="not_a_scene",
     )
-
-    _assert_operation_error(got, "not_a_scene")

--- a/tests/test_e2e_scene_preflight.py
+++ b/tests/test_e2e_scene_preflight.py
@@ -12,15 +12,11 @@ run, and the verdict has to come back within it.
 """
 
 import json
-import subprocess
 import time
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
+from tests.support import Gda
 
 # printerr, not print: gda's stdout carries only the result object (ADR-0002), so
 # the engine's stdout is consumed by the sentinel parse and never forwarded. Its
@@ -64,17 +60,6 @@ def _scene_tscn(script: str) -> str:
     )
 
 
-def _gda_project(project):
-    def gda(*args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-            capture_output=True,
-            text=True,
-        )
-
-    return gda
-
-
 def _scene(project, name: str, script_name: str, source: str):
     (project / script_name).write_text(source, encoding="utf-8")
     (project / name).write_text(_scene_tscn(script_name), encoding="utf-8")
@@ -83,7 +68,7 @@ def _scene(project, name: str, script_name: str, source: str):
 @pytest.mark.e2e
 def test_a_scene_that_comes_up_cleanly_is_started(godot_project):
     _scene(godot_project, "hero.tscn", "hero.gd", READY_SCRIPT)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     preflighted = gda("scene", "preflight", "res://hero.tscn", "--json")
 
@@ -108,7 +93,7 @@ def test_an_error_raised_in_ready_is_reported_though_the_scene_reached_ready(
     # reaches _ready — and is still broken. `status` reports how far it got, the
     # diagnostics say what went wrong, and `started` requires both.
     _scene(godot_project, "encounter.tscn", "encounter.gd", FAILING_READY_SCRIPT)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     # Static validation passes: every dependency resolves and the script compiles.
     validated = gda("scene", "validate", "res://encounter.tscn", "--json")
@@ -137,7 +122,7 @@ def test_a_scene_whose_ready_never_returns_is_a_timeout_verdict_within_the_bound
     # still comes back — as a SUCCESS carrying status=timeout, because "it did not
     # come up" is the answer this command was asked for.
     _scene(godot_project, "hang.tscn", "hang.gd", BLOCKING_READY_SCRIPT)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     started_at = time.monotonic()
     preflighted = gda(
@@ -179,7 +164,7 @@ def test_a_scene_missing_an_unimported_asset_starts_clean_which_is_why_both_exis
         'texture = ExtResource("1_dot")\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     preflighted = gda("scene", "preflight", "res://main.tscn", "--json")
     assert preflighted.returncode == 0, preflighted.stdout + preflighted.stderr
@@ -198,7 +183,7 @@ def test_a_scene_missing_an_unimported_asset_starts_clean_which_is_why_both_exis
 
 @pytest.mark.e2e
 def test_a_missing_scene_is_refused_not_reported_as_a_verdict(godot_project):
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     preflighted = gda("scene", "preflight", "res://nosuch.tscn", "--json")
 
@@ -253,7 +238,7 @@ def test_a_scene_that_hands_off_in_ready_still_counts_as_started(godot_project):
     # that freed itself in _ready is already gone. Sampling reported this shape as
     # not_ready — a scene that plainly started.
     _scene(godot_project, "splash.tscn", "splash.gd", HANDOFF_READY_SCRIPT)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     preflighted = gda("scene", "preflight", "res://splash.tscn", "--json")
 
@@ -270,7 +255,7 @@ def test_the_frame_window_is_what_catches_a_failure_after_ready(godot_project):
     # one-frame window and fails with the default one, because its error lands on
     # frame five. This is why the window is not simply "wait for ready".
     _scene(godot_project, "late.tscn", "late.gd", LATE_FAILURE_SCRIPT)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     narrow = gda("scene", "preflight", "res://late.tscn", "--frames", "1", "--json")
     assert narrow.returncode == 0, narrow.stdout + narrow.stderr
@@ -305,7 +290,7 @@ def test_a_scene_that_quits_from_ready_still_gets_its_ready_verdict(godot_projec
     # moment the signal lands, so the verdict survives the project's exit instead
     # of being misreported as an operation failure (the pre-#709 behavior).
     _scene(godot_project, "splash.tscn", "splash.gd", QUITTING_READY_SCRIPT)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     preflighted = gda("scene", "preflight", "res://splash.tscn", "--json")
 
@@ -349,7 +334,7 @@ def test_a_push_error_raised_in_ready_is_reported_as_a_startup_diagnostic(
     # `started: true` with EMPTY diagnostics — the phantom-clean start the
     # dogfooding note is about, in the most common shape a project writes it.
     _scene(godot_project, "encounter.tscn", "encounter.gd", PUSH_ERROR_READY_SCRIPT)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     # Static validation passes: the scene's dependencies resolve and it compiles.
     # Only booting it reveals what the project itself thinks of what it found.
@@ -402,7 +387,7 @@ def test_an_engine_error_a_script_triggered_is_not_reported_as_the_projects_own(
     # of the project's diagnostics — the record stays unrecognized, and the
     # verbatim stream is where a reader still finds it.
     _scene(godot_project, "indirect.tscn", "indirect.gd", INDIRECT_ERROR_SCRIPT)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     preflighted = gda("scene", "preflight", "res://indirect.tscn", "--json")
 
@@ -442,7 +427,7 @@ def test_a_refused_script_binding_is_not_a_clean_start(godot_project):
     (godot_project / "badbind.tscn").write_text(
         INCOMPATIBLE_BINDING_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     preflighted = gda("scene", "preflight", "res://badbind.tscn", "--json")
 
@@ -480,7 +465,7 @@ def test_a_non_script_binding_is_not_a_clean_start(godot_project):
     (godot_project / "notascript.tscn").write_text(
         NOT_A_SCRIPT_BINDING_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     preflighted = gda("scene", "preflight", "res://notascript.tscn", "--json")
 
@@ -504,7 +489,7 @@ def test_the_timeout_verdict_carries_the_elapsed_clock_and_the_configured_ceilin
     # exactly what this caller configured, not the 30s default the run did not use.
     # Together they are what tells this scene (stuck) from one that was merely slow.
     _scene(godot_project, "stuck.tscn", "stuck.gd", BLOCKING_READY_SCRIPT)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     preflighted = gda(
         "scene", "preflight", "res://stuck.tscn", "--timeout", "3", "--json"
@@ -526,7 +511,7 @@ def test_a_scene_that_comes_up_carries_no_timeout_evidence(godot_project):
     # absent rather than null or zero. A `ready` verdict is byte-identical to what it
     # was before #787 added the keys.
     _scene(godot_project, "hero.tscn", "hero.gd", READY_SCRIPT)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     preflighted = gda("scene", "preflight", "res://hero.tscn", "--json")
 

--- a/tests/test_e2e_scene_security.py
+++ b/tests/test_e2e_scene_security.py
@@ -32,25 +32,13 @@ The contract pinned (verified on Godot 4.6.3):
 """
 
 import json
-import subprocess
-
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
+from tests.support import Gda
 
 from .conftest import project_godot
 
-GODOT = resolve_godot_binary()
-
-
-def _gda(*args: str, cwd=None) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-        cwd=str(cwd) if cwd is not None else None,
-    )
+gda = Gda()
 
 
 # A root script whose _init has a side effect AND prints a forged result block.
@@ -86,12 +74,7 @@ def test_scene_get_does_not_execute_scene_code(godot_project):
 
     # Run from inside the project so res://evil.gd resolves — the condition
     # under which the script would load and (on the buggy path) execute.
-    proc = subprocess.run(
-        [*GDA_CMD, "scene", "get", "evil.tscn", "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-        cwd=str(godot_project),
-    )
+    proc = gda("scene", "get", "evil.tscn", "--json", cwd=godot_project)
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     tree = json.loads(proc.stdout)
@@ -152,14 +135,14 @@ def test_node_list_does_not_execute_scene_script(godot_project):
     # project code and that is a regression, not an intentional behavior change.
     scene = _plant_spied_scene(godot_project)
 
-    listed = _gda("node", "list", str(scene), "--project", str(godot_project), "--json")
+    listed = gda("node", "list", str(scene), "--project", str(godot_project), "--json")
     assert listed.returncode == 0, listed.stdout + listed.stderr
     tree = json.loads(listed.stdout)["root"]
     # The declared tree is reported (not anything the script could have forged).
     assert (tree["name"], tree["type"], tree["path"]) == ("Root", "Node2D", ".")
     assert tree["children"] == []
 
-    got = _gda("scene", "get", str(scene), "--project", str(godot_project), "--json")
+    got = gda("scene", "get", str(scene), "--project", str(godot_project), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["root"]["name"] == "Root"
 
@@ -180,7 +163,7 @@ def test_node_add_executes_pre_existing_scene_script(godot_project):
     # assertion below should flip to assert the marker file does NOT appear.
     scene = _plant_spied_scene(godot_project)
 
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(scene),
@@ -217,7 +200,7 @@ def test_node_get_executes_pre_existing_scene_script(godot_project):
     # marker file does NOT appear.
     scene = _plant_spied_scene(godot_project)
 
-    got = _gda(
+    got = gda(
         "node",
         "get",
         str(scene),
@@ -276,7 +259,7 @@ def test_node_add_forged_sentinel_from_scene_script_fails_loudly(godot_project):
     (godot_project / "forge.gd").write_text(FORGE_GD, encoding="utf-8")
     (godot_project / "forged.tscn").write_text(FORGED_TSCN, encoding="utf-8")
 
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(godot_project / "forged.tscn"),
@@ -352,7 +335,7 @@ def test_autoload_runs_on_scene_get(godot_project):
     (godot_project / "autoload.gd").write_text(AUTOLOAD_GD, encoding="utf-8")
     (godot_project / "plain.tscn").write_text(PLAIN_TSCN, encoding="utf-8")
 
-    got = _gda(
+    got = gda(
         "scene",
         "get",
         str(godot_project / "plain.tscn"),

--- a/tests/test_e2e_scene_security.py
+++ b/tests/test_e2e_scene_security.py
@@ -32,6 +32,7 @@ The contract pinned (verified on Godot 4.6.3):
 """
 
 import json
+
 import pytest
 
 from tests.support import Gda

--- a/tests/test_e2e_scene_validate.py
+++ b/tests/test_e2e_scene_validate.py
@@ -14,14 +14,10 @@ compile, through any gda command.
 """
 
 import json
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
+from tests.support import Gda
 
 GOOD_SCRIPT = """\
 extends Node2D
@@ -72,24 +68,13 @@ script = ExtResource("1_broken")
 """
 
 
-def _gda_project(project):
-    def gda(*args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-            capture_output=True,
-            text=True,
-        )
-
-    return gda
-
-
 @pytest.mark.e2e
 def test_a_sound_scene_validates_and_names_the_project_it_resolved_against(
     godot_project,
 ):
     (godot_project / "hero.gd").write_text(GOOD_SCRIPT, encoding="utf-8")
     (godot_project / "hero.tscn").write_text(GOOD_TSCN, encoding="utf-8")
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://hero.tscn", "--json")
 
@@ -106,7 +91,7 @@ def test_missing_dependencies_are_reported_where_scene_get_reports_nothing(
     godot_project,
 ):
     (godot_project / "main.tscn").write_text(MISSING_DEPS_TSCN, encoding="utf-8")
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     # BEFORE (GDA-DF-040): the read succeeds and the tree looks healthy — the missing
     # script and texture leave no trace in it. This is the gap, pinned.
@@ -151,7 +136,7 @@ def test_an_attached_script_that_does_not_compile_is_a_problem_not_a_failure(
 ):
     (godot_project / "broken.gd").write_text(BROKEN_SCRIPT, encoding="utf-8")
     (godot_project / "main.tscn").write_text(BROKEN_SCRIPT_TSCN, encoding="utf-8")
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://main.tscn", "--json")
 
@@ -194,7 +179,7 @@ def test_an_asset_that_was_never_imported_is_unloadable_not_missing(godot_projec
         'texture = ExtResource("1_dot")\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://main.tscn", "--json")
 
@@ -210,7 +195,7 @@ def test_an_asset_that_was_never_imported_is_unloadable_not_missing(godot_projec
 def test_a_missing_scene_is_refused_not_reported_as_invalid(godot_project):
     # The addressing ladder does not fork for validate: what is not there cannot have
     # a verdict, so it is the same path_not_found every other scene command reports.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://nosuch.tscn", "--json")
 
@@ -259,7 +244,7 @@ def test_a_dependency_broken_from_a_sub_resource_is_a_verdict_not_a_refusal(
     # `not_a_scene` about a file that IS a scene — hiding exactly the broken
     # dependency this command exists to report.
     (godot_project / "main.tscn").write_text(SUB_RESOURCE_TSCN, encoding="utf-8")
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://main.tscn", "--json")
 
@@ -283,7 +268,7 @@ def test_a_binary_scene_is_refused_rather_than_reported_valid(godot_project):
     (godot_project / "hero.gd").write_text(GOOD_SCRIPT, encoding="utf-8")
     (godot_project / "hero.tscn").write_text(GOOD_TSCN, encoding="utf-8")
     (godot_project / "save_binary.gd").write_text(SAVE_AS_BINARY_GD, encoding="utf-8")
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     saved = gda("script", "run", "res://save_binary.gd", "--json")
     assert saved.returncode == 0, saved.stdout + saved.stderr
@@ -349,7 +334,7 @@ def test_an_incompatible_script_binding_is_a_problem_not_a_pass(godot_project):
     (godot_project / "badbind.tscn").write_text(
         INCOMPATIBLE_BINDING_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://badbind.tscn", "--json")
 
@@ -367,7 +352,7 @@ def test_an_incompatible_script_binding_is_a_problem_not_a_pass(godot_project):
 @pytest.mark.e2e
 def test_a_broken_embedded_script_is_a_problem_not_a_pass(godot_project):
     (godot_project / "badembed.tscn").write_text(BROKEN_EMBEDDED_TSCN, encoding="utf-8")
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://badembed.tscn", "--json")
 
@@ -420,7 +405,7 @@ def test_a_non_script_resource_declared_as_script_is_a_problem_not_a_pass(
     (godot_project / "notascript.tscn").write_text(
         NOT_A_SCRIPT_BINDING_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://notascript.tscn", "--json")
 
@@ -441,7 +426,7 @@ def test_an_embedded_non_script_bound_as_script_is_a_problem_not_a_pass(
     (godot_project / "embednotascript.tscn").write_text(
         EMBEDDED_NOT_A_SCRIPT_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://embednotascript.tscn", "--json")
 
@@ -464,7 +449,7 @@ def test_a_tscn_that_is_not_a_scene_document_is_refused_not_diagnosed(godot_proj
         "this is not a scene file at all\n",
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://garbage.tscn", "--json")
 
@@ -485,7 +470,7 @@ def test_a_header_that_merely_starts_with_gd_scene_is_still_refused(godot_projec
         "this is not a Godot scene\n",
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://scenery.tscn", "--json")
 
@@ -507,7 +492,7 @@ def test_an_unclosed_gd_scene_header_is_still_refused(godot_project):
         "this is not a Godot scene\n",
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://unclosed.tscn", "--json")
 
@@ -547,7 +532,7 @@ COMPOSED_PARENT_TSCN = """\
 def test_an_instanced_broken_child_makes_the_parent_invalid(godot_project):
     (godot_project / "child.tscn").write_text(COMPOSED_CHILD_TSCN, encoding="utf-8")
     (godot_project / "parent.tscn").write_text(COMPOSED_PARENT_TSCN, encoding="utf-8")
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     # The child's own verdict is the reference answer.
     child = gda("scene", "validate", "res://child.tscn", "--json")
@@ -601,7 +586,7 @@ def test_a_sound_composed_scene_is_still_valid_and_each_file_checked_once(
         '[node name="LeafDirect" parent="." instance=ExtResource("2_leaf")]\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://top.tscn", "--json")
 
@@ -651,7 +636,7 @@ def test_an_instancing_cycle_terminates_with_a_diagnostic(godot_project):
         '[node name="AInstance" parent="." instance=ExtResource("1_a")]\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://a.tscn", "--json")
 
@@ -678,7 +663,7 @@ def test_a_scene_that_instances_itself_is_one_cycle_not_a_hang(godot_project):
         '[node name="Inner2" parent="." instance=ExtResource("1_self")]\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://self.tscn", "--json")
 
@@ -707,7 +692,7 @@ def test_a_missing_sub_scene_is_the_parents_problem_and_not_reported_twice(
         '[node name="Missing" parent="." instance=ExtResource("1_gone")]\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://parent.tscn", "--json")
 
@@ -764,7 +749,7 @@ def test_a_chain_at_the_depth_bound_is_still_fully_validated(godot_project):
     # the verdict is a real one. This is the half that keeps the bound honest: a
     # cap that fires early would turn ordinary compositions into non-answers.
     _write_instance_chain(godot_project, 16)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://s0.tscn", "--json")
 
@@ -779,7 +764,7 @@ def test_past_the_depth_bound_the_walk_stops_and_says_so(godot_project):
     # One level further. The walk stops at the edge into s17 and reports it —
     # rather than answering `valid: true` about a subtree it never looked at.
     _write_instance_chain(godot_project, 17)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://s0.tscn", "--json")
 
@@ -811,7 +796,7 @@ def test_the_bound_does_not_hide_a_break_above_it(godot_project):
         '[node name="Child" parent="." instance=ExtResource("1_c")]\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://s0.tscn", "--json")
 
@@ -860,7 +845,7 @@ def test_a_sub_scene_referenced_as_data_still_breaks_its_owner(godot_project):
     (godot_project / "parent.tscn").write_text(
         DATA_REFERENCE_PARENT_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://parent.tscn", "--json")
 
@@ -901,7 +886,7 @@ def test_a_binary_sub_scene_is_reported_unchecked_not_silently_skipped(godot_pro
     (godot_project / "parent.tscn").write_text(
         BINARY_SUB_SCENE_PARENT_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     saved = gda("script", "run", "res://save_binary.gd", "--json")
     assert saved.returncode == 0, saved.stdout + saved.stderr
     assert (godot_project / "hero.scn").exists(), saved.stdout + saved.stderr
@@ -941,7 +926,7 @@ def test_a_binary_sub_scene_that_does_not_load_is_still_reported_once(godot_proj
     (godot_project / "parent.tscn").write_text(
         BINARY_SUB_SCENE_PARENT_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     saved = gda("script", "run", "res://save_binary.gd", "--json")
     assert saved.returncode == 0, saved.stdout + saved.stderr
     # Removing the script entirely makes the binary resource itself unloadable.
@@ -981,7 +966,7 @@ def test_two_spellings_of_one_sub_scene_are_one_file(godot_project):
         '[node name="B" parent="." instance=ExtResource("2_a")]\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://alias.tscn", "--json")
 
@@ -1050,7 +1035,7 @@ def test_the_depth_verdict_does_not_depend_on_declaration_order(
     # nothing stood behind), while direct-first validated the leaf first and let
     # `visited` swallow the deep edge in silence (`valid: true`).
     _write_cross_boundary_diamond(godot_project, deep_first=deep_first)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://root.tscn", "--json")
 
@@ -1073,7 +1058,7 @@ def test_a_target_no_route_reaches_in_bound_is_still_reported(godot_project):
         '[node name="Deep" parent="." instance=ExtResource("1_deep")]\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://root.tscn", "--json")
 
@@ -1130,7 +1115,7 @@ def test_a_packed_scene_saved_as_a_res_is_reported_not_skipped(godot_project):
     (godot_project / "parent.tscn").write_text(
         RES_SUB_SCENE_PARENT_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     saved = gda("script", "run", "res://save_res.gd", "--json")
     assert saved.returncode == 0, saved.stdout + saved.stderr
     assert (godot_project / "hero_pack.res").exists(), saved.stdout + saved.stderr
@@ -1168,7 +1153,7 @@ def test_a_res_declared_as_something_else_is_still_not_a_scene_edge(godot_projec
         'metadata/thing = ExtResource("1_p")\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://parent.tscn", "--json")
 
@@ -1242,7 +1227,7 @@ def test_a_sound_graph_converging_above_the_bound_is_valid_in_both_orders(
     # `t.tscn`, one edge below it, was reached on the direct-first file and left
     # past the bound on the deep-first one. Same graph, two verdicts.
     _write_ancestor_convergence(godot_project, deep_first=deep_first, break_leaf=False)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://root.tscn", "--json")
 
@@ -1263,7 +1248,7 @@ def test_a_break_below_the_convergence_is_found_in_both_orders(
     # find the break, not merely stop reporting the bound. One problem, the same
     # one, whichever line the root declares first.
     _write_ancestor_convergence(godot_project, deep_first=deep_first, break_leaf=True)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://root.tscn", "--json")
 
@@ -1295,7 +1280,7 @@ def test_a_subtree_only_the_deep_route_reaches_is_still_reported(godot_project):
         '[node name="Deep" parent="." instance=ExtResource("1_deep")]\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://root.tscn", "--json")
 
@@ -1324,7 +1309,7 @@ def test_an_aliased_root_is_the_same_file_as_the_reference_back_to_it(godot_proj
         '[node name="Inner" parent="." instance=ExtResource("2_self")]\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     canonical = gda("scene", "validate", "res://root.tscn", "--json")
     aliased = gda("scene", "validate", "res://./root.tscn", "--json")
@@ -1356,7 +1341,7 @@ def test_an_edge_problem_lists_every_id_that_names_the_target(godot_project):
         '[node name="InnerB" parent="." instance=ExtResource("2_b")]\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://self.tscn", "--json")
 
@@ -1393,7 +1378,7 @@ def test_a_cycle_below_a_re_expanded_scene_is_reported_once(godot_project):
             '[node name="Child" parent="." instance=ExtResource("1_c")]\n',
             encoding="utf-8",
         )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://root.tscn", "--json")
 
@@ -1471,7 +1456,7 @@ def test_a_deferred_depth_edge_does_not_suppress_a_later_cycle(
     # reported the cycle (measured on Godot 4.6.3 before the fix). One graph, one
     # verdict — the cycle, attributed to the file that declares the closing edge.
     _write_deferred_cycle(godot_project, deep_first=deep_first)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://root.tscn", "--json")
 
@@ -1510,7 +1495,7 @@ script = ExtResource("1_gone")
 @pytest.mark.e2e
 def test_a_problem_names_the_node_a_whole_name_header_read_finds(godot_project):
     (godot_project / "main.tscn").write_text(DECOY_ATTR_TSCN, encoding="utf-8")
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://main.tscn", "--json")
 

--- a/tests/test_e2e_screen.py
+++ b/tests/test_e2e_screen.py
@@ -21,16 +21,12 @@ within the `sun_path` limit.
 
 import json
 import os
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD, assert_windowed_ok
+from tests.support import Gda, assert_windowed_ok
 
-from .conftest import project_godot
-
-GODOT = resolve_godot_binary()
+from .conftest import LIVE_PROJECT_GODOT, project_godot
 
 # The PNG magic the written capture must start with — the proof it is a real,
 # decodable image (not an empty/placeholder buffer).
@@ -47,7 +43,6 @@ MAIN_TSCN = (
     "offset_bottom = 150.0\n"
     "color = Color(0.2, 0.6, 0.9, 1)\n"
 )
-PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
@@ -69,23 +64,8 @@ _needs_display = pytest.mark.usefixtures("windowed_host")
 
 
 def _scaffold(tmp_path):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
-
-
-def _runner(gda, tmp_path):
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [*gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=120,
-        )
-
-    return run
 
 
 @pytest.mark.e2e
@@ -94,7 +74,7 @@ def test_windowed_daemon_captures_a_single_viewport_frame(tmp_path, daemon_runti
     # `daemon start --windowed` -> a WINDOWED engine session -> `screen capture`
     # writes a real PNG of the running viewport (magic + dims > 0).
     _scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out = tmp_path / "shot.png"
 
     try:
@@ -147,7 +127,7 @@ def test_windowed_daemon_captures_a_single_viewport_frame(tmp_path, daemon_runti
 def test_windowed_daemon_inline_embeds_the_base64(tmp_path, daemon_runtime_dir):
     # `screen capture --inline` additionally embeds the base64 PNG in the reply.
     _scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out = tmp_path / "shot.png"
 
     try:
@@ -182,12 +162,12 @@ def test_capture_receipt_reports_the_scene_uid_the_project_provides(
     # whose FILE HEADER carries a uid (as every editor-authored scene does)
     # reports it — read from the header itself, no `.godot/` cache needed. The
     # uid-less arm is the single-frame test above.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(
         f'{header}\n\n[node name="Main" type="Node2D"]\n',
         encoding="utf-8",
     )
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out = tmp_path / "shot.png"
 
     try:
@@ -208,7 +188,7 @@ def test_capture_receipt_names_the_launched_scene_after_a_scene_switch(
     # #660's authoritative semantics (#746 review Spec 1): the receipt's scene
     # fields are the LAUNCHED scene — a session launch fact — so a game that
     # switches scenes mid-session still receipts under the scene it launched.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.gd").write_text(
         "extends Node2D\n"
         "var _frames := 0\n"
@@ -229,7 +209,7 @@ def test_capture_receipt_names_the_launched_scene_after_a_scene_switch(
         '[gd_scene format=3]\n\n[node name="Other" type="Node2D"]\n',
         encoding="utf-8",
     )
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out = tmp_path / "shot.png"
 
     try:
@@ -255,7 +235,7 @@ def test_windowed_daemon_captures_a_frame_window(tmp_path, daemon_runtime_dir):
     # 3 viewport frames over the engine session and returns them in one blocking
     # call; the CLI writes one PNG per frame (path-only).
     _scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out_dir = tmp_path / "frames"
 
     try:
@@ -302,7 +282,7 @@ def test_ninety_frame_capture_completes_with_a_structured_envelope(
     # they establish correlation, not the specific cap. The --summary envelope
     # below stays well under any such limit either way.
     _scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out_dir = tmp_path / "frames"
 
     try:
@@ -353,7 +333,7 @@ def test_headless_session_reports_live_display_unavailable(
     # capture` there is refused with the typed live_display_unavailable (the
     # self-revealing remediation: start --windowed). No file is written.
     _scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out = tmp_path / "shot.png"
 
     try:
@@ -376,7 +356,7 @@ def test_screen_capture_with_no_daemon_reports_daemon_not_running(
     # No daemon started: `screen capture` is the attach-or-fail daemon_not_running
     # (ADR-0017), the same typed error every live op reports with no daemon.
     _scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
 
     cap = run("screen", "capture", "--output", str(tmp_path / "shot.png"))
 
@@ -549,7 +529,7 @@ def test_await_predicate_captures_the_matched_frames_pixels_repeatedly(
     # decoded PNG must show the MATCHED frame's presentation — not the frame
     # before it — on REPEATED captures in one session.
     _predicate_scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
 
     try:
         assert_windowed_ok(run("daemon", "start", "--windowed"))
@@ -579,7 +559,7 @@ def test_await_predicate_that_never_holds_is_the_typed_error(
     # after the declared frame bound — in ~a third of a second, not a timeout —
     # and writes no file.
     _predicate_scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out = tmp_path / "never.png"
 
     try:
@@ -605,7 +585,7 @@ def test_await_events_capture_an_input_triggered_transient(
     # press triggers cannot be missed by a second CLI round trip; the declared
     # release fires before the reply, so no key is left held.
     _predicate_scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out = tmp_path / "flash.png"
 
     try:
@@ -638,7 +618,7 @@ def test_early_match_still_fires_every_scheduled_release(tmp_path, daemon_runtim
     # mouse-button phase, and an action are each verified released afterwards,
     # so no input state leaks into later live operations.
     _predicate_scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
 
     cases = [
         (
@@ -686,7 +666,7 @@ def test_unmet_predicate_error_path_still_fires_every_event(
     # schema/model parity, #743 second re-review) and still fires during the
     # drain, so the reply arrives only after it.
     _predicate_scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out = tmp_path / "never.png"
 
     try:
@@ -717,7 +697,7 @@ def test_predicate_resolution_never_reads_the_property(tmp_path, daemon_runtime_
     # so a scripted getter runs EXACTLY once per sampled frame — frames_waited+1
     # times in total, no pre-read, no re-read at capture.
     _predicate_scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out = tmp_path / "probe.png"
 
     try:
@@ -741,7 +721,7 @@ def test_input_written_state_is_captured_with_its_own_presentation(
     # writes is observed one boundary LATER, together with its own
     # presentation — so the decoded pixels show the matched visual.
     _predicate_scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
 
     try:
         assert_windowed_ok(run("daemon", "start", "--windowed"))
@@ -775,7 +755,7 @@ def test_late_event_failure_is_the_reply_and_writes_no_file(
     # scheduled event FAILS — the reply is that typed failure, no file is
     # written, and the later declared release still drains (no held action).
     _predicate_scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out = tmp_path / "late.png"
 
     try:

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -14,51 +14,12 @@ import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
 from gda.runner import OPERATIONS_GD
-
-from tests.support import GDA_CMD
+from tests.support import GODOT, Gda, assert_operation_error
 
 from .conftest import project_godot
 
-GODOT = resolve_godot_binary()
-
-
-def _gda(*args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT)], capture_output=True, text=True
-    )
-
-
-def _gda_project(project):
-    """A ``_gda`` bound to ``--project`` for res:// enumeration/resolution."""
-
-    def gda(*args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-            capture_output=True,
-            text=True,
-        )
-
-    return gda
-
-
-def _gda_env(extra_env: dict, *args: str) -> subprocess.CompletedProcess:
-    """``_gda`` with extra env vars in the child's environment (issue #226 seam)."""
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-        env={**os.environ, **extra_env},
-    )
-
-
-def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
-    assert proc.returncode == 4, proc.stdout + proc.stderr
-    err = json.loads(proc.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == code
-    return err
+gda = Gda()
 
 
 @pytest.mark.e2e
@@ -67,7 +28,7 @@ def test_script_create_default_template_then_get_round_trip(godot_project):
     # source on disk IS what get reports — the round-trip proves the write.
     script_path = godot_project / "actor.gd"
 
-    created = _gda("script", "create", str(script_path), "--json")
+    created = gda("script", "create", str(script_path), "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     data = json.loads(created.stdout)
@@ -76,7 +37,7 @@ def test_script_create_default_template_then_get_round_trip(godot_project):
     assert data["class_name"] is None
     assert script_path.exists()
 
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     got_data = json.loads(got.stdout)
@@ -93,14 +54,12 @@ def test_script_create_with_extends_parameterizes_the_template(godot_project):
     # --root-type), and get reports it back from the parsed source.
     script_path = godot_project / "sprite.gd"
 
-    created = _gda(
-        "script", "create", str(script_path), "--extends", "Node2D", "--json"
-    )
+    created = gda("script", "create", str(script_path), "--extends", "Node2D", "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     assert json.loads(created.stdout)["extends"] == "Node2D"
 
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["extends"] == "Node2D"
 
@@ -115,14 +74,14 @@ def test_script_create_with_content_round_trips_verbatim_source_and_metadata(
     script_path = godot_project / "hero.gd"
     source = "class_name Hero\nextends Node2D\n\nvar speed := 100\n"
 
-    created = _gda("script", "create", str(script_path), "--content", source, "--json")
+    created = gda("script", "create", str(script_path), "--content", source, "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     create_data = json.loads(created.stdout)
     assert create_data["class_name"] == "Hero"
     assert create_data["extends"] == "Node2D"
 
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     got_data = json.loads(got.stdout)
@@ -136,8 +95,7 @@ def test_script_create_resolves_res_path_against_the_project(godot_project):
     # Script-file addressing via res:// resolves against --project, exactly like
     # scene create (issue #32): the script lands inside the project and reads
     # back through res://.
-    def gda(*args: str) -> subprocess.CompletedProcess:
-        return _gda(*args, "--project", str(godot_project))
+    gda = Gda(godot_project)
 
     created = gda("script", "create", "res://hero.gd", "--extends", "Node2D", "--json")
 
@@ -155,7 +113,7 @@ def test_script_create_creates_missing_parent_directories(godot_project):
     # in created_dirs from outermost to innermost.
     script_path = godot_project / "actors" / "enemies" / "goblin.gd"
 
-    created = _gda("script", "create", str(script_path), "--json")
+    created = gda("script", "create", str(script_path), "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     assert script_path.exists()
@@ -172,14 +130,18 @@ def test_script_create_existing_path_yields_already_exists_without_overwriting(
     # No-clobber: a second create on the same path is refused with already_exists
     # and the original content is left untouched.
     script_path = godot_project / "hero.gd"
-    _gda("script", "create", str(script_path), "--extends", "Node2D", "--json")
+    gda("script", "create", str(script_path), "--extends", "Node2D", "--json")
     before = script_path.read_text(encoding="utf-8")
 
-    again = _gda(
-        "script", "create", str(script_path), "--extends", "Sprite2D", "--json"
+    err = gda.error(
+        "script",
+        "create",
+        str(script_path),
+        "--extends",
+        "Sprite2D",
+        "--json",
+        code="already_exists",
     )
-
-    err = _assert_operation_error(again, "already_exists")
     assert str(script_path) in err["message"]
     assert script_path.read_text(encoding="utf-8") == before
 
@@ -190,9 +152,7 @@ def test_script_create_wrong_extension_yields_invalid_path(godot_project):
     # written.
     target = godot_project / "notes.txt"
 
-    created = _gda("script", "create", str(target), "--json")
-
-    err = _assert_operation_error(created, "invalid_path")
+    err = gda.error("script", "create", str(target), "--json", code="invalid_path")
     assert ".gd" in err["message"]
     assert str(target) in err["message"]
     assert not target.exists()
@@ -206,9 +166,7 @@ def test_script_create_cs_extension_is_refused(godot_project):
     # opaque text.
     target = godot_project / "Player.cs"
 
-    created = _gda("script", "create", str(target), "--json")
-
-    err = _assert_operation_error(created, "invalid_path")
+    err = gda.error("script", "create", str(target), "--json", code="invalid_path")
     assert ".gd" in err["message"]
     assert str(target) in err["message"]
     assert not target.exists()
@@ -218,9 +176,7 @@ def test_script_create_cs_extension_is_refused(godot_project):
 def test_script_get_missing_file_yields_path_not_found(godot_project):
     missing = godot_project / "nope.gd"
 
-    got = _gda("script", "get", str(missing), "--json")
-
-    err = _assert_operation_error(got, "path_not_found")
+    err = gda.error("script", "get", str(missing), "--json", code="path_not_found")
     assert str(missing) in err["message"]
 
 
@@ -237,11 +193,11 @@ def test_script_get_unreadable_file_is_path_not_found_not_empty_source(godot_pro
     locked.write_text("extends Node\n", encoding="utf-8")
     locked.chmod(0o000)
     try:
-        got = _gda("script", "get", str(locked), "--json")
+        got = gda("script", "get", str(locked), "--json")
     finally:
         locked.chmod(0o600)
 
-    err = _assert_operation_error(got, "path_not_found")
+    err = assert_operation_error(got, "path_not_found")
     assert str(locked) in err["message"]
     assert "could not be read" in err["message"]
 
@@ -251,9 +207,7 @@ def test_script_get_wrong_extension_yields_invalid_path(godot_project):
     notes = godot_project / "notes.txt"
     notes.write_text("not a script\n", encoding="utf-8")
 
-    got = _gda("script", "get", str(notes), "--json")
-
-    err = _assert_operation_error(got, "invalid_path")
+    err = gda.error("script", "get", str(notes), "--json", code="invalid_path")
     assert ".gd" in err["message"]
     assert str(notes) in err["message"]
 
@@ -267,12 +221,12 @@ def test_script_create_then_get_preserves_a_path_containing_the_end_sentinel(
     # sentinel must round-trip, not truncate into a parse error.
     script_path = godot_project / "weird<<<GDA:END>>>name.gd"
 
-    created = _gda("script", "create", str(script_path), "--json")
+    created = gda("script", "create", str(script_path), "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     assert json.loads(created.stdout)["path"] == str(script_path)
 
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["source"] == "extends Node\n"
 
@@ -294,14 +248,14 @@ def test_script_get_parses_metadata_past_a_leading_annotation_header(godot_proje
         "\tpass\n"
     )
 
-    created = _gda("script", "create", str(script_path), "--content", source, "--json")
+    created = gda("script", "create", str(script_path), "--content", source, "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     create_data = json.loads(created.stdout)
     assert create_data["class_name"] == "Widget"
     assert create_data["extends"] == "Control"
 
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     got_data = json.loads(got.stdout)
     assert got_data["class_name"] == "Widget"
@@ -321,14 +275,14 @@ def test_script_get_does_not_mistake_declaration_shaped_body_text_for_metadata(
         'extends Node\n\nvar doc := """\nclass_name Injected\nextends Injected\n"""\n'
     )
 
-    created = _gda("script", "create", str(script_path), "--content", source, "--json")
+    created = gda("script", "create", str(script_path), "--content", source, "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     create_data = json.loads(created.stdout)
     assert create_data["extends"] == "Node"
     assert create_data["class_name"] is None
 
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     got_data = json.loads(got.stdout)
     assert got_data["source"] == source
@@ -345,12 +299,12 @@ def test_script_get_keeps_a_quoted_base_class_path_intact(godot_project):
     script_path = godot_project / "derived.gd"
     source = 'extends "res://weapons/a#b.gd"\n'
 
-    created = _gda("script", "create", str(script_path), "--content", source, "--json")
+    created = gda("script", "create", str(script_path), "--content", source, "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     assert json.loads(created.stdout)["extends"] == '"res://weapons/a#b.gd"'
 
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["extends"] == '"res://weapons/a#b.gd"'
 
@@ -361,7 +315,7 @@ def test_script_list_enumerates_created_scripts(godot_project):
     # res://: two scripts created at different depths both appear, each with its
     # res:// path and the class_name/extends parsed from raw source. The listing
     # IS the structured-level verification of what script create wrote.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     assert (
         gda(
@@ -396,7 +350,7 @@ def test_script_list_enumerates_created_scripts(godot_project):
 def test_script_list_on_empty_project_is_an_empty_listing(godot_project):
     # A project with no scripts is a valid, empty listing — not an error (the
     # res://.godot import cache must not leak in as a phantom script).
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     listed = gda("script", "list", "--json")
 
@@ -409,14 +363,8 @@ def test_script_list_without_project_yields_project_not_found(tmp_path):
     # script list cannot enumerate res:// projectless: run from a non-project
     # directory with no --project, it must refuse with the structured
     # project_not_found code rather than return a misleading empty listing.
-    listed = subprocess.run(
-        [*GDA_CMD, "script", "list", "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-        cwd=str(tmp_path),
-    )
+    err = gda.error("script", "list", "--json", cwd=tmp_path, code="project_not_found")
 
-    err = _assert_operation_error(listed, "project_not_found")
     assert "--project" in err["message"]
 
 
@@ -426,7 +374,7 @@ def test_script_delete_removes_a_script_and_names_what_was_removed(godot_project
     # script's metadata. The round-trip verifier: script list before shows the
     # script, delete reports the removed class_name/extends, and script list
     # after no longer shows it.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "script",
@@ -459,9 +407,7 @@ def test_script_delete_removes_a_script_and_names_what_was_removed(godot_project
 def test_script_delete_missing_file_yields_path_not_found(godot_project):
     missing = godot_project / "nope.gd"
 
-    deleted = _gda("script", "delete", str(missing), "--json")
-
-    err = _assert_operation_error(deleted, "path_not_found")
+    err = gda.error("script", "delete", str(missing), "--json", code="path_not_found")
     assert str(missing) in err["message"]
 
 
@@ -473,9 +419,7 @@ def test_script_delete_wrong_extension_yields_invalid_path_and_leaves_it(godot_p
     notes = godot_project / "notes.txt"
     notes.write_text("not a script\n", encoding="utf-8")
 
-    deleted = _gda("script", "delete", str(notes), "--json")
-
-    err = _assert_operation_error(deleted, "invalid_path")
+    err = gda.error("script", "delete", str(notes), "--json", code="invalid_path")
     assert ".gd" in err["message"]
     assert str(notes) in err["message"]
     # The non-script file survives the refusal.
@@ -489,7 +433,7 @@ def test_script_set_search_replace_edits_in_place_and_round_trips_via_get(
     # search-replace mode (issue #118): every literal occurrence of --search is
     # replaced with --replace; script get round-trips the edited source on disk.
     script_path = godot_project / "hero.gd"
-    _gda(
+    gda(
         "script",
         "create",
         str(script_path),
@@ -498,7 +442,7 @@ def test_script_set_search_replace_edits_in_place_and_round_trips_via_get(
         "--json",
     )
 
-    edited = _gda(
+    edited = gda(
         "script",
         "set",
         str(script_path),
@@ -511,7 +455,7 @@ def test_script_set_search_replace_edits_in_place_and_round_trips_via_get(
 
     assert edited.returncode == 0, edited.stdout + edited.stderr
     assert json.loads(edited.stdout)["extends"] == "Node2D"
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     # Both occurrences replaced; the edited source IS what get reports.
     assert json.loads(got.stdout)["source"] == "extends Node2D\nvar a := Node2D\n"
@@ -529,7 +473,7 @@ def test_script_set_with_external_edit_in_window_yields_file_changed_externally(
     # blind write would clobber the external edit. The production-inert seam
     # (GDA_TEST_PERTURB_BEFORE_SAVE) simulates that edit, and the guard refuses.
     script_path = godot_project / "hero.gd"
-    _gda(
+    gda(
         "script",
         "create",
         str(script_path),
@@ -538,8 +482,7 @@ def test_script_set_with_external_edit_in_window_yields_file_changed_externally(
         "--json",
     )
 
-    edited = _gda_env(
-        {"GDA_TEST_PERTURB_BEFORE_SAVE": "1"},
+    err = gda.error(
         "script",
         "set",
         str(script_path),
@@ -548,9 +491,9 @@ def test_script_set_with_external_edit_in_window_yields_file_changed_externally(
         "--replace",
         "2",
         "--json",
+        extra_env={"GDA_TEST_PERTURB_BEFORE_SAVE": "1"},
+        code="file_changed_externally",
     )
-
-    err = _assert_operation_error(edited, "file_changed_externally")
     assert str(script_path) in err["message"]
 
     # The edit did NOT land: the original "var a := 1" is still present (the seam only
@@ -564,7 +507,7 @@ def test_script_set_line_range_replaces_the_span_and_round_trips_via_get(godot_p
     # line-range mode: replace lines 2..3 (1-based, inclusive) with new content;
     # the rest of the file is untouched. Lines are the parts split on "\n".
     script_path = godot_project / "actor.gd"
-    _gda(
+    gda(
         "script",
         "create",
         str(script_path),
@@ -573,7 +516,7 @@ def test_script_set_line_range_replaces_the_span_and_round_trips_via_get(godot_p
         "--json",
     )
 
-    edited = _gda(
+    edited = gda(
         "script",
         "set",
         str(script_path),
@@ -587,7 +530,7 @@ def test_script_set_line_range_replaces_the_span_and_round_trips_via_get(godot_p
     )
 
     assert edited.returncode == 0, edited.stdout + edited.stderr
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["source"] == (
         "extends Node\nvar x := 9\nfunc f(): pass\n"
@@ -598,7 +541,7 @@ def test_script_set_line_range_replaces_the_span_and_round_trips_via_get(godot_p
 def test_script_set_line_range_defaults_end_to_start_for_a_single_line(godot_project):
     # --end-line defaults to --start-line: a single-line replace.
     script_path = godot_project / "single.gd"
-    _gda(
+    gda(
         "script",
         "create",
         str(script_path),
@@ -607,7 +550,7 @@ def test_script_set_line_range_defaults_end_to_start_for_a_single_line(godot_pro
         "--json",
     )
 
-    edited = _gda(
+    edited = gda(
         "script",
         "set",
         str(script_path),
@@ -619,7 +562,7 @@ def test_script_set_line_range_defaults_end_to_start_for_a_single_line(godot_pro
     )
 
     assert edited.returncode == 0, edited.stdout + edited.stderr
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
     assert json.loads(got.stdout)["source"] == "extends Node\nvar a := 99\nvar b := 2\n"
 
 
@@ -631,7 +574,7 @@ def test_script_set_line_range_preserves_crlf_line_endings(godot_project):
     script_path = godot_project / "crlf.gd"
     script_path.write_bytes(b"extends Node\r\nvar a := 1\r\nvar b := 2\r\n")
 
-    edited = _gda(
+    edited = gda(
         "script",
         "set",
         str(script_path),
@@ -653,16 +596,16 @@ def test_script_set_full_overwrites_the_whole_file_and_round_trips_via_get(
 ):
     # full mode: --content with no --start-line overwrites the entire file.
     script_path = godot_project / "full.gd"
-    _gda("script", "create", str(script_path), "--content", "extends Node\n", "--json")
+    gda("script", "create", str(script_path), "--content", "extends Node\n", "--json")
 
     new_source = "class_name Hero\nextends Node2D\n\nvar speed := 100\n"
-    edited = _gda("script", "set", str(script_path), "--content", new_source, "--json")
+    edited = gda("script", "set", str(script_path), "--content", new_source, "--json")
 
     assert edited.returncode == 0, edited.stdout + edited.stderr
     data = json.loads(edited.stdout)
     assert data["class_name"] == "Hero"
     assert data["extends"] == "Node2D"
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
     assert json.loads(got.stdout)["source"] == new_source
 
 
@@ -671,10 +614,10 @@ def test_script_set_no_search_match_is_refused_and_leaves_file_untouched(godot_p
     # A search string the source does not contain is refused with no_search_match
     # and the file is left exactly as it was — the edit landed nowhere.
     script_path = godot_project / "hero.gd"
-    _gda("script", "create", str(script_path), "--content", "extends Node\n", "--json")
+    gda("script", "create", str(script_path), "--content", "extends Node\n", "--json")
     before = script_path.read_text(encoding="utf-8")
 
-    edited = _gda(
+    gda.error(
         "script",
         "set",
         str(script_path),
@@ -683,9 +626,8 @@ def test_script_set_no_search_match_is_refused_and_leaves_file_untouched(godot_p
         "--replace",
         "Node2D",
         "--json",
+        code="no_search_match",
     )
-
-    _assert_operation_error(edited, "no_search_match")
     assert script_path.read_text(encoding="utf-8") == before
 
 
@@ -696,7 +638,7 @@ def test_script_set_out_of_bounds_line_range_is_refused_and_leaves_file_untouche
     # A line range past the file's bounds is refused with invalid_line_range and
     # the file is left untouched.
     script_path = godot_project / "hero.gd"
-    _gda(
+    gda(
         "script",
         "create",
         str(script_path),
@@ -706,7 +648,7 @@ def test_script_set_out_of_bounds_line_range_is_refused_and_leaves_file_untouche
     )
     before = script_path.read_text(encoding="utf-8")
 
-    edited = _gda(
+    gda.error(
         "script",
         "set",
         str(script_path),
@@ -715,9 +657,8 @@ def test_script_set_out_of_bounds_line_range_is_refused_and_leaves_file_untouche
         "--content",
         "var x := 0",
         "--json",
+        code="invalid_line_range",
     )
-
-    _assert_operation_error(edited, "invalid_line_range")
     assert script_path.read_text(encoding="utf-8") == before
 
 
@@ -727,11 +668,15 @@ def test_script_set_missing_file_yields_path_not_found(godot_project):
     # silent create.
     missing = godot_project / "nope.gd"
 
-    edited = _gda(
-        "script", "set", str(missing), "--content", "extends Node\n", "--json"
+    err = gda.error(
+        "script",
+        "set",
+        str(missing),
+        "--content",
+        "extends Node\n",
+        "--json",
+        code="path_not_found",
     )
-
-    err = _assert_operation_error(edited, "path_not_found")
     assert str(missing) in err["message"]
     assert not missing.exists()
 
@@ -749,7 +694,7 @@ def test_script_validate_valid_script_reports_valid_true_no_diagnostics(godot_pr
     # lives in one, so validating it without naming it is now refused. The genuinely
     # projectless arm — a loose `.gd` no project.godot claims — is
     # `tests/test_e2e_res_containment.py`.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     script_path = godot_project / "ok.gd"
     gda(
         "script",
@@ -778,7 +723,7 @@ def test_script_validate_accepts_both_path_forms(godot_project, form):
     # (see tests/test_e2e_script_run.py). Pinned here so the shared representation is
     # a guarded contract on BOTH commands rather than an accident of this build —
     # the property that lets an agent address a script once and use it for either.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     (godot_project / "ok.gd").write_text("extends Node\n", encoding="utf-8")
 
     validated = gda("script", "validate", form, "--json")
@@ -795,7 +740,7 @@ def test_script_validate_broken_script_is_success_with_a_real_diagnostic(godot_p
     # op (exit 0) reporting valid=false, and at least one diagnostic with a real
     # `line` and non-empty `message` — proving the stderr-parsing regex against
     # the REAL engine output, not a fixture.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     script_path = godot_project / "broken.gd"
     # `var x =` with no initializer is a parse error the engine reports on its line.
     gda(
@@ -833,7 +778,7 @@ def test_script_validate_relative_preload_resolves_at_the_real_res_path(godot_pr
     # so the dependent script is valid=true under --project — not a false negative
     # from compiling an anonymous in-memory GDScript that has no res:// location to
     # resolve the relative reference against.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "script",
@@ -876,7 +821,7 @@ def test_script_validate_broken_script_under_project_still_reports_diagnostics(
     # reporting valid=false, and the stderr-parsed line/message diagnostic still
     # works under --project (the reload frame now names the real res:// path, which
     # the diagnostics parser pairs exactly as before).
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     # `var x =` with no initializer is a parse error the engine reports on its line.
     assert (
         gda(
@@ -912,11 +857,9 @@ def test_script_validate_missing_file_yields_path_not_found(godot_project):
     # project context first, which is a different (and equally true) verdict.
     missing = godot_project / "nope.gd"
 
-    validated = _gda_project(godot_project)(
-        "script", "validate", str(missing), "--json"
+    err = Gda(godot_project).error(
+        "script", "validate", str(missing), "--json", code="path_not_found"
     )
-
-    err = _assert_operation_error(validated, "path_not_found")
     assert str(missing) in err["message"]
 
 
@@ -925,9 +868,9 @@ def test_script_validate_wrong_extension_yields_invalid_path(godot_project):
     notes = godot_project / "notes.txt"
     notes.write_text("not a script\n", encoding="utf-8")
 
-    validated = _gda_project(godot_project)("script", "validate", str(notes), "--json")
-
-    err = _assert_operation_error(validated, "invalid_path")
+    err = Gda(godot_project).error(
+        "script", "validate", str(notes), "--json", code="invalid_path"
+    )
     assert ".gd" in err["message"]
 
 
@@ -965,7 +908,7 @@ def test_script_validate_batch_uses_one_engine_launch_for_every_script(tmp_path)
     # dispatch is one process. Three occurrences would be the pre-#663 behaviour
     # (one launch per script) passing every other assertion here.
     project = _batch_project(tmp_path)
-    gda = _gda_project(project)
+    gda = Gda(project)
 
     validated = gda(
         "script", "validate", "res://a.gd", "res://bad.gd", "res://c.gd", "--json"
@@ -999,7 +942,7 @@ def test_script_validate_all_validates_every_script_in_the_project(tmp_path):
     # the same shape, so an agent can screen a whole project in one launch without
     # first listing its scripts.
     project = _batch_project(tmp_path)
-    gda = _gda_project(project)
+    gda = Gda(project)
 
     validated = gda("script", "validate", "--all", "--json")
 
@@ -1026,7 +969,7 @@ def test_script_validate_batch_reports_a_repeated_path_once_per_occurrence(tmp_p
     # — is exactly what a fake runner cannot vouch for. It must, because gda
     # promises entry i corresponds to argument i and so never deduplicates.
     project = _batch_project(tmp_path)
-    gda = _gda_project(project)
+    gda = Gda(project)
 
     validated = gda(
         "script", "validate", "res://bad.gd", "res://a.gd", "res://bad.gd", "--json"
@@ -1073,7 +1016,7 @@ def test_script_validate_all_enumerates_a_nested_dot_godot_directory(tmp_path):
     (project / ".godot" / "engine_cache.gd").write_text(
         "extends Node\n\nvar y =\n", encoding="utf-8"
     )
-    gda = _gda_project(project)
+    gda = Gda(project)
 
     validated = gda("script", "validate", "--all", "--json")
 
@@ -1108,7 +1051,7 @@ def test_script_validate_all_on_a_project_with_no_scripts_is_vacuously_valid(tmp
         project_godot("gda-e2e-bare"), encoding="utf-8"
     )
 
-    validated = _gda_project(project)("script", "validate", "--all", "--json")
+    validated = Gda(project)("script", "validate", "--all", "--json")
 
     assert validated.returncode == 0, validated.stdout + validated.stderr
     data = json.loads(validated.stdout)
@@ -1126,7 +1069,7 @@ def test_script_validate_refuses_a_batch_that_spans_two_projects(tmp_path):
     project = _batch_project(tmp_path)
     _, other_project, outsider = _nested_project_script(tmp_path / "elsewhere")
 
-    validated = _gda(
+    validated = gda(
         "script",
         "validate",
         str(project / "a.gd"),
@@ -1136,7 +1079,7 @@ def test_script_validate_refuses_a_batch_that_spans_two_projects(tmp_path):
         "--json",
     )
 
-    err = _assert_operation_error(validated, "target_outside_project")
+    err = assert_operation_error(validated, "target_outside_project")
     assert str(outsider) in err["message"]
     assert str(project) in err["message"]
     assert other_project.exists()
@@ -1192,28 +1135,15 @@ def test_script_validate_from_an_ancestor_is_refused_and_names_the_owner(tmp_pat
     # as before.
     workspace, project, script = _nested_project_script(tmp_path)
 
-    from_ancestor = subprocess.run(
-        [
-            *GDA_CMD,
-            "script",
-            "validate",
-            "game/deck.gd",
-            "--godot",
-            str(GODOT),
-            "--json",
-        ],
-        capture_output=True,
-        text=True,
-        cwd=workspace,
-    )
+    from_ancestor = gda("script", "validate", "game/deck.gd", "--json", cwd=workspace)
 
-    _assert_operation_error(from_ancestor, "target_outside_project")
+    assert_operation_error(from_ancestor, "target_outside_project")
     evidence = json.loads(from_ancestor.stdout)["error"]["evidence"]
     assert evidence["owning_project"] == str(project.resolve())
     # No engine ran, so the false cascade does not exist to be misread.
     assert '"valid"' not in from_ancestor.stdout
 
-    with_owning_project = _gda(
+    with_owning_project = gda(
         "script", "validate", str(script), "--project", str(project), "--json"
     )
 
@@ -1240,11 +1170,11 @@ def test_script_validate_refuses_a_script_outside_the_resolved_project(tmp_path)
         project_godot("gda-e2e-other"), encoding="utf-8"
     )
 
-    validated = _gda(
+    validated = gda(
         "script", "validate", str(script), "--project", str(other), "--json"
     )
 
-    err = _assert_operation_error(validated, "target_outside_project")
+    err = assert_operation_error(validated, "target_outside_project")
     assert str(script) in err["message"]
     assert str(other) in err["message"]
     # Refused BEFORE parsing: no engine ran, so no diagnostic about the file.
@@ -1288,7 +1218,7 @@ def test_script_validate_accepts_a_file_symlinked_into_the_project(tmp_path):
     (project / "addons" / "cardlib").symlink_to(library, target_is_directory=True)
     through_the_link = project / "addons" / "cardlib" / "deck.gd"
 
-    validated = _gda(
+    validated = gda(
         "script", "validate", str(through_the_link), "--project", str(project), "--json"
     )
 
@@ -1299,16 +1229,15 @@ def test_script_validate_accepts_a_file_symlinked_into_the_project(tmp_path):
     assert data["project_root"] == str(project)
 
     # Same file, outside spelling: outside under both readings, so still refused.
-    from_outside = _gda(
+    gda.error(
         "script",
         "validate",
         str(library / "deck.gd"),
         "--project",
         str(project),
         "--json",
+        code="target_outside_project",
     )
-
-    _assert_operation_error(from_outside, "target_outside_project")
 
 
 @pytest.mark.e2e
@@ -1331,13 +1260,7 @@ def test_script_validate_relative_target_from_an_ancestor_cwd_agrees_with_the_en
         "extends Node\n\nfunc top() -> int:\n\treturn 3\n", encoding="utf-8"
     )
 
-    def from_workspace(*args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT)],
-            capture_output=True,
-            text=True,
-            cwd=tmp_path,
-        )
+    from_workspace = Gda(cwd=tmp_path)
 
     argv = from_workspace(
         "script", "validate", "deck.gd", "--project", "game", "--json"
@@ -1383,7 +1306,7 @@ def test_script_validate_refuses_a_symlink_dot_dot_pivot_out_of_the_project(tmp_
     )
     (project / "pivot").symlink_to(outside / "deep", target_is_directory=True)
 
-    validated = _gda(
+    validated = gda(
         "script",
         "validate",
         str(project / "pivot" / ".." / "deck.gd"),
@@ -1392,7 +1315,7 @@ def test_script_validate_refuses_a_symlink_dot_dot_pivot_out_of_the_project(tmp_
         "--json",
     )
 
-    err = _assert_operation_error(validated, "target_outside_project")
+    err = assert_operation_error(validated, "target_outside_project")
     # The refusal names where the target REALLY is, not the collapsed spelling.
     assert str((outside / "deck.gd").resolve()) in err["message"]
     # Nothing was compiled: no verdict, and no engine diagnostic about the file.
@@ -1418,11 +1341,11 @@ def test_script_validate_refuses_an_outside_path_that_merely_contains_a_scheme(
         "extends Node\n\nfunc scheme_secret() -> int:\n\treturn 7\n", encoding="utf-8"
     )
 
-    validated = _gda(
+    validated = gda(
         "script", "validate", f"{odd}//deck.gd", "--project", str(project), "--json"
     )
 
-    _assert_operation_error(validated, "target_outside_project")
+    assert_operation_error(validated, "target_outside_project")
     assert '"valid"' not in validated.stdout
 
 
@@ -1435,7 +1358,7 @@ def test_script_attach_binds_script_to_node_and_scene_references_it(godot_projec
     # attaches a .gd, and saves. Verify by reading the saved .tscn back: the
     # script path now appears as an ext_resource the node references, the result
     # echoes the script's class_name, and the scene still re-loads (node list).
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1483,7 +1406,7 @@ def test_script_attach_binds_script_to_node_and_scene_references_it(godot_projec
 def test_script_attach_to_a_descendant_node(godot_project):
     # Attach addresses the node by the #53 node path: a descendant, not just the
     # root. The script lands on that exact node.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1530,7 +1453,7 @@ def test_script_attach_to_a_descendant_node(godot_project):
 @pytest.mark.e2e
 def test_script_attach_no_class_name_echoes_null_class_name(godot_project):
     # A script with no class_name attaches fine and the result carries null.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node", "--json"
@@ -1566,7 +1489,7 @@ def test_script_attach_non_compiling_script_yields_script_compile_failed(godot_p
     # saves no script), so attach must refuse with script_compile_failed rather
     # than report a phantom success over a scene with nothing attached. The scene
     # is left untouched.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1588,7 +1511,7 @@ def test_script_attach_non_compiling_script_yields_script_compile_failed(godot_p
     )
     before = (godot_project / "main.tscn").read_text(encoding="utf-8")
 
-    attached = gda(
+    err = gda.error(
         "script",
         "attach",
         "res://main.tscn",
@@ -1597,9 +1520,8 @@ def test_script_attach_non_compiling_script_yields_script_compile_failed(godot_p
         "--script",
         "res://broken.gd",
         "--json",
+        code="script_compile_failed",
     )
-
-    err = _assert_operation_error(attached, "script_compile_failed")
     assert "broken.gd" in err["message"]
     # The refusal leaves the scene exactly as it was — no half-applied mutation.
     assert (godot_project / "main.tscn").read_text(encoding="utf-8") == before
@@ -1612,7 +1534,7 @@ def test_script_attach_missing_preload_target_yields_missing_dependency(
     # A missing preload target is a dependency-ordering problem, not generic
     # prose-only compile stderr: the structured error names the missing res://
     # path, and the scene is left untouched.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1632,7 +1554,7 @@ def test_script_attach_missing_preload_target_yields_missing_dependency(
     )
     before = (godot_project / "main.tscn").read_text(encoding="utf-8")
 
-    attached = gda(
+    err = gda.error(
         "script",
         "attach",
         "res://main.tscn",
@@ -1641,9 +1563,8 @@ def test_script_attach_missing_preload_target_yields_missing_dependency(
         "--script",
         "res://enemy.gd",
         "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(attached, "missing_dependency")
     assert "res://missing_projectile.tscn" in err["message"]
     assert "res://enemy.gd" in err["message"]
     assert (godot_project / "main.tscn").read_text(encoding="utf-8") == before
@@ -1656,7 +1577,7 @@ def test_script_attach_ignores_preload_mentions_in_comments_and_strings(
     # The missing-preload gate must follow executable GDScript syntax, not the
     # project reference graph's raw text scan. Mentioning future assets in comments
     # or string literals is not a preload dependency and must not block attach.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1706,7 +1627,7 @@ def test_script_attach_multiline_missing_preload_target_yields_missing_dependenc
     # A valid preload call may split the opening paren and string literal across
     # lines. It should still get the same stable missing_dependency result as the
     # single-line form.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1735,7 +1656,7 @@ def test_script_attach_multiline_missing_preload_target_yields_missing_dependenc
     )
     before = (godot_project / "main.tscn").read_text(encoding="utf-8")
 
-    attached = gda(
+    err = gda.error(
         "script",
         "attach",
         "res://main.tscn",
@@ -1744,9 +1665,8 @@ def test_script_attach_multiline_missing_preload_target_yields_missing_dependenc
         "--script",
         "res://enemy.gd",
         "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(attached, "missing_dependency")
     assert "res://missing_projectile.tscn" in err["message"]
     assert "res://enemy.gd" in err["message"]
     assert (godot_project / "main.tscn").read_text(encoding="utf-8") == before
@@ -1762,7 +1682,7 @@ def test_script_attach_incompatible_node_type_yields_incompatible_script_type(
     # incompatible_script_type — not script_compile_failed — so the agent fixes
     # the node/script pairing rather than chasing a non-existent syntax error. The
     # scene is left untouched.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1779,7 +1699,7 @@ def test_script_attach_incompatible_node_type_yields_incompatible_script_type(
     )
     before = (godot_project / "main.tscn").read_text(encoding="utf-8")
 
-    attached = gda(
+    err = gda.error(
         "script",
         "attach",
         "res://main.tscn",
@@ -1788,9 +1708,8 @@ def test_script_attach_incompatible_node_type_yields_incompatible_script_type(
         "--script",
         "res://spatial.gd",
         "--json",
+        code="incompatible_script_type",
     )
-
-    err = _assert_operation_error(attached, "incompatible_script_type")
     assert "Node3D" in err["message"]
     assert "Node2D" in err["message"]
     # The refusal leaves the scene untouched.
@@ -1799,7 +1718,7 @@ def test_script_attach_incompatible_node_type_yields_incompatible_script_type(
 
 @pytest.mark.e2e
 def test_script_attach_missing_script_yields_path_not_found(godot_project):
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1807,7 +1726,7 @@ def test_script_attach_missing_script_yields_path_not_found(godot_project):
         == 0
     )
 
-    attached = gda(
+    err = gda.error(
         "script",
         "attach",
         "res://main.tscn",
@@ -1816,15 +1735,14 @@ def test_script_attach_missing_script_yields_path_not_found(godot_project):
         "--script",
         "res://nope.gd",
         "--json",
+        code="path_not_found",
     )
-
-    err = _assert_operation_error(attached, "path_not_found")
     assert "nope.gd" in err["message"]
 
 
 @pytest.mark.e2e
 def test_script_attach_wrong_script_extension_yields_invalid_path(godot_project):
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1833,7 +1751,7 @@ def test_script_attach_wrong_script_extension_yields_invalid_path(godot_project)
     )
     (godot_project / "notes.txt").write_text("not a script\n", encoding="utf-8")
 
-    attached = gda(
+    err = gda.error(
         "script",
         "attach",
         "res://main.tscn",
@@ -1842,9 +1760,8 @@ def test_script_attach_wrong_script_extension_yields_invalid_path(godot_project)
         "--script",
         "res://notes.txt",
         "--json",
+        code="invalid_path",
     )
-
-    err = _assert_operation_error(attached, "invalid_path")
     assert ".gd" in err["message"]
 
 
@@ -1852,7 +1769,7 @@ def test_script_attach_wrong_script_extension_yields_invalid_path(godot_project)
 def test_script_attach_missing_node_yields_node_not_found_and_leaves_scene(
     godot_project,
 ):
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1867,7 +1784,7 @@ def test_script_attach_missing_node_yields_node_not_found_and_leaves_scene(
     )
     before = (godot_project / "main.tscn").read_text(encoding="utf-8")
 
-    attached = gda(
+    err = gda.error(
         "script",
         "attach",
         "res://main.tscn",
@@ -1876,9 +1793,8 @@ def test_script_attach_missing_node_yields_node_not_found_and_leaves_scene(
         "--script",
         "res://hero.gd",
         "--json",
+        code="node_not_found",
     )
-
-    err = _assert_operation_error(attached, "node_not_found")
     assert "Bogus" in err["message"]
     # The refusal leaves the scene untouched.
     assert (godot_project / "main.tscn").read_text(encoding="utf-8") == before
@@ -1886,7 +1802,7 @@ def test_script_attach_missing_node_yields_node_not_found_and_leaves_scene(
 
 @pytest.mark.e2e
 def test_script_attach_missing_scene_yields_path_not_found(godot_project):
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "script", "create", "res://hero.gd", "--extends", "Node2D", "--json"
@@ -1894,7 +1810,7 @@ def test_script_attach_missing_scene_yields_path_not_found(godot_project):
         == 0
     )
 
-    attached = gda(
+    err = gda.error(
         "script",
         "attach",
         "res://missing.tscn",
@@ -1903,9 +1819,8 @@ def test_script_attach_missing_scene_yields_path_not_found(godot_project):
         "--script",
         "res://hero.gd",
         "--json",
+        code="path_not_found",
     )
-
-    err = _assert_operation_error(attached, "path_not_found")
     assert "missing.tscn" in err["message"]
 
 
@@ -1913,7 +1828,7 @@ def test_script_attach_missing_scene_yields_path_not_found(godot_project):
 def test_script_attach_no_prior_script_reports_null_replaced_script(godot_project):
     # attach is overwrite-and-report (issue #132): a node with no prior script is
     # bound and replaced_script is null — the signal that nothing was displaced.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1949,7 +1864,7 @@ def test_script_attach_overwrites_and_reports_the_displaced_script(godot_project
     # would strand the node) but no longer hides the displacement: replaced_script
     # names the prior script's res:// path verbatim. The overwrite is real — the
     # saved .tscn now references the NEW script and no longer the old one.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -2020,9 +1935,9 @@ def test_script_attach_both_scene_and_script_missing_reports_the_scene_first(
     # primary subject (the scene loads + node exists) is validated before the
     # secondary input (the --script arg), one invariant with no exceptions. Before
     # the reorder this surfaced the script's path_not_found and masked the scene.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
-    attached = gda(
+    err = gda.error(
         "script",
         "attach",
         "res://missing.tscn",
@@ -2031,9 +1946,8 @@ def test_script_attach_both_scene_and_script_missing_reports_the_scene_first(
         "--script",
         "res://also_missing.gd",
         "--json",
+        code="path_not_found",
     )
-
-    err = _assert_operation_error(attached, "path_not_found")
     # The reported failure names the SCENE, not the script.
     assert "missing.tscn" in err["message"]
     assert "also_missing.gd" not in err["message"]
@@ -2047,7 +1961,7 @@ def test_script_create_empty_content_round_trips_as_empty_source(godot_project):
     # metadata.
     script_path = godot_project / "empty.gd"
 
-    created = _gda("script", "create", str(script_path), "--content", "", "--json")
+    created = gda("script", "create", str(script_path), "--content", "", "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     create_data = json.loads(created.stdout)
@@ -2055,7 +1969,7 @@ def test_script_create_empty_content_round_trips_as_empty_source(godot_project):
     assert create_data["extends"] is None
     assert script_path.read_text(encoding="utf-8") == ""
 
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     got_data = json.loads(got.stdout)
@@ -2231,6 +2145,7 @@ def _run_harness(project, harness: str = _ATTACH_DROP_HARNESS) -> str:
         ],
         capture_output=True,
         text=True,
+        timeout=120,
     )
     marker_begin, marker_end = "<<<HARNESS>>>", "<<<END>>>"
     out = proc.stdout

--- a/tests/test_e2e_script_run.py
+++ b/tests/test_e2e_script_run.py
@@ -1024,6 +1024,10 @@ def test_script_run_abort_still_lands_within_its_stated_bound(godot_project):
         "--project",
         str(godot_project),
         "--json",
+        # The engine ceiling (120s) sits above the spawn's default bound; a
+        # regressed abort must reach the assertion below with its message, not
+        # die as a TimeoutExpired at 90s.
+        timeout=150,
     )
     elapsed = time.monotonic() - started
 

--- a/tests/test_e2e_script_run.py
+++ b/tests/test_e2e_script_run.py
@@ -64,16 +64,14 @@ headless one-shot script controls its own exit code.
 """
 
 import json
-import subprocess
 import time
 from pathlib import Path
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
+from tests.support import Gda
 
-GODOT = resolve_godot_binary()
+gda = Gda()
 
 # A standalone headless script: do work in _initialize, then quit with a chosen
 # code. `extends SceneTree` makes the script the main loop, the pattern a
@@ -157,40 +155,18 @@ func _initialize() -> void:
 """
 
 
-def _run_gda(*args: str, retry: bool = False) -> subprocess.CompletedProcess:
-    """Invoke ``gda <args>`` as a subprocess (this checkout's editable gda, ADR-0011).
-
-    ``retry`` re-runs once on a transient ``engine_crashed`` — a shared-``user://``
-    log race under parallel e2e (not a gda bug; the race was fixed in #180) — so a
-    happy path does not flake.
-    """
-    for attempt in range(2 if retry else 1):
-        proc = subprocess.run([*GDA_CMD, *args], capture_output=True, text=True)
-        if not retry or proc.returncode == 0:
-            return proc
-        try:
-            code = json.loads(proc.stdout)["error"]["code"]
-        except (ValueError, KeyError, TypeError):
-            return proc
-        if code != "engine_crashed":
-            return proc
-    return proc
-
-
 @pytest.mark.e2e
 def test_script_run_passes_a_clean_run_through(godot_project):
     # Happy path: a script that quit(0) → SUCCESS carrying exit_status 0 and the
     # script's printed line read back from stdout.
     (godot_project / "hello.gd").write_text(HELLO_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://hello.gd",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
         retry=True,
     )
@@ -210,14 +186,12 @@ def test_script_run_non_zero_quit_is_success_not_a_gda_failure(godot_project):
     # the non-zero code and the message are DATA the agent reads, not a gda error.
     (godot_project / "fail.gd").write_text(FAIL_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://fail.gd",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
         retry=True,
     )
@@ -238,14 +212,12 @@ def test_script_run_accepts_both_path_forms(godot_project, form):
     # `script validate` and `script run`.
     (godot_project / "hello.gd").write_text(HELLO_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         form,
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
         retry=True,
     )
@@ -265,14 +237,12 @@ def test_script_run_absolute_path_is_invalid_path(godot_project):
     # invalid_path decided BEFORE any launch — an explicit ABI edge (ADR-0031).
     (godot_project / "hello.gd").write_text(HELLO_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         str(godot_project / "hello.gd"),  # absolute, even though it EXISTS
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -310,14 +280,12 @@ def test_script_run_non_project_scoped_paths_are_refused_before_launch(
     # engine against `res://user:/x.gd`, an address the caller never typed. The
     # upward escapes moved to the containment arm below with #763 — same refusal,
     # same pre-launch timing, the shared code.
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         script,
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -351,14 +319,12 @@ def test_script_run_escapes_are_the_shared_containment_refusal(godot_project, sc
     # project, which is the ADR-0009 widening ADR-0031 cites as its reason for
     # refusing absolute paths. #763 keeps the refusal and moves it onto the code
     # every command reports this condition under.
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         script,
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -379,14 +345,12 @@ def test_script_run_does_not_overreject_unicode_spaces_godot_preserves(
     # so the request must launch and reach the ordinary entry-load verdict rather
     # than fail pre-launch as invalid_path.
     script = f"res://missing.gd{suffix}"
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         script,
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -403,12 +367,7 @@ def test_script_run_without_a_project_is_project_not_found(tmp_path):
     projectless = tmp_path / "empty"
     projectless.mkdir()
 
-    run = subprocess.run(
-        [*GDA_CMD, "script", "run", "res://hello.gd", "--godot", str(GODOT), "--json"],
-        capture_output=True,
-        text=True,
-        cwd=str(projectless),
-    )
+    run = gda("script", "run", "res://hello.gd", "--json", cwd=projectless)
 
     assert run.returncode == 4, run.stdout + run.stderr
     err = json.loads(run.stdout)["error"]
@@ -421,14 +380,12 @@ def test_script_run_missing_script_is_script_not_found(godot_project):
     # GDA-DF-032 against the REAL engine: Godot exits 0 for a res:// script that does
     # not exist, printing the load errors to stderr only. The verdict must come from
     # that stderr — a structured failure, never {"exit_status": 0}.
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://no-such-script.gd",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -459,14 +416,12 @@ def test_script_run_parse_error_dependency_is_script_compile_failed(godot_projec
     (godot_project / "suite.gd").write_text(BAD_DEPENDENCY_GD, encoding="utf-8")
     (godot_project / "broken_dep.gd").write_text(BROKEN_DEP_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://suite.gd",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -510,14 +465,12 @@ def test_script_run_runtime_error_is_a_success_carrying_diagnostics(godot_projec
     # in stderr prose: it is a classified diagnostic an agent can branch on.
     (godot_project / "runtime_error.gd").write_text(RUNTIME_ERROR_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://runtime_error.gd",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
         retry=True,
     )
@@ -557,14 +510,12 @@ def test_script_run_missing_entry_verdict_survives_path_aliasing(
     # identity restores the specific verdict for every spelling.
     (godot_project / "sub").mkdir(exist_ok=True)
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         spelling,
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -598,14 +549,12 @@ def test_script_run_compile_failed_verdict_survives_path_aliasing(
     (godot_project / "suite.gd").write_text(BAD_DEPENDENCY_GD, encoding="utf-8")
     (godot_project / "broken_dep.gd").write_text(BROKEN_DEP_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         spelling,
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -626,14 +575,12 @@ def test_script_run_runtime_resource_load_failure_is_a_success_with_diagnostics(
         RUNTIME_RESOURCE_LOAD_GD, encoding="utf-8"
     )
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://runtime_load.gd",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
         retry=True,
     )
@@ -657,15 +604,13 @@ def test_script_run_strict_fails_on_an_explicit_non_zero_quit(godot_project):
     # parsing the JSON.
     (godot_project / "fail.gd").write_text(FAIL_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://fail.gd",
         "--strict",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -697,15 +642,13 @@ def test_script_run_strict_envelope_carries_the_suites_stdout(godot_project):
     # a CI caller that only gets an exit code and an empty diagnostics learns nothing.
     (godot_project / "suite_fail.gd").write_text(FAILING_SUITE_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://suite_fail.gd",
         "--strict",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -731,15 +674,13 @@ def test_script_run_strict_leaves_a_passing_script_a_success(godot_project):
     # success, so a CI step can pass --strict unconditionally.
     (godot_project / "hello.gd").write_text(HELLO_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://hello.gd",
         "--strict",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
         retry=True,
     )
@@ -757,15 +698,8 @@ def test_script_run_unlaunchable_binary_is_binary_not_found(godot_project):
     # GDScript-mirrored code.
     (godot_project / "hello.gd").write_text(HELLO_GD, encoding="utf-8")
 
-    run = _run_gda(
-        "script",
-        "run",
-        "res://hello.gd",
-        "--project",
-        str(godot_project),
-        "--godot",
-        str(godot_project / "no-such-godot"),
-        "--json",
+    run = Gda(godot=godot_project / "no-such-godot")(
+        "script", "run", "res://hello.gd", "--project", str(godot_project), "--json"
     )
 
     assert run.returncode == 127, run.stdout + run.stderr
@@ -823,7 +757,7 @@ def test_script_run_returns_the_captured_error_of_an_aborted_run(godot_project):
     (godot_project / "aborts.gd").write_text(ABORTS_BEFORE_QUIT_GD, encoding="utf-8")
 
     started = time.monotonic()
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://aborts.gd",
@@ -833,8 +767,6 @@ def test_script_run_returns_the_captured_error_of_an_aborted_run(godot_project):
         "60",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
     elapsed = time.monotonic() - started
@@ -863,7 +795,7 @@ def test_script_run_timeout_returns_partial_output_elapsed_and_a_phase(godot_pro
     # a silent hang. No marker is declared here, so this is the plain timeout path.
     (godot_project / "slow.gd").write_text(SLOW_BUT_HEALTHY_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://slow.gd",
@@ -871,8 +803,6 @@ def test_script_run_timeout_returns_partial_output_elapsed_and_a_phase(godot_pro
         "4",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -904,7 +834,7 @@ def test_script_run_without_a_marker_waits_out_the_timeout_but_still_captures(
     (godot_project / "aborts.gd").write_text(ABORTS_BEFORE_QUIT_GD, encoding="utf-8")
 
     started = time.monotonic()
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://aborts.gd",
@@ -912,8 +842,6 @@ def test_script_run_without_a_marker_waits_out_the_timeout_but_still_captures(
         "5",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
     elapsed = time.monotonic() - started
@@ -993,7 +921,7 @@ def test_script_run_ends_a_silent_survivor_by_the_declared_contract(godot_projec
     (godot_project / "survivor.gd").write_text(QUIET_SURVIVOR_GD, encoding="utf-8")
 
     started = time.monotonic()
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://survivor.gd",
@@ -1003,8 +931,6 @@ def test_script_run_ends_a_silent_survivor_by_the_declared_contract(godot_projec
         "60",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
     elapsed = time.monotonic() - started
@@ -1027,7 +953,7 @@ def test_script_run_leaves_the_same_survivor_alone_without_a_marker(godot_projec
     # gda must not judge.
     (godot_project / "survivor.gd").write_text(QUIET_SURVIVOR_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://survivor.gd",
@@ -1035,8 +961,6 @@ def test_script_run_leaves_the_same_survivor_alone_without_a_marker(godot_projec
         "60",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -1059,7 +983,7 @@ def test_script_run_spares_a_survivor_that_prints_progress(godot_project):
     # satisfiable by a quiet-working script, not a trap.
     (godot_project / "progress.gd").write_text(PROGRESS_SURVIVOR_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://progress.gd",
@@ -1069,8 +993,6 @@ def test_script_run_spares_a_survivor_that_prints_progress(godot_project):
         "60",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -1091,7 +1013,7 @@ def test_script_run_abort_still_lands_within_its_stated_bound(godot_project):
     (godot_project / "aborts.gd").write_text(ABORTS_BEFORE_QUIT_GD, encoding="utf-8")
 
     started = time.monotonic()
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://aborts.gd",
@@ -1101,8 +1023,6 @@ def test_script_run_abort_still_lands_within_its_stated_bound(godot_project):
         "120",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
     elapsed = time.monotonic() - started
@@ -1133,14 +1053,12 @@ def test_script_run_stdout_above_the_cap_truncates_and_spills(godot_project):
 
     (godot_project / "big.gd").write_text(BIG_PRINTER_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://big.gd",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
         retry=True,
     )

--- a/tests/test_e2e_user_data.py
+++ b/tests/test_e2e_user_data.py
@@ -44,11 +44,8 @@ from pathlib import Path
 
 import pytest
 
-from gda.binary import resolve_godot_binary
 from gda.runner import data_path_env, engine_data_path
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
+from tests.support import GDA_CMD, GODOT, Gda
 
 # A project whose file logging is at the ENGINE DEFAULT (on for desktop), i.e. what
 # a real user project looks like — see the module docstring.
@@ -161,10 +158,6 @@ def _env(home: Path, **extra: str) -> dict:
     return {**os.environ, "HOME": str(home), "GDA_GODOT": str(GODOT), **extra}
 
 
-def _run_gda(*args: str, env: dict) -> subprocess.CompletedProcess:
-    return subprocess.run([*GDA_CMD, *args], capture_output=True, text=True, env=env)
-
-
 @pytest.mark.e2e
 def test_control_unprotected_launch_really_does_die_on_the_restriction(
     restricted_home, logging_project
@@ -185,6 +178,7 @@ def test_control_unprotected_launch_really_does_die_on_the_restriction(
         capture_output=True,
         text=True,
         env=_env(home),
+        timeout=120,
     )
 
     assert MARKER not in proc.stdout, (
@@ -204,14 +198,13 @@ def test_script_validate_completes_under_a_read_only_app_data_dir(
     # restriction really do kill an unprotected launch.
     home, _ = restricted_home
 
-    run = _run_gda(
+    run = Gda(godot=None, env=_env(home))(
         "script",
         "validate",
         str(logging_project / "hello.gd"),
         "--project",
         str(logging_project),
         "--json",
-        env=_env(home),
     )
 
     assert run.returncode == 0, run.stdout + run.stderr
@@ -227,14 +220,13 @@ def test_script_run_completes_under_a_read_only_app_data_dir(
 ):
     home, _ = restricted_home
 
-    run = _run_gda(
+    run = Gda(godot=None, env=_env(home))(
         "script",
         "run",
         "res://hello.gd",
         "--project",
         str(logging_project),
         "--json",
-        env=_env(home),
     )
 
     assert run.returncode == 0, run.stdout + run.stderr
@@ -254,10 +246,9 @@ def test_unwritable_log_target_is_a_typed_environment_error(
     # typed environment code before the engine starts — never a signal-11 backtrace.
     home, data_path = restricted_home
 
-    run = _run_gda(
+    run = Gda(godot=None, env=_env(home, GDA_USER_DATA_ROOT=str(data_path / "denied")))(
         "info",
         "--json",
-        env=_env(home, GDA_USER_DATA_ROOT=str(data_path / "denied")),
     )
 
     assert run.returncode == 127, run.stdout + run.stderr
@@ -301,7 +292,7 @@ def test_a_root_whose_derived_data_path_is_blocked_is_refused(
     blocker.parent.mkdir(parents=True, exist_ok=True)
     blocker.write_text("not a directory", encoding="utf-8")
 
-    run = _run_gda(
+    run = Gda(godot=None, env={**os.environ, "GDA_GODOT": str(GODOT)})(
         "--user-data-root",
         str(root),
         "script",
@@ -310,7 +301,6 @@ def test_a_root_whose_derived_data_path_is_blocked_is_refused(
         "--project",
         str(logging_project),
         "--json",
-        env={**os.environ, "GDA_GODOT": str(GODOT)},
     )
 
     assert run.returncode == 127, run.stdout + run.stderr
@@ -336,7 +326,7 @@ def test_user_data_root_makes_user_writable_again(restricted_home, logging_proje
     home, _ = restricted_home
     root = logging_project.parent / "udr"
 
-    run = _run_gda(
+    run = Gda(godot=None, env=_env(home))(
         "--user-data-root",
         str(root),
         "script",
@@ -345,7 +335,6 @@ def test_user_data_root_makes_user_writable_again(restricted_home, logging_proje
         "--project",
         str(logging_project),
         "--json",
-        env=_env(home),
     )
 
     assert run.returncode == 0, run.stdout + run.stderr
@@ -394,7 +383,7 @@ def test_concurrent_invocations_never_touch_the_shared_rotated_log(
     ]
     # communicate() before returncode: draining the pipes is what lets each child
     # exit, so waiting first can deadlock on a full pipe buffer.
-    results = [(*p.communicate(), p.returncode) for p in procs]
+    results = [(*p.communicate(timeout=120), p.returncode) for p in procs]
 
     for out, err, code in results:
         assert code == 0, out + err
@@ -429,22 +418,15 @@ def test_relative_root_on_the_sentinel_channel_lands_under_gda_cwd(
     workdir = tmp_path / "workdir"
     workdir.mkdir()
 
-    run = subprocess.run(
-        [
-            *GDA_CMD,
-            "--user-data-root",
-            "./rel",
-            "script",
-            "validate",
-            str(logging_project / "hello.gd"),
-            "--project",
-            str(logging_project),
-            "--json",
-        ],
-        capture_output=True,
-        text=True,
-        cwd=str(workdir),
-        env={**os.environ, "GDA_GODOT": str(GODOT)},
+    run = Gda(godot=None, env={**os.environ, "GDA_GODOT": str(GODOT)}, cwd=workdir)(
+        "--user-data-root",
+        "./rel",
+        "script",
+        "validate",
+        str(logging_project / "hello.gd"),
+        "--project",
+        str(logging_project),
+        "--json",
     )
 
     assert run.returncode == 0, run.stdout + run.stderr
@@ -470,27 +452,20 @@ def test_relative_root_on_the_export_channel_lands_under_gda_cwd(
     workdir.mkdir()
     artifact = logging_project / "dist" / "packed.pck"
 
-    run = subprocess.run(
-        [
-            *GDA_CMD,
-            "--user-data-root",
-            "./rel",
-            "export",
-            "run",
-            "--preset",
-            "Linux/X11",
-            "--mode",
-            "pack",
-            "--output",
-            str(artifact),
-            "--project",
-            str(logging_project),
-            "--json",
-        ],
-        capture_output=True,
-        text=True,
-        cwd=str(workdir),
-        env={**os.environ, "GDA_GODOT": str(GODOT)},
+    run = Gda(godot=None, env={**os.environ, "GDA_GODOT": str(GODOT)}, cwd=workdir)(
+        "--user-data-root",
+        "./rel",
+        "export",
+        "run",
+        "--preset",
+        "Linux/X11",
+        "--mode",
+        "pack",
+        "--output",
+        str(artifact),
+        "--project",
+        str(logging_project),
+        "--json",
     )
 
     assert run.returncode == 0, run.stdout + run.stderr

--- a/tests/test_e2e_write_value_fidelity.py
+++ b/tests/test_e2e_write_value_fidelity.py
@@ -33,12 +33,8 @@ import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-
 from tests.live_number_corpus import LIVE_NUMBER_CORPUS, value_bits
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
+from tests.support import GODOT, Gda
 
 
 # --- the policy, expressed independently of the GDScript that implements it ----
@@ -324,26 +320,6 @@ WRITE_CASES = [
 ]
 
 
-def _headless_runner(project):
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(project),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=180,
-        )
-
-    return run
-
-
 @pytest.fixture
 def probe_project(godot_project):
     (godot_project / "probe.gd").write_text(PROBE_GD, encoding="utf-8")
@@ -360,7 +336,7 @@ def test_node_set_refuses_a_literal_the_parser_destroys(probe_project):
     rewritten with it.
     """
     scene = probe_project / "main.tscn"
-    run = _headless_runner(probe_project)
+    run = Gda(probe_project, json_output=True, timeout=180)
 
     for literal, refused, note in WRITE_CASES:
         before = scene.read_text(encoding="utf-8")
@@ -407,7 +383,7 @@ def test_node_set_refuses_a_literal_the_parser_destroys(probe_project):
 def test_the_refusal_is_narrow_and_names_its_remedy(probe_project):
     """It refuses a LOSS, not a magnitude, and tells the caller what to type instead."""
     scene = probe_project / "main.tscn"
-    run = _headless_runner(probe_project)
+    run = Gda(probe_project, json_output=True, timeout=180)
 
     # A value that is not a number at all keeps the message it always had: the
     # fidelity note must not relabel an ordinary coercion failure.
@@ -555,7 +531,7 @@ def test_node_set_refuses_a_destroyed_number_inside_a_container(probe_project):
     scalar, alive on the one path its per-component walk could not reach.
     """
     scene = probe_project / "main.tscn"
-    run = _headless_runner(probe_project)
+    run = Gda(probe_project, json_output=True, timeout=180)
 
     for prop, value, note in CONTAINER_REFUSED:
         before = scene.read_text(encoding="utf-8")
@@ -639,7 +615,7 @@ def test_the_note_explains_only_the_refusal_it_diagnosed(probe_project):
     `test_node_set_refuses_a_destroyed_number_inside_a_container`.)
     """
     scene = probe_project / "main.tscn"
-    run = _headless_runner(probe_project)
+    run = Gda(probe_project, json_output=True, timeout=180)
 
     def message(*args):
         result = run("node", "set", str(scene), "--node", ".", *args)
@@ -707,7 +683,7 @@ def test_project_set_shares_the_refusal(probe_project):
         + '\n[gda]\n\nprobe/value=1.5\nprobe/dict={"a": 1.0}\nprobe/arr=[1.0]\n',
         encoding="utf-8",
     )
-    run = _headless_runner(probe_project)
+    run = Gda(probe_project, json_output=True, timeout=180)
 
     refused = run(
         "project", "set", "gda/probe/value", "--value", "0.000000000000000001"
@@ -760,7 +736,7 @@ def test_resource_set_shares_the_refusal(probe_project):
     (probe_project / "probe_res.gd").write_text(RESOURCE_PROBE_GD, encoding="utf-8")
     resource = probe_project / "probe.tres"
     resource.write_text(RESOURCE_PROBE_TRES, encoding="utf-8")
-    run = _headless_runner(probe_project)
+    run = Gda(probe_project, json_output=True, timeout=180)
 
     # The scalar rule first, so a container failure below cannot be a `resource
     # set` that never had the rule at all.
@@ -826,7 +802,7 @@ def test_game_set_refuses_the_same_literals_against_a_real_daemon(
     (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "live_main.gd").write_text(LIVE_MAIN_GD, encoding="utf-8")
 
-    run = _headless_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=180)
     try:
         assert run("daemon", "start").returncode == 0
 

--- a/tests/test_e2e_write_value_fidelity.py
+++ b/tests/test_e2e_write_value_fidelity.py
@@ -36,6 +36,8 @@ import pytest
 from tests.live_number_corpus import LIVE_NUMBER_CORPUS, value_bits
 from tests.support import GODOT, Gda
 
+from .conftest import LIVE_PROJECT_GODOT
+
 
 # --- the policy, expressed independently of the GDScript that implements it ----
 
@@ -772,8 +774,8 @@ def test_resource_set_shares_the_refusal(probe_project):
 
 # --- the command tier: live `game set` through a real daemon -------------------
 
-LIVE_MAIN_GD = 'extends Node2D\n\nvar v := 1.5\nvar n := 0\nvar d := {"seed": 1.0}\nvar a := [1.0]\n'
-LIVE_MAIN_TSCN = (
+SET_MAIN_GD = 'extends Node2D\n\nvar v := 1.5\nvar n := 0\nvar d := {"seed": 1.0}\nvar a := [1.0]\n'
+SET_MAIN_TSCN = (
     "[gd_scene load_steps=2 format=3]\n\n"
     '[ext_resource type="Script" path="res://live_main.gd" id="1"]\n\n'
     '[node name="Main" type="Node2D"]\n'
@@ -794,13 +796,9 @@ def test_game_set_refuses_the_same_literals_against_a_real_daemon(
     This is why the block is mirrored, and why it is exercised through a real
     session rather than trusted to the drift test.
     """
-    from .conftest import project_godot
-
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
-    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
-    (tmp_path / "live_main.gd").write_text(LIVE_MAIN_GD, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(SET_MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "live_main.gd").write_text(SET_MAIN_GD, encoding="utf-8")
 
     run = Gda(tmp_path, json_output=True, timeout=180)
     try:


### PR DESCRIPTION
Closes #817

One deep `gda` invoker for the e2e tier, in place of the fifteen adapters over the
one `subprocess.run([sys.executable, "-m", "gda", ...])` seam (#299).

## The interface (`tests/support.py`)

```python
GODOT = resolve_godot_binary()        # the tier's one resolved engine
DEFAULT_TIMEOUT = 90.0                # what one spawn waits before it is wedged

class Gda:
    def __init__(self, project=None, *, godot=GODOT, json_output=False,
                 env=None, extra_env=None, cwd=None, timeout=DEFAULT_TIMEOUT): ...
    def __call__(self, *args, cwd=None, timeout=None, extra_env=None,
                 stdin=None, retry=False) -> CompletedProcess[str]
    def json(self, *args, **overrides) -> dict    # asserts exit 0, returns the result
    def error(self, *args, code, **overrides) -> dict  # asserts the ADR-0002 envelope

def import_project(project, *, timeout=180.0) -> CompletedProcess[str]
```

An instance binds what a module repeats — project, engine, child environment,
working directory, timeout, and whether `--json` is baked in — and offers three
forms over that binding: the raw run, the JSON form, and the operation-error
form. `project=None` is the project-less form (`gda version`, `gda info --godot`,
the "no project" refusals); `godot=None` drops `--godot` for the tests that spell
the engine themselves or set `$GDA_GODOT`. Bound options are appended after the
command's own argv, as before, so the cwd-relative-target tests still exercise
what they exercised.

`assert_operation_error` now reads a `CompletedProcess` as well as a Typer
`Result`, so one function spells the operation-failure contract for both tiers;
`Gda.error` is its run-and-assert front. `conftest` gains the live scaffold
(`LIVE_PROJECT_GODOT`, `LIVE_MAIN_TSCN`, `SCRIPTED_MAIN_TSCN`) beside the
`project_godot` builder that makes it — the copies lived in eight and five
modules.

## What went

- `_gda` (14 modules, four signatures), `_gda_project` (9), `_gda_env` (3),
  `_run_gda` (3), `_gda_runner`, `_gda_json`, `_runner`, `_headless_runner`,
  `_live_runner`, `_result`, and twenty-six in-test `def run(*args)` closures
- `_import_project` (5, one of which ignored the engine's exit code) and
  `_native_import` (whose four call sites asserted that code by hand)
- `_assert_operation_error` (8 byte-identical copies)
- `GODOT = resolve_godot_binary()` (38 modules)
- The live `PROJECT_GODOT` / `MAIN_TSCN` copies

Every spawn now carries a timeout — eleven helpers had none — including the two
raw engine probes and the six concurrent children in the user-data test.

Two hand-written `project.godot` texts go through `project_godot()`: the
resource-import module's (which #817 names) and `gda info`'s, which did **not**
disable file logging and so could have written a shared `user://logs` (#180).

## Wrappers and arguments kept, and why

- `retry=True` on `__call__` — `script run`'s re-run once on a transient
  `engine_crashed` (#180). One module uses it; it is an argument rather than a
  second spawn.
- `env=` on the binding — the user-data tests REQUIRE a caller-supplied
  environment (a redirected `HOME` plus `$GDA_GODOT`), so it is stated at the
  binding rather than merged over `os.environ`.
- `extra_env=` — the `GDA_TEST_PERTURB_*` seams (#226) and the two tests that
  point `XDG_RUNTIME_DIR`/`XDG_DATA_HOME` somewhere empty.
- `timeout=` at the binding — `120` for the windowed daemon/screen sessions
  (as before), `180` for the import-heavy modules (resource import, the two
  number-fidelity modules, the live-transport probe), which is what those call
  sites already passed. No test needed a bound above 90 s that did not already
  state one; the launch-timeout and marker tests bound the ENGINE with `--timeout
  4`/`5`/`60`, well inside the default.
- `_property_value(gda, node, name)` in the input module — a reader, not a
  spawn; it now takes the invoker.

Where a run existed only to be asserted on, the two statements become one
`gda.error(..., code=...)` (127 sites); the ten runs a test reads again
afterwards keep the two-step form over the same shared assertion.

## Definition of Done

| Gate | Command | Result |
| --- | --- | --- |
| lint | `uv run --frozen ruff check .` | All checks passed |
| format | `uv run --frozen ruff format --check .` | 492 files already formatted |
| types | `uv run --frozen pyright` | 0 errors, 0 warnings, 0 informations |
| collection | `uv run --frozen pytest --collect-only -q -p no:cacheprovider \| grep '::' \| sort` at head and at `ad6e7af7` | 3,075 IDs each; `diff` reports no difference |
| unit tier | `uv run --frozen pytest -m "not e2e" -q -p no:cacheprovider` | 2429 passed, 646 deselected |
| e2e 1/7 | `pytest -m e2e -q -rs tests/test_e2e_node.py` | 108 passed in 325.81s |
| e2e 2/7 | `... test_e2e_script/scene/scene_exports/asset_file` | 109 passed in 148.76s |
| e2e 3/7 | `... test_e2e_resource/object_property/classname_resolution/resource_import` | 62 passed in 142.31s |
| e2e 4/7 | `... test_e2e_project/project_analysis/project_walk/res_containment/scene_security/info/params_json/op_robustness` | 118 passed in 123.23s |
| e2e 5/7 | `... test_e2e_script_run/scene_validate/scene_preflight/export/export_run/launch_timeout` | 123 passed, 1 skipped in 120.97s |
| e2e 6/7 | `... test_e2e_daemon/game/input/screen/perf/diag/logger/live_number_transport/harness_install/mcp_*/user_data/headless_number_reads/write_value_fidelity` | 121 passed in 216.08s |
| e2e 7/7 | `... tests/test_daemon_ops.py` (the four e2e-marked tests outside `test_e2e_*`) | 4 passed in 0.38s |
| e2e total | | **645 passed, 1 skipped** — the skip is the Linux-only `XDG_DATA_HOME` template test |
| size | `git diff --stat ad6e7af7..HEAD` | 41 files, 1656 insertions, 2876 deletions (**net −1220** under `tests/`) |

Run serially, one pytest e2e process at a time.

surface diff: none — tests only.

## Review round (independent review at 7381358a8 → fixes at cf64cb173)

Verdict was MERGEABLE WITH NITS (0 P1, 0 P2, 8 P3). Finding → resolution:

- Adopted: the script-run abort test's engine ceiling (120 s) sat above the spawn's 90 s default — it now passes `timeout=150`; the launch-timeout module's hand-spelled `project.godot` (the one that launches an engine) now comes from `project_godot()`; conftest's live-scaffold comment lists the actual consumers (eleven modules take the project, three the node-path scene, two the scripted one); the stale `_gda_project` comment in export-run is gone; scene-security's import groups are separated; the two counts above corrected (26 closures, 10 re-read runs).
- Declined, with reasons: the user-data `communicate(timeout=120)` does not kill the remaining children on a timeout — pre-existing shape, bounded now where it was unbounded before, and a timeout there is already a failed test; `Gda.error`'s `**overrides` is untyped and cannot carry `needle`/`diagnostics` — the two-step form (`assert_operation_error(gda(...), code, needle=...)`) is the explicit spelling every such site uses, and widening `.error` would give the invoker two ways to say one thing.
- Noted: four module-level `PROJECT_GODOT`/`MAIN_TSCN` names remain (project_analysis, project_walk, harness_install, screen) — none is a copy: the two projects go through `project_godot()`, the scenes are those modules' own subjects. Four bare `config_version=5` project texts remain in `daemon_not_running` refusal tests that never launch an engine; left as is.
