### PR TITLE
ci(gda): run both pytest tiers on pytest-xdist (#818)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,9 @@ jobs:
         run: python scripts/harness_version_guard.py "$BASE_SHA" "$HEAD_SHA"
 
       - name: Run unit tests
-        run: uv run --frozen pytest -m "not e2e"
+        # Four workers (the runner has four vCPUs); `loadgroup` keeps the
+        # `xdist_group`-marked tests together and load-balances the rest (#818).
+        run: uv run --frozen pytest -m "not e2e" -n 4 --dist loadgroup
 
       # The root testpaths excludes the example game; run its PURE-Python tier here
       # (no Godot). The "engine" and "e2e" tiers need a real engine and run in the
@@ -480,7 +482,10 @@ jobs:
         # -rs surfaces skip reasons in the log (e.g. absent export templates, or no
         # DisplayServer for windowed capture), so a silently-skipped e2e is visible
         # rather than mistaken for a pass.
-        run: uv run --frozen pytest -m e2e -rs
+        # Four workers, as the unit step; every e2e spawn has its own project,
+        # user-data placement and daemon socket dir, and the windowed tests are
+        # grouped on one worker (#818).
+        run: uv run --frozen pytest -m e2e -rs -n 4 --dist loadgroup
 
       # The example game's engine-backed tiers: the data round-trip + logic seam
       # (engine marker) and the live daemon loop (e2e). install-godot exported

--- a/README.md
+++ b/README.md
@@ -628,7 +628,7 @@ uv sync                       # set up the environment
 uv run pytest                 # run the full suite (includes e2e tests against a real Godot)
 uv run pytest -m "not e2e"    # unit tests only (no Godot binary required)
 uv run pytest -m e2e          # only the end-to-end tests (needs Godot 4.4+ on this machine)
-uv run pytest -n 4 --dist loadgroup   # the same, on four workers — what CI runs
+uv run pytest -n 4 --dist loadgroup   # any tier above on four workers, as CI runs each
 
 uv run ruff check .           # lint
 uv run ruff format .          # auto-format (append --check to verify without writing)

--- a/README.md
+++ b/README.md
@@ -628,6 +628,7 @@ uv sync                       # set up the environment
 uv run pytest                 # run the full suite (includes e2e tests against a real Godot)
 uv run pytest -m "not e2e"    # unit tests only (no Godot binary required)
 uv run pytest -m e2e          # only the end-to-end tests (needs Godot 4.4+ on this machine)
+uv run pytest -n 4 --dist loadgroup   # the same, on four workers — what CI runs
 
 uv run ruff check .           # lint
 uv run ruff format .          # auto-format (append --check to verify without writing)

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=465ec4f02a22747e675bfbee6bdba48edd474a3da79ec654943c9741a747c302 -->
+<!-- gda-readme-i18n: source=README.md sha256=7df2a345ba40bb5b7d090e2c84660e5dbd60fc51aea86727e322cc0e1f4cb6ab -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -639,6 +639,7 @@ uv sync                       # set up the environment
 uv run pytest                 # run the full suite (includes e2e tests against a real Godot)
 uv run pytest -m "not e2e"    # unit tests only (no Godot binary required)
 uv run pytest -m e2e          # only the end-to-end tests (needs Godot 4.4+ on this machine)
+uv run pytest -n 4 --dist loadgroup   # lo mismo, en cuatro workers — lo que ejecuta la CI
 
 uv run ruff check .           # lint
 uv run ruff format .          # auto-format (append --check to verify without writing)

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=7df2a345ba40bb5b7d090e2c84660e5dbd60fc51aea86727e322cc0e1f4cb6ab -->
+<!-- gda-readme-i18n: source=README.md sha256=4a9280269cf9d3736b7e026aaeec5a30cec96824f74faa65a01b6e14b8eb4aac -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -639,7 +639,7 @@ uv sync                       # set up the environment
 uv run pytest                 # run the full suite (includes e2e tests against a real Godot)
 uv run pytest -m "not e2e"    # unit tests only (no Godot binary required)
 uv run pytest -m e2e          # only the end-to-end tests (needs Godot 4.4+ on this machine)
-uv run pytest -n 4 --dist loadgroup   # lo mismo, en cuatro workers — lo que ejecuta la CI
+uv run pytest -n 4 --dist loadgroup   # cualquier nivel de arriba en cuatro workers, como la CI ejecuta cada uno
 
 uv run ruff check .           # lint
 uv run ruff format .          # auto-format (append --check to verify without writing)

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=7df2a345ba40bb5b7d090e2c84660e5dbd60fc51aea86727e322cc0e1f4cb6ab -->
+<!-- gda-readme-i18n: source=README.md sha256=4a9280269cf9d3736b7e026aaeec5a30cec96824f74faa65a01b6e14b8eb4aac -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -641,7 +641,7 @@ uv sync                       # set up the environment
 uv run pytest                 # run the full suite (includes e2e tests against a real Godot)
 uv run pytest -m "not e2e"    # unit tests only (no Godot binary required)
 uv run pytest -m e2e          # only the end-to-end tests (needs Godot 4.4+ on this machine)
-uv run pytest -n 4 --dist loadgroup   # 同じ内容を 4 ワーカーで実行 — CI が実行する形
+uv run pytest -n 4 --dist loadgroup   # 上のどの階層も 4 ワーカーで実行 — CI が各階層をこう実行する
 
 uv run ruff check .           # lint
 uv run ruff format .          # auto-format (append --check to verify without writing)

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=465ec4f02a22747e675bfbee6bdba48edd474a3da79ec654943c9741a747c302 -->
+<!-- gda-readme-i18n: source=README.md sha256=7df2a345ba40bb5b7d090e2c84660e5dbd60fc51aea86727e322cc0e1f4cb6ab -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -641,6 +641,7 @@ uv sync                       # set up the environment
 uv run pytest                 # run the full suite (includes e2e tests against a real Godot)
 uv run pytest -m "not e2e"    # unit tests only (no Godot binary required)
 uv run pytest -m e2e          # only the end-to-end tests (needs Godot 4.4+ on this machine)
+uv run pytest -n 4 --dist loadgroup   # 同じ内容を 4 ワーカーで実行 — CI が実行する形
 
 uv run ruff check .           # lint
 uv run ruff format .          # auto-format (append --check to verify without writing)

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=7df2a345ba40bb5b7d090e2c84660e5dbd60fc51aea86727e322cc0e1f4cb6ab -->
+<!-- gda-readme-i18n: source=README.md sha256=4a9280269cf9d3736b7e026aaeec5a30cec96824f74faa65a01b6e14b8eb4aac -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -623,7 +623,7 @@ uv sync                       # set up the environment
 uv run pytest                 # run the full suite (includes e2e tests against a real Godot)
 uv run pytest -m "not e2e"    # unit tests only (no Godot binary required)
 uv run pytest -m e2e          # only the end-to-end tests (needs Godot 4.4+ on this machine)
-uv run pytest -n 4 --dist loadgroup   # 同上，四个 worker 并行——CI 的运行方式
+uv run pytest -n 4 --dist loadgroup   # 上面任一层改为四个 worker 并行——CI 对每层都这样跑
 
 uv run ruff check .           # lint
 uv run ruff format .          # auto-format (append --check to verify without writing)

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=465ec4f02a22747e675bfbee6bdba48edd474a3da79ec654943c9741a747c302 -->
+<!-- gda-readme-i18n: source=README.md sha256=7df2a345ba40bb5b7d090e2c84660e5dbd60fc51aea86727e322cc0e1f4cb6ab -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -623,6 +623,7 @@ uv sync                       # set up the environment
 uv run pytest                 # run the full suite (includes e2e tests against a real Godot)
 uv run pytest -m "not e2e"    # unit tests only (no Godot binary required)
 uv run pytest -m e2e          # only the end-to-end tests (needs Godot 4.4+ on this machine)
+uv run pytest -n 4 --dist loadgroup   # 同上，四个 worker 并行——CI 的运行方式
 
 uv run ruff check .           # lint
 uv run ruff format .          # auto-format (append --check to verify without writing)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,11 @@ build-backend = "uv_build"
 dev = [
     "jsonschema>=4.26.0",
     "pytest>=9.0.3",
+    # Both pytest tiers run on four workers (`-n 4 --dist loadgroup`, #818): the
+    # suite is wall-clock bound by process waits and engine boots, not CPU. The
+    # `xdist_group("windowed")` mark keeps the tests that open a real window on
+    # one worker, so two windowed sessions never share the host display at once.
+    "pytest-xdist>=3.8.0",
     # The MCP SDK is also a dev dependency (not just the `[mcp]` extra) so
     # `uv run pytest` has it for the gda-mcp fast/e2e tiers (ADR-0013).
     "mcp>=2,<3",

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -909,6 +909,7 @@ def test_daemon_uninstall_is_refused_while_running(tmp_path, daemon_runtime_dir)
 
 
 @pytest.mark.e2e
+@pytest.mark.xdist_group("windowed")  # shares the host display (#818)
 def test_daemon_status_surfaces_the_windowed_display_mode(tmp_path, daemon_runtime_dir):
     # #251: `daemon status` reports the running daemon's launch-time display mode,
     # read over STATUS_OP through the `gda` CLI, so an agent can tell whether a
@@ -1216,6 +1217,7 @@ def test_daemon_serves_live_ops_while_scenetree_paused(tmp_path, daemon_runtime_
 
 
 @pytest.mark.e2e
+@pytest.mark.xdist_group("windowed")  # shares the host display (#818)
 def test_daemon_serves_screen_capture_while_scenetree_paused(
     tmp_path, daemon_runtime_dir
 ):

--- a/tests/test_e2e_input.py
+++ b/tests/test_e2e_input.py
@@ -722,6 +722,7 @@ def test_two_clicks_leave_diag_errors_empty(tmp_path, daemon_runtime_dir):
 
 @pytest.mark.e2e
 @pytest.mark.usefixtures("windowed_host")
+@pytest.mark.xdist_group("windowed")  # shares the host display (#818)
 def test_two_windowed_clicks_leave_diag_errors_empty(tmp_path, daemon_runtime_dir):
     # The exact #647 reproduction: a WINDOWED daemon session, two successful
     # clicks, an empty `diag errors`. The windowed path also carries the

--- a/tests/test_e2e_screen.py
+++ b/tests/test_e2e_screen.py
@@ -44,7 +44,12 @@ MAIN_TSCN = (
     "color = Color(0.2, 0.6, 0.9, 1)\n"
 )
 
-pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
+pytestmark = [
+    pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"),
+    # The windowed captures share the host display: one worker under xdist's
+    # `--dist loadgroup`, so two windowed sessions never compete for it (#818).
+    pytest.mark.xdist_group("windowed"),
+]
 
 # A WINDOWED engine session needs a usable host DisplayServer. This is NOT a
 # "macOS always has one" assumption: headless macOS (SSH / CI / sandbox) has no

--- a/uv.lock
+++ b/uv.lock
@@ -230,6 +230,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "gda"
 version = "0.13.0"
 source = { editable = "." }
@@ -254,6 +263,7 @@ dev = [
     { name = "pillow" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -276,6 +286,7 @@ dev = [
     { name = "pillow", specifier = ">=11.0" },
     { name = "pyright", specifier = ">=1.1.411,<1.2" },
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.15.19,<0.16" },
 ]
 
@@ -739,6 +750,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #818

## What

- `pytest-xdist` (3.8.0) joins the dev dependency group; `uv.lock` updated.
- CI: the `python` job's unit step and the `godot-e2e` job's e2e step run `-n 4 --dist loadgroup` (`-rs` kept on e2e). Explicit `-n 4`: the runner has four vCPUs, and locally `-n 8` measured slower than `-n 4` on a four-performance-core machine.
- `xdist_group("windowed")`: the whole screen module (module-level mark beside its existing `skipif`), input's windowed click test, and daemon's two windowed tests. Ungrouped tests distribute as under `--dist load`.
- README development block: one added line for the four-worker invocation. The three translated READMEs mirror that line (translated by the author, disclosed here for the native check) and their sync markers are re-stamped with `scripts/update_readme_i18n.py`.

No test added, removed or renamed; no assertion change; no product change. Surface diff: none beyond the README line.

## Evidence (local macOS, this branch = dev tip + #815, #816, #817)

| tier | serial | `-n 4 --dist loadgroup` |
| --- | --- | --- |
| unit, 2,429 tests | 47.5 s (dev), 67.4 s (main before #815) | 16.7–17.2 s, seven consecutive runs green |
| e2e, 646 tests | 1,215 s (main) | 373 s in two halves: 414 passed / 215 s + 231 passed, 1 skipped / 158 s |

Grouping: with `-n 3 --dist loadgroup -v`, every screen test and the windowed input test report the same worker id; the info tests spread across workers (log kept with the run).

Isolation audit (from the issue, re-checked on this tree): daemon sockets use a per-test `mkdtemp`; no fixed ports; no bare `os.environ` writes; no module-level mutable state; every e2e spawn has its own project, user-data placement and socket dir (#817 gave every spawn a timeout). On a display-less Linux runner the windowed verdict is a pure `$DISPLAY` / `$WAYLAND_DISPLAY` read, so the 19 windowed skips are worker-safe and happen before any spawn.

Disclosed: the very first `-n 4` run on this branch reported 2 failures — one was the README i18n sync test (the added line; fixed by mirroring it into the translations and re-stamping), the other's name was not captured; seven subsequent unit runs and both e2e halves were green. Known load-sensitive test outside this diff: `test_launch::test_timeout_synthesizes_a_result_that_keeps_what_the_run_produced` asserts `1.0 <= elapsed < 3.0` against a real child and went red twice under a reviewer's deliberately overloaded mutation runs (base behaviour, #816's review); it passed in every xdist run here. Fallback if CI flakes: a `timing` group or `-n 3` on the e2e job, decided on a real flake.

## CI evidence

- PR CI (unit tier under xdist): see the checks on this PR.
- `workflow_dispatch` with `run-e2e=true` on this branch — run 33792443503, all 15 jobs green:

| step | before (nightly 33731851136 on main) | this branch |
| --- | --- | --- |
| Run unit tests | 84.2 s, 2,427 passed / 2 skipped | 35.3 s, 2,427 passed / 2 skipped |
| Run Godot e2e tests | 1,361.9 s (22:41), 627 passed / 19 skipped | 503.2 s (8:23), 627 passed / 19 skipped |
| Godot e2e job total | 28.6 min | 14.2 min |

- Flake found while gathering the local evidence and filed per this issue's acceptance criterion: `test_launch::test_a_watchless_launch_streams_and_never_ends_a_run_early` (and less often `::test_timeout_synthesizes_a_result_that_keeps_what_the_run_produced`) race a real 1.0 s deadline against the fake engine's first output; reproduced 10/12 with the timing modules concentrated on four workers on an oversubscribed machine, 1/10 in full-tier runs, 0/1 on the CI runner. Fixed on dev before this PR merges (see the linked issue); the fix is the #728 clock technique, no new tests.

## Review round (independent review at f9d06c403 → fix at b45742ded)

Verdict MERGEABLE WITH NITS (0 P1, 1 P2, 2 P3). The P2 was a merge-mechanics fact, not a defect: the PR base was stale and the flake it disclosed is fixed on dev by #825 (issue #824), so this PR merges onto the current dev tip, where the reviewer measured 10 / 10 green under `-n 4 --dist loadgroup` (the PR head alone: 14 / 24 red on macOS, 7 / 7 green serial, 0 / 1 red on the Linux CI runner). The reviewer also found the flake's mechanism: macOS Gatekeeper's first-execution scan of a freshly written executable (20 concurrent fresh `/bin/sh` stand-ins: median 3.3 s, max 6.0 s; one reused script: ~0.3 s flat) — macOS-only, which is why CI never saw it; a session-scoped shared stand-in would save ~0.3 s per launch test locally (follow-up candidate, not this round). P3 adopted: the README comment now says the line runs any tier on four workers as CI runs each tier (it ran "the same" as nothing, and CI runs the tiers in separate jobs); the three translations mirror it and are re-stamped. P3 declined: comment-column alignment — the command is longer than the column its neighbours share. Timing bounds the reviewer measured as the next candidates if CI flakes: `test_daemon_socket_lifecycle` at the 0.35 s scheduling slack (`:522`) and the 0.5 s trickle bound (`:787`); neither fired in 34 parallel runs.
