### PR TITLE
test(gda): tests optimisation round — deep invokers, hot paths, pytest-xdist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,9 @@ jobs:
         run: python scripts/harness_version_guard.py "$BASE_SHA" "$HEAD_SHA"
 
       - name: Run unit tests
-        run: uv run --frozen pytest -m "not e2e"
+        # Four workers (the runner has four vCPUs); `loadgroup` keeps the
+        # `xdist_group`-marked tests together and load-balances the rest (#818).
+        run: uv run --frozen pytest -m "not e2e" -n 4 --dist loadgroup
 
       # The root testpaths excludes the example game; run its PURE-Python tier here
       # (no Godot). The "engine" and "e2e" tiers need a real engine and run in the
@@ -480,7 +482,10 @@ jobs:
         # -rs surfaces skip reasons in the log (e.g. absent export templates, or no
         # DisplayServer for windowed capture), so a silently-skipped e2e is visible
         # rather than mistaken for a pass.
-        run: uv run --frozen pytest -m e2e -rs
+        # Four workers, as the unit step; every e2e spawn has its own project,
+        # user-data placement and daemon socket dir, and the windowed tests are
+        # grouped on one worker (#818).
+        run: uv run --frozen pytest -m e2e -rs -n 4 --dist loadgroup
 
       # The example game's engine-backed tiers: the data round-trip + logic seam
       # (engine marker) and the live daemon loop (e2e). install-godot exported

--- a/README.md
+++ b/README.md
@@ -628,6 +628,7 @@ uv sync                       # set up the environment
 uv run pytest                 # run the full suite (includes e2e tests against a real Godot)
 uv run pytest -m "not e2e"    # unit tests only (no Godot binary required)
 uv run pytest -m e2e          # only the end-to-end tests (needs Godot 4.4+ on this machine)
+uv run pytest -n 4 --dist loadgroup   # any tier above on four workers, as CI runs each
 
 uv run ruff check .           # lint
 uv run ruff format .          # auto-format (append --check to verify without writing)

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=465ec4f02a22747e675bfbee6bdba48edd474a3da79ec654943c9741a747c302 -->
+<!-- gda-readme-i18n: source=README.md sha256=4a9280269cf9d3736b7e026aaeec5a30cec96824f74faa65a01b6e14b8eb4aac -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -639,6 +639,7 @@ uv sync                       # set up the environment
 uv run pytest                 # run the full suite (includes e2e tests against a real Godot)
 uv run pytest -m "not e2e"    # unit tests only (no Godot binary required)
 uv run pytest -m e2e          # only the end-to-end tests (needs Godot 4.4+ on this machine)
+uv run pytest -n 4 --dist loadgroup   # cualquier nivel de arriba en cuatro workers, como la CI ejecuta cada uno
 
 uv run ruff check .           # lint
 uv run ruff format .          # auto-format (append --check to verify without writing)

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=465ec4f02a22747e675bfbee6bdba48edd474a3da79ec654943c9741a747c302 -->
+<!-- gda-readme-i18n: source=README.md sha256=4a9280269cf9d3736b7e026aaeec5a30cec96824f74faa65a01b6e14b8eb4aac -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -641,6 +641,7 @@ uv sync                       # set up the environment
 uv run pytest                 # run the full suite (includes e2e tests against a real Godot)
 uv run pytest -m "not e2e"    # unit tests only (no Godot binary required)
 uv run pytest -m e2e          # only the end-to-end tests (needs Godot 4.4+ on this machine)
+uv run pytest -n 4 --dist loadgroup   # 上のどの階層も 4 ワーカーで実行 — CI が各階層をこう実行する
 
 uv run ruff check .           # lint
 uv run ruff format .          # auto-format (append --check to verify without writing)

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=465ec4f02a22747e675bfbee6bdba48edd474a3da79ec654943c9741a747c302 -->
+<!-- gda-readme-i18n: source=README.md sha256=4a9280269cf9d3736b7e026aaeec5a30cec96824f74faa65a01b6e14b8eb4aac -->
 
 # godot-agent (`gda`): Godot AI Agent CLI, Skill, and MCP Server
 
@@ -623,6 +623,7 @@ uv sync                       # set up the environment
 uv run pytest                 # run the full suite (includes e2e tests against a real Godot)
 uv run pytest -m "not e2e"    # unit tests only (no Godot binary required)
 uv run pytest -m e2e          # only the end-to-end tests (needs Godot 4.4+ on this machine)
+uv run pytest -n 4 --dist loadgroup   # 上面任一层改为四个 worker 并行——CI 对每层都这样跑
 
 uv run ruff check .           # lint
 uv run ruff format .          # auto-format (append --check to verify without writing)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,11 @@ build-backend = "uv_build"
 dev = [
     "jsonschema>=4.26.0",
     "pytest>=9.0.3",
+    # Both pytest tiers run on four workers (`-n 4 --dist loadgroup`, #818): the
+    # suite is wall-clock bound by process waits and engine boots, not CPU. The
+    # `xdist_group("windowed")` mark keeps the tests that open a real window on
+    # one worker, so two windowed sessions never share the host display at once.
+    "pytest-xdist>=3.8.0",
     # The MCP SDK is also a dev dependency (not just the `[mcp]` extra) so
     # `uv run pytest` has it for the gda-mcp fast/e2e tiers (ADR-0013).
     "mcp>=2,<3",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,6 +87,35 @@ def project_godot(name: str = "gda-e2e-fixture", extra: str = "") -> str:
 # logging-disable rationale lives in exactly one place.
 PROJECT_GODOT = project_godot()
 
+# The live tier's scaffold: a project that names a main scene, and the two main
+# scenes its modules run. A live module needs a game to launch, so the eleven
+# that launch one (`daemon`, `game`, `input`, `screen`, `perf`, `diag`, `logger`,
+# `mcp_live`, `live_number_transport`, `write_value_fidelity` and the harness
+# install tests) take the project from here; `daemon`, `perf` and `mcp_live`
+# take the node-path scene, `diag` and `logger` the scripted one. The copies
+# they carried were one edit away from disagreeing about what "the live fixture
+# project" is, so they live here beside the builder that makes them. A module
+# whose scene is its own subject (the coloured rect `screen` captures, the bare
+# root the harness-install gate watches, the reference graph `project analysis`
+# walks) keeps that scene local — it is not a copy of anything.
+LIVE_PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
+
+# A main scene with a child node, for a live module that addresses a node path.
+LIVE_MAIN_TSCN = (
+    "[gd_scene format=3]\n\n"
+    '[node name="Main" type="Node2D"]\n\n'
+    '[node name="Player" type="Node2D" parent="."]\n'
+)
+
+# A main scene that runs `res://main.gd`, for a live module whose subject is what
+# the running game PRINTS (the session log, the runtime errors read back).
+SCRIPTED_MAIN_TSCN = (
+    "[gd_scene load_steps=2 format=3]\n\n"
+    '[ext_resource type="Script" path="res://main.gd" id="1"]\n\n'
+    '[node name="Main" type="Node2D"]\n'
+    'script = ExtResource("1")\n'
+)
+
 
 @pytest.fixture
 def godot_project(tmp_path):

--- a/tests/mcp_support.py
+++ b/tests/mcp_support.py
@@ -14,6 +14,7 @@ The fast tiers drive the surface from the **real** aggregate dump
 true mirror of the live ``gda`` surface, not a hand-stubbed subset.
 """
 
+import functools
 import warnings
 from pathlib import Path
 from typing import Callable, Optional
@@ -55,12 +56,15 @@ class FakeGdaRunner:
         return self.responder(args, stdin)
 
 
+@functools.cache
 def real_manifest_json() -> str:
     """The live ``gda schema`` manifest as JSON, built in-process (no subprocess).
 
     ``gda schema`` spawns no Godot (ADR-0012), so the manifest is produced
     directly from the Typer tree — giving the fake seam the *real* whole surface
-    to register against.
+    to register against. Built ONCE per process (#815): the surface is immutable
+    for the process lifetime (the registration tests assert exactly that for the
+    server's cache hint), and every ``schema_then`` responder used to rebuild it.
     """
     return build_surface_manifest(app).model_dump_json()
 

--- a/tests/support.py
+++ b/tests/support.py
@@ -12,12 +12,22 @@ between modules or imported test-module-to-test-module (issue #39).
 """
 
 import json
+import os
 import re
 import subprocess
 import sys
 import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
+from typer.testing import CliRunner, Result
+
+from gda.cli import app
 from gda.runner import RunResult
+
+if TYPE_CHECKING:  # the daemon imports stay deferred; the annotation does not
+    from gda.daemon.server import DaemonServer
 
 # Typer renders help and usage errors through Rich, which colorizes when it
 # believes it is on a terminal — under GitHub Actions it does, while a local
@@ -146,6 +156,14 @@ class FakeExportRunner:
         return self.output
 
 
+# The line every real engine run writes before anything a command cares about.
+# A canned stdout carries it so the fake run looks like a real one and the
+# sentinel parser has the same preamble to skip. Spelled ONCE: the version in it
+# is arbitrary fixture data, and 65 hand-typed copies made it read like a version
+# each test depended on (issue #816).
+ENGINE_BANNER = "Godot Engine v4.6.3.stable.official\n"
+
+
 def sentinel(payload: dict) -> str:
     """Wrap ``payload`` in the ADR-0002 result sentinels, as operations.gd emits."""
     return raw_sentinel(json.dumps(payload))
@@ -201,6 +219,197 @@ def inject_live_runner(monkeypatch, result: RunResult) -> FakeRunner:
         "gda.dispatch.make_live_runner", lambda binary, project=None: fake
     )
     return fake
+
+
+def recording_runner(monkeypatch, result: RunResult) -> list[Path | None]:
+    """Swap the runner seam for one that RECORDS the project it was built with.
+
+    :func:`inject_runner` throws the factory's arguments away; this keeps them.
+    The seam ``gda.dispatch.make_runner(binary, project)`` is where the resolved
+    ``--project`` becomes visible to a test, because the runner turns it into the
+    engine's ``--path`` (issue #32). Returns the list the factory appends to — one
+    entry per runner built, in order — so a caller reads the project it expects,
+    or the whole list where the number of builds is the point.
+    """
+    projects: list[Path | None] = []
+
+    def record(binary, project=None):
+        projects.append(project)
+        return FakeRunner(result)
+
+    monkeypatch.setattr("gda.dispatch.make_runner", record)
+    return projects
+
+
+def minimal_project(directory: Path) -> Path:
+    """Make ``directory`` the minimum a Godot project needs, and return it.
+
+    A ``project.godot`` holding a ``config_version`` is all that makes a directory
+    a project (ADR-0006), so this is what a command test needs whenever the CLI
+    must resolve one. The directory is created when it does not exist, so a test
+    can name a subdirectory of ``tmp_path`` in one call.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    return directory
+
+
+def invoke_cli(
+    monkeypatch,
+    argv: list[str],
+    *,
+    stdout: str = "",
+    stderr: str = "",
+    exit_code: int = 0,
+    banner: bool = True,
+    stdin: str | None = None,
+) -> tuple[Result, FakeRunner]:
+    """Run ``argv`` through the CLI against ONE canned engine run.
+
+    The invocation ritual every headless command test repeats: prefix the
+    :data:`ENGINE_BANNER` to the canned ``stdout``, swap the runner seam for a
+    :class:`FakeRunner` that replays it, and invoke the Typer app. Returns the
+    ``CliRunner`` result and the fake, so a test that only reads the result
+    writes ``result, _ = invoke_cli(...)`` and one that also checks what was
+    dispatched keeps the fake.
+
+    ``banner=False`` stages the ``stdout`` bytes ALONE. A real run always writes
+    the banner, so the default is what a test wants — except where the staged
+    stdout is itself the input under test (a frame with no result sentinel, a
+    malformed one), and adding a preamble would change the subject rather than
+    make the fixture faithful.
+
+    ``stdin`` is the text the CLI reads from standard input, for the one channel
+    that takes its payload there (``--params-json -``).
+    """
+    fake = inject_runner(
+        monkeypatch,
+        RunResult(
+            stdout=(ENGINE_BANNER + stdout) if banner else stdout,
+            stderr=stderr,
+            exit_code=exit_code,
+        ),
+    )
+    return CliRunner().invoke(app, argv, input=stdin), fake
+
+
+def invoke_operation_error(
+    monkeypatch,
+    argv: list[str],
+    code: str,
+    message: str,
+    operation: str | None = None,
+) -> Result:
+    """Run ``argv`` against an engine run that REPORTED ``code``/``message``.
+
+    The failure twin of :func:`invoke_cli`: the canned run carries an ADR-0002
+    operation-error envelope instead of a result payload, exits non-zero, and
+    writes the runner's own progress notice on stderr — which the envelope then
+    echoes as ``diagnostics``. ``operation`` names the operation in that notice;
+    leave it out where the notice names none.
+    """
+    named = f": {operation}" if operation else ""
+    return invoke_cli(
+        monkeypatch,
+        argv,
+        stdout=error_sentinel(code, message),
+        stderr=f"gda: running operation{named}\n",
+        exit_code=1,
+    )[0]
+
+
+def operation_error_invoker(
+    argv: list[str] | Callable[..., list[str]], operation: str | None = None
+) -> Callable[..., Result]:
+    """Bind one command to :func:`invoke_operation_error`.
+
+    An error-test module states a command's argv and operation name ONCE and gets
+    back an ``invoke(monkeypatch, code, message)`` its tests call, so each test
+    names only the failure it stages. ``argv`` may instead be a callable that
+    BUILDS the command line — the form a command needs whose argv varies per test
+    (a node path, a uid target); the bound invoker forwards its extra keywords to
+    that callable.
+    """
+
+    def invoke(monkeypatch, code: str, message: str, **argv_kwargs):
+        command = argv(**argv_kwargs) if callable(argv) else argv
+        return invoke_operation_error(monkeypatch, command, code, message, operation)
+
+    return invoke
+
+
+def assert_operation_error(
+    result: Result, code: str, needle: str | None = None, diagnostics: str | None = None
+) -> dict:
+    """Assert ``result`` is the operation-category failure for ``code``, and return it.
+
+    The read side of :func:`invoke_operation_error`, and the one place the ADR-0002
+    operation-failure contract is spelled: exit 4 for the category, the
+    ``operation`` category on the envelope, and the stable code an agent branches
+    on. ``needle`` additionally asserts a fragment of the message; ``diagnostics``
+    asserts the raw stderr the envelope carries, and is always passed EXPLICITLY —
+    a module that checks it says so at the call site rather than inheriting it.
+    Returns the parsed error, so a caller asserts anything further on it.
+    """
+    assert result.exit_code == 4, result.stdout
+    err = json.loads(result.stdout)["error"]
+    assert err["category"] == "operation"
+    assert err["code"] == code
+    if needle is not None:
+        assert needle in err["message"]
+    if diagnostics is not None:
+        assert err["diagnostics"] == diagnostics
+    return err
+
+
+class FakeProc:
+    """A stand-in ``subprocess.Popen``: ``poll()`` returns ``returncode``.
+
+    ``None`` means alive, so a test flips liveness by assigning ``returncode``.
+    One double for every daemon test that needs an engine process without
+    spawning one — the session only ever polls it and reads its pid.
+
+    ``pid`` is gda's OWN pid, deliberately: teardown reads the pid to find the
+    process group it owns, and the own-group guard then resolves this stand-in to
+    no group at all. An invented pid would instead resolve to whichever real
+    process holds it — which a test would then signal.
+
+    NOT :class:`RecordingSpawn`'s ``_CannedProcess``: this one answers liveness and
+    nothing else, and no test reads a stream from it. Reach for the other when the
+    subject is a SPAWN — an argv, a cwd, an environment, and real readable streams
+    for the launch primitive to drain.
+    """
+
+    pid = os.getpid()
+
+    def __init__(self, returncode: int | None = None) -> None:
+        self.returncode = returncode
+
+    def poll(self):
+        return self.returncode
+
+
+def server_with_session(
+    tmp_path: Path, log_file: Path, alive: bool = True
+) -> "DaemonServer":
+    """A ``DaemonServer`` holding a stand-in :class:`FakeProc` session.
+
+    The fixture the log-backed live reads need (``diag errors``, ``logger tail``,
+    #224/#281): the server serves them from the session's remembered log file, so
+    the test writes a log and asks the server, with no engine and no socket.
+    ``alive`` decides whether the session's process still polls as running.
+    """
+    from gda.daemon.discovery import daemon_paths
+    from gda.daemon.server import DaemonServer
+    from gda.daemon.session import EngineSession
+
+    server = DaemonServer(daemon_paths(minimal_project(tmp_path)), godot="godot")
+    server._session = EngineSession(
+        cast(subprocess.Popen, FakeProc(None if alive else 0)),
+        conn=None,
+        log_file=log_file,
+    )
+    return server
 
 
 def capture_receipt_reply(**overrides) -> dict:
@@ -1046,7 +1255,12 @@ class RecordingSpawn:
 
 
 class _CannedProcess:
-    """The child :class:`RecordingSpawn` hands back — see its docstring."""
+    """The child :class:`RecordingSpawn` hands back — see its docstring.
+
+    The heavier of the two process doubles: real readable streams, a wait that can
+    time out, a terminate that ends it. A daemon test that only needs the session
+    to answer "still alive?" wants :class:`FakeProc` instead.
+    """
 
     def __init__(
         self, stdout: bytes, stderr: bytes, returncode: int, *, alive: bool

--- a/tests/support.py
+++ b/tests/support.py
@@ -17,12 +17,13 @@ import re
 import subprocess
 import sys
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from typer.testing import CliRunner, Result
 
+from gda.binary import resolve_godot_binary
 from gda.cli import app
 from gda.runner import RunResult
 
@@ -108,11 +109,193 @@ def assert_no_pydantic_dump(message: str) -> None:
 GDA_CMD = [sys.executable, "-m", "gda"]
 
 
-def templates_installed(gda, preset: str = "Linux/X11") -> bool:
+# The Godot binary the e2e tier drives, resolved ONCE for the whole tier by the
+# same precedence gda itself uses (``--godot`` > ``$GDA_GODOT`` > the RULES.md
+# default). Every e2e module used to resolve its own copy; one constant keeps the
+# path a test passes as ``--godot`` and the path ``conftest`` gates the tier on
+# from drifting apart.
+GODOT = resolve_godot_binary()
+
+# What one `gda` e2e spawn waits before the test calls it wedged. Long enough for
+# a real engine to boot, import and answer on a loaded machine; short enough that
+# a wedged engine fails one test instead of hanging the whole tier. A call that
+# legitimately needs longer states its own bound; no spawn goes unbounded.
+DEFAULT_TIMEOUT = 90.0
+
+
+class Gda:
+    """The e2e tier's one out-of-process ``gda`` invoker.
+
+    Every e2e spawn goes through here, so the tier has ONE adapter over the
+    ``[sys.executable, "-m", "gda"]`` seam (:data:`GDA_CMD`, #299) instead of a
+    per-module copy of :func:`subprocess.run`. Out of process is the point: the
+    e2e tier proves the shipped CLI, not an in-process Typer call.
+
+    An instance BINDS what a module repeats — the project, the engine, the child
+    environment, the working directory, the timeout, and whether ``--json`` is
+    baked in — and exposes three forms over that binding:
+
+    * calling it runs the command and returns the raw
+      :class:`subprocess.CompletedProcess`, for a test that reads an exit code,
+      a stream, or a failure of any category;
+    * :meth:`json` asserts the run succeeded and returns the parsed result;
+    * :meth:`error` asserts the ADR-0002 operation-failure envelope for one
+      :term:`Gda error code` and returns the parsed error.
+
+    ``project=None`` builds the project-less form the commands that resolve no
+    project need (``gda version``, ``gda info --godot``, the "no project"
+    refusals); ``godot=None`` drops ``--godot`` for the few tests that spell the
+    engine themselves or read it from ``$GDA_GODOT``.
+
+    Bound options are appended AFTER the command's own argv, in the
+    ``--project``, ``--godot``, ``--json`` order, because a few tests read a
+    target relative to the working directory and the placement of the target
+    among the options is part of what they exercise.
+    """
+
+    def __init__(
+        self,
+        project: Path | str | None = None,
+        *,
+        godot: Path | str | None = GODOT,
+        json_output: bool = False,
+        env: Mapping[str, str] | None = None,
+        extra_env: Mapping[str, str] | None = None,
+        cwd: Path | str | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> None:
+        tail: list[str] = []
+        if project is not None:
+            tail += ["--project", str(project)]
+        if godot is not None:
+            tail += ["--godot", str(godot)]
+        if json_output:
+            tail.append("--json")
+        self._tail = tail
+        self._json_output = json_output
+        self._env = env
+        self._extra_env = extra_env
+        self._cwd = cwd
+        self._timeout = timeout
+
+    def __call__(
+        self,
+        *args: str,
+        cwd: Path | str | None = None,
+        timeout: float | None = None,
+        extra_env: Mapping[str, str] | None = None,
+        stdin: str | None = None,
+        retry: bool = False,
+    ) -> "subprocess.CompletedProcess[str]":
+        """Run ``gda <args>`` and return the finished process.
+
+        ``cwd``, ``timeout`` and ``extra_env`` override the binding for this one
+        call; ``stdin`` is the text the CLI reads from standard input (the
+        ``--params-json -`` channel). ``retry`` re-runs once on a transient
+        ``engine_crashed`` — a shared-``user://`` log race under parallel e2e,
+        not a gda bug (#180) — so a happy path does not flake on it.
+
+        ``extra_env`` reaches the ENGINE too: the CLI passes no ``env=`` to its
+        own Godot subprocess, so the engine inherits whatever gda was given —
+        the channel the production-inert ``GDA_TEST_PERTURB_BEFORE_SAVE`` test
+        seam rides on (issue #226).
+        """
+        argv = [*GDA_CMD, *args, *self._tail]
+        cwd = self._cwd if cwd is None else cwd
+        proc = self._spawn(
+            argv,
+            cwd=cwd,
+            timeout=self._timeout if timeout is None else timeout,
+            extra_env=extra_env,
+            stdin=stdin,
+        )
+        if retry and proc.returncode != 0 and _run_error_code(proc) == "engine_crashed":
+            proc = self._spawn(
+                argv,
+                cwd=cwd,
+                timeout=self._timeout if timeout is None else timeout,
+                extra_env=extra_env,
+                stdin=stdin,
+            )
+        return proc
+
+    def json(self, *args: str, **overrides) -> dict:
+        """Run ``gda <args> --json``, assert it succeeded, and return the result."""
+        proc = self(*self._with_json(args), **overrides)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        return json.loads(proc.stdout)
+
+    def error(self, *args: str, code: str, **overrides) -> dict:
+        """Run ``gda <args> --json`` and assert it failed the operation with ``code``."""
+        return assert_operation_error(self(*self._with_json(args), **overrides), code)
+
+    def _with_json(self, args: tuple[str, ...]) -> tuple[str, ...]:
+        """``args`` guaranteed to ask for JSON, which both parsing forms need."""
+        if self._json_output or "--json" in args:
+            return args
+        return (*args, "--json")
+
+    def _spawn(
+        self,
+        argv: list[str],
+        *,
+        cwd: Path | str | None,
+        timeout: float,
+        extra_env: Mapping[str, str] | None,
+        stdin: str | None,
+    ) -> "subprocess.CompletedProcess[str]":
+        extra = {**(self._extra_env or {}), **(extra_env or {})}
+        if self._env is not None:
+            env = {**self._env, **extra}
+        else:
+            env = {**os.environ, **extra} if extra else None
+        return subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=None if cwd is None else str(cwd),
+            timeout=timeout,
+            input=stdin,
+        )
+
+
+def _run_error_code(proc: "subprocess.CompletedProcess[str]") -> str | None:
+    """The ``Gda error code`` a finished run reported, or ``None`` if it reported none."""
+    try:
+        return json.loads(proc.stdout)["error"]["code"]
+    except (ValueError, KeyError, TypeError):
+        return None
+
+
+def import_project(
+    project: Path | str, *, timeout: float = 180.0
+) -> "subprocess.CompletedProcess[str]":
+    """Run the engine's headless import pass over ``project``, and assert it passed.
+
+    The precondition several e2e scenarios need: a ``class_name`` registers in
+    ``.godot/global_script_class_list.cfg``, and a UID resolves through the UID
+    cache, only after a project scan — the step a CI pipeline runs before using
+    either. The engine's exit code is asserted here, so an import that failed
+    surfaces as itself rather than as a confusing later assertion about a class
+    name that was never registered. The finished process is returned for the
+    caller that reads what the pass printed.
+    """
+    imported = subprocess.run(
+        [str(GODOT), "--headless", "--path", str(project), "--import"],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    assert imported.returncode == 0, imported.stdout + imported.stderr
+    return imported
+
+
+def templates_installed(gda: Gda, preset: str = "Linux/X11") -> bool:
     """Whether the running engine has export templates, via ``gda export get``.
 
-    ``gda`` is a bound ``gda <args> --json`` callable (e.g. the e2e tests'
-    ``_gda_project``). The single source of truth for the e2e template-presence
+    ``gda`` is a project-bound :class:`Gda`. The single source of truth for the
+    e2e template-presence
     policy, shared by the export-run happy-path skip and the harness template-gate
     behavioural proof (#301). ``preset`` only needs to NAME a preset that exists in
     the project so ``export get`` succeeds; the verdict itself is preset-independent
@@ -121,9 +304,7 @@ def templates_installed(gda, preset: str = "Linux/X11") -> bool:
     version dir present but the host platform's file missing still sees ``True`` and
     must tolerate the export failing later.
     """
-    got = gda("export", "get", "--preset", preset, "--json")
-    assert got.returncode == 0, got.stdout + got.stderr
-    return json.loads(got.stdout)["templates_installed"]
+    return gda.json("export", "get", "--preset", preset)["templates_installed"]
 
 
 class FakeRunner:
@@ -339,7 +520,10 @@ def operation_error_invoker(
 
 
 def assert_operation_error(
-    result: Result, code: str, needle: str | None = None, diagnostics: str | None = None
+    result: "Result | subprocess.CompletedProcess[str]",
+    code: str,
+    needle: str | None = None,
+    diagnostics: str | None = None,
 ) -> dict:
     """Assert ``result`` is the operation-category failure for ``code``, and return it.
 
@@ -350,9 +534,23 @@ def assert_operation_error(
     asserts the raw stderr the envelope carries, and is always passed EXPLICITLY —
     a module that checks it says so at the call site rather than inheriting it.
     Returns the parsed error, so a caller asserts anything further on it.
+
+    Both tiers' invocation results are read: a Typer ``Result`` from an in-process
+    CLI call, and a finished ``CompletedProcess`` from an e2e :class:`Gda` spawn
+    (which is where :meth:`Gda.error` lands). The contract asserted is the same
+    envelope either way; only where the exit code sits, and how much of the run to
+    quote when the assertion fails, differ.
     """
-    assert result.exit_code == 4, result.stdout
-    err = json.loads(result.stdout)["error"]
+    if isinstance(result, subprocess.CompletedProcess):
+        exit_code, stdout, evidence = (
+            result.returncode,
+            result.stdout,
+            result.stdout + result.stderr,
+        )
+    else:
+        exit_code, stdout, evidence = result.exit_code, result.stdout, result.stdout
+    assert exit_code == 4, evidence
+    err = json.loads(stdout)["error"]
     assert err["category"] == "operation"
     assert err["code"] == code
     if needle is not None:

--- a/tests/test_asset_file_commands.py
+++ b/tests/test_asset_file_commands.py
@@ -10,17 +10,14 @@ edit-mode interface is the script set interface (issue #118), reused here.
 
 import json
 
-from typer.testing import CliRunner
 
-from gda.cli import app
 from gda.commands.script import ScriptSetMode
-from gda.runner import RunResult
 from tests.support import (
     SHADER_CREATE_RESULT,
     SHADER_GET_RESULT,
     SHADER_SET_RESULT,
     THEME_CREATE_RESULT,
-    inject_runner,
+    invoke_cli,
     sentinel,
 )
 
@@ -29,13 +26,8 @@ from tests.support import (
 
 def test_shader_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
     # Engine banner noise around the sentinel, diagnostics on stderr (ADR-0002).
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(SHADER_CREATE_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "shader",
             "create",
@@ -44,6 +36,8 @@ def test_shader_create_json_maps_success_to_json_object_and_exit_zero(monkeypatc
             "canvas_item",
             "--json",
         ],
+        stdout=sentinel(SHADER_CREATE_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -68,13 +62,10 @@ def test_shader_create_json_maps_success_to_json_object_and_exit_zero(monkeypatc
 def test_shader_create_default_template_passes_null_content_and_type(monkeypatch):
     # The bare template: no --content, no --shader-type. Both pass through as
     # null, so the operation writes its default canvas_item template.
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_CREATE_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["shader", "create", "/tmp/proj/wave.gdshader", "--json"]
+        ["shader", "create", "/tmp/proj/wave.gdshader", "--json"],
+        stdout=sentinel(SHADER_CREATE_RESULT),
     )
 
     assert result.exit_code == 0
@@ -87,23 +78,8 @@ def test_shader_create_default_template_passes_null_content_and_type(monkeypatch
 
 
 def test_shader_create_content_passes_verbatim_source(monkeypatch):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=sentinel(
-                {
-                    "path": "/tmp/proj/x.gdshader",
-                    "shader_type": "spatial",
-                    "created_dirs": [],
-                }
-            ),
-            stderr="",
-            exit_code=0,
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "shader",
             "create",
@@ -112,6 +88,13 @@ def test_shader_create_content_passes_verbatim_source(monkeypatch):
             "shader_type spatial;\n",
             "--json",
         ],
+        stdout=sentinel(
+            {
+                "path": "/tmp/proj/x.gdshader",
+                "shader_type": "spatial",
+                "created_dirs": [],
+            }
+        ),
     )
 
     assert result.exit_code == 0
@@ -130,13 +113,8 @@ def test_shader_create_content_passes_verbatim_source(monkeypatch):
 def test_shader_create_content_and_type_are_mutually_exclusive(monkeypatch):
     # Verbatim content is not templated, so a shader_type has nowhere to go;
     # supplying both is a usage error (exit 2), never a silent precedence rule.
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_CREATE_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "shader",
             "create",
@@ -147,6 +125,7 @@ def test_shader_create_content_and_type_are_mutually_exclusive(monkeypatch):
             "spatial",
             "--json",
         ],
+        stdout=sentinel(SHADER_CREATE_RESULT),
     )
 
     assert result.exit_code == 2
@@ -160,11 +139,10 @@ def test_shader_create_content_and_type_are_mutually_exclusive(monkeypatch):
 def test_shader_get_json_emits_source_and_metadata_and_exit_zero(monkeypatch):
     # shader get is the verifier (issue #115): it reads a shader's source back as
     # raw text with its shader_type, so a create round-trips.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(SHADER_GET_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["shader", "get", "/tmp/proj/wave.gdshader", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["shader", "get", "/tmp/proj/wave.gdshader", "--json"],
+        stdout=sentinel(SHADER_GET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -181,13 +159,8 @@ def test_shader_set_search_replace_dispatches_search_and_replace(monkeypatch):
     # search-replace mode: --search/--replace ride through; the other mode params
     # pass as null. The CLI resolves the edit mode once and stamps the explicit
     # `mode` discriminator (issue #133) — the SAME ScriptSetMode as script set.
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "shader",
             "set",
@@ -198,6 +171,7 @@ def test_shader_set_search_replace_dispatches_search_and_replace(monkeypatch):
             "spatial",
             "--json",
         ],
+        stdout=sentinel(SHADER_SET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -218,13 +192,8 @@ def test_shader_set_search_replace_dispatches_search_and_replace(monkeypatch):
 
 
 def test_shader_set_line_range_dispatches_start_end_and_content(monkeypatch):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "shader",
             "set",
@@ -237,6 +206,7 @@ def test_shader_set_line_range_dispatches_start_end_and_content(monkeypatch):
             "shader_type spatial;",
             "--json",
         ],
+        stdout=sentinel(SHADER_SET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -257,13 +227,8 @@ def test_shader_set_line_range_dispatches_start_end_and_content(monkeypatch):
 
 
 def test_shader_set_full_overwrite_dispatches_content_only(monkeypatch):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "shader",
             "set",
@@ -272,6 +237,7 @@ def test_shader_set_full_overwrite_dispatches_content_only(monkeypatch):
             "shader_type spatial;\n",
             "--json",
         ],
+        stdout=sentinel(SHADER_SET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -299,39 +265,28 @@ def _assert_set_usage_error(fake, result):
 
 
 def test_shader_set_no_flags_is_a_usage_error(monkeypatch):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["shader", "set", "/tmp/proj/wave.gdshader", "--json"]
+        ["shader", "set", "/tmp/proj/wave.gdshader", "--json"],
+        stdout=sentinel(SHADER_SET_RESULT),
     )
 
     _assert_set_usage_error(fake, result)
 
 
 def test_shader_set_search_without_replace_is_a_usage_error(monkeypatch):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["shader", "set", "/tmp/proj/wave.gdshader", "--search", "x", "--json"]
+        ["shader", "set", "/tmp/proj/wave.gdshader", "--search", "x", "--json"],
+        stdout=sentinel(SHADER_SET_RESULT),
     )
 
     _assert_set_usage_error(fake, result)
 
 
 def test_shader_set_search_replace_and_content_are_mutually_exclusive(monkeypatch):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "shader",
             "set",
@@ -344,6 +299,7 @@ def test_shader_set_search_replace_and_content_are_mutually_exclusive(monkeypatc
             "z",
             "--json",
         ],
+        stdout=sentinel(SHADER_SET_RESULT),
     )
 
     _assert_set_usage_error(fake, result)
@@ -353,12 +309,12 @@ def test_shader_set_search_replace_and_content_are_mutually_exclusive(monkeypatc
 
 
 def test_theme_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(THEME_CREATE_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["theme", "create", "/tmp/proj/ui.tres", "--json"],
+        stdout=sentinel(THEME_CREATE_RESULT),
+        stderr="engine diagnostic\n",
     )
-
-    result = CliRunner().invoke(app, ["theme", "create", "/tmp/proj/ui.tres", "--json"])
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -372,12 +328,11 @@ def test_theme_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch
 
 
 def test_shader_create_human_output(monkeypatch):
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_CREATE_RESULT), stderr="", exit_code=0),
+        ["shader", "create", "/tmp/proj/wave.gdshader"],
+        stdout=sentinel(SHADER_CREATE_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["shader", "create", "/tmp/proj/wave.gdshader"])
 
     assert result.exit_code == 0
     assert (
@@ -387,12 +342,11 @@ def test_shader_create_human_output(monkeypatch):
 
 
 def test_shader_get_human_output_renders_metadata_then_source(monkeypatch):
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_GET_RESULT), stderr="", exit_code=0),
+        ["shader", "get", "/tmp/proj/wave.gdshader"],
+        stdout=sentinel(SHADER_GET_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["shader", "get", "/tmp/proj/wave.gdshader"])
 
     assert result.exit_code == 0
     assert "/tmp/proj/wave.gdshader (shader_type canvas_item)" in result.stdout
@@ -400,13 +354,10 @@ def test_shader_get_human_output_renders_metadata_then_source(monkeypatch):
 
 
 def test_shader_set_human_output_renders_metadata(monkeypatch):
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_SET_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["shader", "set", "/tmp/proj/wave.gdshader", "--content", "x"]
+        ["shader", "set", "/tmp/proj/wave.gdshader", "--content", "x"],
+        stdout=sentinel(SHADER_SET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -414,12 +365,11 @@ def test_shader_set_human_output_renders_metadata(monkeypatch):
 
 
 def test_theme_create_human_output(monkeypatch):
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(THEME_CREATE_RESULT), stderr="", exit_code=0),
+        ["theme", "create", "/tmp/proj/ui.tres"],
+        stdout=sentinel(THEME_CREATE_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["theme", "create", "/tmp/proj/ui.tres"])
 
     assert result.exit_code == 0
     assert result.stdout.strip() == "created /tmp/proj/ui.tres (Theme)"

--- a/tests/test_asset_file_errors.py
+++ b/tests/test_asset_file_errors.py
@@ -10,51 +10,24 @@ no_search_match / invalid_line_range) rather than minting parallel ones, exactly
 as the script group did.
 """
 
-import json
+from tests.support import assert_operation_error, operation_error_invoker
 
-from typer.testing import CliRunner
+_shader_create = operation_error_invoker(
+    ["shader", "create", "/x/wave.gdshader", "--json"], "shader-create"
+)
 
-from gda.cli import app
-from gda.runner import RunResult
-from tests.support import error_sentinel, inject_runner
+_shader_get = operation_error_invoker(
+    ["shader", "get", "/x/wave.gdshader", "--json"], "shader-get"
+)
 
+_shader_set = operation_error_invoker(
+    ["shader", "set", "/x/wave.gdshader", "--search", "a", "--replace", "b", "--json"],
+    "shader-set",
+)
 
-def _invoke(monkeypatch, argv, code, message, op):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr=f"gda: running operation: {op}\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, argv)
-
-
-def _create_argv():
-    return ["shader", "create", "/x/wave.gdshader", "--json"]
-
-
-def _get_argv():
-    return ["shader", "get", "/x/wave.gdshader", "--json"]
-
-
-def _set_argv():
-    return [
-        "shader",
-        "set",
-        "/x/wave.gdshader",
-        "--search",
-        "a",
-        "--replace",
-        "b",
-        "--json",
-    ]
-
-
-def _theme_argv():
-    return ["theme", "create", "/x/ui.tres", "--json"]
+_theme_create = operation_error_invoker(
+    ["theme", "create", "/x/ui.tres", "--json"], "theme-create"
+)
 
 
 # --- shader create: path collision (no-clobber) + wrong extension ----------
@@ -64,95 +37,61 @@ def test_shader_create_collision_reuses_stable_already_exists_code(monkeypatch):
     # No-clobber: a create whose target already exists reuses the registered
     # already_exists code (the same one scene/script create use), leaving the
     # file untouched — the shader group mints no parallel collision code.
-    result = _invoke(
-        monkeypatch,
-        _create_argv(),
-        "already_exists",
-        "shader target already exists: /x/wave.gdshader",
-        "shader-create",
+    result = _shader_create(
+        monkeypatch, "already_exists", "shader target already exists: /x/wave.gdshader"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "already_exists"
-    assert "/x/wave.gdshader" in err["message"]
-    assert err["diagnostics"] == "gda: running operation: shader-create\n"
+    assert_operation_error(
+        result,
+        "already_exists",
+        "/x/wave.gdshader",
+        diagnostics="gda: running operation: shader-create\n",
+    )
 
 
 def test_shader_create_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
-    result = _invoke(
-        monkeypatch,
-        _create_argv(),
-        "invalid_path",
-        "shader path must end in .gdshader: /x/wave.txt",
-        "shader-create",
+    result = _shader_create(
+        monkeypatch, "invalid_path", "shader path must end in .gdshader: /x/wave.txt"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "invalid_path"
-    assert ".gdshader" in err["message"]
+    assert_operation_error(result, "invalid_path", ".gdshader")
 
 
 def test_shader_create_unwritable_target_reuses_stable_save_failed_code(monkeypatch):
-    result = _invoke(
-        monkeypatch,
-        _create_argv(),
-        "save_failed",
-        "failed to save shader to /x/wave.gdshader",
-        "shader-create",
+    result = _shader_create(
+        monkeypatch, "save_failed", "failed to save shader to /x/wave.gdshader"
     )
 
-    assert result.exit_code == 4
-    assert json.loads(result.stdout)["error"]["code"] == "save_failed"
+    assert_operation_error(result, "save_failed")
 
 
 # --- shader get/set: file not found + wrong extension ----------------------
 
 
 def test_shader_get_missing_file_reuses_stable_path_not_found_code(monkeypatch):
-    result = _invoke(
-        monkeypatch,
-        _get_argv(),
-        "path_not_found",
-        "shader file does not exist: /x/wave.gdshader",
-        "shader-get",
+    result = _shader_get(
+        monkeypatch, "path_not_found", "shader file does not exist: /x/wave.gdshader"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/wave.gdshader" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/wave.gdshader")
 
 
 def test_shader_get_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
-    result = _invoke(
-        monkeypatch,
-        _get_argv(),
-        "invalid_path",
-        "shader path must end in .gdshader: /x/notes.txt",
-        "shader-get",
+    result = _shader_get(
+        monkeypatch, "invalid_path", "shader path must end in .gdshader: /x/notes.txt"
     )
 
-    assert result.exit_code == 4
-    assert json.loads(result.stdout)["error"]["code"] == "invalid_path"
+    assert_operation_error(result, "invalid_path")
 
 
 def test_shader_set_missing_file_reuses_stable_path_not_found_code(monkeypatch):
     # set edits an existing shader; a missing target is path_not_found, never a
     # silent create (the same rule as script set).
-    result = _invoke(
-        monkeypatch,
-        _set_argv(),
-        "path_not_found",
-        "shader file does not exist: /x/wave.gdshader",
-        "shader-set",
+    result = _shader_set(
+        monkeypatch, "path_not_found", "shader file does not exist: /x/wave.gdshader"
     )
 
-    assert result.exit_code == 4
-    assert json.loads(result.stdout)["error"]["code"] == "path_not_found"
+    assert_operation_error(result, "path_not_found")
 
 
 # --- shader set: bad edit range / no search-replace match (reused codes) ----
@@ -162,80 +101,47 @@ def test_shader_set_no_search_match_maps_to_stable_no_search_match_code(monkeypa
     # search-replace mode: a search string the source does not contain is the
     # registered no_search_match code (reused from script set), so an agent
     # learns the edit landed nowhere rather than parsing prose.
-    result = _invoke(
-        monkeypatch,
-        _set_argv(),
-        "no_search_match",
-        'search string not found in shader: "xyzzy"',
-        "shader-set",
+    result = _shader_set(
+        monkeypatch, "no_search_match", 'search string not found in shader: "xyzzy"'
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "no_search_match"
-    assert "xyzzy" in err["message"]
+    assert_operation_error(result, "no_search_match", "xyzzy")
 
 
 def test_shader_set_invalid_line_range_maps_to_stable_invalid_line_range_code(
     monkeypatch,
 ):
-    result = _invoke(
+    result = _shader_set(
         monkeypatch,
-        _set_argv(),
         "invalid_line_range",
         "line range 5..9 is outside the shader's bounds (1..3) or ends before it starts",
-        "shader-set",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "invalid_line_range"
-    assert "1..3" in err["message"]
+    assert_operation_error(result, "invalid_line_range", "1..3")
 
 
 # --- theme create: path collision + wrong extension ------------------------
 
 
 def test_theme_create_collision_reuses_stable_already_exists_code(monkeypatch):
-    result = _invoke(
-        monkeypatch,
-        _theme_argv(),
-        "already_exists",
-        "theme target already exists: /x/ui.tres",
-        "theme-create",
+    result = _theme_create(
+        monkeypatch, "already_exists", "theme target already exists: /x/ui.tres"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "already_exists"
-    assert "/x/ui.tres" in err["message"]
+    assert_operation_error(result, "already_exists", "/x/ui.tres")
 
 
 def test_theme_create_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
-    result = _invoke(
-        monkeypatch,
-        _theme_argv(),
-        "invalid_path",
-        "theme path must end in .tres: /x/ui.txt",
-        "theme-create",
+    result = _theme_create(
+        monkeypatch, "invalid_path", "theme path must end in .tres: /x/ui.txt"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "invalid_path"
-    assert ".tres" in err["message"]
+    assert_operation_error(result, "invalid_path", ".tres")
 
 
 def test_theme_create_unwritable_target_reuses_stable_save_failed_code(monkeypatch):
-    result = _invoke(
-        monkeypatch,
-        _theme_argv(),
-        "save_failed",
-        "failed to save theme to /x/ui.tres",
-        "theme-create",
+    result = _theme_create(
+        monkeypatch, "save_failed", "failed to save theme to /x/ui.tres"
     )
 
-    assert result.exit_code == 4
-    assert json.loads(result.stdout)["error"]["code"] == "save_failed"
+    assert_operation_error(result, "save_failed")

--- a/tests/test_daemon_diag.py
+++ b/tests/test_daemon_diag.py
@@ -24,37 +24,21 @@ from gda.daemon.protocol import write_frame
 from gda.daemon.server import DaemonServer
 from gda.daemon.session import EngineSession, SceneMismatch, launch_session
 from gda.parser import parse_result
-from tests.support import no_engine_teardown
+from tests.support import (
+    FakeProc,
+    minimal_project,
+    no_engine_teardown,
+    server_with_session,
+)
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
-
-
-class _FakeProc:
-    """A stand-in subprocess.Popen: ``poll()`` returns ``returncode`` (None = alive)."""
-
-    def __init__(self, returncode=None):
-        self.returncode = returncode
-
-    def poll(self):
-        return self.returncode
-
-    # gda's OWN pid, deliberately: teardown reads the pid to find the process
-    # group it owns, and the own-group guard then resolves this stand-in to no
-    # group at all. An invented pid would instead resolve to whichever real
-    # process holds it — which a test would then signal.
-    pid = os.getpid()
-
-
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
 
 
 # --- Slice 1: launch carries --log-file and the session remembers the path ---
 
 
 def test_launch_session_passes_log_file_arg_and_remembers_path(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     log_file = tmp_path / "session.log"
     captured = {}
 
@@ -100,7 +84,7 @@ def test_launch_session_passes_log_file_arg_and_remembers_path(monkeypatch, tmp_
 def test_engine_session_exposes_its_log_file_path(tmp_path):
     log_file = tmp_path / "s.log"
     session = EngineSession(
-        cast(subprocess.Popen, _FakeProc()), conn=None, log_file=log_file
+        cast(subprocess.Popen, FakeProc()), conn=None, log_file=log_file
     )
     assert session.log_file == log_file
 
@@ -143,7 +127,7 @@ def _capture_launch_argv(monkeypatch, project, **launch_kw):
 
 
 def test_launch_session_inserts_scene_before_path_when_set(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     argv = _capture_launch_argv(monkeypatch, project, scene="res://B.tscn")
 
     # `--scene <path>` is an ENGINE option: present, paired, and BEFORE `--path`
@@ -163,7 +147,7 @@ def test_launch_session_inserts_scene_before_path_when_set(monkeypatch, tmp_path
 def test_launch_session_accepts_a_uid_scene_selector(monkeypatch, tmp_path):
     # Godot's `--scene` accepts a `uid://…` value too; the launch passes it through
     # verbatim in the same engine-option slot AND in the harness tail.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     argv = _capture_launch_argv(monkeypatch, project, scene="uid://abc123")
 
     assert argv[argv.index("--scene") + 1] == "uid://abc123"
@@ -175,7 +159,7 @@ def test_launch_session_omits_scene_by_default(monkeypatch, tmp_path):
     # No selector: behaviour unchanged — the engine runs the project's main_scene,
     # so no `--scene` engine option appears in the argv. The harness tail still
     # carries a slot for the selector — an EMPTY string (no selector requested).
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     argv = _capture_launch_argv(monkeypatch, project)
 
     assert "--scene" not in argv
@@ -213,7 +197,7 @@ def _launch_with_fake_harness(monkeypatch, tmp_path, *, token, verify, scene):
     second frame. Returns the launch_session outcome (or the raised exception class
     via pytest.raises in the caller).
     """
-    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc())
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: FakeProc())
     no_engine_teardown(monkeypatch)
     daemon_end, harness_end = socket.socketpair()
     # The harness presents its token, then the scene-verification frame.
@@ -240,7 +224,7 @@ def _launch_with_fake_harness(monkeypatch, tmp_path, *, token, verify, scene):
 
 
 def test_launch_returns_verified_session_when_scene_ok(monkeypatch, tmp_path):
-    _project(tmp_path)
+    minimal_project(tmp_path)
     session = _launch_with_fake_harness(
         monkeypatch,
         tmp_path,
@@ -252,7 +236,7 @@ def test_launch_returns_verified_session_when_scene_ok(monkeypatch, tmp_path):
 
 
 def test_launch_raises_scene_mismatch_when_loaded_scene_differs(monkeypatch, tmp_path):
-    _project(tmp_path)
+    minimal_project(tmp_path)
     with pytest.raises(SceneMismatch):
         _launch_with_fake_harness(
             monkeypatch,
@@ -268,7 +252,7 @@ def test_launch_with_no_selector_does_not_require_a_verification_frame(
 ):
     # No selector: scene_ok is trivially true (the harness sends it as ok), and the
     # session is verified — the main_scene default is unchanged.
-    _project(tmp_path)
+    minimal_project(tmp_path)
     session = _launch_with_fake_harness(
         monkeypatch,
         tmp_path,
@@ -280,10 +264,10 @@ def test_launch_with_no_selector_does_not_require_a_verification_frame(
 
 
 def test_launch_returns_none_on_bad_token(monkeypatch, tmp_path):
-    _project(tmp_path)
+    minimal_project(tmp_path)
     # A wrong token aborts the handshake BEFORE the verification frame: a generic
     # launch failure (None), distinct from a scene mismatch.
-    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc())
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: FakeProc())
     no_engine_teardown(monkeypatch)
     daemon_end, harness_end = socket.socketpair()
     write_frame(harness_end, b"WRONG")
@@ -321,10 +305,10 @@ class _NoAcceptListener:
 def test_failed_launch_records_signal_death_when_child_already_died(
     monkeypatch, tmp_path
 ):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     # A child that reports it aborted by SIGABRT (returncode -6) — what a windowed
     # session with no usable DisplayServer does before the harness can connect.
-    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc(-6))
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: FakeProc(-6))
     no_engine_teardown(monkeypatch)
 
     diagnostics: list[str] = []
@@ -347,10 +331,10 @@ def test_failed_launch_records_signal_death_when_child_already_died(
 def test_failed_launch_records_harness_hung_when_child_still_alive(
     monkeypatch, tmp_path
 ):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     # A child still alive (poll() is None) when the harness never connected: the
     # "engine up, harness hung" case, distinct from a crashed child.
-    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc(None))
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: FakeProc(None))
     no_engine_teardown(monkeypatch)
 
     diagnostics: list[str] = []
@@ -377,14 +361,14 @@ def test_failed_launch_diagnostics_excludes_stale_session_log(
     # the deterministic session-log path. If a PREVIOUS session left content there, it
     # must NOT leak into the current failure's diagnostics. launch_session truncates
     # the log BEFORE spawning, so the tail reads EMPTY for a pre-logger abort.
-    server = DaemonServer(daemon_paths(_project(tmp_path)), godot="godot")
+    server = DaemonServer(daemon_paths(minimal_project(tmp_path)), godot="godot")
     log_path = server.paths.session_log
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_path.write_text("STALE-PREVIOUS-SESSION-OUTPUT", encoding="utf-8")
 
     # A REAL launch_session runs (truncating the log), spawns a fake child that dies
     # pre-logger by SIGABRT and writes nothing, and no harness connects -> None.
-    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _FakeProc(-6))
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: FakeProc(-6))
     no_engine_teardown(monkeypatch)
     server._harness_listener = cast(socket.socket, _NoAcceptListener())
 
@@ -404,22 +388,12 @@ def test_failed_launch_diagnostics_excludes_stale_session_log(
 # --- Slice 2: the daemon serves diag from the remembered log file ---
 
 
-def _server_with_session(tmp_path, log_file, alive=True):
-    server = DaemonServer(daemon_paths(_project(tmp_path)), godot="godot")
-    server._session = EngineSession(
-        cast(subprocess.Popen, _FakeProc(None if alive else 0)),
-        conn=None,
-        log_file=log_file,
-    )
-    return server
-
-
 def test_diag_errors_reads_structured_errors_from_the_log(tmp_path):
     log_file = tmp_path / "session.log"
     log_file.write_text(
         "print output\nERROR: boom\n   at: _ready (res://main.gd:9)\n", encoding="utf-8"
     )
-    server = _server_with_session(tmp_path, log_file)
+    server = server_with_session(tmp_path, log_file)
 
     reply = server._handle({"op": "diag-errors", "params": {}})
     assert reply is not None
@@ -437,7 +411,7 @@ def test_diag_errors_limit_tails_the_most_recent_n(tmp_path):
         "ERROR: one\n   at: a (res://a.gd:1)\nERROR: two\n   at: b (res://b.gd:2)\n",
         encoding="utf-8",
     )
-    server = _server_with_session(tmp_path, log_file)
+    server = server_with_session(tmp_path, log_file)
 
     reply = server._handle({"op": "diag-errors", "params": {"limit": 1}})
     assert reply is not None
@@ -454,7 +428,7 @@ def test_diag_serves_even_when_the_session_process_has_died(tmp_path):
     log_file.write_text(
         "ERROR: crashed\n   at: _ready (res://main.gd:3)\n", encoding="utf-8"
     )
-    server = _server_with_session(tmp_path, log_file, alive=False)
+    server = server_with_session(tmp_path, log_file, alive=False)
 
     reply = server._handle({"op": "diag-errors", "params": {}})
     assert reply is not None
@@ -466,7 +440,7 @@ def test_diag_serves_even_when_the_session_process_has_died(tmp_path):
 def test_diag_empty_log_is_an_empty_result_not_an_error(tmp_path):
     log_file = tmp_path / "session.log"
     log_file.write_text("", encoding="utf-8")
-    server = _server_with_session(tmp_path, log_file)
+    server = server_with_session(tmp_path, log_file)
 
     errors_reply = server._handle({"op": "diag-errors", "params": {}})
     assert errors_reply is not None
@@ -483,7 +457,7 @@ def test_diag_with_no_session_launched_is_engine_session_not_running(
     # spawn an engine session as a side effect, even with a Godot binary set (that
     # hidden project-code-execution side effect is the bug under ADR-0009).
     op = "diag-errors"
-    server = DaemonServer(daemon_paths(_project(tmp_path)), godot="godot")
+    server = DaemonServer(daemon_paths(minimal_project(tmp_path)), godot="godot")
 
     # Trip-wire: if diag tries to launch a session, fail loudly.
     def _boom(*args, **kwargs):
@@ -506,7 +480,7 @@ def test_diag_with_a_remembered_session_but_missing_file_is_live_log_unavailable
 ):
     # A session was launched (remembered) but its log file is gone/unreadable.
     log_file = tmp_path / "missing.log"  # never created
-    server = _server_with_session(tmp_path, log_file, alive=False)
+    server = server_with_session(tmp_path, log_file, alive=False)
 
     reply = server._handle({"op": "diag-errors", "params": {}})
     assert reply is not None

--- a/tests/test_daemon_lifecycle_payload.py
+++ b/tests/test_daemon_lifecycle_payload.py
@@ -61,6 +61,12 @@ def _unavailable(
 
 
 def _project(tmp_path):
+    """Not support.minimal_project: the payload reports the application NAME.
+
+    The daemon lifecycle payload echoes the project name it read, so this suite
+    needs a project.godot that carries one — a different file, not the shared
+    minimum plus a second write of the same path.
+    """
     (tmp_path / "project.godot").write_text(
         'config_version=5\n\n[application]\n\nconfig/name="t"\n', encoding="utf-8"
     )

--- a/tests/test_daemon_logger.py
+++ b/tests/test_daemon_logger.py
@@ -9,40 +9,15 @@ log file, plus the same no-session / missing-file typed errors ``diag`` returns.
 """
 
 import os
-import subprocess
-from typing import cast
 
 import pytest
 
 from gda.daemon.discovery import daemon_paths
 from gda.daemon.server import DaemonServer
-from gda.daemon.session import EngineSession
 from gda.parser import parse_result
+from tests.support import minimal_project, server_with_session
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
-
-
-class _FakeProc:
-    def __init__(self, returncode=None):
-        self.returncode = returncode
-
-    def poll(self):
-        return self.returncode
-
-
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
-
-
-def _server_with_session(tmp_path, log_file, alive=True):
-    server = DaemonServer(daemon_paths(_project(tmp_path)), godot="godot")
-    server._session = EngineSession(
-        cast(subprocess.Popen, _FakeProc(None if alive else 0)),
-        conn=None,
-        log_file=log_file,
-    )
-    return server
 
 
 def test_logger_tail_reads_structured_records_from_the_log(tmp_path):
@@ -50,7 +25,7 @@ def test_logger_tail_reads_structured_records_from_the_log(tmp_path):
     log_file.write_text(
         "print output\nERROR: boom\n   at: _ready (res://main.gd:9)\n", encoding="utf-8"
     )
-    server = _server_with_session(tmp_path, log_file)
+    server = server_with_session(tmp_path, log_file)
 
     reply = server._handle({"op": "logger-tail", "params": {}})
     assert reply is not None
@@ -70,7 +45,7 @@ def test_logger_tail_raw_returns_verbatim_info_records(tmp_path):
     # LogRecord[]), so even an `ERROR:` header stays an unclassified info line.
     log_file = tmp_path / "session.log"
     log_file.write_text("known line\nERROR: boom\n", encoding="utf-8")
-    server = _server_with_session(tmp_path, log_file)
+    server = server_with_session(tmp_path, log_file)
 
     reply = server._handle({"op": "logger-tail", "params": {"raw": True}})
     assert reply is not None
@@ -88,7 +63,7 @@ def test_logger_tail_level_filters_by_minimum_severity(tmp_path):
         "ERROR: boom\n   at: g (res://b.gd:2)\n",
         encoding="utf-8",
     )
-    server = _server_with_session(tmp_path, log_file)
+    server = server_with_session(tmp_path, log_file)
 
     reply = server._handle({"op": "logger-tail", "params": {"level": "warning"}})
     assert reply is not None
@@ -102,7 +77,7 @@ def test_logger_tail_level_filters_by_minimum_severity(tmp_path):
 def test_logger_tail_limit_tails_the_most_recent_n(tmp_path):
     log_file = tmp_path / "session.log"
     log_file.write_text("one\ntwo\nthree\n", encoding="utf-8")
-    server = _server_with_session(tmp_path, log_file)
+    server = server_with_session(tmp_path, log_file)
 
     reply = server._handle({"op": "logger-tail", "params": {"limit": 1}})
     assert reply is not None
@@ -119,7 +94,7 @@ def test_logger_tail_serves_even_when_the_session_process_has_died(tmp_path):
     log_file.write_text(
         "ERROR: crashed\n   at: _ready (res://main.gd:3)\n", encoding="utf-8"
     )
-    server = _server_with_session(tmp_path, log_file, alive=False)
+    server = server_with_session(tmp_path, log_file, alive=False)
 
     reply = server._handle({"op": "logger-tail", "params": {}})
     assert reply is not None
@@ -132,7 +107,7 @@ def test_logger_tail_serves_even_when_the_session_process_has_died(tmp_path):
 def test_logger_tail_empty_log_is_an_empty_result_not_an_error(tmp_path):
     log_file = tmp_path / "session.log"
     log_file.write_text("", encoding="utf-8")
-    server = _server_with_session(tmp_path, log_file)
+    server = server_with_session(tmp_path, log_file)
 
     reply = server._handle({"op": "logger-tail", "params": {}})
     assert reply is not None
@@ -144,7 +119,7 @@ def test_logger_tail_empty_log_is_an_empty_result_not_an_error(tmp_path):
 def test_logger_tail_with_no_session_is_engine_session_not_running(tmp_path):
     # ADR-0022: a daemon-served log op observes an already-launched session; it does
     # NOT launch one. With none launched this lifetime it is a structured error.
-    server = DaemonServer(daemon_paths(_project(tmp_path)), godot="godot")
+    server = DaemonServer(daemon_paths(minimal_project(tmp_path)), godot="godot")
 
     reply = server._handle({"op": "logger-tail", "params": {}})
     assert reply is not None
@@ -159,7 +134,7 @@ def test_logger_tail_with_a_remembered_session_but_missing_file_is_live_log_unav
     tmp_path,
 ):
     log_file = tmp_path / "missing.log"  # never created
-    server = _server_with_session(tmp_path, log_file, alive=False)
+    server = server_with_session(tmp_path, log_file, alive=False)
 
     reply = server._handle({"op": "logger-tail", "params": {}})
     assert reply is not None

--- a/tests/test_daemon_ops.py
+++ b/tests/test_daemon_ops.py
@@ -21,6 +21,7 @@ from gda.commands.daemon import (
     run_daemon_stop_operation,
 )
 from gda.harness.install import HARNESS_VERSION
+from tests.support import minimal_project
 
 pytestmark = [
     pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"),
@@ -33,13 +34,8 @@ pytestmark = [
 _OK_VERSION = lambda binary: (4, 6)  # noqa: E731
 
 
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
-
-
 def test_daemon_start_status_stop_lifecycle(tmp_path, daemon_runtime_dir):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     paths = daemon_paths(project)
 
     try:
@@ -81,7 +77,7 @@ def test_daemon_status_reports_a_windowed_daemons_mode(tmp_path, daemon_runtime_
     # read back by `daemon status`. No engine session is launched here (lazy launch,
     # ADR-0017) — the daemon process merely records the declared mode — so this needs
     # no display and is headless-CI safe.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
 
     try:
         started = run_daemon_start_operation(
@@ -108,7 +104,7 @@ def test_daemon_status_reports_a_windowed_daemons_mode(tmp_path, daemon_runtime_
 def test_live_version_gate_rejects_below_4_6(tmp_path, daemon_runtime_dir):
     from gda.errors import Failure
 
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     outcome = run_daemon_start_operation(
         project, None, version_check=lambda binary: (4, 5)
     )
@@ -118,7 +114,7 @@ def test_live_version_gate_rejects_below_4_6(tmp_path, daemon_runtime_dir):
 
 
 def test_daemon_status_and_stop_when_not_running(tmp_path, daemon_runtime_dir):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
 
     status = run_daemon_status_operation(project)
     assert isinstance(status, DaemonStatusResult) and status.running is False

--- a/tests/test_daemon_server.py
+++ b/tests/test_daemon_server.py
@@ -25,13 +25,9 @@ from gda.commands.daemon import (
 )
 from gda.errors import Failure
 from gda.parser import build_result, parse_result
+from tests.support import FakeProc, minimal_project
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
-
-
-class _FakeProc:
-    def poll(self):
-        return None
 
 
 def _unavailable(
@@ -47,7 +43,7 @@ def _unavailable(
 
 
 def test_live_op_without_a_launchable_session_is_engine_session_not_running(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     # No Godot binary -> ensure_session cannot launch -> engine_session_not_running.
     server = DaemonServer(daemon_paths(tmp_path), godot="")
 
@@ -82,8 +78,7 @@ def test_malformed_control_request_is_dropped_not_raised(tmp_path):
 
 
 def _project_with_marker(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return daemon_paths(tmp_path)
+    return daemon_paths(minimal_project(tmp_path))
 
 
 def test_scene_mismatch_at_launch_is_a_typed_live_scene_not_found(
@@ -120,7 +115,7 @@ def test_a_verified_session_is_reused_without_re_checking_the_scene(
     # multiple live ops (no per-request disk/scene re-validation), so deleting the
     # scene file after launch cannot break a live op.
     calls = {"n": 0}
-    served = EngineSession(cast(subprocess.Popen, _FakeProc()), conn=None)
+    served = EngineSession(cast(subprocess.Popen, FakeProc()), conn=None)
     monkeypatch.setattr(
         served,
         "request",
@@ -230,7 +225,7 @@ def test_windowed_no_display_is_live_windowed_unavailable_without_launching(
     # windowed daemon on a host with no usable DisplayServer refuses a live op with the
     # typed live_windowed_unavailable AND never calls launch_session — so a doomed
     # windowed Godot is never spawned, even if `daemon start --windowed` slipped through.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
 
     def _must_not_launch(*a, **k):
         raise AssertionError("launch_session must not be called with no usable display")
@@ -264,7 +259,7 @@ def test_windowed_denied_relays_the_permission_code_not_the_capability_one(
     # so it also carries the machine-readable `probe` — deliberately widening the live
     # wire envelope with that ONE optional key (#667 review), rather than reporting
     # less here than the optional CLI fail-fast reports.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
 
     def _must_not_launch(*a, **k):
         raise AssertionError("launch_session must not be called with no usable display")
@@ -299,7 +294,7 @@ def test_a_relayed_refusal_without_a_probe_keeps_the_narrow_wire_shape(
     # The widening is OPTIONAL: every live reply that has no probe — which is all of
     # them except the windowed refusals — is byte-identical to before, so the key can
     # never appear as a null for the harness-emitted and daemon-synthesized codes.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     monkeypatch.setattr("gda.daemon.server.launch_session", lambda *a, **k: None)
     server = DaemonServer(daemon_paths(tmp_path), godot="godot")
     server._harness_listener = cast(socket.socket, object())
@@ -316,7 +311,7 @@ def test_windowed_with_a_usable_display_reaches_launch(tmp_path, monkeypatch):
     # The guard is display-gated: a usable display (the check returns None) does NOT
     # short-circuit — the launch proceeds (here to the generic engine_session_not_running
     # via a patched None launch), proving the guard fires ONLY on no-display.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     calls = {"n": 0}
 
     def _launch(*a, **k):
@@ -345,7 +340,7 @@ def test_headless_windowed_false_never_consults_the_display_check(
 ):
     # A default (headless) daemon must never consult the display check — a headless
     # session needs no window server; only a windowed session is gated.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
 
     def _boom() -> WindowedUnavailable | None:
         raise AssertionError("a headless daemon must not run the display check")
@@ -366,7 +361,7 @@ def test_headless_windowed_false_never_consults_the_display_check(
 def test_no_scene_selector_runs_main_scene_unchanged(tmp_path):
     # The selector-less default is unchanged: straight to the launch path (which here
     # is engine_session_not_running with no real binary), no scene verification.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     server = DaemonServer(daemon_paths(tmp_path), godot="")
 
     reply = server._handle({"op": "game-tree", "params": {}})
@@ -410,7 +405,7 @@ def test_engine_session_request_times_out_as_live_timeout(monkeypatch):
     # hang the daemon forever (ADR-0021).
     monkeypatch.setattr("gda.daemon.session.OP_TIMEOUT", 0.2)
     daemon_end, silent_harness = socket.socketpair()
-    session = EngineSession(cast(subprocess.Popen, _FakeProc()), daemon_end)
+    session = EngineSession(cast(subprocess.Popen, FakeProc()), daemon_end)
     try:
         reply = session.request("game-tree", {})
         assert parse_result(reply["stdout"])["error"]["code"] == "live_timeout"
@@ -444,7 +439,7 @@ def test_the_live_timeout_message_hedges_its_causes_and_rules_out_a_pause(monkey
     # unactionable class would repeat #684's mistake in a third direction.
     monkeypatch.setattr("gda.daemon.session.OP_TIMEOUT", 0.2)
     daemon_end, silent_harness = socket.socketpair()
-    session = EngineSession(cast(subprocess.Popen, _FakeProc()), daemon_end)
+    session = EngineSession(cast(subprocess.Popen, FakeProc()), daemon_end)
     try:
         reply = session.request("game-tree", {})
     finally:
@@ -475,7 +470,7 @@ def test_a_trickled_reply_cannot_outlast_the_relays_own_bound(monkeypatch):
     # bound rather than a defence.
     monkeypatch.setattr("gda.daemon.session.OP_TIMEOUT", 0.3)
     daemon_end, harness = socket.socketpair()
-    session = EngineSession(cast(subprocess.Popen, _FakeProc()), daemon_end)
+    session = EngineSession(cast(subprocess.Popen, FakeProc()), daemon_end)
 
     def _trickle() -> None:
         # A WELL-FORMED reply, so a relay that waits it out succeeds — the point
@@ -515,7 +510,7 @@ def test_a_timed_out_relay_leaves_the_session_dead_to_the_daemon(monkeypatch):
     # the next session-needing op rebuilds it through the launch boundary.
     monkeypatch.setattr("gda.daemon.session.OP_TIMEOUT", 0.2)
     daemon_end, harness = socket.socketpair()
-    proc = _FakeProc()
+    proc = FakeProc()
     session = EngineSession(cast(subprocess.Popen, proc), daemon_end)
     try:
         first = session.request("game-tree", {})

--- a/tests/test_daemon_socket_lifecycle.py
+++ b/tests/test_daemon_socket_lifecycle.py
@@ -1232,7 +1232,10 @@ def test_the_owner_keeps_the_group_a_reaped_leader_cannot_name(tmp_path):
         assert _capture_owned_pgid(leader) is None, (
             "the reaped leader still names a group"
         )
-        session.close(time.monotonic() + 5.0)
+        # The deadline is this test's own, not a product constant: the descendant
+        # ignores SIGTERM, so the teardown polls it out in full before it
+        # escalates. 0.2s is the outcome's cost, not 5s (#815).
+        session.close(time.monotonic() + 0.2)
         _assert_gone(descendant, "descendant")
     finally:
         _reap_group(descendant, leader.pid)
@@ -1313,7 +1316,9 @@ def test_the_group_is_retired_even_when_the_leader_obeys_sigterm(monkeypatch):
         _OBEYS_SIGTERM_WITH_STUBBORN_CHILD
     )
     try:
-        _terminate(leader, time.monotonic() + 5.0, owned_pgid=owned_pgid)
+        # Same test-chosen deadline as above: the stubborn descendant makes the
+        # wait run to the deadline, so it is kept short (#815).
+        _terminate(leader, time.monotonic() + 0.2, owned_pgid=owned_pgid)
         assert leader.returncode == -signal.SIGTERM  # the leader DID obey
         _assert_gone(descendant, "descendant")
     finally:

--- a/tests/test_daemon_socket_lifecycle.py
+++ b/tests/test_daemon_socket_lifecycle.py
@@ -50,7 +50,7 @@ from gda.daemon.session import (
 from gda.errors import Failure
 from gda.live_runner import DaemonRunner
 from gda.parser import build_result, parse_result
-from tests.support import no_engine_teardown
+from tests.support import FakeProc, minimal_project, no_engine_teardown
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
@@ -159,27 +159,6 @@ def _stubborn_child(**kwargs) -> subprocess.Popen:
     return proc
 
 
-def _project(tmp_path: Path) -> Path:
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
-
-
-class _Proc:
-    """A stand-in engine process whose liveness the test flips."""
-
-    def __init__(self, code: "int | None" = None) -> None:
-        self.code = code
-
-    def poll(self):
-        return self.code
-
-    # gda's OWN pid, deliberately: teardown reads the pid to find the process
-    # group it owns, and the own-group guard then resolves this stand-in to no
-    # group at all. An invented pid would instead resolve to whichever real
-    # process holds it — which a test would then signal.
-    pid = os.getpid()
-
-
 class _ServedSession:
     """A fake session that serves every relayed op — a structural SessionHandle."""
 
@@ -250,7 +229,7 @@ def _no_launch(*args, **kwargs):
 def test_serve_binds_both_sockets_and_answers_status(
     tmp_path, daemon_runtime_dir, monkeypatch
 ):
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_no_launch)
 
     with _serving(server, paths, monkeypatch):
@@ -271,7 +250,7 @@ def test_a_stale_slot_left_by_a_crash_is_reclaimed(
 ):
     # A crashed predecessor leaves socket files bound-then-abandoned and a pidfile
     # whose advisory lock nobody holds. A fresh serve() must reclaim the slot.
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     paths.runtime_dir.mkdir(parents=True, exist_ok=True)
     for stale in (paths.cli_socket, paths.harness_socket):
         abandoned = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -294,7 +273,7 @@ def test_a_double_start_loses_without_touching_the_live_daemons_slot(
     # reachable ones), and not its pidfile CONTENT either — a pre-lock
     # truncation erases the winner's recorded identity, so status, attach, and
     # stop all read the live daemon as not running (#723 review).
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     winner = DaemonServer(paths, godot="godot", launch=_no_launch)
 
     with _serving(winner, paths, monkeypatch):
@@ -322,7 +301,7 @@ def test_cleanup_removes_the_slot_before_releasing_the_lock(
     # fresh slot inside the cleanup window — which the predecessor's remaining
     # unlinks then destroy. Instrumenting unlink pins the order: every slot
     # path must be removed while the lock is still held.
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_no_launch)
     slot = {paths.cli_socket, paths.harness_socket, paths.pidfile}
     held_at_unlink: dict = {}
@@ -354,7 +333,7 @@ def test_cleanup_removes_the_slot_before_releasing_the_lock(
 def test_stop_op_unlinks_the_sockets_and_pidfile(
     tmp_path, daemon_runtime_dir, monkeypatch
 ):
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_no_launch)
 
     with _serving(server, paths, monkeypatch) as thread:
@@ -375,7 +354,7 @@ def test_a_termination_signal_cleans_up_the_slot(tmp_path, daemon_runtime_dir):
     # re-enactment is deliberately NOT used here — on Linux, closing a listener
     # from another thread does not wake a blocked accept, which is a fact about
     # threads, not about the signal path under test.
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_no_launch)
 
     child = os.fork()
@@ -418,7 +397,7 @@ def test_an_overlong_socket_path_is_refused_at_start(tmp_path, monkeypatch):
     # spawn, instead of the daemon's bind() failing and start timing out vaguely.
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / ("x" * 150)))
 
-    outcome = run_daemon_start_operation(_project(tmp_path), "godot")
+    outcome = run_daemon_start_operation(minimal_project(tmp_path), "godot")
 
     assert isinstance(outcome, Failure)
     assert outcome.error.code == "daemon_not_running"
@@ -438,7 +417,7 @@ def test_the_first_live_op_launches_the_session_lazily_and_reuses_it(
         calls["n"] += 1
         return session
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     with _serving(server, paths, monkeypatch):
@@ -457,7 +436,7 @@ def test_a_failed_launch_is_the_typed_engine_session_not_running(
     def _launch(*args, **kwargs):
         return None
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     with _serving(server, paths, monkeypatch):
@@ -479,7 +458,7 @@ def test_a_session_dying_mid_request_reports_disconnect_then_relaunches(
     no_engine_teardown(monkeypatch)  # the dying session is a stand-in, not a child
     ours, theirs = socket.socketpair()
     theirs.close()  # the harness end is gone: the relay write breaks mid-request
-    proc = _Proc(code=None)  # alive at the pre-request liveness check
+    proc = FakeProc(returncode=None)  # alive at the pre-request liveness check
     dying = EngineSession(cast(subprocess.Popen, proc), conn=ours)
 
     launches: list = []
@@ -490,12 +469,12 @@ def test_a_session_dying_mid_request_reports_disconnect_then_relaunches(
             return dying
         return _ServedSession()
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     with _serving(server, paths, monkeypatch):
         first = _request(paths, {"op": "game-tree", "params": {}})
-        proc.code = 1  # the engine process is now observed dead
+        proc.returncode = 1  # the engine process is now observed dead
         second = _request(paths, {"op": "game-tree", "params": {}})
 
     assert first is not None
@@ -520,7 +499,7 @@ def test_wait_ready_launches_once_and_reports_the_bounded_wait(
         launches.append(kwargs.get("deadline"))
         return session
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     with _serving(server, paths, monkeypatch):
@@ -568,7 +547,7 @@ def test_status_reports_the_minted_session_identity_across_the_lifecycle(
         sessions.append(session)
         return session
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     with _serving(server, paths, monkeypatch):
@@ -618,7 +597,7 @@ def test_a_failed_replacement_launch_retains_the_last_established_identity(
         sessions.append(session)
         return session
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     with _serving(server, paths, monkeypatch):
@@ -652,11 +631,11 @@ def test_launch_session_places_the_identity_on_the_harness_tail(
 
     def _record_spawn(argv, **kwargs):
         spawned.append(argv)
-        return _Proc(code=None)
+        return FakeProc(returncode=None)
 
     monkeypatch.setattr(subprocess, "Popen", _record_spawn)
     no_engine_teardown(monkeypatch)
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     paths.runtime_dir.mkdir(parents=True, exist_ok=True)
     listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     listener.bind(str(paths.harness_socket))
@@ -696,7 +675,7 @@ def test_wait_ready_relays_the_typed_launch_failure(
     def _launch(*args, **kwargs):
         return None
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     with _serving(server, paths, monkeypatch):
@@ -715,9 +694,11 @@ def test_a_silent_handshake_peer_cannot_hold_the_launch_past_the_deadline(
     # accept, the token frame, and the verification frame. A peer that connects
     # and then never speaks used to block the token read forever — here the
     # REAL launch_session must give up within the bound and record why.
-    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _Proc(code=None))
+    monkeypatch.setattr(
+        subprocess, "Popen", lambda argv, **kw: FakeProc(returncode=None)
+    )
     no_engine_teardown(monkeypatch)
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     paths.runtime_dir.mkdir(parents=True, exist_ok=True)
     listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     listener.bind(str(paths.harness_socket))
@@ -758,9 +739,11 @@ def test_a_trickling_handshake_peer_cannot_hold_the_launch_past_the_deadline(
     # to be recomputed per recv, not set once per frame. Measured before the fix
     # at a 0.04s/byte trickle on a 0.05s bound: 0.7s for the token frame, 2.1s
     # for the verification frame — and the trickle rate is the peer's to choose.
-    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _Proc(code=None))
+    monkeypatch.setattr(
+        subprocess, "Popen", lambda argv, **kw: FakeProc(returncode=None)
+    )
     no_engine_teardown(monkeypatch)
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     paths.runtime_dir.mkdir(parents=True, exist_ok=True)
     listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     listener.bind(str(paths.harness_socket))
@@ -817,10 +800,10 @@ def test_a_slow_spawn_cannot_revive_the_callers_expired_deadline(
 
     def _slow_popen(argv, **kwargs):
         time.sleep(0.12)  # a spawn that costs more than the whole budget
-        return _Proc(code=None)
+        return FakeProc(returncode=None)
 
     monkeypatch.setattr(subprocess, "Popen", _slow_popen)
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     paths.runtime_dir.mkdir(parents=True, exist_ok=True)
     listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     listener.bind(str(paths.harness_socket))
@@ -858,7 +841,7 @@ def test_launch_preparation_that_crosses_the_deadline_spawns_nothing(
 
     def _record_spawn(argv, **kwargs):
         spawned.append(time.monotonic())
-        return _Proc(code=None)
+        return FakeProc(returncode=None)
 
     real_write = Path.write_bytes
 
@@ -869,7 +852,7 @@ def test_launch_preparation_that_crosses_the_deadline_spawns_nothing(
     monkeypatch.setattr(subprocess, "Popen", _record_spawn)
     monkeypatch.setattr(Path, "write_bytes", _slow_write)
     no_engine_teardown(monkeypatch)
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     paths.runtime_dir.mkdir(parents=True, exist_ok=True)
     listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     listener.bind(str(paths.harness_socket))
@@ -904,11 +887,11 @@ def test_a_deadline_spent_by_the_spawn_is_not_blamed_on_the_harness(
     # failure and plainly false here: the token is already queued.
     def _slow_popen(argv, **kwargs):
         time.sleep(0.12)
-        return _Proc(code=None)
+        return FakeProc(returncode=None)
 
     monkeypatch.setattr(subprocess, "Popen", _slow_popen)
     no_engine_teardown(monkeypatch)
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     paths.runtime_dir.mkdir(parents=True, exist_ok=True)
     listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     listener.bind(str(paths.harness_socket))
@@ -961,7 +944,7 @@ def test_retiring_a_stale_session_is_charged_to_the_callers_deadline(
         launches.append(kwargs.get("deadline"))
         return stale if len(launches) == 1 else None
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
     queued: list = []
 
@@ -1128,7 +1111,7 @@ def test_the_live_clients_ceiling_covers_the_whole_round_trip(
     # INACTIVITY timeout, not a round-trip ceiling — a trickling daemon could
     # hold the CLI indefinitely. Same absolute-instant rule as every other read.
     monkeypatch.setattr("gda.live_runner.LIVE_REQUEST_TIMEOUT", 0.3)
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     paths.runtime_dir.mkdir(parents=True, exist_ok=True)
     listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     listener.bind(str(paths.cli_socket))
@@ -1280,7 +1263,7 @@ def test_a_permission_error_does_not_mean_the_group_is_empty(monkeypatch):
 
     monkeypatch.setattr(os, "killpg", _permission_denied)
 
-    assert _group_standing(1234, cast(subprocess.Popen, _Proc()))
+    assert _group_standing(1234, cast(subprocess.Popen, FakeProc()))
 
 
 def test_a_descendant_may_finish_its_own_cleanup_inside_the_deadline(tmp_path):
@@ -1385,9 +1368,11 @@ def test_a_stuck_handshake_does_not_freeze_the_daemon(
     # serve loop while a peer occupies the harness socket silently. wait-ready
     # must come back typed within its bound, and — the daemon serving one
     # request at a time — the NEXT control request must still be served.
-    monkeypatch.setattr(subprocess, "Popen", lambda argv, **kw: _Proc(code=None))
+    monkeypatch.setattr(
+        subprocess, "Popen", lambda argv, **kw: FakeProc(returncode=None)
+    )
     no_engine_teardown(monkeypatch)
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot")  # the real launch seam default
 
     with _serving(server, paths, monkeypatch):
@@ -1422,7 +1407,7 @@ def test_wait_ready_rebuilds_a_session_whose_channel_broke(
     no_engine_teardown(monkeypatch)
     ours, theirs = socket.socketpair()
     theirs.close()
-    zombie = EngineSession(cast(subprocess.Popen, _Proc(code=None)), conn=ours)
+    zombie = EngineSession(cast(subprocess.Popen, FakeProc(returncode=None)), conn=ours)
 
     launches: list = []
 
@@ -1430,7 +1415,7 @@ def test_wait_ready_rebuilds_a_session_whose_channel_broke(
         launches.append(1)
         return zombie if len(launches) == 1 else _ServedSession()
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     with _serving(server, paths, monkeypatch):
@@ -1457,7 +1442,9 @@ def test_wait_ready_rebuilds_a_session_whose_relay_timed_out(
     monkeypatch.setattr("gda.daemon.session.OP_TIMEOUT", 0.2)
     no_engine_teardown(monkeypatch)
     ours, silent_harness = socket.socketpair()
-    desynced = EngineSession(cast(subprocess.Popen, _Proc(code=None)), conn=ours)
+    desynced = EngineSession(
+        cast(subprocess.Popen, FakeProc(returncode=None)), conn=ours
+    )
 
     launches: list = []
 
@@ -1465,7 +1452,7 @@ def test_wait_ready_rebuilds_a_session_whose_relay_timed_out(
         launches.append(1)
         return desynced if len(launches) == 1 else _ServedSession()
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     try:
@@ -1501,7 +1488,7 @@ def test_a_teardown_cannot_outlast_the_readiness_deadline(
         return proc
 
     monkeypatch.setattr(subprocess, "Popen", _spawn_stubborn_child)
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot")  # the real launch + teardown
     queued: list = []
 
@@ -1567,7 +1554,7 @@ def test_launched_is_reported_by_the_launch_owner(
         launches.append(1)
         return flip if len(launches) == 1 else _ServedSession()
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     with _serving(server, paths, monkeypatch):
@@ -1604,7 +1591,7 @@ def test_every_declared_daemon_served_op_is_intercepted_not_relayed(
     def _launch(*args, **kwargs):
         return session
 
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_launch)
 
     with _serving(server, paths, monkeypatch):
@@ -1623,7 +1610,7 @@ def test_the_wire_boundary_re_enforces_the_wait_ready_bound(
     # #725 review finding 4: the finite (0, 50] rule holds at the IPC boundary
     # too — this socket can be driven by clients other than gda's CLI, and an
     # unbounded or non-finite value would defeat the bound the op promises.
-    paths = daemon_paths(_project(tmp_path))
+    paths = daemon_paths(minimal_project(tmp_path))
     server = DaemonServer(paths, godot="godot", launch=_no_launch)
 
     with _serving(server, paths, monkeypatch):

--- a/tests/test_daemon_wait_ready_commands.py
+++ b/tests/test_daemon_wait_ready_commands.py
@@ -14,12 +14,12 @@ from typer.testing import CliRunner
 from gda.cli import app
 from gda.exit_codes import EXIT_LIVE
 from gda.runner import RunResult
-from tests.support import inject_live_runner, sentinel
-
-
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
+from tests.support import (
+    assert_operation_error,
+    inject_live_runner,
+    minimal_project,
+    sentinel,
+)
 
 
 READY = {"pid": 4242, "launched": True}
@@ -31,7 +31,8 @@ def test_wait_ready_reports_the_established_session_as_json(monkeypatch, tmp_pat
     )
 
     result = CliRunner().invoke(
-        app, ["daemon", "wait-ready", "--project", str(_project(tmp_path)), "--json"]
+        app,
+        ["daemon", "wait-ready", "--project", str(minimal_project(tmp_path)), "--json"],
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -54,7 +55,7 @@ def test_wait_ready_passes_the_caller_bound_through(monkeypatch, tmp_path):
             "--timeout",
             "10",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -69,7 +70,7 @@ def test_wait_ready_human_output_names_the_launch_state(monkeypatch, tmp_path):
     )
 
     result = CliRunner().invoke(
-        app, ["daemon", "wait-ready", "--project", str(_project(tmp_path))]
+        app, ["daemon", "wait-ready", "--project", str(minimal_project(tmp_path))]
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -87,7 +88,7 @@ def test_wait_ready_human_output_reports_an_already_serving_session(
     )
 
     result = CliRunner().invoke(
-        app, ["daemon", "wait-ready", "--project", str(_project(tmp_path))]
+        app, ["daemon", "wait-ready", "--project", str(minimal_project(tmp_path))]
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -99,7 +100,8 @@ def test_wait_ready_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_p
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
 
     result = CliRunner().invoke(
-        app, ["daemon", "wait-ready", "--project", str(_project(tmp_path)), "--json"]
+        app,
+        ["daemon", "wait-ready", "--project", str(minimal_project(tmp_path)), "--json"],
     )
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
@@ -112,7 +114,7 @@ def test_wait_ready_refuses_an_out_of_range_bound_on_argv(monkeypatch, tmp_path)
     # The params model owns the (0, 50] bound (ADR-0015): the argv path
     # translates its refusal into the Click usage error. 50 caps the wait under
     # the live channel's 60s client-side round-trip bound.
-    project = str(_project(tmp_path))
+    project = str(minimal_project(tmp_path))
     for bad in ("0", "60", "inf", "nan"):
         result = CliRunner().invoke(
             app, ["daemon", "wait-ready", "--timeout", bad, "--project", project]
@@ -130,10 +132,9 @@ def test_wait_ready_refuses_an_out_of_range_bound_on_params_json(monkeypatch, tm
             "--params-json",
             json.dumps({"timeout": 60}),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
 
-    assert result.exit_code == 4, result.stdout + result.stderr
-    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+    assert_operation_error(result, "invalid_params")

--- a/tests/test_diag_commands.py
+++ b/tests/test_diag_commands.py
@@ -20,12 +20,8 @@ from tests.support import (
     error_sentinel,
     inject_live_runner,
     sentinel,
+    minimal_project,
 )
-
-
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
 
 
 def test_diag_errors_emits_structured_errors_json_through_the_live_channel(
@@ -37,7 +33,7 @@ def test_diag_errors_emits_structured_errors_json_through_the_live_channel(
     )
 
     result = CliRunner().invoke(
-        app, ["diag", "errors", "--project", str(_project(tmp_path)), "--json"]
+        app, ["diag", "errors", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -69,7 +65,7 @@ def test_diag_errors_passes_limit_through(monkeypatch, tmp_path):
             "--limit",
             "5",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -91,7 +87,7 @@ def test_diag_errors_rejects_a_non_positive_limit_on_the_argv_path(tmp_path):
                 "--limit",
                 bad,
                 "--project",
-                str(_project(tmp_path)),
+                str(minimal_project(tmp_path)),
                 "--json",
             ],
         )
@@ -105,7 +101,7 @@ def test_diag_errors_human_output_renders_levels(monkeypatch, tmp_path):
     )
 
     result = CliRunner().invoke(
-        app, ["diag", "errors", "--project", str(_project(tmp_path))]
+        app, ["diag", "errors", "--project", str(minimal_project(tmp_path))]
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -122,7 +118,7 @@ def test_diag_errors_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
 
     result = CliRunner().invoke(
-        app, ["diag", "errors", "--project", str(_project(tmp_path)), "--json"]
+        app, ["diag", "errors", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
@@ -144,7 +140,7 @@ def test_diag_errors_log_unavailable_is_a_typed_live_error(monkeypatch, tmp_path
     )
 
     result = CliRunner().invoke(
-        app, ["diag", "errors", "--project", str(_project(tmp_path)), "--json"]
+        app, ["diag", "errors", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
@@ -169,7 +165,7 @@ def test_diag_params_json_rejects_a_non_positive_limit_as_invalid_params(
                 "--params-json",
                 json.dumps({"limit": bad}),
                 "--project",
-                str(_project(tmp_path)),
+                str(minimal_project(tmp_path)),
                 "--json",
             ],
         )

--- a/tests/test_e2e_asset_file.py
+++ b/tests/test_e2e_asset_file.py
@@ -12,25 +12,9 @@ import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
+from tests.support import GODOT, Gda
 
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
-
-
-def _gda(*args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT)], capture_output=True, text=True
-    )
-
-
-def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
-    assert proc.returncode == 4, proc.stdout + proc.stderr
-    err = json.loads(proc.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == code
-    return err
+gda = Gda()
 
 
 # --- shader create → get → set round-trip ----------------------------------
@@ -43,7 +27,7 @@ def test_shader_create_default_template_then_get_round_trip(godot_project):
     # write.
     shader_path = godot_project / "wave.gdshader"
 
-    created = _gda("shader", "create", str(shader_path), "--json")
+    created = gda("shader", "create", str(shader_path), "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     data = json.loads(created.stdout)
@@ -51,7 +35,7 @@ def test_shader_create_default_template_then_get_round_trip(godot_project):
     assert data["shader_type"] == "canvas_item"
     assert shader_path.exists()
 
-    got = _gda("shader", "get", str(shader_path), "--json")
+    got = gda("shader", "get", str(shader_path), "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     got_data = json.loads(got.stdout)
@@ -65,14 +49,14 @@ def test_shader_create_default_template_then_get_round_trip(godot_project):
 def test_shader_create_with_type_parameterizes_the_template(godot_project):
     shader_path = godot_project / "world.gdshader"
 
-    created = _gda(
+    created = gda(
         "shader", "create", str(shader_path), "--shader-type", "spatial", "--json"
     )
 
     assert created.returncode == 0, created.stdout + created.stderr
     assert json.loads(created.stdout)["shader_type"] == "spatial"
 
-    got = _gda("shader", "get", str(shader_path), "--json")
+    got = gda("shader", "get", str(shader_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["shader_type"] == "spatial"
 
@@ -89,12 +73,12 @@ def test_shader_create_with_content_round_trips_verbatim_source(godot_project):
         "}\n"
     )
 
-    created = _gda("shader", "create", str(shader_path), "--content", source, "--json")
+    created = gda("shader", "create", str(shader_path), "--content", source, "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     assert json.loads(created.stdout)["shader_type"] == "canvas_item"
 
-    got = _gda("shader", "get", str(shader_path), "--json")
+    got = gda("shader", "get", str(shader_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["source"] == source
 
@@ -105,9 +89,9 @@ def test_shader_set_search_replace_round_trips_through_get(godot_project):
     # reused script-set interface, issue #115): edit the shader_type and read it
     # back changed.
     shader_path = godot_project / "edit.gdshader"
-    _gda("shader", "create", str(shader_path), "--json")
+    gda("shader", "create", str(shader_path), "--json")
 
-    edited = _gda(
+    edited = gda(
         "shader",
         "set",
         str(shader_path),
@@ -121,7 +105,7 @@ def test_shader_set_search_replace_round_trips_through_get(godot_project):
     assert edited.returncode == 0, edited.stdout + edited.stderr
     assert json.loads(edited.stdout)["shader_type"] == "spatial"
 
-    got = _gda("shader", "get", str(shader_path), "--json")
+    got = gda("shader", "get", str(shader_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["source"] == "shader_type spatial;\n"
 
@@ -129,13 +113,13 @@ def test_shader_set_search_replace_round_trips_through_get(godot_project):
 @pytest.mark.e2e
 def test_shader_set_full_overwrite_round_trips_through_get(godot_project):
     shader_path = godot_project / "full.gdshader"
-    _gda("shader", "create", str(shader_path), "--json")
+    gda("shader", "create", str(shader_path), "--json")
     new_source = "shader_type particles;\n"
 
-    edited = _gda("shader", "set", str(shader_path), "--content", new_source, "--json")
+    edited = gda("shader", "set", str(shader_path), "--content", new_source, "--json")
 
     assert edited.returncode == 0, edited.stdout + edited.stderr
-    got = _gda("shader", "get", str(shader_path), "--json")
+    got = gda("shader", "get", str(shader_path), "--json")
     assert json.loads(got.stdout)["source"] == new_source
 
 
@@ -145,36 +129,40 @@ def test_shader_set_full_overwrite_round_trips_through_get(godot_project):
 @pytest.mark.e2e
 def test_shader_create_no_clobber_existing_file(godot_project):
     shader_path = godot_project / "once.gdshader"
-    assert _gda("shader", "create", str(shader_path), "--json").returncode == 0
+    assert gda("shader", "create", str(shader_path), "--json").returncode == 0
     before = shader_path.read_text(encoding="utf-8")
 
-    again = _gda(
+    gda.error(
         "shader",
         "create",
         str(shader_path),
         "--content",
         "shader_type spatial;\n",
         "--json",
+        code="already_exists",
     )
-
-    _assert_operation_error(again, "already_exists")
     # The original file is untouched — no-clobber.
     assert shader_path.read_text(encoding="utf-8") == before
 
 
 @pytest.mark.e2e
 def test_shader_get_missing_file_is_path_not_found(godot_project):
-    missing = _gda("shader", "get", str(godot_project / "nope.gdshader"), "--json")
-    _assert_operation_error(missing, "path_not_found")
+    gda.error(
+        "shader",
+        "get",
+        str(godot_project / "nope.gdshader"),
+        "--json",
+        code="path_not_found",
+    )
 
 
 @pytest.mark.e2e
 def test_shader_set_no_search_match_leaves_file_untouched(godot_project):
     shader_path = godot_project / "nomatch.gdshader"
-    _gda("shader", "create", str(shader_path), "--json")
+    gda("shader", "create", str(shader_path), "--json")
     before = shader_path.read_text(encoding="utf-8")
 
-    edited = _gda(
+    gda.error(
         "shader",
         "set",
         str(shader_path),
@@ -183,18 +171,17 @@ def test_shader_set_no_search_match_leaves_file_untouched(godot_project):
         "--replace",
         "z",
         "--json",
+        code="no_search_match",
     )
-
-    _assert_operation_error(edited, "no_search_match")
     assert shader_path.read_text(encoding="utf-8") == before
 
 
 @pytest.mark.e2e
 def test_shader_set_invalid_line_range_is_invalid_line_range(godot_project):
     shader_path = godot_project / "range.gdshader"
-    _gda("shader", "create", str(shader_path), "--json")
+    gda("shader", "create", str(shader_path), "--json")
 
-    edited = _gda(
+    gda.error(
         "shader",
         "set",
         str(shader_path),
@@ -205,9 +192,8 @@ def test_shader_set_invalid_line_range_is_invalid_line_range(godot_project):
         "--content",
         "x",
         "--json",
+        code="invalid_line_range",
     )
-
-    _assert_operation_error(edited, "invalid_line_range")
 
 
 # --- theme create: a genuinely LOADABLE .tres ------------------------------
@@ -220,7 +206,7 @@ def test_theme_create_produces_a_loadable_tres(godot_project):
     # assert the loaded resource is a Theme — the structured-level proof.
     theme_path = godot_project / "ui.tres"
 
-    created = _gda("theme", "create", str(theme_path), "--json")
+    created = gda("theme", "create", str(theme_path), "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     data = json.loads(created.stdout)
@@ -236,17 +222,16 @@ def test_theme_create_produces_a_loadable_tres(godot_project):
 @pytest.mark.e2e
 def test_theme_create_no_clobber_existing_file(godot_project):
     theme_path = godot_project / "dup.tres"
-    assert _gda("theme", "create", str(theme_path), "--json").returncode == 0
+    assert gda("theme", "create", str(theme_path), "--json").returncode == 0
 
-    again = _gda("theme", "create", str(theme_path), "--json")
-
-    _assert_operation_error(again, "already_exists")
+    gda.error("theme", "create", str(theme_path), "--json", code="already_exists")
 
 
 @pytest.mark.e2e
 def test_theme_create_wrong_extension_is_invalid_path(godot_project):
-    bad = _gda("theme", "create", str(godot_project / "ui.txt"), "--json")
-    _assert_operation_error(bad, "invalid_path")
+    gda.error(
+        "theme", "create", str(godot_project / "ui.txt"), "--json", code="invalid_path"
+    )
 
 
 def _load_resource_class(resource_path) -> str:
@@ -270,6 +255,7 @@ def _load_resource_class(resource_path) -> str:
         [str(GODOT), "--headless", "--script", str(probe)],
         capture_output=True,
         text=True,
+        timeout=120,
     )
     out = proc.stdout
     start = out.find("<<<CLASS>>>") + len("<<<CLASS>>>")

--- a/tests/test_e2e_classname_resolution.py
+++ b/tests/test_e2e_classname_resolution.py
@@ -29,16 +29,12 @@ when the cache misses. These tests exercise the change through the REAL engine
 """
 
 import json
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
+from tests.support import Gda, assert_operation_error, import_project
 
 from .conftest import project_godot
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
 
 # Built through ``project_godot`` so e2e file logging stays disabled (issue #180).
 CLASSNAME_RES_PROJECT_GODOT = project_godot(name="gda-classname-res-fixture")
@@ -66,35 +62,6 @@ func taunt() -> void:
 """
 
 
-def _gda(project, *args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-        capture_output=True,
-        text=True,
-    )
-
-
-def _import_project(project) -> None:
-    # An editor/import scan is what populates .godot/global_script_class_cache.cfg
-    # (tier 2). Scenario (b) runs it; scenarios (a), (c), (d) deliberately do NOT,
-    # so the resolver must fall through to the static scan (tier 3).
-    imported = subprocess.run(
-        [str(GODOT), "--headless", "--path", str(project), "--import"],
-        capture_output=True,
-        text=True,
-        timeout=120,
-    )
-    assert imported.returncode == 0, imported.stdout + imported.stderr
-
-
-def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
-    assert proc.returncode == 4, proc.stdout + proc.stderr
-    err = json.loads(proc.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == code
-    return err
-
-
 @pytest.fixture
 def uncached_project(tmp_path):
     """An editor-never-opened project (NO .godot/) with project-local classes."""
@@ -119,8 +86,7 @@ def test_resource_create_resolves_project_class_name_without_editor_cache(
     assert not (uncached_project / ".godot").exists()
     resource_path = uncached_project / "panda.tres"
 
-    created = _gda(
-        uncached_project,
+    created = Gda(uncached_project)(
         "resource",
         "create",
         str(resource_path),
@@ -144,8 +110,7 @@ def test_node_add_resolves_project_class_name_without_editor_cache(uncached_proj
     # node add resolves a project-local class_name Node via the static scan.
     assert not (uncached_project / ".godot").exists()
     scene_path = uncached_project / "main.tscn"
-    created = _gda(
-        uncached_project,
+    created = Gda(uncached_project)(
         "scene",
         "create",
         str(scene_path),
@@ -155,8 +120,8 @@ def test_node_add_resolves_project_class_name_without_editor_cache(uncached_proj
     )
     assert created.returncode == 0, created.stdout + created.stderr
 
-    added = _gda(
-        uncached_project, "node", "add", str(scene_path), "--type", "Hero", "--json"
+    added = Gda(uncached_project)(
+        "node", "add", str(scene_path), "--type", "Hero", "--json"
     )
 
     assert added.returncode == 0, added.stdout + added.stderr
@@ -175,7 +140,7 @@ def test_find_references_resolves_project_class_name_without_editor_cache(
     # no more "not a res:// path or a registered class_name" for a real class.
     assert not (uncached_project / ".godot").exists()
 
-    proc = _gda(uncached_project, "project", "find-references", "Hero", "--json")
+    proc = Gda(uncached_project)("project", "find-references", "Hero", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     data = json.loads(proc.stdout)
@@ -192,12 +157,14 @@ def test_find_references_resolves_project_class_name_without_editor_cache(
 def test_editor_opened_project_resolves_via_cache_unchanged(uncached_project):
     # With a populated .godot/ cache (tier 2), resolution is unchanged — the
     # static-scan fallback is unobservable for an editor-opened project.
-    _import_project(uncached_project)
+    # An editor/import scan is what populates .godot/global_script_class_cache.cfg
+    # (tier 2). Only this scenario runs it; (a), (c) and (d) deliberately do NOT,
+    # so the resolver must fall through to the static scan (tier 3).
+    import_project(uncached_project)
     assert (uncached_project / ".godot").exists()
     resource_path = uncached_project / "panda_cached.tres"
 
-    created = _gda(
-        uncached_project,
+    created = Gda(uncached_project)(
         "resource",
         "create",
         str(resource_path),
@@ -244,8 +211,7 @@ def _assert_ambiguous(err: dict) -> None:
 
 @pytest.mark.e2e
 def test_resource_create_ambiguous_class_name(ambiguous_project):
-    created = _gda(
-        ambiguous_project,
+    created = Gda(ambiguous_project)(
         "resource",
         "create",
         str(ambiguous_project / "x.tres"),
@@ -253,7 +219,7 @@ def test_resource_create_ambiguous_class_name(ambiguous_project):
         "Dup",
         "--json",
     )
-    _assert_ambiguous(_assert_operation_error(created, "ambiguous_class_name"))
+    _assert_ambiguous(assert_operation_error(created, "ambiguous_class_name"))
     # Nothing was written for the rejected type.
     assert not (ambiguous_project / "x.tres").exists()
 
@@ -261,8 +227,7 @@ def test_resource_create_ambiguous_class_name(ambiguous_project):
 @pytest.mark.e2e
 def test_node_add_ambiguous_class_name(ambiguous_project):
     scene_path = ambiguous_project / "main.tscn"
-    created = _gda(
-        ambiguous_project,
+    created = Gda(ambiguous_project)(
         "scene",
         "create",
         str(scene_path),
@@ -272,18 +237,18 @@ def test_node_add_ambiguous_class_name(ambiguous_project):
     )
     assert created.returncode == 0, created.stdout + created.stderr
 
-    added = _gda(
-        ambiguous_project, "node", "add", str(scene_path), "--type", "Dup", "--json"
+    added = Gda(ambiguous_project)(
+        "node", "add", str(scene_path), "--type", "Dup", "--json"
     )
 
-    _assert_ambiguous(_assert_operation_error(added, "ambiguous_class_name"))
+    _assert_ambiguous(assert_operation_error(added, "ambiguous_class_name"))
 
 
 @pytest.mark.e2e
 def test_find_references_ambiguous_class_name(ambiguous_project):
-    proc = _gda(ambiguous_project, "project", "find-references", "Dup", "--json")
+    proc = Gda(ambiguous_project)("project", "find-references", "Dup", "--json")
 
-    _assert_ambiguous(_assert_operation_error(proc, "ambiguous_class_name"))
+    _assert_ambiguous(assert_operation_error(proc, "ambiguous_class_name"))
 
 
 # --- (d) unknown type: actionable message, no editor-cache implication -------
@@ -291,17 +256,15 @@ def test_find_references_ambiguous_class_name(ambiguous_project):
 
 @pytest.mark.e2e
 def test_resource_create_unknown_type_message_is_actionable(uncached_project):
-    created = _gda(
-        uncached_project,
+    err = Gda(uncached_project).error(
         "resource",
         "create",
         str(uncached_project / "nope.tres"),
         "--type",
         "Nope",
         "--json",
+        code="invalid_resource_type",
     )
-
-    err = _assert_operation_error(created, "invalid_resource_type")
     msg = err["message"]
     assert "Nope" in msg
     # The actionable cause: the class is not declared in a .gd (a misspelling).
@@ -315,8 +278,7 @@ def test_resource_create_unknown_type_message_is_actionable(uncached_project):
 @pytest.mark.e2e
 def test_node_add_unknown_type_message_is_actionable(uncached_project):
     scene_path = uncached_project / "main.tscn"
-    created = _gda(
-        uncached_project,
+    created = Gda(uncached_project)(
         "scene",
         "create",
         str(scene_path),
@@ -326,11 +288,15 @@ def test_node_add_unknown_type_message_is_actionable(uncached_project):
     )
     assert created.returncode == 0, created.stdout + created.stderr
 
-    added = _gda(
-        uncached_project, "node", "add", str(scene_path), "--type", "Nope", "--json"
+    err = Gda(uncached_project).error(
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "Nope",
+        "--json",
+        code="invalid_node_type",
     )
-
-    err = _assert_operation_error(added, "invalid_node_type")
     msg = err["message"]
     assert "Nope" in msg
     assert "no .gd script declares class_name Nope" in msg
@@ -350,8 +316,7 @@ def test_resource_create_project_class_emits_no_engine_error(uncached_project):
     # probe, so the static-scan resolution is silent.
     assert not (uncached_project / ".godot").exists()
 
-    created = _gda(
-        uncached_project,
+    created = Gda(uncached_project)(
         "resource",
         "create",
         str(uncached_project / "quiet.tres"),
@@ -368,8 +333,7 @@ def test_resource_create_project_class_emits_no_engine_error(uncached_project):
 def test_node_add_project_class_emits_no_engine_error(uncached_project):
     assert not (uncached_project / ".godot").exists()
     scene_path = uncached_project / "main.tscn"
-    created = _gda(
-        uncached_project,
+    created = Gda(uncached_project)(
         "scene",
         "create",
         str(scene_path),
@@ -379,8 +343,8 @@ def test_node_add_project_class_emits_no_engine_error(uncached_project):
     )
     assert created.returncode == 0, created.stdout + created.stderr
 
-    added = _gda(
-        uncached_project, "node", "add", str(scene_path), "--type", "Hero", "--json"
+    added = Gda(uncached_project)(
+        "node", "add", str(scene_path), "--type", "Hero", "--json"
     )
 
     assert added.returncode == 0, added.stdout + added.stderr
@@ -393,8 +357,7 @@ def test_ambiguous_class_name_carries_no_cannot_get_class(ambiguous_project):
     # of UNRELATED error envelopes on the fallback path — an ambiguous_class_name
     # failure carried "Cannot get class 'Dup'", pointing away from the real
     # cause. Neither the envelope's diagnostics nor stderr embeds it now.
-    created = _gda(
-        ambiguous_project,
+    created = Gda(ambiguous_project)(
         "resource",
         "create",
         str(ambiguous_project / "x.tres"),
@@ -403,7 +366,7 @@ def test_ambiguous_class_name_carries_no_cannot_get_class(ambiguous_project):
         "--json",
     )
 
-    err = _assert_operation_error(created, "ambiguous_class_name")
+    err = assert_operation_error(created, "ambiguous_class_name")
     assert "Cannot get class" not in err.get("diagnostics", "")
     assert "Cannot get class" not in created.stderr
 
@@ -414,8 +377,7 @@ def test_builtin_classes_resolve_unchanged_and_silent(uncached_project):
     # built-in Resource (Gradient) still resolve on the ClassDB tier exactly as
     # before — never reaching the class_name resolver — and stay silent.
     scene_path = uncached_project / "builtin.tscn"
-    created = _gda(
-        uncached_project,
+    created = Gda(uncached_project)(
         "scene",
         "create",
         str(scene_path),
@@ -426,16 +388,15 @@ def test_builtin_classes_resolve_unchanged_and_silent(uncached_project):
     assert created.returncode == 0, created.stdout + created.stderr
     assert "ERROR:" not in created.stderr, created.stderr
 
-    added = _gda(
-        uncached_project, "node", "add", str(scene_path), "--type", "Sprite2D", "--json"
+    added = Gda(uncached_project)(
+        "node", "add", str(scene_path), "--type", "Sprite2D", "--json"
     )
     assert added.returncode == 0, added.stdout + added.stderr
     assert json.loads(added.stdout)["type"] == "Sprite2D"
     assert "ERROR:" not in added.stderr, added.stderr
 
     resource_path = uncached_project / "builtin.tres"
-    res = _gda(
-        uncached_project,
+    res = Gda(uncached_project)(
         "resource",
         "create",
         str(resource_path),

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -909,6 +909,7 @@ def test_daemon_uninstall_is_refused_while_running(tmp_path, daemon_runtime_dir)
 
 
 @pytest.mark.e2e
+@pytest.mark.xdist_group("windowed")  # shares the host display (#818)
 def test_daemon_status_surfaces_the_windowed_display_mode(tmp_path, daemon_runtime_dir):
     # #251: `daemon status` reports the running daemon's launch-time display mode,
     # read over STATUS_OP through the `gda` CLI, so an agent can tell whether a
@@ -1216,6 +1217,7 @@ def test_daemon_serves_live_ops_while_scenetree_paused(tmp_path, daemon_runtime_
 
 
 @pytest.mark.e2e
+@pytest.mark.xdist_group("windowed")  # shares the host display (#818)
 def test_daemon_serves_screen_capture_while_scenetree_paused(
     tmp_path, daemon_runtime_dir
 ):

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -23,7 +23,6 @@ import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
 from gda.harness.install import (
     HARNESS_FILE,
     HARNESS_RES_DIR,
@@ -31,22 +30,13 @@ from gda.harness.install import (
     installed_harness_version,
 )
 
-from tests.support import GDA_CMD, assert_windowed_ok
+from tests.support import Gda, assert_windowed_ok, import_project
 
-from .conftest import project_godot
-
-GODOT = resolve_godot_binary()
+from .conftest import LIVE_MAIN_TSCN, LIVE_PROJECT_GODOT
 
 # A main scene so the launched session has a runtime SceneTree to read; a Player
 # Node2D child carries a Vector2 storage property (position) for the game get/set
 # round trip (#220). File logging stays disabled via project_godot (issue #180).
-MAIN_TSCN = (
-    "[gd_scene format=3]\n\n"
-    '[node name="Main" type="Node2D"]\n\n'
-    '[node name="Player" type="Node2D" parent="."]\n'
-)
-PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
-
 RECT_MAIN_TSCN = (
     "[gd_scene format=3]\n\n"
     '[node name="Main" type="Control"]\n\n'
@@ -74,29 +64,12 @@ pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"
 
 @pytest.mark.e2e
 def test_daemon_serves_a_real_runtime_tree(tmp_path, daemon_runtime_dir):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
 
     # XDG_RUNTIME_DIR is set short by the daemon_runtime_dir fixture; the spawned
     # daemon inherits it through the subprocess environment.
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -125,26 +98,9 @@ def test_wait_ready_makes_a_first_diag_errors_serve(tmp_path, daemon_runtime_dir
     # no warm-up live op, no sleep loop. Without the wait, the first
     # `diag errors` reports engine_session_not_running by design (it must never
     # be the thing that launches the project's code, ADR-0022).
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -187,27 +143,10 @@ def test_daemon_serves_game_get_set_round_trip(tmp_path, daemon_runtime_dir):
     # The #220 DoD: a real daemon → engine session → `game set` mutates a runtime
     # property, applied at a frame boundary, and `game get` observes the change —
     # State consistency (ADR-0020) end-to-end through the real harness over UDS.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -251,9 +190,9 @@ def test_daemon_game_rect_reads_free_positioned_control_rect(
 ):
     # #419: `game rect` reads rendered viewport-space geometry, not storage
     # properties, so a free-positioned Control reports get_global_rect().
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(RECT_MAIN_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -277,9 +216,9 @@ def test_daemon_game_set_control_position_updates_offsets_preserving_size(
 ):
     # #464: live `game set` mirrors headless `node set` for Control.position by
     # applying an actionable offset write while preserving the current size.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(CONTROL_POSITION_MAIN_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -321,9 +260,9 @@ def test_daemon_game_set_container_managed_control_position_names_offset_alterna
 ):
     # A Container owns direct-child layout; `game set position` reports an
     # actionable live error instead of claiming a write the next layout pass owns.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(RECT_MAIN_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -354,9 +293,9 @@ def test_daemon_game_rect_reads_container_managed_child_rect(
 ):
     # #419: container-managed Controls have layout output even when a storage
     # property read is the wrong surface. `game rect` returns the rendered rect.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(RECT_MAIN_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -388,9 +327,9 @@ def test_daemon_game_rect_reads_container_managed_child_rect(
 def test_daemon_game_rect_rejects_non_control_node(tmp_path, daemon_runtime_dir):
     # #419: the command is intentionally Control-specific; a live node that
     # exists but is not a Control gets a typed LIVE error.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -458,10 +397,10 @@ def test_daemon_game_get_projects_compound_values_with_live_fallback(
     # JSON object, while a Node-valued property — a non-whitelisted runtime
     # Object — stays the str() fallback (the whitelist keeps the shared
     # projection safe against projecting a whole live scene tree).
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(PROJECTION_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(PROJECTION_PLAYER_GD, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -489,10 +428,10 @@ def test_daemon_game_get_reads_explicit_plain_script_dictionary_variable(
 ):
     # #422: a plain non-exported script variable is addressable when explicitly
     # named, but it remains outside the unfiltered storage-property listing.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(SCRIPT_VARIABLE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(SCRIPT_VARIABLE_PLAYER_GD, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -521,10 +460,10 @@ def test_daemon_game_set_mutates_explicit_plain_script_dictionary_variable(
 ):
     # #422: script-variable writes are live-session state seeding only. A later
     # read in the same session observes the mutation; nothing is persisted.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(SCRIPT_VARIABLE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(SCRIPT_VARIABLE_PLAYER_GD, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -581,10 +520,10 @@ def test_daemon_game_set_preserves_json_container_integer_and_float_types(
 ):
     # #427 live-side parity: the mirrored harness coercion must preserve JSON
     # integer vs float values in the same session state that game get observes.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(SCRIPT_VARIABLE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(SCRIPT_VARIABLE_PLAYER_GD, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -621,10 +560,10 @@ def test_daemon_game_set_preserves_json_container_integer_and_float_types(
 def test_daemon_game_get_unknown_explicit_script_variable_reports_unknown_property(
     tmp_path, daemon_runtime_dir
 ):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(SCRIPT_VARIABLE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(SCRIPT_VARIABLE_PLAYER_GD, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -645,10 +584,10 @@ def test_daemon_game_get_unknown_explicit_script_variable_reports_unknown_proper
 def test_daemon_game_set_uncoercible_script_variable_reports_target_type(
     tmp_path, daemon_runtime_dir
 ):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(SCRIPT_VARIABLE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(SCRIPT_VARIABLE_PLAYER_GD, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -678,12 +617,12 @@ def test_daemon_game_set_uncoercible_script_variable_reports_target_type(
 def test_daemon_game_set_readonly_script_variable_reports_unverified_observed_value(
     tmp_path, daemon_runtime_dir
 ):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(SCRIPT_VARIABLE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(
         READONLY_SCRIPT_VARIABLE_PLAYER_GD, encoding="utf-8"
     )
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -720,12 +659,12 @@ def test_daemon_game_set_readonly_script_variable_reports_unverified_observed_va
 def test_daemon_game_set_edge_trigger_reports_unverified_then_side_effect_is_readable(
     tmp_path, daemon_runtime_dir
 ):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(SCRIPT_VARIABLE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(
         EDGE_TRIGGER_SCRIPT_VARIABLE_PLAYER_GD, encoding="utf-8"
     )
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -758,35 +697,6 @@ def test_daemon_game_set_edge_trigger_reports_unverified_then_side_effect_is_rea
         run("daemon", "stop")
 
 
-def _gda(tmp_path, env, timeout=90):
-    """A `gda <args> --project <tmp> --godot <GODOT> --json` subprocess helper.
-
-    ``timeout`` defaults to 90s (the value every existing call site relied on
-    implicitly); a windowed session is heavier to launch, so callers that start
-    one pass a larger value (e.g. ``timeout=120``, matching the windowed e2e
-    tests elsewhere) instead of hand-rolling a near-duplicate of this helper.
-    """
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=timeout,
-        )
-
-    return run
-
-
 @pytest.mark.e2e
 def test_daemon_start_re_syncs_harness_after_a_version_bump(
     tmp_path, daemon_runtime_dir
@@ -797,9 +707,9 @@ def test_daemon_start_re_syncs_harness_after_a_version_bump(
     # stale value, stop the daemon, and start again. The second start must detect
     # the mismatch and re-materialize (harness_synced True), syncing the on-disk
     # version back to HARNESS_VERSION.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
+    run = Gda(tmp_path, json_output=True)
     harness = tmp_path / HARNESS_RES_DIR / HARNESS_FILE
 
     try:
@@ -837,9 +747,9 @@ def test_daemon_install_then_uninstall_is_paired_and_idempotent(
     # #225 D2: a real start installs the harness; with the daemon stopped,
     # `daemon uninstall` removes BOTH the [autoload] entry and the files (paired),
     # and a second uninstall is an idempotent no-op success.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
+    run = Gda(tmp_path, json_output=True)
     harness = tmp_path / HARNESS_RES_DIR / HARNESS_FILE
 
     try:
@@ -888,8 +798,8 @@ def test_daemon_round_trip_restores_the_project_it_started_from(
     # harness, its sidecar and `addons/` are deliberately NOT ignored, so any residue
     # shows up.
     project_godot = tmp_path / "project.godot"
-    project_godot.write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    project_godot.write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / ".gitignore").write_text(".godot/\n", encoding="utf-8")
     before = project_godot.read_bytes()
 
@@ -909,7 +819,7 @@ def test_daemon_round_trip_restores_the_project_it_started_from(
     assert committed.returncode == 0, committed.stdout + committed.stderr
     assert git("status", "--porcelain").stdout == ""  # a clean baseline to diff against
 
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
     harness = tmp_path / HARNESS_RES_DIR / HARNESS_FILE
 
     try:
@@ -934,12 +844,7 @@ def test_daemon_round_trip_restores_the_project_it_started_from(
 
         # Now let the ENGINE scan the project, the way a human opening the editor on
         # it does. This is what writes the .uid sidecar next to the installed harness.
-        imported = subprocess.run(
-            [str(GODOT), "--headless", "--path", str(tmp_path), "--import"],
-            capture_output=True,
-            text=True,
-            timeout=180,
-        )
+        imported = import_project(tmp_path)
         sidecar = harness.with_name(f"{HARNESS_FILE}.uid")
         assert sidecar.exists(), (
             "the engine did not write the .uid sidecar, so the removal assertions "
@@ -986,9 +891,9 @@ def test_daemon_uninstall_is_refused_while_running(tmp_path, daemon_runtime_dir)
     # #225 D2: uninstall is refused while a daemon is running — it would yank the
     # harness autoload out from under the live engine session. The CLI surfaces the
     # daemon_running error at the LIVE exit (6), and the install is untouched.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
+    run = Gda(tmp_path, json_output=True)
     harness = tmp_path / HARNESS_RES_DIR / HARNESS_FILE
 
     try:
@@ -1011,9 +916,9 @@ def test_daemon_status_surfaces_the_windowed_display_mode(tmp_path, daemon_runti
     # `windowed` null (clean, hang-free fallback); a default start -> false; a
     # `--windowed` start -> true. The daemon records the mode at start; no engine
     # session is launched here (lazy launch, ADR-0017), so this needs no display.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
+    run = Gda(tmp_path, json_output=True)
 
     # No daemon running yet: running False, windowed null.
     before = json.loads(run("daemon", "status").stdout)
@@ -1063,11 +968,11 @@ def test_daemon_start_scene_runs_the_chosen_scene_not_main(
     # scene B — `game tree` reports B's root (not Main's), proving the engine received
     # `--scene` (before `--path`) — and `project.godot`'s `main_scene` is UNCHANGED
     # (no mutation, F6-equivalent). With scenes A (main) + B present.
-    project_text = PROJECT_GODOT
+    project_text = LIVE_PROJECT_GODOT
     (tmp_path / "project.godot").write_text(project_text, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "B.tscn").write_text(B_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start", "--scene", "res://B.tscn")
@@ -1096,9 +1001,9 @@ def test_daemon_start_nonexistent_scene_is_typed_live_scene_not_found(
     # (LIVE exit 6) on the first live op — NEVER a silent fall back to main_scene.
     # Detected at launch by the harness (the loaded scene != the requested selector),
     # surfaced when the lazy launch is triggered by `game tree`.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start", "--scene", "res://does_not_exist.tscn")
@@ -1119,9 +1024,9 @@ def test_daemon_start_nonexistent_uid_is_typed_not_silent_main_scene(
     # to main_scene. Launch-time harness verification catches this — the loaded scene
     # (main) != the requested uid — and surfaces a typed `live_scene_not_found`, NOT a
     # silent success on main_scene.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start", "--scene", "uid://doesnotexist000")
@@ -1141,10 +1046,10 @@ def test_daemon_start_scene_against_a_running_daemon_is_a_typed_refusal(
     # #278 review finding 3: `--scene` only takes effect at daemon START. Against a
     # daemon that is already running it is a typed `daemon_already_running` refusal,
     # NOT a silent no-op that quietly ignores the chosen scene.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "B.tscn").write_text(B_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         assert run("daemon", "start").returncode == 0
@@ -1164,11 +1069,11 @@ def test_scene_verified_once_at_launch_survives_deleting_the_file(
     # live session bound to scene B keeps serving B after B.tscn is deleted on disk —
     # the running game does not reload disk edits (ADR-0017/0020 session-bound state),
     # so a later `game tree` STILL reports B, not `live_scene_not_found`.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
     b_scene = tmp_path / "B.tscn"
     b_scene.write_text(B_TSCN, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     try:
         assert run("daemon", "start", "--scene", "res://B.tscn").returncode == 0
@@ -1244,10 +1149,10 @@ def test_daemon_serves_live_ops_while_scenetree_paused(tmp_path, daemon_runtime_
     # everywhere a daemon e2e runs — including CI's display-less godot-e2e job; the
     # `screen capture` leg needs a real DisplayServer and lives in the windowed-gated
     # test below instead.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(PAUSE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(PAUSE_PLAYER_GD, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ})
+    run = Gda(tmp_path, json_output=True)
 
     def ticker_ticks() -> int:
         got = run("game", "get", "/root/Main/Ticker", "--property", "ticks")
@@ -1331,10 +1236,10 @@ def test_daemon_serves_screen_capture_while_scenetree_paused(
 
     require_windowed_host()
 
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(PAUSE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(PAUSE_PLAYER_GD, encoding="utf-8")
-    run = _gda(tmp_path, {**os.environ}, timeout=120)
+    run = Gda(tmp_path, json_output=True, timeout=120)
 
     def ticker_ticks() -> int:
         got = run("game", "get", "/root/Main/Ticker", "--property", "ticks")

--- a/tests/test_e2e_diag.py
+++ b/tests/test_e2e_diag.py
@@ -20,17 +20,13 @@ serially in review.
 
 import json
 import os
-import subprocess
 import time
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
+from tests.support import Gda
 
-from .conftest import project_godot
-
-GODOT = resolve_godot_binary()
+from .conftest import LIVE_PROJECT_GODOT, SCRIPTED_MAIN_TSCN
 
 # A main scene whose root script emits a KNOWN runtime error and a KNOWN print
 # line at `_ready`, so the daemon's Session log captures both for `diag` to read
@@ -43,14 +39,6 @@ func _ready() -> void:
 	print("known line")
 	push_error("known error")
 """
-
-MAIN_TSCN = (
-    "[gd_scene load_steps=2 format=3]\n\n"
-    '[ext_resource type="Script" path="res://main.gd" id="1"]\n\n'
-    '[node name="Main" type="Node2D"]\n'
-    'script = ExtResource("1")\n'
-)
-PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
 
 # A main scene whose `_ready` calls a chain a() -> b() that triggers a runtime
 # GDScript error (calling a method on a null), so the engine emits a `GDScript
@@ -77,28 +65,11 @@ pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"
 def test_diag_reads_back_a_known_runtime_error_and_log_line(
     tmp_path, daemon_runtime_dir
 ):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(SCRIPTED_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "main.gd").write_text(MAIN_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     # Correct lifecycle (ADR-0022): `gda diag` OBSERVES an already-launched session
     # — it does NOT create one. So the session must be launched by a NON-diagnostic
@@ -152,28 +123,11 @@ def test_diag_reads_back_a_multi_frame_callstack(tmp_path, daemon_runtime_dir):
     # — not just the top `file:line`. Same lifecycle as the sibling test: a
     # NON-diag live op (`game tree`) launches + warms the session, THEN diag
     # observes the daemon-owned Session log.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(SCRIPTED_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "main.gd").write_text(CALLSTACK_MAIN_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     def poll_errors(needle, timeout=15.0):
         deadline = time.monotonic() + timeout

--- a/tests/test_e2e_export.py
+++ b/tests/test_e2e_export.py
@@ -13,14 +13,10 @@ not a fixed value.
 """
 
 import json
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
+from tests.support import Gda
 
 # Two presets in the canonical format Godot writes export_presets.cfg: a
 # runnable Linux preset and a non-runnable Web preset, each with its sibling
@@ -64,38 +60,11 @@ def _expected_templates_version() -> str:
     re-adding the ``.0`` patch — fail RED here, instead of silently making the
     template-gate e2e skip (templates_installed would go False on a .0 engine).
     """
-    info = subprocess.run(
-        [*GDA_CMD, "info", "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-    )
-    assert info.returncode == 0, info.stdout + info.stderr
-    v = json.loads(info.stdout)
+    v = Gda().json("info")
     base = f"{v['major']}.{v['minor']}"
     if v["patch"]:
         base += f".{v['patch']}"
     return f"{base}.{v['status']}"
-
-
-def _gda_project(project):
-    """A ``gda`` bound to ``--project`` for res:// resolution of the cfg."""
-
-    def gda(*args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-            capture_output=True,
-            text=True,
-        )
-
-    return gda
-
-
-def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
-    assert proc.returncode == 4, proc.stdout + proc.stderr
-    err = json.loads(proc.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == code
-    return err
 
 
 @pytest.mark.e2e
@@ -106,7 +75,7 @@ def test_export_list_enumerates_presets_from_export_presets_cfg(godot_project):
     (godot_project / "export_presets.cfg").write_text(
         EXPORT_PRESETS_CFG, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     listed = gda("export", "list", "--json")
 
@@ -126,7 +95,7 @@ def test_export_list_empty_cfg_is_an_empty_listing(godot_project):
     # An export_presets.cfg that defines no presets is a valid, empty listing —
     # not an error (distinct from no cfg at all).
     (godot_project / "export_presets.cfg").write_text("", encoding="utf-8")
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     listed = gda("export", "list", "--json")
 
@@ -140,11 +109,9 @@ def test_export_list_no_cfg_yields_export_presets_not_found(godot_project):
     # export list refuses with the structured export_presets_not_found code rather
     # than a misleading empty listing, so an agent knows the project defines no
     # presets.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
-    listed = gda("export", "list", "--json")
-
-    err = _assert_operation_error(listed, "export_presets_not_found")
+    err = gda.error("export", "list", "--json", code="export_presets_not_found")
     assert "export_presets.cfg" in err["message"]
 
 
@@ -153,14 +120,9 @@ def test_export_list_without_project_yields_project_not_found(tmp_path):
     # export list reads export_presets.cfg in a project, so it cannot run
     # projectless: run from a non-project directory with no --project, it refuses
     # with project_not_found rather than returning a misleading empty listing.
-    listed = subprocess.run(
-        [*GDA_CMD, "export", "list", "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-        cwd=str(tmp_path),
+    err = Gda().error(
+        "export", "list", "--json", cwd=tmp_path, code="project_not_found"
     )
-
-    err = _assert_operation_error(listed, "project_not_found")
     assert "--project" in err["message"]
 
 
@@ -173,7 +135,7 @@ def test_export_get_reports_preset_details_and_template_status(godot_project):
     (godot_project / "export_presets.cfg").write_text(
         EXPORT_PRESETS_CFG, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     got = gda("export", "get", "--preset", "Web", "--json")
 
@@ -200,7 +162,7 @@ def test_export_get_reports_export_path_of_a_preset_with_one(godot_project):
     (godot_project / "export_presets.cfg").write_text(
         EXPORT_PRESETS_CFG, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     got = gda("export", "get", "--preset", "Linux/X11", "--json")
 
@@ -218,11 +180,11 @@ def test_export_get_unknown_preset_yields_export_preset_not_found(godot_project)
     (godot_project / "export_presets.cfg").write_text(
         EXPORT_PRESETS_CFG, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
-    got = gda("export", "get", "--preset", "Nope", "--json")
-
-    err = _assert_operation_error(got, "export_preset_not_found")
+    err = gda.error(
+        "export", "get", "--preset", "Nope", "--json", code="export_preset_not_found"
+    )
     assert "Nope" in err["message"]
 
 
@@ -230,9 +192,9 @@ def test_export_get_unknown_preset_yields_export_preset_not_found(godot_project)
 def test_export_get_no_cfg_yields_export_presets_not_found(godot_project):
     # export get over a project with no export_presets.cfg reports the same
     # export_presets_not_found mode as export list — there is nothing to address.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
-    got = gda("export", "get", "--preset", "Web", "--json")
-
-    err = _assert_operation_error(got, "export_presets_not_found")
+    err = gda.error(
+        "export", "get", "--preset", "Web", "--json", code="export_presets_not_found"
+    )
     assert "export_presets.cfg" in err["message"]

--- a/tests/test_e2e_export_run.py
+++ b/tests/test_e2e_export_run.py
@@ -30,23 +30,19 @@ unconditionally.
 
 import json
 import os
-import subprocess
 import sys
 import zipfile
 from pathlib import Path
 
 import pytest
 
-from gda.binary import resolve_godot_binary
 from gda.harness.install import (
     HARNESS_AUTOLOAD_NAME,
     HARNESS_FILE,
     HARNESS_RES_DIR,
     install_harness,
 )
-from tests.support import GDA_CMD, templates_installed
-
-GODOT = resolve_godot_binary()
+from tests.support import Gda, templates_installed
 
 # A runnable Linux preset writing to build/game.x86_64, plus a non-runnable
 # preset with NO export_path (to exercise export_path_unset). Sibling `.options`
@@ -84,19 +80,6 @@ binary_format/embed_pck=false
 """
 
 
-def _gda_project(project):
-    """A ``gda`` bound to ``--godot`` + ``--project`` for the real engine."""
-
-    def gda(*args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-            capture_output=True,
-            text=True,
-        )
-
-    return gda
-
-
 @pytest.mark.e2e
 def test_export_run_unknown_preset_reuses_export_get_error(godot_project):
     # export run resolves the preset via export get first, so an unknown preset is
@@ -105,7 +88,7 @@ def test_export_run_unknown_preset_reuses_export_get_error(godot_project):
     (godot_project / "export_presets.cfg").write_text(
         EXPORT_PRESETS_CFG, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     run = gda("export", "run", "--preset", "Nope", "--json")
 
@@ -123,7 +106,7 @@ def test_export_run_unset_path_yields_export_path_unset(godot_project):
     (godot_project / "export_presets.cfg").write_text(
         EXPORT_PRESETS_CFG, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     run = gda("export", "run", "--preset", "NoPath", "--json")
 
@@ -158,7 +141,7 @@ def test_export_run_writes_to_configured_export_path(godot_project):
     )
     configured_rel = "build/game.x86_64"
     artifact = godot_project / configured_rel
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     run = gda("export", "run", "--preset", "Linux/X11", "--json")
 
@@ -211,7 +194,7 @@ def test_export_run_pack_writes_pck_without_templates(godot_project):
     )
     artifact = godot_project / "dist" / "packed.pck"
     configured = godot_project / "build/game.x86_64"
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     run = gda(
         "export",
@@ -256,27 +239,18 @@ def test_export_run_pack_accepts_a_relative_project(godot_project):
     artifact = godot_project / "dist" / "packed.pck"
 
     # Drive gda from the project's PARENT with a RELATIVE --project (the failing
-    # case) — NOT the absolute path _gda_project passes.
-    run = subprocess.run(
-        [
-            *GDA_CMD,
-            "export",
-            "run",
-            "--preset",
-            "Linux/X11",
-            "--mode",
-            "pack",
-            "--output",
-            str(artifact),
-            "--json",
-            "--godot",
-            str(GODOT),
-            "--project",
-            godot_project.name,  # RELATIVE; resolved against the cwd below
-        ],
-        capture_output=True,
-        text=True,
-        cwd=str(godot_project.parent),
+    # case) — NOT the absolute path a project-bound invoker passes.
+    run = Gda(godot_project.name)(  # RELATIVE project; resolved against the cwd
+        "export",
+        "run",
+        "--preset",
+        "Linux/X11",
+        "--mode",
+        "pack",
+        "--output",
+        str(artifact),
+        "--json",
+        cwd=godot_project.parent,
     )
 
     # No skip: pack must RUN to completion regardless of template presence. Before
@@ -314,7 +288,7 @@ def test_export_run_pack_omits_installed_harness_and_restores_it(godot_project):
     assert HARNESS_AUTOLOAD_NAME in project_godot.read_text(encoding="utf-8")
 
     artifact = godot_project / "dist" / "packed.zip"
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     run = gda(
         "export",
@@ -380,22 +354,13 @@ def test_export_run_without_templates_yields_export_templates_missing(
     empty_data = tmp_path / "empty-xdg"
     empty_data.mkdir()
 
-    run = subprocess.run(
-        [
-            *GDA_CMD,
-            "export",
-            "run",
-            "--preset",
-            "Linux/X11",
-            "--json",
-            "--godot",
-            str(GODOT),
-            "--project",
-            str(godot_project),
-        ],
-        capture_output=True,
-        text=True,
-        env={**os.environ, "XDG_DATA_HOME": str(empty_data)},
+    run = Gda(godot_project)(
+        "export",
+        "run",
+        "--preset",
+        "Linux/X11",
+        "--json",
+        extra_env={"XDG_DATA_HOME": str(empty_data)},
     )
 
     assert run.returncode == 4, run.stdout + run.stderr
@@ -444,7 +409,7 @@ def test_templates_installed_is_true_when_host_templates_are_on_disk(godot_proje
     (godot_project / "export_presets.cfg").write_text(
         EXPORT_PRESETS_CFG, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     # templates_installed is preset-independent (it only checks the version dir
     # exists), so any real preset works; the on-disk check above is the source of truth.

--- a/tests/test_e2e_game.py
+++ b/tests/test_e2e_game.py
@@ -9,45 +9,14 @@ RULES.md DoD the fake-runner command tests do not count toward this gate.
 """
 
 import json
-import os
-import subprocess
 import time
 
 import pytest
 
 from gda.exit_codes import EXIT_LIVE
+from tests.support import Gda
 
-from tests.support import GDA_CMD
-
-
-def _gda_runner(project, timeout: int = 90):
-    """One project/Godot-aware `gda` invoker for this module's live e2es (#749 review).
-
-    The protocol arguments, environment and timeout were repeated per test and
-    could drift; this is the single place they live.
-    """
-    from gda.binary import resolve_godot_binary
-
-    godot = resolve_godot_binary()
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(project),
-                "--godot",
-                str(godot),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env={**os.environ},
-            timeout=timeout,
-        )
-
-    return run
+from .conftest import LIVE_PROJECT_GODOT
 
 
 @pytest.mark.e2e
@@ -55,12 +24,8 @@ def test_game_tree_without_a_daemon_reports_daemon_not_running(tmp_path):
     (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
 
     # An empty runtime dir so discovery finds no daemon for this fresh project.
-    env = {**os.environ, "XDG_RUNTIME_DIR": str(tmp_path / "run")}
-    proc = subprocess.run(
-        [*GDA_CMD, "game", "tree", "--project", str(tmp_path), "--json"],
-        capture_output=True,
-        text=True,
-        env=env,
+    proc = Gda(tmp_path, godot=None)(
+        "game", "tree", "--json", extra_env={"XDG_RUNTIME_DIR": str(tmp_path / "run")}
     )
 
     assert proc.returncode == EXIT_LIVE, proc.stdout + proc.stderr
@@ -106,15 +71,11 @@ def test_game_get_projects_a_path_less_texture_with_optional_digest(
     # under object_string, NO resource_path key — with digest null by default;
     # with --texture-digest, two same-class textures with different content
     # get different digests and same-content textures the same one.
-    from .conftest import project_godot
-
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(TEXTURE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(TEXTURE_PLAYER_GD, encoding="utf-8")
 
-    run = _gda_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True)
 
     def texture_value(prop, *extra):
         got = run("game", "get", "/root/Main/Player", "--property", prop, *extra)
@@ -285,17 +246,13 @@ CALL_MAIN_TSCN = (
 def test_game_call_serves_declared_methods_and_refuses_the_rest(
     tmp_path, daemon_runtime_dir
 ):
-    from .conftest import project_godot
-
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(CALL_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "call_base.gd").write_text(CALL_BASE_GD, encoding="utf-8")
     (tmp_path / "call_child.gd").write_text(CALL_CHILD_GD, encoding="utf-8")
     (tmp_path / "call_main.gd").write_text(CALL_MAIN_GD, encoding="utf-8")
 
-    run = _gda_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True)
 
     def call(node, method, *extra):
         return run("game", "call", node, "--method", method, *extra)
@@ -383,11 +340,7 @@ def test_declaring_gda_callable_in_both_base_and_subclass_is_an_engine_parse_err
     # GDScript forbids redeclaring a base class's constant, so an opted-in chain
     # has at most one declaration owner. The failure is loud — the script does
     # not load — never a silently wrong allowlist.
-    from .conftest import project_godot
-
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "call_base.gd").write_text(CALL_BASE_GD, encoding="utf-8")
     (tmp_path / "call_main.gd").write_text(
         'extends "res://call_base.gd"\n\n'
@@ -404,7 +357,7 @@ def test_declaring_gda_callable_in_both_base_and_subclass_is_an_engine_parse_err
         encoding="utf-8",
     )
 
-    run = _gda_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True)
 
     try:
         assert run("daemon", "start").returncode == 0
@@ -434,17 +387,13 @@ def test_game_call_refuses_arguments_the_engine_would_not_convert(
     # (and polluting the Session log). Every refusal below was a false success at
     # the reviewed head; every acceptance below is a conversion the engine really
     # performs, so the gate mirrors the engine rather than over-refusing.
-    from .conftest import project_godot
-
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(CALL_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "call_base.gd").write_text(CALL_BASE_GD, encoding="utf-8")
     (tmp_path / "call_child.gd").write_text(CALL_CHILD_GD, encoding="utf-8")
     (tmp_path / "call_main.gd").write_text(CALL_MAIN_GD, encoding="utf-8")
 
-    run = _gda_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True)
 
     def call(method, args):
         return run("game", "call", "/root/Main", "--method", method, "--args", args)
@@ -496,17 +445,13 @@ def test_game_call_non_finite_args_never_reach_the_session(
     # the daemon retired the channel — the NEXT call relaunched the session and
     # its runtime state was gone. The refusal now happens in the params model,
     # before the wire: fast, typed, and the session identity is untouched.
-    from .conftest import project_godot
-
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(CALL_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "call_base.gd").write_text(CALL_BASE_GD, encoding="utf-8")
     (tmp_path / "call_child.gd").write_text(CALL_CHILD_GD, encoding="utf-8")
     (tmp_path / "call_main.gd").write_text(CALL_MAIN_GD, encoding="utf-8")
 
-    run = _gda_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True)
 
     try:
         assert run("daemon", "start").returncode == 0
@@ -566,17 +511,13 @@ def test_game_call_argument_gate_agrees_with_the_engine(tmp_path, daemon_runtime
     # oracle is the engine itself: `probe_direct` performs the call inside the
     # game and reports whether the method body RAN. gda must call exactly when
     # the engine would, so the table can never drift silently again.
-    from .conftest import project_godot
-
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(CALL_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "call_base.gd").write_text(CALL_BASE_GD, encoding="utf-8")
     (tmp_path / "call_child.gd").write_text(CALL_CHILD_GD, encoding="utf-8")
     (tmp_path / "call_main.gd").write_text(CALL_MAIN_GD, encoding="utf-8")
 
-    run = _gda_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True)
 
     # (method, JSON arguments) pairs spanning every retained live source-to-target
     # conversion edge, plus identity and refusal boundaries. Empty Arrays isolate
@@ -672,17 +613,14 @@ def test_game_call_refuses_integers_the_wire_cannot_carry(tmp_path, daemon_runti
     # to …984 instead of …986; 1.2e29 arrived as -2). The bound is now refused at
     # the input boundary; the largest exact value still goes through unchanged.
     from gda.commands.game import MAX_EXACT_JSON_INT
-    from .conftest import project_godot
 
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(CALL_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "call_base.gd").write_text(CALL_BASE_GD, encoding="utf-8")
     (tmp_path / "call_child.gd").write_text(CALL_CHILD_GD, encoding="utf-8")
     (tmp_path / "call_main.gd").write_text(CALL_MAIN_GD, encoding="utf-8")
 
-    run = _gda_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True)
 
     try:
         assert run("daemon", "start").returncode == 0
@@ -749,17 +687,13 @@ def test_game_call_refuses_integers_the_wire_cannot_carry(tmp_path, daemon_runti
 @pytest.mark.e2e
 def test_game_call_preserves_large_finite_float_arguments(tmp_path, daemon_runtime_dir):
     """The live wire preserves high-range finite binary64 arguments."""
-    from .conftest import project_godot
-
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(CALL_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "call_base.gd").write_text(CALL_BASE_GD, encoding="utf-8")
     (tmp_path / "call_child.gd").write_text(CALL_CHILD_GD, encoding="utf-8")
     (tmp_path / "call_main.gd").write_text(CALL_MAIN_GD, encoding="utf-8")
 
-    run = _gda_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True)
 
     try:
         assert run("daemon", "start").returncode == 0

--- a/tests/test_e2e_harness_install.py
+++ b/tests/test_e2e_harness_install.py
@@ -39,7 +39,6 @@ from typing import NamedTuple
 
 import pytest
 
-from gda.binary import resolve_godot_binary
 from gda.daemon.protocol import read_frame
 from gda.harness.install import (
     HARNESS_AUTOLOAD_NAME,
@@ -48,16 +47,13 @@ from gda.harness.install import (
     install_harness,
 )
 
-from tests.support import GDA_CMD, templates_installed
+from tests.support import GODOT, Gda, templates_installed
 
-from .conftest import project_godot
-
-GODOT = resolve_godot_binary()
+from .conftest import LIVE_PROJECT_GODOT, project_godot
 
 # A trivial main scene so a normal (non-`--script`) boot runs the autoload's
 # `_ready`; file logging stays disabled via project_godot (issue #180).
 MAIN_TSCN = '[gd_scene format=3]\n\n[node name="Main" type="Node"]\n'
-PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
 
 # The harness only connects when a `gda-daemon` marker is present in the user args
 # (StreamPeerUDS.connect_to_host). An inert boot opens nothing, so none of these
@@ -79,7 +75,7 @@ def _assert_inert_boot(out: str, returncode: int) -> None:
 
 @pytest.mark.e2e
 def test_installed_harness_boots_inert_in_a_real_engine(tmp_path):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
 
     result = install_harness(tmp_path)
@@ -110,7 +106,7 @@ def test_exported_pck_with_harness_runs_inert(tmp_path):
     # harness is genuinely IN the pack, then RUN that .pck with no `gda-daemon`
     # marker — the packed GdaHarness autoload must boot clean and open nothing (the
     # exact failure ADR-0018 guards: a dangling/active autoload in an exported game).
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
     install_harness(tmp_path)
 
@@ -368,14 +364,7 @@ def test_template_feature_gates_the_harness_only_in_exported_builds(
     (tmp_path / "export_presets.cfg").write_text(target.presets_cfg, encoding="utf-8")
     install_harness(tmp_path)
 
-    def gda(*args):  # bound `gda export get` for the templates-presence gate
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(tmp_path)],
-            capture_output=True,
-            text=True,
-        )
-
-    if not templates_installed(gda, preset=target.preset):
+    if not templates_installed(Gda(tmp_path), preset=target.preset):
         pytest.skip(
             f"export templates for the running engine + {target.preset!r} are not "
             "installed; the template-gate BEHAVIOURAL proof cannot export a template "
@@ -481,15 +470,10 @@ def test_daemon_install_leaves_a_project_a_real_engine_boots_inert(tmp_path):
     # same way the fast install tests' does — the autoload loads, and stays inert with
     # no daemon marker. Driven through a REAL `gda` subprocess (no daemon involved),
     # so the recipe, the JSON receipt and the engine's verdict are all exercised.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
 
-    installed = subprocess.run(
-        [*GDA_CMD, "daemon", "install", "--project", str(tmp_path), "--json"],
-        capture_output=True,
-        text=True,
-        timeout=60,
-    )
+    installed = Gda(tmp_path, godot=None, timeout=60)("daemon", "install", "--json")
 
     assert installed.returncode == 0, installed.stdout + installed.stderr
     receipt = json.loads(installed.stdout)
@@ -510,12 +494,7 @@ def test_daemon_install_leaves_a_project_a_real_engine_boots_inert(tmp_path):
     _assert_inert_boot(proc.stdout + proc.stderr, proc.returncode)
 
     # And `gda daemon uninstall` reverses it, so the pair is symmetric end to end.
-    removed = subprocess.run(
-        [*GDA_CMD, "daemon", "uninstall", "--project", str(tmp_path), "--json"],
-        capture_output=True,
-        text=True,
-        timeout=60,
-    )
+    removed = Gda(tmp_path, godot=None, timeout=60)("daemon", "uninstall", "--json")
     assert removed.returncode == 0, removed.stdout + removed.stderr
     assert json.loads(removed.stdout)["removed"] is True
     assert not (tmp_path / "addons" / "gda_harness").exists()

--- a/tests/test_e2e_headless_number_reads.py
+++ b/tests/test_e2e_headless_number_reads.py
@@ -21,11 +21,8 @@ claims anything about it.
 
 import json
 import math
-import subprocess
 
 import pytest
-
-from gda.binary import resolve_godot_binary
 
 from tests.live_number_corpus import (
     LIVE_NUMBER_CORPUS,
@@ -34,9 +31,7 @@ from tests.live_number_corpus import (
     tally_outcome,
     value_bits,
 )
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
+from tests.support import Gda
 
 # One exported float per corpus row plus the whole corpus as a packed array, so
 # the scalar arm of the value projection and its element-wise arm are both read
@@ -84,33 +79,12 @@ PROBE_TSCN = (
 )
 
 
-def _gda(project):
-    """A bound ``gda <args> --project <p> --godot <g> --json`` runner."""
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(project),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=180,
-        )
-
-    return run
-
-
 def _probe_project(project):
     """Write the probe scene into ``project`` and return its bound runner."""
     (project / "numbers.gd").write_text(_probe_source(), encoding="utf-8")
     (project / "numbers.tscn").write_text(PROBE_TSCN, encoding="utf-8")
-    return _gda(project)
+    # 180s: a read of the whole corpus boots the engine on every row.
+    return Gda(project, json_output=True, timeout=180)
 
 
 def _exports_by_name(run) -> dict:
@@ -221,7 +195,7 @@ def test_a_project_setting_round_trips_through_set_and_get(godot_project):
     from both — while `project.godot` held the value the caller sent. These are the
     two literals #771 quotes, and they are the round-trip the catalog promises.
     """
-    run = _gda(godot_project)
+    run = Gda(godot_project, json_output=True, timeout=180)
     setting = "physics/2d/default_gravity"
 
     for literal, expected in (

--- a/tests/test_e2e_info.py
+++ b/tests/test_e2e_info.py
@@ -7,23 +7,19 @@ supported version (>= 4.4) per ADR-0003.
 """
 
 import json
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
+from tests.support import Gda
 
-GODOT = resolve_godot_binary()
+from .conftest import project_godot
+
+gda = Gda()
 
 
 @pytest.mark.e2e
 def test_gda_info_json_against_real_godot():
-    proc = subprocess.run(
-        [*GDA_CMD, "info", "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-    )
+    proc = gda("info", "--json")
 
     assert proc.returncode == 0, proc.stderr
     # stdout is a single valid JSON object.
@@ -41,11 +37,7 @@ def test_gda_info_missing_binary_yields_structured_error_end_to_end():
     # against a binary that cannot launch. No installed engine required — the
     # point is that the path does NOT exist. The runner synthesizes exit 127,
     # the CLI emits a structured JSON error on stdout.
-    proc = subprocess.run(
-        [*GDA_CMD, "info", "--godot", "/nonexistent/Godot", "--json"],
-        capture_output=True,
-        text=True,
-    )
+    proc = Gda(godot="/nonexistent/Godot")("info", "--json")
 
     assert proc.returncode == 127
     err = json.loads(proc.stdout)["error"]
@@ -62,14 +54,10 @@ def test_gda_info_accepts_a_project_and_still_reports_the_engine(tmp_path):
     # (ADR-0006), not that the flag is parsed and dropped. Against a REAL engine: the
     # version comes back unchanged, so the uniform argv costs nothing.
     (tmp_path / "project.godot").write_text(
-        'config_version=5\n\n[application]\n\nconfig/name="probe"\n', encoding="utf-8"
+        project_godot(name="probe"), encoding="utf-8"
     )
 
-    proc = subprocess.run(
-        [*GDA_CMD, "info", "--project", str(tmp_path), "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-    )
+    proc = Gda(tmp_path)("info", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     data = json.loads(proc.stdout)
@@ -77,22 +65,14 @@ def test_gda_info_accepts_a_project_and_still_reports_the_engine(tmp_path):
 
     # And it is the SAME answer as the projectless probe — the project does not
     # change what `info` reports.
-    projectless = subprocess.run(
-        [*GDA_CMD, "info", "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-    )
+    projectless = gda("info", "--json")
     assert json.loads(projectless.stdout) == data
 
 
 @pytest.mark.e2e
 def test_gda_info_refuses_a_project_that_is_not_one(tmp_path):
     # Validated, not merely accepted — through the real CLI, before any engine runs.
-    proc = subprocess.run(
-        [*GDA_CMD, "info", "--project", str(tmp_path), "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-    )
+    proc = Gda(tmp_path)("info", "--json")
 
     assert proc.returncode == 4, proc.stdout + proc.stderr
     assert json.loads(proc.stdout)["error"]["code"] == "project_not_found"

--- a/tests/test_e2e_input.py
+++ b/tests/test_e2e_input.py
@@ -722,6 +722,7 @@ def test_two_clicks_leave_diag_errors_empty(tmp_path, daemon_runtime_dir):
 
 @pytest.mark.e2e
 @pytest.mark.usefixtures("windowed_host")
+@pytest.mark.xdist_group("windowed")  # shares the host display (#818)
 def test_two_windowed_clicks_leave_diag_errors_empty(tmp_path, daemon_runtime_dir):
     # The exact #647 reproduction: a WINDOWED daemon session, two successful
     # clicks, an empty `diag errors`. The windowed path also carries the

--- a/tests/test_e2e_input.py
+++ b/tests/test_e2e_input.py
@@ -14,16 +14,12 @@ project_godot (#180).
 
 import json
 import os
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD, assert_windowed_ok
+from tests.support import Gda, assert_windowed_ok
 
-from .conftest import project_godot
-
-GODOT = resolve_godot_binary()
+from .conftest import LIVE_PROJECT_GODOT, project_godot
 
 # A Player whose `_input` moves it right on KEY_RIGHT — so an injected key event
 # rides the game's real input flow into `_input` and mutates `position.x`, observed
@@ -130,7 +126,6 @@ PHYSICS_ACTION_PLAYER_GD = (
     "\t\tposition.x += SPEED * delta\n"
 )
 
-PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
 
 # A project.godot whose [input] section declares `move_right` so the running
 # InputMap has the action `input action move_right` drives (InputMap.has_action).
@@ -230,28 +225,11 @@ def test_daemon_serves_input_key_observed_via_game_get(tmp_path, daemon_runtime_
     # The #221 DoD: a real daemon -> engine session -> `input key Right` pushes a key
     # event into the running game, whose `_input` moves the Player, observed via
     # `game get` — end-to-end through the real harness over UDS (ADR-0020).
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(KEY_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(KEY_PLAYER_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     try:
         assert run("daemon", "start").returncode == 0
@@ -293,28 +271,11 @@ def test_daemon_serves_input_mouse_click_observed_via_game_get(
     # InputEventMouseButton through the real `push_input` viewport path into the
     # running game's `_input`, which snaps the Player to the click position —
     # observed via `game get` (ADR-0020).
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MOUSE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(MOUSE_PLAYER_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     try:
         assert run("daemon", "start").returncode == 0
@@ -355,28 +316,11 @@ def test_mouse_input_reports_event_position_when_tracked_mouse_position_is_stale
     # #462: in the default daemon session, Godot accepts the injected event position
     # but does not expose a reliable seam for updating the engine-tracked mouse
     # position. Pin that limitation so the documented workaround remains true.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(TRACKED_MOUSE_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(TRACKED_MOUSE_PLAYER_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     def player_property(name: str):
         got = run("game", "get", "/root/Main/Player", "--property", name)
@@ -422,28 +366,11 @@ def test_input_sequence_drags_mouse_with_held_button_mask(tmp_path, daemon_runti
     # #461: a press -> move(s) -> release gesture stays inside one `input sequence`
     # RPC. The game reads event.position and event.button_mask, not tracked mouse
     # position, because #462 documents the tracked-position limitation.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(DRAG_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(DRAG_PLAYER_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     def player_property(name: str):
         got = run("game", "get", "/root/Main/Player", "--property", name)
@@ -486,24 +413,7 @@ def test_daemon_serves_input_action_observed_via_game_get(tmp_path, daemon_runti
     (tmp_path / "main.tscn").write_text(ACTION_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(ACTION_PLAYER_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     try:
         assert run("daemon", "start").returncode == 0
@@ -549,28 +459,11 @@ def test_add_input_action_makes_the_action_immediately_driveable(
     # action exists only because add-input-action persisted it. Ordering matters:
     # the InputMap loads from project.godot at engine launch, so the headless add
     # runs BEFORE `daemon start`.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(ACTION_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(ACTION_PLAYER_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     # Register the action headlessly FIRST — before any engine session exists.
     added = run("project", "add-input-action", "move_right", "--key", "Right")
@@ -613,28 +506,11 @@ def test_daemon_serves_input_sequence_across_frames(tmp_path, daemon_runtime_dir
     # multi-frame base (#223), returned as ONE blocking result. Three Right presses at
     # frames 0/1/2 each move the Player by 10, so position.x advances by 30 over the
     # window — observed via game get.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(KEY_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(KEY_PLAYER_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     events = json.dumps(
         [
@@ -688,24 +564,7 @@ def test_input_sequence_physics_frame_hold_matches_predicted_displacement(
     (tmp_path / "main.tscn").write_text(ACTION_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(PHYSICS_ACTION_PLAYER_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     hold_frames = 12
     physics_fps = 60
@@ -767,28 +626,11 @@ def test_input_action_unknown_action_reports_live_unknown_action(
 ):
     # An action absent from the running InputMap is the typed harness op-error,
     # relayed through the daemon (exit-0 sentinel) and mapped by classify_live.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(KEY_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(KEY_PLAYER_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     from gda.exit_codes import EXIT_LIVE
 
@@ -803,23 +645,14 @@ def test_input_action_unknown_action_reports_live_unknown_action(
 
 
 def _button_project(tmp_path):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(BUTTON_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "ui.gd").write_text(BUTTON_UI_GD, encoding="utf-8")
 
 
-def _gda_json(tmp_path, env, *args):
-    return subprocess.run(
-        [*GDA_CMD, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
-        capture_output=True,
-        text=True,
-        env=env,
-        timeout=90,
-    )
-
-
-def _property_value(tmp_path, env, node, name):
-    got = _gda_json(tmp_path, env, "game", "get", node, "--property", name)
+def _property_value(gda, node, name):
+    """One property's projected value, read live off the running game."""
+    got = gda("game", "get", node, "--property", name)
     assert got.returncode == 0, got.stdout + got.stderr
     return next(p for p in json.loads(got.stdout)["properties"] if p["name"] == name)[
         "value"
@@ -835,12 +668,12 @@ def test_mouse_click_performs_the_complete_activation_gesture(
     # press that leaves the button held down forever. Repeated clicks keep
     # activating, because each gesture releases what it pressed.
     _button_project(tmp_path)
-    env = {**os.environ}
+    gda = Gda(tmp_path, json_output=True)
 
     try:
-        assert _gda_json(tmp_path, env, "daemon", "start").returncode == 0
+        assert gda("daemon", "start").returncode == 0
 
-        first = _gda_json(tmp_path, env, "input", "mouse-click", "50", "20")
+        first = gda("input", "mouse-click", "50", "20")
         assert first.returncode == 0, first.stdout + first.stderr
         doc = json.loads(first.stdout)
         # The structured gesture evidence: the three phases at their frames.
@@ -851,18 +684,18 @@ def test_mouse_click_performs_the_complete_activation_gesture(
         ]
 
         # The Button observed the COMPLETE activation: down, up, and `pressed`.
-        assert _property_value(tmp_path, env, "/root/Main", "pressed_count") == 1
-        assert _property_value(tmp_path, env, "/root/Main", "down_count") == 1
-        assert _property_value(tmp_path, env, "/root/Main", "up_count") == 1
+        assert _property_value(gda, "/root/Main", "pressed_count") == 1
+        assert _property_value(gda, "/root/Main", "down_count") == 1
+        assert _property_value(gda, "/root/Main", "up_count") == 1
         # The gesture included the initial move (GDA-DF-004's "initial move").
-        assert _property_value(tmp_path, env, "/root/Main", "motion_seen") is True
+        assert _property_value(gda, "/root/Main", "motion_seen") is True
 
-        second = _gda_json(tmp_path, env, "input", "mouse-click", "50", "20")
+        second = gda("input", "mouse-click", "50", "20")
         assert second.returncode == 0, second.stdout + second.stderr
-        assert _property_value(tmp_path, env, "/root/Main", "pressed_count") == 2
-        assert _property_value(tmp_path, env, "/root/Main", "up_count") == 2
+        assert _property_value(gda, "/root/Main", "pressed_count") == 2
+        assert _property_value(gda, "/root/Main", "up_count") == 2
     finally:
-        _gda_json(tmp_path, env, "daemon", "stop")
+        gda("daemon", "stop")
 
 
 @pytest.mark.e2e
@@ -872,23 +705,19 @@ def test_two_clicks_leave_diag_errors_empty(tmp_path, daemon_runtime_dir):
     # EMPTY — not merely free of one known message — so a consumer can use an
     # empty result as clean runtime evidence after a multi-click playtest.
     _button_project(tmp_path)
-    env = {**os.environ}
+    gda = Gda(tmp_path, json_output=True)
 
     try:
-        assert _gda_json(tmp_path, env, "daemon", "start").returncode == 0
+        assert gda("daemon", "start").returncode == 0
 
-        assert (
-            _gda_json(tmp_path, env, "input", "mouse-click", "50", "20").returncode == 0
-        )
-        assert (
-            _gda_json(tmp_path, env, "input", "mouse-click", "50", "20").returncode == 0
-        )
+        assert gda("input", "mouse-click", "50", "20").returncode == 0
+        assert gda("input", "mouse-click", "50", "20").returncode == 0
 
-        diag = _gda_json(tmp_path, env, "diag", "errors")
+        diag = gda("diag", "errors")
         assert diag.returncode == 0, diag.stdout + diag.stderr
         assert json.loads(diag.stdout)["errors"] == []
     finally:
-        _gda_json(tmp_path, env, "daemon", "stop")
+        gda("daemon", "stop")
 
 
 @pytest.mark.e2e
@@ -901,18 +730,18 @@ def test_two_windowed_clicks_leave_diag_errors_empty(tmp_path, daemon_runtime_di
     # (tests.support.require_windowed_host); a capability refusal skips, a
     # confined run fails loudly (#345/#667).
     _button_project(tmp_path)
-    env = {**os.environ}
+    gda = Gda(tmp_path, json_output=True)
 
     try:
-        assert_windowed_ok(_gda_json(tmp_path, env, "daemon", "start", "--windowed"))
+        assert_windowed_ok(gda("daemon", "start", "--windowed"))
 
-        assert_windowed_ok(_gda_json(tmp_path, env, "input", "mouse-click", "50", "20"))
-        assert_windowed_ok(_gda_json(tmp_path, env, "input", "mouse-click", "50", "20"))
+        assert_windowed_ok(gda("input", "mouse-click", "50", "20"))
+        assert_windowed_ok(gda("input", "mouse-click", "50", "20"))
 
-        diag = assert_windowed_ok(_gda_json(tmp_path, env, "diag", "errors"))
+        diag = assert_windowed_ok(gda("diag", "errors"))
         assert json.loads(diag.stdout)["errors"] == []
     finally:
-        _gda_json(tmp_path, env, "daemon", "stop")
+        gda("daemon", "stop")
 
 
 @pytest.mark.e2e
@@ -921,14 +750,12 @@ def test_sequence_mouse_click_event_activates_a_button(tmp_path, daemon_runtime_
     # (#652): the harness pushes the press and the release on the same frame,
     # which fully activates a default Button.
     _button_project(tmp_path)
-    env = {**os.environ}
+    gda = Gda(tmp_path, json_output=True)
 
     try:
-        assert _gda_json(tmp_path, env, "daemon", "start").returncode == 0
+        assert gda("daemon", "start").returncode == 0
 
-        injected = _gda_json(
-            tmp_path,
-            env,
+        injected = gda(
             "input",
             "sequence",
             "--events",
@@ -936,10 +763,10 @@ def test_sequence_mouse_click_event_activates_a_button(tmp_path, daemon_runtime_
         )
         assert injected.returncode == 0, injected.stdout + injected.stderr
 
-        assert _property_value(tmp_path, env, "/root/Main", "pressed_count") == 1
-        assert _property_value(tmp_path, env, "/root/Main", "up_count") == 1
+        assert _property_value(gda, "/root/Main", "pressed_count") == 1
+        assert _property_value(gda, "/root/Main", "up_count") == 1
     finally:
-        _gda_json(tmp_path, env, "daemon", "stop")
+        gda("daemon", "stop")
 
 
 @pytest.mark.e2e
@@ -949,15 +776,15 @@ def test_tap_advances_a_focus_driven_ui_exactly_once_repeatably(
     # The #652 tap DoD (GDA-DF-034): one key tap advances a focus-driven UI
     # exactly ONE step, and does so repeatably — the press and the release land
     # on separate process frames, and only the press navigates.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(FOCUS_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "ui.gd").write_text(FOCUS_UI_GD, encoding="utf-8")
-    env = {**os.environ}
+    gda = Gda(tmp_path, json_output=True)
 
     try:
-        assert _gda_json(tmp_path, env, "daemon", "start").returncode == 0
+        assert gda("daemon", "start").returncode == 0
 
-        first = _gda_json(tmp_path, env, "input", "tap", "--key", "Down")
+        first = gda("input", "tap", "--key", "Down")
         assert first.returncode == 0, first.stdout + first.stderr
         doc = json.loads(first.stdout)
         assert doc["phases"] == [
@@ -968,14 +795,14 @@ def test_tap_advances_a_focus_driven_ui_exactly_once_repeatably(
         assert doc["focus_before"] == "/root/Main/A", doc
         assert doc["focus_after"] == "/root/Main/B", doc
 
-        second = _gda_json(tmp_path, env, "input", "tap", "--key", "Down")
+        second = gda("input", "tap", "--key", "Down")
         assert second.returncode == 0, second.stdout + second.stderr
         doc = json.loads(second.stdout)
         # Repeatably: the next tap advances exactly one more step, B -> C.
         assert doc["focus_before"] == "/root/Main/B", doc
         assert doc["focus_after"] == "/root/Main/C", doc
     finally:
-        _gda_json(tmp_path, env, "daemon", "stop")
+        gda("daemon", "stop")
 
 
 @pytest.mark.e2e
@@ -988,27 +815,27 @@ def test_tap_action_produces_exactly_one_press_and_release_edge(
     (tmp_path / "project.godot").write_text(ACTION_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(ACTION_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(TAP_ACTION_PLAYER_GD, encoding="utf-8")
-    env = {**os.environ}
+    gda = Gda(tmp_path, json_output=True)
 
     try:
-        assert _gda_json(tmp_path, env, "daemon", "start").returncode == 0
+        assert gda("daemon", "start").returncode == 0
 
-        first = _gda_json(tmp_path, env, "input", "tap", "--action", "move_right")
+        first = gda("input", "tap", "--action", "move_right")
         assert first.returncode == 0, first.stdout + first.stderr
         doc = json.loads(first.stdout)
         assert doc["action"] == "move_right"
         assert doc["key"] is None
 
         node = "/root/Main/Player"
-        assert _property_value(tmp_path, env, node, "pressed_edges") == 1
-        assert _property_value(tmp_path, env, node, "released_edges") == 1
+        assert _property_value(gda, node, "pressed_edges") == 1
+        assert _property_value(gda, node, "released_edges") == 1
 
-        second = _gda_json(tmp_path, env, "input", "tap", "--action", "move_right")
+        second = gda("input", "tap", "--action", "move_right")
         assert second.returncode == 0, second.stdout + second.stderr
-        assert _property_value(tmp_path, env, node, "pressed_edges") == 2
-        assert _property_value(tmp_path, env, node, "released_edges") == 2
+        assert _property_value(gda, node, "pressed_edges") == 2
+        assert _property_value(gda, node, "released_edges") == 2
     finally:
-        _gda_json(tmp_path, env, "daemon", "stop")
+        gda("daemon", "stop")
 
 
 @pytest.mark.e2e
@@ -1018,12 +845,12 @@ def test_input_key_without_a_daemon_reports_daemon_not_running(tmp_path):
 
     from gda.exit_codes import EXIT_LIVE
 
-    env = {**os.environ, "XDG_RUNTIME_DIR": str(tmp_path / "run")}
-    proc = subprocess.run(
-        [*GDA_CMD, "input", "key", "Right", "--project", str(tmp_path), "--json"],
-        capture_output=True,
-        text=True,
-        env=env,
+    proc = Gda(tmp_path, godot=None)(
+        "input",
+        "key",
+        "Right",
+        "--json",
+        extra_env={"XDG_RUNTIME_DIR": str(tmp_path / "run")},
     )
 
     assert proc.returncode == EXIT_LIVE, proc.stdout + proc.stderr

--- a/tests/test_e2e_launch_timeout.py
+++ b/tests/test_e2e_launch_timeout.py
@@ -45,10 +45,19 @@ from gda.runner import SubprocessGodotRunner
 from tests.conftest import project_godot
 from tests.support import GODOT, Gda
 
-# The ceiling every arm gives its wedged engine. Long enough for a real Godot to
-# boot and print, short enough that three arms plus gda's terminate grace stay
-# well inside a test run.
-CEILING_SECONDS = 4.0
+# The ceiling each arm gives its wedged engine, by the engine path it boots (#827).
+# The GAME path (the sentinel channel) boots and prints in well under a second, so
+# 4.0s bounds it with a wide margin. The EDITOR path (`--import`, `--export-*`)
+# takes seconds to reach the plugin, and more the more editors boot at once. On
+# one 8-core macOS host (2026-09-04): 1.6–2.4s serially, 2.1–4.6s with four
+# concurrent editor passes, 3.4–8.3s with eight (the low ends from a cool host,
+# the high ends right after an hour of full load), and up to 16.5s with stray CPU
+# load on top — so under pytest-xdist a 4.0s ceiling raced the boot and once lost:
+# the diagnostics held the banner but no plugin line. A slower CI runner scales
+# these up. 30s clears the eight-way figures 3.6x and the loaded worst case 1.8x;
+# each editor arm spends it in full, which xdist parallelism absorbs.
+GAME_CEILING_SECONDS = 4.0
+EDITOR_CEILING_SECONDS = 30.0
 
 # A blocking autoload: it announces itself on BOTH streams and then never returns.
 # `printerr` matters — gda's stdout carries the ADR-0002 result object, so the
@@ -113,12 +122,14 @@ def _wedged_project(tmp_path: Path, *, autoload: bool, plugin: bool) -> Path:
     return tmp_path
 
 
-def _assert_bounded(elapsed: float) -> None:
+def _assert_bounded(elapsed: float, ceiling: float) -> None:
     """The run was ended by gda's ceiling, not by the engine and not by luck."""
-    assert elapsed >= CEILING_SECONDS, f"the run ended early, at {elapsed:.1f}s"
-    # The ceiling plus gda's terminate-then-kill grace, generously. A wedged
-    # GDScript loop ignores the SIGTERM, so the grace is always spent in full.
-    assert elapsed < CEILING_SECONDS + 20, f"the run overran its bound: {elapsed:.1f}s"
+    assert elapsed >= ceiling, f"the run ended early, at {elapsed:.1f}s"
+    # The ceiling plus gda's terminate-then-kill grace and its reader join,
+    # generously: the bound holds whether the wedged engine dies on the SIGTERM
+    # at once (observed: the arms end within 0.4s of the ceiling) or sits out the
+    # grace and takes the SIGKILL.
+    assert elapsed < ceiling + 20, f"the run overran its bound: {elapsed:.1f}s"
 
 
 def _assert_caller_first_remediation(message: str) -> None:
@@ -146,14 +157,14 @@ def _assert_caller_first_remediation(message: str) -> None:
 
 
 def _assert_timeout_envelope(
-    failure: Failure, label: str, *, expect: list[str]
+    failure: Failure, label: str, ceiling: float, *, expect: list[str]
 ) -> None:
     error = failure.error
     assert error.code == "launch_timeout", error
     assert error.category.value == "environment"
     assert error.message.startswith(f"{label} launched but did not return")
-    assert f"timeout of {CEILING_SECONDS}s" in error.message
-    assert "elapsed 4." in error.message, error.message
+    assert f"timeout of {ceiling}s" in error.message
+    assert f"elapsed {int(ceiling)}." in error.message, error.message
     assert "16384 UTF-8 bytes (16 KiB)" in error.message
     _assert_caller_first_remediation(error.message)
     for expected in expect:
@@ -163,18 +174,19 @@ def _assert_timeout_envelope(
 @pytest.mark.e2e
 def test_a_wedged_sentinel_op_reports_what_the_engine_printed(tmp_path):
     project = _wedged_project(tmp_path, autoload=True, plugin=False)
-    runner = SubprocessGodotRunner(GODOT, project=project, timeout=CEILING_SECONDS)
+    runner = SubprocessGodotRunner(GODOT, project=project, timeout=GAME_CEILING_SECONDS)
 
     started = time.monotonic()
     raw = runner.run("info", {})
     elapsed = time.monotonic() - started
 
-    _assert_bounded(elapsed)
+    _assert_bounded(elapsed, GAME_CEILING_SECONDS)
     outcome = classify_run(raw, GODOT, EngineVersion)
     assert isinstance(outcome, Failure)
     _assert_timeout_envelope(
         outcome,
         "Godot",
+        GAME_CEILING_SECONDS,
         # Both streams, and both from the engine itself: the banner it printed on
         # its own, and the autoload's two lines from before it stopped returning.
         expect=["Godot Engine v", "AUTOLOAD REACHED", "AUTOLOAD WEDGED"],
@@ -184,13 +196,15 @@ def test_a_wedged_sentinel_op_reports_what_the_engine_printed(tmp_path):
 @pytest.mark.e2e
 def test_a_wedged_export_reports_what_the_engine_printed(tmp_path):
     project = _wedged_project(tmp_path, autoload=False, plugin=True)
-    runner = SubprocessExportRunner(GODOT, project=project, timeout=CEILING_SECONDS)
+    runner = SubprocessExportRunner(
+        GODOT, project=project, timeout=EDITOR_CEILING_SECONDS
+    )
 
     started = time.monotonic()
     raw = runner.run("Linux/X11", "release", "build/game.x86_64")
     elapsed = time.monotonic() - started
 
-    _assert_bounded(elapsed)
+    _assert_bounded(elapsed, EDITOR_CEILING_SECONDS)
     outcome = classify_export_run(
         raw,
         GODOT,
@@ -202,7 +216,10 @@ def test_a_wedged_export_reports_what_the_engine_printed(tmp_path):
     )
     assert isinstance(outcome, Failure)
     _assert_timeout_envelope(
-        outcome, "Godot export", expect=["PLUGIN REACHED", "PLUGIN WEDGED"]
+        outcome,
+        "Godot export",
+        EDITOR_CEILING_SECONDS,
+        expect=["PLUGIN REACHED", "PLUGIN WEDGED"],
     )
 
 
@@ -220,18 +237,18 @@ def test_a_wedged_import_pass_reports_what_the_engine_printed(tmp_path):
         "import",
         "res://icon.png",
         "--timeout",
-        str(CEILING_SECONDS),
+        str(EDITOR_CEILING_SECONDS),
         "--json",
     )
     elapsed = time.monotonic() - started
 
-    _assert_bounded(elapsed)
+    _assert_bounded(elapsed, EDITOR_CEILING_SECONDS)
     assert run.returncode == 124, run.stdout + run.stderr
     error = json.loads(run.stdout)["error"]
     assert error["code"] == "launch_timeout"
     assert error["message"].startswith("Godot import launched but did not return")
-    assert f"timeout of {CEILING_SECONDS}s" in error["message"]
-    assert "elapsed 4." in error["message"]
+    assert f"timeout of {EDITOR_CEILING_SECONDS}s" in error["message"]
+    assert f"elapsed {int(EDITOR_CEILING_SECONDS)}." in error["message"]
     _assert_caller_first_remediation(error["message"])
     assert "PLUGIN WEDGED" in error["diagnostics"]
     # #687 (the ADR-0004 amendment) end to end, on a REAL wedged engine: the three
@@ -242,8 +259,8 @@ def test_a_wedged_import_pass_reports_what_the_engine_printed(tmp_path):
     # because the clock and the phase are readings of a real process: a fake
     # RunResult would assert only the can.
     evidence = error["evidence"]
-    assert evidence["timeout_seconds"] == CEILING_SECONDS
-    assert evidence["elapsed_seconds"] >= CEILING_SECONDS
+    assert evidence["timeout_seconds"] == EDITOR_CEILING_SECONDS
+    assert evidence["elapsed_seconds"] >= EDITOR_CEILING_SECONDS
     # The engine printed before it wedged, so it reached its own startup: this is the
     # phase that says raise the ceiling, not the one that says suspect the binary.
     assert evidence["termination_phase"] == "output_seen"

--- a/tests/test_e2e_launch_timeout.py
+++ b/tests/test_e2e_launch_timeout.py
@@ -32,21 +32,18 @@ CLI arm would have to spend a real minute or ten. ``resource import`` does expos
 """
 
 import json
-import subprocess
 import time
 from pathlib import Path
 
 import pytest
 
-from gda.binary import resolve_godot_binary
 from gda.commands.export import ExportRunMode, classify_export_run
 from gda.errors import Failure, classify_run
 from gda.export_runner import SubprocessExportRunner
 from gda.models import EngineVersion
 from gda.runner import SubprocessGodotRunner
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
+from tests.conftest import project_godot
+from tests.support import GODOT, Gda
 
 # The ceiling every arm gives its wedged engine. Long enough for a real Godot to
 # boot and print, short enough that three arms plus gda's terminate grace stay
@@ -95,17 +92,12 @@ script="plugin.gd"
 
 def _wedged_project(tmp_path: Path, *, autoload: bool, plugin: bool) -> Path:
     """A project whose engine startup never finishes on the requested path(s)."""
-    sections = [
-        "config_version=5\n\n[application]\n\n",
-        'config/name="t714"\n\n',
-        # The e2e file-logging policy (#180): no launch here writes a shared
-        # user://logs/godot.log, so concurrent runs cannot contend over it.
-        "[debug]\n\nfile_logging/enable_file_logging=false\n"
-        "file_logging/enable_file_logging.pc=false\n\n",
-    ]
+    # Built through the one e2e builder so the file-logging policy (#180) is
+    # inherited, not re-spelled: every launch here boots a real engine.
+    sections = []
     if autoload:
         (tmp_path / "wedge.gd").write_text(BLOCKING_AUTOLOAD_GD, encoding="utf-8")
-        sections.append('[autoload]\n\nWedge="*res://wedge.gd"\n\n')
+        sections.append('[autoload]\n\nWedge="*res://wedge.gd"\n')
     if plugin:
         addon = tmp_path / "addons" / "wedge"
         addon.mkdir(parents=True)
@@ -115,7 +107,9 @@ def _wedged_project(tmp_path: Path, *, autoload: bool, plugin: bool) -> Path:
             "[editor_plugins]\n\n"
             'enabled=PackedStringArray("res://addons/wedge/plugin.cfg")\n'
         )
-    (tmp_path / "project.godot").write_text("".join(sections), encoding="utf-8")
+    (tmp_path / "project.godot").write_text(
+        project_godot(name="t714", extra="\n".join(sections)), encoding="utf-8"
+    )
     return tmp_path
 
 
@@ -221,22 +215,13 @@ def test_a_wedged_import_pass_reports_what_the_engine_printed(tmp_path):
     (project / "icon.png").write_bytes(b"\x89PNG not really an image")
 
     started = time.monotonic()
-    run = subprocess.run(
-        [
-            *GDA_CMD,
-            "resource",
-            "import",
-            "res://icon.png",
-            "--timeout",
-            str(CEILING_SECONDS),
-            "--project",
-            str(project),
-            "--godot",
-            str(GODOT),
-            "--json",
-        ],
-        capture_output=True,
-        text=True,
+    run = Gda(project)(
+        "resource",
+        "import",
+        "res://icon.png",
+        "--timeout",
+        str(CEILING_SECONDS),
+        "--json",
     )
     elapsed = time.monotonic() - started
 

--- a/tests/test_e2e_live_number_transport.py
+++ b/tests/test_e2e_live_number_transport.py
@@ -20,11 +20,9 @@ flatten must be REFUSED instead of quietly arriving as ``0.0``.
 import json
 import math
 import struct
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
 from gda.live_numbers import wire_flattens_to_zero
 
 from tests.live_number_corpus import (
@@ -35,9 +33,9 @@ from tests.live_number_corpus import (
     tally_outcome,
     value_bits,
 )
-from tests.support import GDA_CMD, panel_text
+from tests.support import Gda, panel_text
 
-GODOT = resolve_godot_binary()
+from .conftest import LIVE_PROJECT_GODOT
 
 _PROBE_BODY = """\
 func _hex(v: float) -> String:
@@ -104,24 +102,7 @@ def _ulp_gap(sent: float, arrived: float) -> int:
 def _engine_rows(project) -> dict[str, tuple[str, str, str]]:
     """Run the probe through `gda script run` and index its lines by value bits."""
     (project / "probe.gd").write_text(_probe_source(), encoding="utf-8")
-    run = subprocess.run(
-        [
-            *GDA_CMD,
-            "script",
-            "run",
-            "res://probe.gd",
-            "--project",
-            str(project),
-            "--godot",
-            str(GODOT),
-            "--json",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=180,
-    )
-    assert run.returncode == 0, run.stdout + run.stderr
-    result = json.loads(run.stdout)
+    result = Gda(project, timeout=180).json("script", "run", "res://probe.gd")
     assert result["exit_status"] == 0, result
 
     rows: dict[str, tuple[str, str, str]] = {}
@@ -237,40 +218,16 @@ NUMBERS_MAIN_TSCN = (
 )
 
 
-def _live_runner(project):
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(project),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
-
-    return run
-
-
 @pytest.mark.e2e
 def test_live_reads_carry_small_and_many_digit_floats_exactly(
     tmp_path, daemon_runtime_dir
 ):
     """`game get` reports the value the running game holds, bit for bit."""
-    from .conftest import project_godot
-
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(NUMBERS_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "numbers_main.gd").write_text(NUMBERS_MAIN_GD, encoding="utf-8")
 
-    run = _live_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     try:
         assert run("daemon", "start").returncode == 0
 
@@ -308,15 +265,11 @@ def test_live_call_refuses_an_argument_the_wire_would_flatten(
     tmp_path, daemon_runtime_dir
 ):
     """A value the parser cannot carry is refused, not silently delivered as 0.0."""
-    from .conftest import project_godot
-
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(NUMBERS_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "numbers_main.gd").write_text(NUMBERS_MAIN_GD, encoding="utf-8")
 
-    run = _live_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     try:
         assert run("daemon", "start").returncode == 0
 
@@ -386,15 +339,11 @@ def test_every_live_ingress_refuses_a_flattening_value_against_a_real_daemon(
     event the same way. Each is driven here through a real daemon and a real
     engine session, so a guard that only existed in a unit test could not pass.
     """
-    from .conftest import project_godot
-
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(NUMBERS_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "numbers_main.gd").write_text(NUMBERS_MAIN_GD, encoding="utf-8")
 
-    run = _live_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     try:
         assert run("daemon", "start").returncode == 0
         before = json.loads(run("daemon", "status").stdout)["session_id"]

--- a/tests/test_e2e_logger.py
+++ b/tests/test_e2e_logger.py
@@ -30,12 +30,9 @@ import time
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
+from tests.support import GODOT, Gda
 
-from .conftest import project_godot
-
-GODOT = resolve_godot_binary()
+from .conftest import LIVE_PROJECT_GODOT, SCRIPTED_MAIN_TSCN
 
 # A main scene whose root script emits a KNOWN print line, a KNOWN warning, and a
 # KNOWN error at `_ready`, so the daemon's Session log captures all three for
@@ -58,14 +55,6 @@ func _ready() -> void:
 	push_error("known error")
 """
 
-MAIN_TSCN = (
-    "[gd_scene load_steps=2 format=3]\n\n"
-    '[ext_resource type="Script" path="res://main.gd" id="1"]\n\n'
-    '[node name="Main" type="Node2D"]\n'
-    'script = ExtResource("1")\n'
-)
-PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
-
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
 
@@ -73,28 +62,11 @@ pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"
 def test_logger_tail_reads_back_structured_records_and_raw_lines(
     tmp_path, daemon_runtime_dir
 ):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(SCRIPTED_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "main.gd").write_text(MAIN_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     def poll_records(extra_args, needle, timeout=15.0):
         # The session is already launched + warmed by `game tree`; this short poll
@@ -218,8 +190,8 @@ def test_gda_log_is_inert_outside_a_daemon_launched_session(tmp_path):
     # calls GdaHarness.gda_log(...), and assert the sentinel is absent.
     from gda.harness.install import install_harness
 
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(SCRIPTED_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "main.gd").write_text(PLAIN_MAIN_GD, encoding="utf-8")
     install_harness(
         tmp_path

--- a/tests/test_e2e_mcp_live.py
+++ b/tests/test_e2e_mcp_live.py
@@ -34,32 +34,21 @@ import anyio
 import pytest
 from mcp import Client
 
-from gda.binary import GODOT_BIN_ENV, resolve_godot_binary
+from gda.binary import GODOT_BIN_ENV
 from gda.mcp.project_context import GDA_PROJECT_ENV
 from gda.mcp.runner import SubprocessGdaRunner
 from gda.mcp.server import build_server
+from tests.support import GODOT
 
-from .conftest import project_godot
+from .conftest import LIVE_MAIN_TSCN, LIVE_PROJECT_GODOT
 from .mcp_support import tool_text
-
-GODOT = resolve_godot_binary()
-
-# Reuse test_e2e_daemon's scaffold: a main scene so the launched session has a
-# runtime SceneTree to read; a Player child mirrors the daemon e2e fixture. File
-# logging stays disabled via project_godot (issue #180).
-MAIN_TSCN = (
-    "[gd_scene format=3]\n\n"
-    '[node name="Main" type="Node2D"]\n\n'
-    '[node name="Player" type="Node2D" parent="."]\n'
-)
-PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
 
 def _scaffold_project(tmp_path):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
 
 
 def _pin_env(monkeypatch, project):

--- a/tests/test_e2e_mcp_project_context.py
+++ b/tests/test_e2e_mcp_project_context.py
@@ -20,11 +20,10 @@ from mcp import Client
 from mcp.types import ListRootsResult, Root
 from pydantic import FileUrl
 
-from gda.binary import GODOT_BIN_ENV, resolve_godot_binary
+from gda.binary import GODOT_BIN_ENV
 from gda.mcp.runner import SubprocessGdaRunner
 from gda.mcp.server import build_server
-
-GODOT = resolve_godot_binary()
+from tests.support import GODOT
 
 
 def _call_tool(server, name, arguments, *, roots=None):

--- a/tests/test_e2e_mcp_stdio.py
+++ b/tests/test_e2e_mcp_stdio.py
@@ -22,9 +22,8 @@ import pytest
 from mcp import Client, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
-from gda.binary import GODOT_BIN_ENV, resolve_godot_binary
-
-GODOT = resolve_godot_binary()
+from gda.binary import GODOT_BIN_ENV
+from tests.support import GODOT
 
 
 def _server_params() -> StdioServerParameters:

--- a/tests/test_e2e_mcp_tracer.py
+++ b/tests/test_e2e_mcp_tracer.py
@@ -12,11 +12,10 @@ import anyio
 import pytest
 from mcp import Client
 
-from gda.binary import GODOT_BIN_ENV, resolve_godot_binary
+from gda.binary import GODOT_BIN_ENV
 from gda.mcp.runner import SubprocessGdaRunner
 from gda.mcp.server import build_server
-
-GODOT = resolve_godot_binary()
+from tests.support import GODOT
 
 
 @pytest.mark.e2e

--- a/tests/test_e2e_node.py
+++ b/tests/test_e2e_node.py
@@ -7,50 +7,13 @@ verification of ``node add``'s effect.
 """
 
 import json
-import os
 import re
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
+from tests.support import Gda, import_project
 
-GODOT = resolve_godot_binary()
-
-
-def _gda(*args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT)], capture_output=True, text=True
-    )
-
-
-def _gda_env(extra_env: dict, *args: str) -> subprocess.CompletedProcess:
-    """``_gda`` with extra env vars in the child's environment.
-
-    The CLI passes no ``env=`` to its Godot subprocess, so the engine inherits
-    this environment — the channel the production-inert
-    ``GDA_TEST_PERTURB_BEFORE_SAVE`` test seam rides on (issue #226).
-    """
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-        env={**os.environ, **extra_env},
-    )
-
-
-def _gda_project(project):
-    """``gda`` bound to ``--project`` so ``res://`` ext_resources resolve."""
-
-    def gda(*args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-            capture_output=True,
-            text=True,
-        )
-
-    return gda
+gda = Gda()
 
 
 def _no_gda_temp_siblings(project) -> bool:
@@ -59,14 +22,12 @@ def _no_gda_temp_siblings(project) -> bool:
 
 
 def _create_scene(scene_path) -> None:
-    created = _gda(
-        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
-    )
+    created = gda("scene", "create", str(scene_path), "--root-type", "Node2D", "--json")
     assert created.returncode == 0, created.stdout + created.stderr
 
 
 def _root_children(scene_path) -> list[dict]:
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
     assert listed.returncode == 0, listed.stdout + listed.stderr
     return json.loads(listed.stdout)["root"]["children"]
 
@@ -80,7 +41,7 @@ def test_node_add_then_list_round_trip(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(scene_path),
@@ -99,7 +60,7 @@ def test_node_add_then_list_round_trip(godot_project):
     assert data["name"] == "Hero"
     assert data["type"] == "Sprite2D"
 
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
 
     assert listed.returncode == 0, listed.stdout + listed.stderr
     tree = json.loads(listed.stdout)
@@ -119,7 +80,7 @@ def test_node_add_index_inserts_at_zero_based_sibling_position(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     for name in ("HP", "MP", "EXP"):
-        added = _gda(
+        added = gda(
             "node",
             "add",
             str(scene_path),
@@ -131,7 +92,7 @@ def test_node_add_index_inserts_at_zero_based_sibling_position(godot_project):
         )
         assert added.returncode == 0, added.stdout + added.stderr
 
-    inserted = _gda(
+    inserted = gda(
         "node",
         "add",
         str(scene_path),
@@ -158,7 +119,7 @@ def test_node_add_under_nested_parent_path(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    first = _gda(
+    first = gda(
         "node",
         "add",
         str(scene_path),
@@ -170,7 +131,7 @@ def test_node_add_under_nested_parent_path(godot_project):
     )
     assert first.returncode == 0, first.stdout + first.stderr
 
-    second = _gda(
+    second = gda(
         "node",
         "add",
         str(scene_path),
@@ -188,7 +149,7 @@ def test_node_add_under_nested_parent_path(godot_project):
     assert data["path"] == "Hero/Hitbox"
     assert data["type"] == "Area2D"
 
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
 
     assert listed.returncode == 0, listed.stdout + listed.stderr
     hero = json.loads(listed.stdout)["root"]["children"][0]
@@ -205,7 +166,7 @@ def test_node_add_preserves_existing_ext_resource_ids_on_scene_repack(godot_proj
     # string helper: node add exercises the shared _load_for_mutation ->
     # _repack_and_save tail, then script attach proves a newly introduced resource
     # still receives a fresh non-colliding id.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     scene_path = godot_project / "main.tscn"
     (godot_project / "hero.gd").write_text("extends Node2D\n", encoding="utf-8")
     (godot_project / "enemy.gd").write_text("extends Node2D\n", encoding="utf-8")
@@ -282,7 +243,7 @@ def test_node_add_preserves_first_id_when_duplicate_ext_resource_path_is_canonic
     # ResourceSaver canonicalizes duplicate ext_resources for the same path down to
     # one entry. gda should keep the first old id for that canonical path instead of
     # accepting a new random id.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     scene_path = godot_project / "main.tscn"
     (godot_project / "hero.gd").write_text("extends Node2D\n", encoding="utf-8")
     scene_path.write_text(
@@ -327,7 +288,7 @@ def test_node_add_default_name_is_the_type_name(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    added = _gda("node", "add", str(scene_path), "--type", "Sprite2D", "--json")
+    added = gda("node", "add", str(scene_path), "--type", "Sprite2D", "--json")
 
     assert added.returncode == 0, added.stdout + added.stderr
     data = json.loads(added.stdout)
@@ -346,7 +307,7 @@ def test_node_add_builtin_type_reports_null_script_class(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(scene_path),
@@ -370,7 +331,7 @@ def test_node_add_instance_preserves_existing_ext_resource_ids(godot_project):
     # pre-existing ext_resource id (and the ExtResource("...") references
     # pointing at them) byte-identical, while the newly introduced PackedScene
     # ext_resource receives a fresh non-colliding id.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     (godot_project / "hero.gd").write_text("extends Node2D\n", encoding="utf-8")
     (godot_project / "hud.tscn").write_text(
         "\n".join(
@@ -422,7 +383,7 @@ def test_node_add_instance_composes_a_scene_and_round_trips(godot_project):
     # instance=ExtResource(...) node entry, exactly what the editor writes),
     # and the composed scene must LOAD: node get instantiates the host, so it
     # proves the engine resolves the instanced child to its real root class.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     (godot_project / "hud.tscn").write_text(
         "\n".join(
             [
@@ -511,30 +472,26 @@ def test_node_add_instance_composes_a_scene_and_round_trips(godot_project):
     assert _no_gda_temp_siblings(godot_project)
 
 
-def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
-    assert proc.returncode == 4, proc.stdout + proc.stderr
-    err = json.loads(proc.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == code
-    return err
-
-
 @pytest.mark.e2e
 def test_node_add_instance_missing_scene_yields_missing_dependency(godot_project):
     # The #392/#396 dependency precedent applied to composition (#399): a
     # missing instanced-scene path is a structured missing_dependency naming
     # the path — never a silent or prose-only failure — and the host file
     # stays untouched.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    added = gda(
-        "node", "add", "res://main.tscn", "--instance", "res://ghost.tscn", "--json"
+    err = gda.error(
+        "node",
+        "add",
+        "res://main.tscn",
+        "--instance",
+        "res://ghost.tscn",
+        "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(added, "missing_dependency")
     assert "res://ghost.tscn" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -548,7 +505,7 @@ def test_node_add_instance_with_broken_dependency_yields_missing_dependency(
     # scene) is a dependency-shaped failure, not a "wrong kind of file" one:
     # missing_dependency naming the instance path the caller passed (engine
     # diagnostics name the nested culprit), never not_a_scene.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     (godot_project / "hud.tscn").write_text(
         "\n".join(
             [
@@ -568,11 +525,15 @@ def test_node_add_instance_with_broken_dependency_yields_missing_dependency(
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    added = gda(
-        "node", "add", "res://main.tscn", "--instance", "res://hud.tscn", "--json"
+    err = gda.error(
+        "node",
+        "add",
+        "res://main.tscn",
+        "--instance",
+        "res://hud.tscn",
+        "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(added, "missing_dependency")
     assert "res://hud.tscn" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -582,17 +543,21 @@ def test_node_add_instance_non_scene_file_yields_not_a_scene(godot_project):
     # --instance must reference a PackedScene: a file that exists but loads as
     # something else (a script here) is refused with not_a_scene, naming the
     # offending path.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     (godot_project / "hero.gd").write_text("extends Node2D\n", encoding="utf-8")
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    added = gda(
-        "node", "add", "res://main.tscn", "--instance", "res://hero.gd", "--json"
+    err = gda.error(
+        "node",
+        "add",
+        "res://main.tscn",
+        "--instance",
+        "res://hero.gd",
+        "--json",
+        code="not_a_scene",
     )
-
-    err = _assert_operation_error(added, "not_a_scene")
     assert "res://hero.gd" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -603,16 +568,20 @@ def test_node_add_instance_of_the_host_itself_yields_cyclic_target(godot_project
     # never finish loading. The direct cycle is refused up front with the
     # registered cyclic_target code, leaving the file untouched (deeper A→B→A
     # cycles remain the engine's load-time problem, out of gda's guard).
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    added = gda(
-        "node", "add", "res://main.tscn", "--instance", "res://main.tscn", "--json"
+    err = gda.error(
+        "node",
+        "add",
+        "res://main.tscn",
+        "--instance",
+        "res://main.tscn",
+        "--json",
+        code="cyclic_target",
     )
-
-    err = _assert_operation_error(added, "cyclic_target")
     assert "res://main.tscn" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -621,9 +590,15 @@ def test_node_add_instance_of_the_host_itself_yields_cyclic_target(godot_project
 def test_node_add_to_missing_scene_yields_path_not_found(godot_project):
     missing = godot_project / "missing.tscn"
 
-    added = _gda("node", "add", str(missing), "--type", "Sprite2D", "--json")
-
-    err = _assert_operation_error(added, "path_not_found")
+    err = gda.error(
+        "node",
+        "add",
+        str(missing),
+        "--type",
+        "Sprite2D",
+        "--json",
+        code="path_not_found",
+    )
     assert str(missing) in err["message"]
 
 
@@ -635,7 +610,7 @@ def test_node_add_bad_parent_yields_parent_not_found_and_leaves_file_unchanged(
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -644,9 +619,8 @@ def test_node_add_bad_parent_yields_parent_not_found_and_leaves_file_unchanged(
         "--parent",
         "Bogus/Path",
         "--json",
+        code="parent_not_found",
     )
-
-    err = _assert_operation_error(added, "parent_not_found")
     assert "Bogus/Path" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -657,7 +631,7 @@ def _scene_with_nested_children(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     for name, parent in (("A", "."), ("B", "A")):
-        added = _gda(
+        added = gda(
             "node",
             "add",
             str(scene_path),
@@ -684,7 +658,7 @@ def test_node_add_parent_path_escaping_or_absolute_stays_rejected(godot_project,
     scene_path = _scene_with_nested_children(godot_project)
     before = scene_path.read_text(encoding="utf-8")
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -695,9 +669,8 @@ def test_node_add_parent_path_escaping_or_absolute_stays_rejected(godot_project,
         "--parent",
         form,
         "--json",
+        code="parent_not_found",
     )
-
-    err = _assert_operation_error(added, "parent_not_found")
     assert form in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -717,7 +690,7 @@ def test_node_add_rejects_non_canonical_parent_path(godot_project, form):
     scene_path = _scene_with_nested_children(godot_project)
     before = scene_path.read_text(encoding="utf-8")
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -728,9 +701,8 @@ def test_node_add_rejects_non_canonical_parent_path(godot_project, form):
         "--parent",
         form,
         "--json",
+        code="parent_not_found",
     )
-
-    err = _assert_operation_error(added, "parent_not_found")
     assert form in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -741,7 +713,7 @@ def test_node_add_explicit_dot_parent_addresses_the_root(godot_project):
     # form node list reports for the root, and the CLI's --parent default.
     scene_path = _scene_with_nested_children(godot_project)
 
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(scene_path),
@@ -762,7 +734,7 @@ def test_node_add_explicit_dot_parent_addresses_the_root(godot_project):
 def test_node_add_name_collision_yields_duplicate_node_name(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    first = _gda(
+    first = gda(
         "node",
         "add",
         str(scene_path),
@@ -775,7 +747,7 @@ def test_node_add_name_collision_yields_duplicate_node_name(godot_project):
     assert first.returncode == 0, first.stdout + first.stderr
     before = scene_path.read_text(encoding="utf-8")
 
-    again = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -784,9 +756,8 @@ def test_node_add_name_collision_yields_duplicate_node_name(godot_project):
         "--name",
         "Hero",
         "--json",
+        code="duplicate_node_name",
     )
-
-    err = _assert_operation_error(again, "duplicate_node_name")
     assert "Hero" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -802,7 +773,7 @@ def test_node_add_invalid_index_yields_invalid_child_index_and_leaves_file_uncha
     # them, and child_count+1 is out of range.
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    first = _gda(
+    first = gda(
         "node",
         "add",
         str(scene_path),
@@ -815,7 +786,7 @@ def test_node_add_invalid_index_yields_invalid_child_index_and_leaves_file_uncha
     assert first.returncode == 0, first.stdout + first.stderr
     before = scene_path.read_text(encoding="utf-8")
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -826,9 +797,8 @@ def test_node_add_invalid_index_yields_invalid_child_index_and_leaves_file_uncha
         "--index",
         index,
         "--json",
+        code="invalid_child_index",
     )
-
-    err = _assert_operation_error(added, "invalid_child_index")
     assert index in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -846,11 +816,11 @@ def test_node_add_collision_with_internal_child_yields_duplicate_node_name(
     # correct on Godot 4.6.3: get_node_or_null resolves through the engine's
     # child-name map, which includes internal children.
     scene_path = godot_project / "ui.tscn"
-    created = _gda(
+    created = gda(
         "scene", "create", str(scene_path), "--root-type", "Control", "--json"
     )
     assert created.returncode == 0, created.stdout + created.stderr
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(scene_path),
@@ -863,7 +833,7 @@ def test_node_add_collision_with_internal_child_yields_duplicate_node_name(
     assert added.returncode == 0, added.stdout + added.stderr
     before = scene_path.read_text(encoding="utf-8")
 
-    colliding = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -874,9 +844,8 @@ def test_node_add_collision_with_internal_child_yields_duplicate_node_name(
         "--parent",
         "Scroll",
         "--json",
+        code="duplicate_node_name",
     )
-
-    err = _assert_operation_error(colliding, "duplicate_node_name")
     assert "_h_scroll" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -887,9 +856,15 @@ def test_node_add_unknown_type_yields_invalid_node_type(godot_project):
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    added = _gda("node", "add", str(scene_path), "--type", "NotAClass", "--json")
-
-    err = _assert_operation_error(added, "invalid_node_type")
+    err = gda.error(
+        "node",
+        "add",
+        str(scene_path),
+        "--type",
+        "NotAClass",
+        "--json",
+        code="invalid_node_type",
+    )
     assert "NotAClass" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -899,7 +874,7 @@ def test_node_add_rejects_name_godot_would_rewrite(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -908,9 +883,8 @@ def test_node_add_rejects_name_godot_would_rewrite(godot_project):
         "--name",
         "Bad%Name",
         "--json",
+        code="invalid_node_name",
     )
-
-    err = _assert_operation_error(added, "invalid_node_name")
     assert "Bad%Name" in err["message"]
 
 
@@ -919,7 +893,7 @@ def test_node_add_rejects_name_godot_would_rewrite(godot_project):
 
 def _get_property(scene_path, node: str, name: str):
     """Read one property dict (by name) off a node via `gda node get --json`."""
-    got = _gda("node", "get", str(scene_path), "--node", node, "--json")
+    got = gda("node", "get", str(scene_path), "--node", node, "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     for prop in json.loads(got.stdout)["properties"]:
         if prop["name"] == name:
@@ -934,7 +908,7 @@ def test_node_get_reports_typed_properties(godot_project):
     # declared Godot type, and value in the JSON projection.
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(scene_path),
@@ -946,7 +920,7 @@ def test_node_get_reports_typed_properties(godot_project):
     )
     assert added.returncode == 0, added.stdout + added.stderr
 
-    got = _gda("node", "get", str(scene_path), "--node", "Hero", "--json")
+    got = gda("node", "get", str(scene_path), "--node", "Hero", "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     data = json.loads(got.stdout)
@@ -967,7 +941,7 @@ def test_node_get_addresses_the_root_with_dot(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    got = _gda("node", "get", str(scene_path), "--node", ".", "--json")
+    got = gda("node", "get", str(scene_path), "--node", ".", "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     data = json.loads(got.stdout)
@@ -979,9 +953,15 @@ def test_node_get_missing_node_yields_node_not_found(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    got = _gda("node", "get", str(scene_path), "--node", "Bogus", "--json")
-
-    err = _assert_operation_error(got, "node_not_found")
+    err = gda.error(
+        "node",
+        "get",
+        str(scene_path),
+        "--node",
+        "Bogus",
+        "--json",
+        code="node_not_found",
+    )
     assert "Bogus" in err["message"]
 
 
@@ -1006,11 +986,11 @@ def test_node_set_coerces_and_round_trips_via_get(
     # rules documented in the command catalog.
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    _gda(
+    gda(
         "node", "add", str(scene_path), "--type", "Sprite2D", "--name", "Hero", "--json"
     )
 
-    was_set = _gda(
+    was_set = gda(
         "node",
         "set",
         str(scene_path),
@@ -1047,7 +1027,7 @@ def test_node_set_control_position_updates_offsets_preserving_size(godot_project
         encoding="utf-8",
     )
 
-    was_set = _gda(
+    was_set = gda(
         "node",
         "set",
         str(scene_path),
@@ -1098,7 +1078,7 @@ def test_node_set_container_managed_control_position_names_offset_alternatives(
     )
     before = scene_path.read_text(encoding="utf-8")
 
-    was_set = _gda(
+    err = gda.error(
         "node",
         "set",
         str(scene_path),
@@ -1109,9 +1089,8 @@ def test_node_set_container_managed_control_position_names_offset_alternatives(
         "--value",
         "20,30",
         "--json",
+        code="unknown_property",
     )
-
-    err = _assert_operation_error(was_set, "unknown_property")
     for name in ("offset_left", "offset_top", "offset_right", "offset_bottom"):
         assert name in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
@@ -1135,7 +1114,7 @@ def test_node_set_coerces_json_dictionary_and_array_via_get(godot_project):
         'script = ExtResource("1")\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     stats_set = gda(
         "node",
@@ -1206,7 +1185,7 @@ def test_node_set_preserves_json_container_integer_and_float_types(godot_project
         'script = ExtResource("1")\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     was_set = gda(
         "node",
@@ -1257,7 +1236,7 @@ def test_node_set_typed_dictionary_coerces_entries_to_declared_value_type(
         'script = ExtResource("1")\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     was_set = gda(
         "node",
@@ -1306,7 +1285,7 @@ def test_node_set_typed_array_coerces_elements_to_declared_element_type(
         'script = ExtResource("1")\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     was_set = gda(
         "node",
@@ -1342,12 +1321,12 @@ def test_node_set_unknown_property_yields_unknown_property_and_leaves_file_uncha
 ):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    _gda(
+    gda(
         "node", "add", str(scene_path), "--type", "Sprite2D", "--name", "Hero", "--json"
     )
     before = scene_path.read_text(encoding="utf-8")
 
-    was_set = _gda(
+    err = gda.error(
         "node",
         "set",
         str(scene_path),
@@ -1358,9 +1337,8 @@ def test_node_set_unknown_property_yields_unknown_property_and_leaves_file_uncha
         "--value",
         "1",
         "--json",
+        code="unknown_property",
     )
-
-    err = _assert_operation_error(was_set, "unknown_property")
     assert "no_such_prop" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -1374,12 +1352,12 @@ def test_node_set_uncoercible_value_yields_uncoercible_value_and_leaves_file_unc
     # the scene file is left untouched.
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    _gda(
+    gda(
         "node", "add", str(scene_path), "--type", "Sprite2D", "--name", "Hero", "--json"
     )
     before = scene_path.read_text(encoding="utf-8")
 
-    was_set = _gda(
+    err = gda.error(
         "node",
         "set",
         str(scene_path),
@@ -1390,9 +1368,8 @@ def test_node_set_uncoercible_value_yields_uncoercible_value_and_leaves_file_unc
         "--value",
         "not_a_vector",
         "--json",
+        code="uncoercible_value",
     )
-
-    err = _assert_operation_error(was_set, "uncoercible_value")
     assert "Vector2" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -1403,7 +1380,7 @@ def test_node_set_missing_node_yields_node_not_found(godot_project):
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    was_set = _gda(
+    err = gda.error(
         "node",
         "set",
         str(scene_path),
@@ -1414,9 +1391,8 @@ def test_node_set_missing_node_yields_node_not_found(godot_project):
         "--value",
         "1,2",
         "--json",
+        code="node_not_found",
     )
-
-    err = _assert_operation_error(was_set, "node_not_found")
     assert "Bogus" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -1431,7 +1407,7 @@ def test_node_set_refuses_scene_whose_sub_scene_cannot_resolve(godot_project):
     (godot_project / "gone.tscn").unlink(missing_ok=True)
     before = parent.read_text(encoding="utf-8")
 
-    was_set = _gda(
+    err = gda.error(
         "node",
         "set",
         str(parent),
@@ -1444,9 +1420,8 @@ def test_node_set_refuses_scene_whose_sub_scene_cannot_resolve(godot_project):
         "--project",
         str(godot_project),
         "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(was_set, "missing_dependency")
     assert "ChildInstance" in err["message"]
     assert parent.read_text(encoding="utf-8") == before
 
@@ -1462,7 +1437,7 @@ def test_node_list_reports_all_siblings_at_one_level_in_tree_order(godot_project
     _create_scene(scene_path)
     siblings = [("A", "Node2D"), ("B", "Sprite2D"), ("C", "Area2D")]
     for name, node_type in siblings:
-        added = _gda(
+        added = gda(
             "node",
             "add",
             str(scene_path),
@@ -1474,7 +1449,7 @@ def test_node_list_reports_all_siblings_at_one_level_in_tree_order(godot_project
         )
         assert added.returncode == 0, added.stdout + added.stderr
 
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
 
     assert listed.returncode == 0, listed.stdout + listed.stderr
     children = json.loads(listed.stdout)["root"]["children"]
@@ -1490,9 +1465,7 @@ def test_node_list_reports_all_siblings_at_one_level_in_tree_order(godot_project
 def test_node_list_missing_scene_yields_path_not_found(godot_project):
     missing = godot_project / "missing.tscn"
 
-    listed = _gda("node", "list", str(missing), "--json")
-
-    err = _assert_operation_error(listed, "path_not_found")
+    err = gda.error("node", "list", str(missing), "--json", code="path_not_found")
     assert str(missing) in err["message"]
 
 
@@ -1501,9 +1474,7 @@ def test_node_list_non_scene_file_yields_not_a_scene(godot_project):
     notes = godot_project / "notes.txt"
     notes.write_text("not a scene\n", encoding="utf-8")
 
-    listed = _gda("node", "list", str(notes), "--json")
-
-    _assert_operation_error(listed, "not_a_scene")
+    gda.error("node", "list", str(notes), "--json", code="not_a_scene")
 
 
 # A legal editable-children fixture, in the engine's own serialization (issue
@@ -1598,7 +1569,7 @@ def test_node_add_preserves_editable_instance_overrides(godot_project):
     # the editable instance. Verified to hold on Godot 4.6.3.
     parent = _write_instance_fixture(godot_project)
 
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(parent),
@@ -1638,7 +1609,7 @@ def test_node_add_preserves_preexisting_plain_instance_stub(godot_project):
     # gain a class `type=` attribute.
     parent = _write_plain_instance_fixture(godot_project)
 
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(parent),
@@ -1671,7 +1642,7 @@ def test_node_add_does_not_promote_instance_baseline_to_host_override(godot_proj
     # serialize them into the host scene.
     parent = _write_plain_instance_fixture(godot_project, instance_override="")
 
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(parent),
@@ -1705,11 +1676,17 @@ def test_node_add_without_project_context_refuses_rather_than_drops_instances(
     parent = _write_instance_fixture(godot_project)
     before = parent.read_text(encoding="utf-8")
 
-    added = _gda(
-        "node", "add", str(parent), "--type", "Marker2D", "--name", "M", "--json"
+    err = gda.error(
+        "node",
+        "add",
+        str(parent),
+        "--type",
+        "Marker2D",
+        "--name",
+        "M",
+        "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(added, "missing_dependency")
     assert "ChildInstance" in err["message"]
     assert parent.read_text(encoding="utf-8") == before
 
@@ -1725,7 +1702,7 @@ def test_node_add_refuses_scene_whose_sub_scene_cannot_resolve(godot_project):
     (godot_project / "gone.tscn").unlink(missing_ok=True)
     before = parent.read_text(encoding="utf-8")
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(parent),
@@ -1736,9 +1713,8 @@ def test_node_add_refuses_scene_whose_sub_scene_cannot_resolve(godot_project):
         "--project",
         str(godot_project),
         "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(added, "missing_dependency")
     assert "ChildInstance" in err["message"]
     assert parent.read_text(encoding="utf-8") == before
 
@@ -1750,7 +1726,7 @@ def test_node_add_refuses_scene_whose_attached_script_preloads_missing_asset(
     # A scene mutation must not report clean success when an already-attached
     # script has a now-missing preload target. The structured error names the
     # missing res:// path and the scene remains byte-identical.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1808,7 +1784,7 @@ def test_node_add_refuses_scene_whose_attached_script_preloads_missing_asset(
     )
     assert "uid=" in script_line_before
 
-    added = gda(
+    err = gda.error(
         "node",
         "add",
         "res://main.tscn",
@@ -1817,9 +1793,8 @@ def test_node_add_refuses_scene_whose_attached_script_preloads_missing_asset(
         "--name",
         "M",
         "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(added, "missing_dependency")
     assert "res://enemy_projectile.tscn" in err["message"]
     assert "res://enemy.gd" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
@@ -1849,7 +1824,7 @@ def test_node_add_refuses_scene_that_instantiates_to_null(godot_project):
     )
     before = parent.read_text(encoding="utf-8")
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(parent),
@@ -1860,9 +1835,8 @@ def test_node_add_refuses_scene_that_instantiates_to_null(godot_project):
         "--project",
         str(godot_project),
         "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(added, "missing_dependency")
     assert str(parent) in err["message"]
     assert parent.read_text(encoding="utf-8") == before
 
@@ -1890,7 +1864,7 @@ def test_node_add_refuses_scene_whose_declared_class_is_substituted(godot_projec
     scene_path.write_text(MISSING_CLASS_TSCN, encoding="utf-8")
     before = scene_path.read_text(encoding="utf-8")
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -1899,9 +1873,8 @@ def test_node_add_refuses_scene_whose_declared_class_is_substituted(godot_projec
         "--name",
         "M",
         "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(added, "missing_dependency")
     assert "Widget (declared TotallyMissingClass, materialized" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -1912,18 +1885,6 @@ extends Node2D
 """
 
 
-def _import_project(project) -> None:
-    # class_name registration lives in .godot/global_script_class_list.cfg,
-    # which only a project scan produces — run the engine's headless import
-    # step the way a CI pipeline would before using script classes.
-    imported = subprocess.run(
-        [str(GODOT), "--headless", "--path", str(project), "--import"],
-        capture_output=True,
-        text=True,
-    )
-    assert imported.returncode == 0, imported.stdout + imported.stderr
-
-
 @pytest.mark.e2e
 def test_node_add_by_class_name_attaches_the_script(godot_project):
     # The second half of --type's contract (issue #53): a class_name registered
@@ -1932,11 +1893,11 @@ def test_node_add_by_class_name_attaches_the_script(godot_project):
     # script_class, so an agent can assert the script attach without reading
     # the .tscn.
     (godot_project / "hero.gd").write_text(HERO_GD, encoding="utf-8")
-    _import_project(godot_project)
+    import_project(godot_project)
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(scene_path),
@@ -1954,7 +1915,7 @@ def test_node_add_by_class_name_attaches_the_script(godot_project):
     assert data["type"] == "Node2D"
     assert data["script_class"] == "Hero"
 
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
 
     assert listed.returncode == 0, listed.stdout + listed.stderr
     hero = json.loads(listed.stdout)["root"]["children"][0]
@@ -1972,7 +1933,7 @@ def test_node_add_by_unregistered_class_name_yields_invalid_node_type(godot_proj
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -1981,9 +1942,8 @@ def test_node_add_by_unregistered_class_name_yields_invalid_node_type(godot_proj
         "--project",
         str(godot_project),
         "--json",
+        code="invalid_node_type",
     )
-
-    err = _assert_operation_error(added, "invalid_node_type")
     assert "Hero" in err["message"]
 
 
@@ -2006,13 +1966,13 @@ def test_node_add_by_registered_but_broken_class_name_names_the_script(godot_pro
     # distinct uninstantiable_script code naming the script, with the scene
     # file left unchanged.
     (godot_project / "hero.gd").write_text(HERO_GD, encoding="utf-8")
-    _import_project(godot_project)
+    import_project(godot_project)
     (godot_project / "hero.gd").write_text(BROKEN_HERO_GD, encoding="utf-8")
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -2021,9 +1981,8 @@ def test_node_add_by_registered_but_broken_class_name_names_the_script(godot_pro
         "--project",
         str(godot_project),
         "--json",
+        code="uninstantiable_script",
     )
-
-    err = _assert_operation_error(added, "uninstantiable_script")
     assert "Hero" in err["message"]
     assert "hero.gd" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
@@ -2044,12 +2003,12 @@ def test_node_add_by_non_node_class_name_yields_invalid_node_type(godot_project)
     # invalid_node_type (not uninstantiable_script), with a message naming the
     # script and the real cause rather than "not a registered class_name".
     (godot_project / "loot.gd").write_text(LOOT_GD, encoding="utf-8")
-    _import_project(godot_project)
+    import_project(godot_project)
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -2058,9 +2017,8 @@ def test_node_add_by_non_node_class_name_yields_invalid_node_type(godot_project)
         "--project",
         str(godot_project),
         "--json",
+        code="invalid_node_type",
     )
-
-    err = _assert_operation_error(added, "invalid_node_type")
     assert "Loot" in err["message"]
     assert "not a Node-derived script" in err["message"]
     assert "loot.gd" in err["message"]
@@ -2088,12 +2046,12 @@ def test_node_add_by_class_name_whose_init_requires_args_names_the_constructor(
     # script.new() cannot construct it. Same misdiagnosis risk as the broken
     # script: the type IS registered, the constructor is the problem.
     (godot_project / "hero.gd").write_text(NEEDS_ARGS_HERO_GD, encoding="utf-8")
-    _import_project(godot_project)
+    import_project(godot_project)
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    added = _gda(
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -2102,9 +2060,8 @@ def test_node_add_by_class_name_whose_init_requires_args_names_the_constructor(
         "--project",
         str(godot_project),
         "--json",
+        code="uninstantiable_script",
     )
-
-    err = _assert_operation_error(added, "uninstantiable_script")
     assert "Hero" in err["message"]
     assert "hero.gd" in err["message"]
     assert "_init" in err["message"]
@@ -2120,15 +2077,15 @@ def test_node_remove_deletes_node_and_subtree_round_trip(godot_project):
     # and its whole subtree, verified through a fresh node list — the deletion
     # is on disk, not just in the reporting process. A sibling is untouched.
     scene_path = _scene_with_nested_children(godot_project)  # root -> A -> B
-    _gda("node", "add", str(scene_path), "--type", "Node2D", "--name", "C", "--json")
+    gda("node", "add", str(scene_path), "--type", "Node2D", "--name", "C", "--json")
 
-    removed = _gda("node", "remove", str(scene_path), "--node", "A", "--json")
+    removed = gda("node", "remove", str(scene_path), "--node", "A", "--json")
 
     assert removed.returncode == 0, removed.stdout + removed.stderr
     data = json.loads(removed.stdout)
     assert (data["path"], data["name"], data["type"]) == ("A", "A", "Node2D")
 
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
     assert listed.returncode == 0, listed.stdout + listed.stderr
     children = json.loads(listed.stdout)["root"]["children"]
     names = {child["name"] for child in children}
@@ -2141,12 +2098,12 @@ def test_node_remove_nested_node_leaves_ancestors(godot_project):
     # Removing a descendant deletes only its subtree; its parent survives.
     scene_path = _scene_with_nested_children(godot_project)  # root -> A -> B
 
-    removed = _gda("node", "remove", str(scene_path), "--node", "A/B", "--json")
+    removed = gda("node", "remove", str(scene_path), "--node", "A/B", "--json")
 
     assert removed.returncode == 0, removed.stdout + removed.stderr
     assert json.loads(removed.stdout)["path"] == "A/B"
 
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
     a = json.loads(listed.stdout)["root"]["children"][0]
     assert a["name"] == "A"
     assert a["children"] == []
@@ -2158,9 +2115,15 @@ def test_node_remove_missing_node_yields_node_not_found(godot_project):
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    removed = _gda("node", "remove", str(scene_path), "--node", "Bogus", "--json")
-
-    err = _assert_operation_error(removed, "node_not_found")
+    err = gda.error(
+        "node",
+        "remove",
+        str(scene_path),
+        "--node",
+        "Bogus",
+        "--json",
+        code="node_not_found",
+    )
     assert "Bogus" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -2174,7 +2137,7 @@ def _scene_with_emitter_and_receiver(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     for node_type, name in (("Timer", "Emitter"), ("Node2D", "Receiver")):
-        added = _gda(
+        added = gda(
             "node",
             "add",
             str(scene_path),
@@ -2204,7 +2167,7 @@ def test_node_connect_signal_records_a_connection_that_round_trips(godot_project
     # mutation is on disk (a re-read shows it), not just in the reporting process.
     scene_path = _scene_with_emitter_and_receiver(godot_project)
 
-    connected = _gda(
+    connected = gda(
         "node",
         "connect-signal",
         str(scene_path),
@@ -2239,7 +2202,7 @@ def test_node_connect_signal_allows_a_not_yet_defined_target_method(godot_projec
     # authored afterward. The connection is recorded with the dangling method.
     scene_path = _scene_with_emitter_and_receiver(godot_project)
 
-    connected = _gda(
+    connected = gda(
         "node",
         "connect-signal",
         str(scene_path),
@@ -2269,7 +2232,7 @@ def test_node_connect_signal_unknown_signal_yields_signal_not_found(godot_projec
     scene_path = _scene_with_emitter_and_receiver(godot_project)
     before = scene_path.read_text(encoding="utf-8")
 
-    connected = _gda(
+    err = gda.error(
         "node",
         "connect-signal",
         str(scene_path),
@@ -2282,9 +2245,8 @@ def test_node_connect_signal_unknown_signal_yields_signal_not_found(godot_projec
         "--method",
         "on_timeout",
         "--json",
+        code="signal_not_found",
     )
-
-    err = _assert_operation_error(connected, "signal_not_found")
     assert "no_such_signal" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -2295,7 +2257,7 @@ def test_node_connect_signal_already_connected_yields_already_connected(godot_pr
     # rather than a noisy engine failure or a silent re-apply; the file is
     # unchanged after the second attempt.
     scene_path = _scene_with_emitter_and_receiver(godot_project)
-    first = _gda(
+    first = gda(
         "node",
         "connect-signal",
         str(scene_path),
@@ -2312,7 +2274,7 @@ def test_node_connect_signal_already_connected_yields_already_connected(godot_pr
     assert first.returncode == 0, first.stdout + first.stderr
     before = scene_path.read_text(encoding="utf-8")
 
-    again = _gda(
+    err = gda.error(
         "node",
         "connect-signal",
         str(scene_path),
@@ -2325,9 +2287,8 @@ def test_node_connect_signal_already_connected_yields_already_connected(godot_pr
         "--method",
         "on_timeout",
         "--json",
+        code="already_connected",
     )
-
-    err = _assert_operation_error(again, "already_connected")
     assert "Receiver.on_timeout" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -2337,7 +2298,7 @@ def test_node_connect_signal_missing_source_node_yields_node_not_found(godot_pro
     scene_path = _scene_with_emitter_and_receiver(godot_project)
     before = scene_path.read_text(encoding="utf-8")
 
-    connected = _gda(
+    err = gda.error(
         "node",
         "connect-signal",
         str(scene_path),
@@ -2350,9 +2311,8 @@ def test_node_connect_signal_missing_source_node_yields_node_not_found(godot_pro
         "--method",
         "on_timeout",
         "--json",
+        code="node_not_found",
     )
-
-    err = _assert_operation_error(connected, "node_not_found")
     assert "source" in err["message"]
     assert "Bogus" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
@@ -2368,9 +2328,15 @@ def test_node_remove_root_yields_cannot_target_root(godot_project):
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    removed = _gda("node", "remove", str(scene_path), "--node", ".", "--json")
-
-    _assert_operation_error(removed, "cannot_target_root")
+    gda.error(
+        "node",
+        "remove",
+        str(scene_path),
+        "--node",
+        ".",
+        "--json",
+        code="cannot_target_root",
+    )
     assert scene_path.read_text(encoding="utf-8") == before
 
 
@@ -2384,11 +2350,11 @@ def test_node_duplicate_copies_node_under_same_parent_with_fresh_name(godot_proj
     # is reported — verified through a fresh node list. The source survives.
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    _gda(
+    gda(
         "node", "add", str(scene_path), "--type", "Sprite2D", "--name", "Hero", "--json"
     )
 
-    duplicated = _gda("node", "duplicate", str(scene_path), "--node", "Hero", "--json")
+    duplicated = gda("node", "duplicate", str(scene_path), "--node", "Hero", "--json")
 
     assert duplicated.returncode == 0, duplicated.stdout + duplicated.stderr
     data = json.loads(duplicated.stdout)
@@ -2400,7 +2366,7 @@ def test_node_duplicate_copies_node_under_same_parent_with_fresh_name(godot_proj
     assert "/" not in data["path"]
     assert data["path"] == data["name"]
 
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
     children = json.loads(listed.stdout)["root"]["children"]
     names = sorted(child["name"] for child in children)
     # Both the source and its fresh-named copy are present as siblings.
@@ -2415,8 +2381,8 @@ def test_node_duplicate_copies_the_whole_subtree(godot_project):
     # copy must carry an equivalent child under the new node path.
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    _gda("node", "add", str(scene_path), "--type", "Node2D", "--name", "Hero", "--json")
-    _gda(
+    gda("node", "add", str(scene_path), "--type", "Node2D", "--name", "Hero", "--json")
+    gda(
         "node",
         "add",
         str(scene_path),
@@ -2429,11 +2395,11 @@ def test_node_duplicate_copies_the_whole_subtree(godot_project):
         "--json",
     )
 
-    duplicated = _gda("node", "duplicate", str(scene_path), "--node", "Hero", "--json")
+    duplicated = gda("node", "duplicate", str(scene_path), "--node", "Hero", "--json")
     assert duplicated.returncode == 0, duplicated.stdout + duplicated.stderr
     new_name = json.loads(duplicated.stdout)["name"]
 
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
     by_name = {c["name"]: c for c in json.loads(listed.stdout)["root"]["children"]}
     copy = by_name[new_name]
     # The copied subtree carries the child, re-pathed under the new parent.
@@ -2448,7 +2414,7 @@ def test_node_duplicate_nested_node_lands_under_its_own_parent(godot_project):
     # node path shares the source's parent prefix.
     scene_path = _scene_with_nested_children(godot_project)  # root -> A -> B
 
-    duplicated = _gda("node", "duplicate", str(scene_path), "--node", "A/B", "--json")
+    duplicated = gda("node", "duplicate", str(scene_path), "--node", "A/B", "--json")
 
     assert duplicated.returncode == 0, duplicated.stdout + duplicated.stderr
     data = json.loads(duplicated.stdout)
@@ -2464,9 +2430,15 @@ def test_node_duplicate_missing_node_yields_node_not_found(godot_project):
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    duplicated = _gda("node", "duplicate", str(scene_path), "--node", "Bogus", "--json")
-
-    err = _assert_operation_error(duplicated, "node_not_found")
+    err = gda.error(
+        "node",
+        "duplicate",
+        str(scene_path),
+        "--node",
+        "Bogus",
+        "--json",
+        code="node_not_found",
+    )
     assert "Bogus" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -2479,9 +2451,15 @@ def test_node_duplicate_root_yields_cannot_target_root(godot_project):
     _create_scene(scene_path)
     before = scene_path.read_text(encoding="utf-8")
 
-    duplicated = _gda("node", "duplicate", str(scene_path), "--node", ".", "--json")
-
-    _assert_operation_error(duplicated, "cannot_target_root")
+    gda.error(
+        "node",
+        "duplicate",
+        str(scene_path),
+        "--node",
+        ".",
+        "--json",
+        code="cannot_target_root",
+    )
     assert scene_path.read_text(encoding="utf-8") == before
 
 
@@ -2495,8 +2473,8 @@ def test_node_move_reparents_node_and_subtree_round_trip(godot_project):
     # list: the moved node now sits under the target, carrying its child.
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    _gda("node", "add", str(scene_path), "--type", "Node2D", "--name", "Hero", "--json")
-    _gda(
+    gda("node", "add", str(scene_path), "--type", "Node2D", "--name", "Hero", "--json")
+    gda(
         "node",
         "add",
         str(scene_path),
@@ -2508,7 +2486,7 @@ def test_node_move_reparents_node_and_subtree_round_trip(godot_project):
         "Hero",
         "--json",
     )
-    _gda(
+    gda(
         "node",
         "add",
         str(scene_path),
@@ -2519,7 +2497,7 @@ def test_node_move_reparents_node_and_subtree_round_trip(godot_project):
         "--json",
     )
 
-    moved = _gda(
+    moved = gda(
         "node", "move", str(scene_path), "--node", "Hero", "--to", "Enemies", "--json"
     )
 
@@ -2529,7 +2507,7 @@ def test_node_move_reparents_node_and_subtree_round_trip(godot_project):
     assert data["new_parent"] == "Enemies"
     assert data["path"] == "Enemies/Hero"
 
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
     by_name = {c["name"]: c for c in json.loads(listed.stdout)["root"]["children"]}
     # Hero is no longer a direct child of the root; it sits under Enemies, with
     # its subtree intact.
@@ -2555,7 +2533,7 @@ def test_node_move_index_places_reparented_node_in_destination_order(godot_proje
         ("Slime", "Enemies"),
         ("Bat", "Enemies"),
     ):
-        added = _gda(
+        added = gda(
             "node",
             "add",
             str(scene_path),
@@ -2569,7 +2547,7 @@ def test_node_move_index_places_reparented_node_in_destination_order(godot_proje
         )
         assert added.returncode == 0, added.stdout + added.stderr
 
-    moved = _gda(
+    moved = gda(
         "node",
         "move",
         str(scene_path),
@@ -2599,16 +2577,14 @@ def test_node_move_to_root_reparents_under_the_root(godot_project):
     # up to be a direct child of the scene root.
     scene_path = _scene_with_nested_children(godot_project)  # root -> A -> B
 
-    moved = _gda(
-        "node", "move", str(scene_path), "--node", "A/B", "--to", ".", "--json"
-    )
+    moved = gda("node", "move", str(scene_path), "--node", "A/B", "--to", ".", "--json")
 
     assert moved.returncode == 0, moved.stdout + moved.stderr
     data = json.loads(moved.stdout)
     assert data["new_parent"] == "."
     assert data["path"] == "B"
 
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
     names = {c["name"] for c in json.loads(listed.stdout)["root"]["children"]}
     assert names == {"A", "B"}
 
@@ -2621,7 +2597,7 @@ def test_node_move_index_reorders_same_parent_without_rebuilding_node(godot_proj
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     for name in ("HP", "MP", "EXP"):
-        added = _gda(
+        added = gda(
             "node",
             "add",
             str(scene_path),
@@ -2632,7 +2608,7 @@ def test_node_move_index_reorders_same_parent_without_rebuilding_node(godot_proj
             "--json",
         )
         assert added.returncode == 0, added.stdout + added.stderr
-    set_text = _gda(
+    set_text = gda(
         "node",
         "set",
         str(scene_path),
@@ -2645,7 +2621,7 @@ def test_node_move_index_reorders_same_parent_without_rebuilding_node(godot_proj
         "--json",
     )
     assert set_text.returncode == 0, set_text.stdout + set_text.stderr
-    child = _gda(
+    child = gda(
         "node",
         "add",
         str(scene_path),
@@ -2659,7 +2635,7 @@ def test_node_move_index_reorders_same_parent_without_rebuilding_node(godot_proj
     )
     assert child.returncode == 0, child.stdout + child.stderr
 
-    moved = _gda(
+    moved = gda(
         "node",
         "move",
         str(scene_path),
@@ -2678,7 +2654,7 @@ def test_node_move_index_reorders_same_parent_without_rebuilding_node(godot_proj
     assert [child["name"] for child in root_children] == ["HP", "EXP", "MP"]
     exp = root_children[1]
     assert exp["children"][0]["path"] == "EXP/Icon"
-    got = _gda("node", "get", str(scene_path), "--node", "EXP", "--json")
+    got = gda("node", "get", str(scene_path), "--node", "EXP", "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     properties = {
         prop["name"]: prop["value"] for prop in json.loads(got.stdout)["properties"]
@@ -2695,7 +2671,7 @@ def test_node_move_invalid_index_yields_invalid_child_index_and_leaves_file_unch
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     for name in ("HP", "MP", "EXP"):
-        added = _gda(
+        added = gda(
             "node",
             "add",
             str(scene_path),
@@ -2708,7 +2684,7 @@ def test_node_move_invalid_index_yields_invalid_child_index_and_leaves_file_unch
         assert added.returncode == 0, added.stdout + added.stderr
     before = scene_path.read_text(encoding="utf-8")
 
-    moved = _gda(
+    err = gda.error(
         "node",
         "move",
         str(scene_path),
@@ -2719,9 +2695,8 @@ def test_node_move_invalid_index_yields_invalid_child_index_and_leaves_file_unch
         "--index",
         "3",
         "--json",
+        code="invalid_child_index",
     )
-
-    err = _assert_operation_error(moved, "invalid_child_index")
     assert "3" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -2734,11 +2709,17 @@ def test_node_move_under_own_descendant_yields_cyclic_target(godot_project):
     scene_path = _scene_with_nested_children(godot_project)  # root -> A -> B
     before = scene_path.read_text(encoding="utf-8")
 
-    moved = _gda(
-        "node", "move", str(scene_path), "--node", "A", "--to", "A/B", "--json"
+    err = gda.error(
+        "node",
+        "move",
+        str(scene_path),
+        "--node",
+        "A",
+        "--to",
+        "A/B",
+        "--json",
+        code="cyclic_target",
     )
-
-    err = _assert_operation_error(moved, "cyclic_target")
     assert "A/B" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -2750,9 +2731,17 @@ def test_node_move_under_itself_yields_cyclic_target(godot_project):
     scene_path = _scene_with_nested_children(godot_project)  # root -> A -> B
     before = scene_path.read_text(encoding="utf-8")
 
-    moved = _gda("node", "move", str(scene_path), "--node", "A", "--to", "A", "--json")
-
-    _assert_operation_error(moved, "cyclic_target")
+    gda.error(
+        "node",
+        "move",
+        str(scene_path),
+        "--node",
+        "A",
+        "--to",
+        "A",
+        "--json",
+        code="cyclic_target",
+    )
     assert scene_path.read_text(encoding="utf-8") == before
 
 
@@ -2763,11 +2752,17 @@ def test_node_move_to_missing_parent_yields_parent_not_found(godot_project):
     scene_path = _scene_with_nested_children(godot_project)  # root -> A -> B
     before = scene_path.read_text(encoding="utf-8")
 
-    moved = _gda(
-        "node", "move", str(scene_path), "--node", "A/B", "--to", "Bogus", "--json"
+    err = gda.error(
+        "node",
+        "move",
+        str(scene_path),
+        "--node",
+        "A/B",
+        "--to",
+        "Bogus",
+        "--json",
+        code="parent_not_found",
     )
-
-    err = _assert_operation_error(moved, "parent_not_found")
     assert "Bogus" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -2781,8 +2776,8 @@ def test_node_move_name_collision_at_destination_yields_duplicate_node_name(
     # node add reports), leaving the file untouched.
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
-    _gda("node", "add", str(scene_path), "--type", "Node2D", "--name", "Hero", "--json")
-    _gda(
+    gda("node", "add", str(scene_path), "--type", "Node2D", "--name", "Hero", "--json")
+    gda(
         "node",
         "add",
         str(scene_path),
@@ -2792,7 +2787,7 @@ def test_node_move_name_collision_at_destination_yields_duplicate_node_name(
         "Enemies",
         "--json",
     )
-    _gda(
+    gda(
         "node",
         "add",
         str(scene_path),
@@ -2806,11 +2801,17 @@ def test_node_move_name_collision_at_destination_yields_duplicate_node_name(
     )
     before = scene_path.read_text(encoding="utf-8")
 
-    moved = _gda(
-        "node", "move", str(scene_path), "--node", "Hero", "--to", "Enemies", "--json"
+    err = gda.error(
+        "node",
+        "move",
+        str(scene_path),
+        "--node",
+        "Hero",
+        "--to",
+        "Enemies",
+        "--json",
+        code="duplicate_node_name",
     )
-
-    err = _assert_operation_error(moved, "duplicate_node_name")
     assert "Hero" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -2819,7 +2820,7 @@ def test_node_move_name_collision_at_destination_yields_duplicate_node_name(
 def test_node_connect_signal_missing_target_node_yields_node_not_found(godot_project):
     scene_path = _scene_with_emitter_and_receiver(godot_project)
 
-    connected = _gda(
+    err = gda.error(
         "node",
         "connect-signal",
         str(scene_path),
@@ -2832,9 +2833,8 @@ def test_node_connect_signal_missing_target_node_yields_node_not_found(godot_pro
         "--method",
         "on_timeout",
         "--json",
+        code="node_not_found",
     )
-
-    err = _assert_operation_error(connected, "node_not_found")
     assert "target" in err["message"]
     assert "Bogus" in err["message"]
 
@@ -2844,7 +2844,7 @@ def test_node_disconnect_signal_removes_an_existing_connection(godot_project):
     # disconnect-signal removes a connection connect-signal recorded; the round-
     # trip read shows the [connection] is gone from the saved file.
     scene_path = _scene_with_emitter_and_receiver(godot_project)
-    connected = _gda(
+    connected = gda(
         "node",
         "connect-signal",
         str(scene_path),
@@ -2861,7 +2861,7 @@ def test_node_disconnect_signal_removes_an_existing_connection(godot_project):
     assert connected.returncode == 0, connected.stdout + connected.stderr
     assert _connection_lines(scene_path)  # the connection is there first
 
-    disconnected = _gda(
+    disconnected = gda(
         "node",
         "disconnect-signal",
         str(scene_path),
@@ -2892,7 +2892,7 @@ def test_node_disconnect_signal_absent_connection_yields_connection_not_found(
     scene_path = _scene_with_emitter_and_receiver(godot_project)
     before = scene_path.read_text(encoding="utf-8")
 
-    disconnected = _gda(
+    err = gda.error(
         "node",
         "disconnect-signal",
         str(scene_path),
@@ -2905,9 +2905,8 @@ def test_node_disconnect_signal_absent_connection_yields_connection_not_found(
         "--method",
         "on_timeout",
         "--json",
+        code="connection_not_found",
     )
-
-    err = _assert_operation_error(disconnected, "connection_not_found")
     assert "Emitter.timeout" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -2917,11 +2916,17 @@ def test_node_move_missing_node_yields_node_not_found(godot_project):
     scene_path = _scene_with_nested_children(godot_project)
     before = scene_path.read_text(encoding="utf-8")
 
-    moved = _gda(
-        "node", "move", str(scene_path), "--node", "Bogus", "--to", ".", "--json"
+    err = gda.error(
+        "node",
+        "move",
+        str(scene_path),
+        "--node",
+        "Bogus",
+        "--to",
+        ".",
+        "--json",
+        code="node_not_found",
     )
-
-    err = _assert_operation_error(moved, "node_not_found")
     assert "Bogus" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -2934,7 +2939,7 @@ def test_node_disconnect_signal_missing_signal_yields_signal_not_found(godot_pro
     scene_path = _scene_with_emitter_and_receiver(godot_project)
     before = scene_path.read_text(encoding="utf-8")
 
-    disconnected = _gda(
+    err = gda.error(
         "node",
         "disconnect-signal",
         str(scene_path),
@@ -2947,9 +2952,8 @@ def test_node_disconnect_signal_missing_signal_yields_signal_not_found(godot_pro
         "--method",
         "on_timeout",
         "--json",
+        code="signal_not_found",
     )
-
-    err = _assert_operation_error(disconnected, "signal_not_found")
     assert "no_such_signal" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -2961,9 +2965,17 @@ def test_node_move_root_yields_cannot_target_root(godot_project):
     scene_path = _scene_with_nested_children(godot_project)
     before = scene_path.read_text(encoding="utf-8")
 
-    moved = _gda("node", "move", str(scene_path), "--node", ".", "--to", "A", "--json")
-
-    _assert_operation_error(moved, "cannot_target_root")
+    gda.error(
+        "node",
+        "move",
+        str(scene_path),
+        "--node",
+        ".",
+        "--to",
+        "A",
+        "--json",
+        code="cannot_target_root",
+    )
     assert scene_path.read_text(encoding="utf-8") == before
 
 
@@ -2977,13 +2989,13 @@ def test_node_move_to_current_parent_is_a_noop_preserving_sibling_order(godot_pr
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
     for name in ("A", "B", "C"):
-        added = _gda(
+        added = gda(
             "node", "add", str(scene_path), "--type", "Node2D", "--name", name, "--json"
         )
         assert added.returncode == 0, added.stdout + added.stderr
     before = scene_path.read_text(encoding="utf-8")
 
-    moved = _gda("node", "move", str(scene_path), "--node", "A", "--to", ".", "--json")
+    moved = gda("node", "move", str(scene_path), "--node", "A", "--to", ".", "--json")
 
     assert moved.returncode == 0, moved.stdout + moved.stderr
     assert scene_path.read_text(encoding="utf-8") == before
@@ -2992,7 +3004,7 @@ def test_node_move_to_current_parent_is_a_noop_preserving_sibling_order(godot_pr
     assert data["new_parent"] == "."
     assert data["path"] == "A"
 
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
     assert listed.returncode == 0, listed.stdout + listed.stderr
     order = [c["name"] for c in json.loads(listed.stdout)["root"]["children"]]
     # Sibling order is preserved: A was not shuffled to the end.
@@ -3010,7 +3022,7 @@ def test_node_move_preserves_editable_instance_overrides(godot_project):
     # Verified empirically against Godot 4.6.3.
     parent = _write_instance_fixture(godot_project)
     # A destination parent to reparent the instance under.
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(parent),
@@ -3024,7 +3036,7 @@ def test_node_move_preserves_editable_instance_overrides(godot_project):
     )
     assert added.returncode == 0, added.stdout + added.stderr
 
-    moved = _gda(
+    moved = gda(
         "node",
         "move",
         str(parent),
@@ -3059,7 +3071,7 @@ def test_node_move_preserves_editable_instance_overrides(godot_project):
 def test_node_connect_signal_to_missing_scene_yields_path_not_found(godot_project):
     missing = godot_project / "missing.tscn"
 
-    connected = _gda(
+    err = gda.error(
         "node",
         "connect-signal",
         str(missing),
@@ -3072,9 +3084,8 @@ def test_node_connect_signal_to_missing_scene_yields_path_not_found(godot_projec
         "--method",
         "on_timeout",
         "--json",
+        code="path_not_found",
     )
-
-    err = _assert_operation_error(connected, "path_not_found")
     assert str(missing) in err["message"]
 
 
@@ -3085,7 +3096,7 @@ def test_node_add_leaves_no_temp_file_on_success(godot_project):
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(scene_path),
@@ -3115,8 +3126,7 @@ def test_node_add_with_external_edit_in_window_yields_file_changed_externally(
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    added = _gda_env(
-        {"GDA_TEST_PERTURB_BEFORE_SAVE": "1"},
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -3125,15 +3135,15 @@ def test_node_add_with_external_edit_in_window_yields_file_changed_externally(
         "--name",
         "Hero",
         "--json",
+        extra_env={"GDA_TEST_PERTURB_BEFORE_SAVE": "1"},
+        code="file_changed_externally",
     )
-
-    err = _assert_operation_error(added, "file_changed_externally")
     assert str(scene_path) in err["message"]
 
     # The mutation did NOT land: a fresh list shows no "Hero" child. (The seam
     # perturbs the file by one byte, so we assert the EFFECT — the node is absent —
     # not byte-identical content.)
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
     assert listed.returncode == 0, listed.stdout + listed.stderr
     tree = json.loads(listed.stdout)
     child_names = [c["name"] for c in tree["root"]["children"]]
@@ -3159,8 +3169,7 @@ def test_node_add_with_external_edit_during_instantiate_yields_file_changed_exte
     scene_path = godot_project / "main.tscn"
     _create_scene(scene_path)
 
-    added = _gda_env(
-        {"GDA_TEST_PERTURB_AFTER_LOAD": "1"},
+    err = gda.error(
         "node",
         "add",
         str(scene_path),
@@ -3169,13 +3178,13 @@ def test_node_add_with_external_edit_during_instantiate_yields_file_changed_exte
         "--name",
         "Hero",
         "--json",
+        extra_env={"GDA_TEST_PERTURB_AFTER_LOAD": "1"},
+        code="file_changed_externally",
     )
-
-    err = _assert_operation_error(added, "file_changed_externally")
     assert str(scene_path) in err["message"]
 
     # The mutation did NOT land despite the edit landing in the earlier window.
-    listed = _gda("node", "list", str(scene_path), "--json")
+    listed = gda("node", "list", str(scene_path), "--json")
     assert listed.returncode == 0, listed.stdout + listed.stderr
     child_names = [c["name"] for c in json.loads(listed.stdout)["root"]["children"]]
     assert "Hero" not in child_names, child_names
@@ -3212,7 +3221,7 @@ def test_node_get_projects_a_path_less_texture_headless(godot_project):
         encoding="utf-8",
     )
 
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     got = gda("node", "get", "res://main.tscn", "--node", ".", "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
@@ -3253,7 +3262,7 @@ def test_node_get_keeps_non_res_pathed_textures_on_the_string_fallback(godot_pro
         encoding="utf-8",
     )
 
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     got = gda("node", "get", "res://main.tscn", "--node", ".", "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
@@ -3294,7 +3303,7 @@ def test_inline_projection_drops_a_storage_property_named_object_string(
         encoding="utf-8",
     )
 
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     got = gda("node", "get", "res://main.tscn", "--node", ".", "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
@@ -3342,13 +3351,19 @@ def test_node_add_refuses_a_broken_script_behind_a_type_decoy(godot_project):
         encoding="utf-8",
     )
     before = (godot_project / "main.tscn").read_text(encoding="utf-8")
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
-    added = gda(
-        "node", "add", "res://main.tscn", "--type", "Marker2D", "--name", "M", "--json"
+    err = gda.error(
+        "node",
+        "add",
+        "res://main.tscn",
+        "--type",
+        "Marker2D",
+        "--name",
+        "M",
+        "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(added, "missing_dependency")
     assert "res://enemy_projectile.tscn" in err["message"]
     assert (godot_project / "main.tscn").read_text(encoding="utf-8") == before
 
@@ -3369,9 +3384,9 @@ def test_node_add_refuses_a_broken_script_declared_by_a_relative_path(godot_proj
         encoding="utf-8",
     )
     before = (godot_project / "scenes" / "main.tscn").read_text(encoding="utf-8")
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
-    added = gda(
+    err = gda.error(
         "node",
         "add",
         "res://scenes/main.tscn",
@@ -3380,9 +3395,8 @@ def test_node_add_refuses_a_broken_script_declared_by_a_relative_path(godot_proj
         "--name",
         "M",
         "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(added, "missing_dependency")
     assert "res://enemy_projectile.tscn" in err["message"]
     assert (godot_project / "scenes" / "main.tscn").read_text(
         encoding="utf-8"
@@ -3402,7 +3416,7 @@ def test_node_add_does_not_read_a_script_prefixed_property_as_a_binding(godot_pr
         'script_owner = ExtResource("1_enemy")\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     added = gda(
         "node", "add", "res://main.tscn", "--type", "Marker2D", "--name", "M", "--json"

--- a/tests/test_e2e_object_property.py
+++ b/tests/test_e2e_object_property.py
@@ -19,52 +19,10 @@ the generic ``uncoercible_value``), leaving the target file untouched.
 """
 
 import json
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
-
-
-def _gda_project(project):
-    """A ``gda`` bound to ``--godot`` and ``--project`` so ``res://`` resolves."""
-
-    def gda(*args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-            capture_output=True,
-            text=True,
-        )
-
-    return gda
-
-
-def _import_project(project) -> None:
-    """Run a one-shot headless import so the project's class_name list is written.
-
-    A script ``class_name`` only registers in
-    ``.godot/global_script_class_list.cfg`` after a project scan — the realistic
-    precondition for resolving ``Player`` / ``PlayerConfig`` by class_name
-    (mirrors the node/resource class_name e2e tests).
-    """
-    imported = subprocess.run(
-        [str(GODOT), "--headless", "--path", str(project), "--import"],
-        capture_output=True,
-        text=True,
-        timeout=120,
-    )
-    assert imported.returncode == 0, imported.stdout + imported.stderr
-
-
-def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
-    assert proc.returncode == 4, proc.stdout + proc.stderr
-    err = json.loads(proc.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == code
-    return err
+from tests.support import Gda, import_project
 
 
 def _scene_with_collision_shape(gda, project):
@@ -117,7 +75,7 @@ def test_node_set_object_property_wires_ext_resource_end_to_end(godot_project):
     # workflow wires CollisionShape2D.shape to an existing RectangleShape2D by its
     # res:// path, and the saved scene reloads with the resource attached as an
     # EXTERNAL reference (ext_resource), never inlined.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     scene_path = _scene_with_collision_shape(gda, godot_project)
     _box_shape(gda, godot_project)
 
@@ -174,7 +132,7 @@ def test_resource_set_object_property_wires_ext_resource(godot_project):
     # The resource-on-resource half (ADR-0033): resource set assigns an existing
     # Gradient to GradientTexture1D.gradient (an engine-class-typed Object property)
     # by res:// path, saved as an ext_resource on the .tres.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     tex = gda(
         "resource", "create", "res://tex.tres", "--type", "GradientTexture1D", "--json"
     )
@@ -225,13 +183,13 @@ def test_node_set_object_type_mismatch_yields_resource_type_mismatch(godot_proje
     # A res:// resource whose type is incompatible with the property's expected
     # engine class is a DISTINCT resource_type_mismatch — not uncoercible_value —
     # naming both the actual and the expected class; the scene is left untouched.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     scene_path = _scene_with_collision_shape(gda, godot_project)
     grad = gda("resource", "create", "res://grad.tres", "--type", "Gradient", "--json")
     assert grad.returncode == 0, grad.stdout + grad.stderr
     before = scene_path.read_text(encoding="utf-8")
 
-    was_set = gda(
+    err = gda.error(
         "node",
         "set",
         "res://main.tscn",
@@ -242,9 +200,8 @@ def test_node_set_object_type_mismatch_yields_resource_type_mismatch(godot_proje
         "--value",
         "res://grad.tres",
         "--json",
+        code="resource_type_mismatch",
     )
-
-    err = _assert_operation_error(was_set, "resource_type_mismatch")
     assert "Gradient" in err["message"]
     assert "Shape2D" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
@@ -255,11 +212,11 @@ def test_node_set_object_non_res_value_yields_expected_resource_path(godot_proje
     # A non-res:// value for an Object-typed property is a DISTINCT
     # expected_resource_path (a comma-form scalar that would coerce for a Vector2 is
     # NOT accepted here) — not uncoercible_value; the scene is left untouched.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     scene_path = _scene_with_collision_shape(gda, godot_project)
     before = scene_path.read_text(encoding="utf-8")
 
-    was_set = gda(
+    err = gda.error(
         "node",
         "set",
         "res://main.tscn",
@@ -270,9 +227,8 @@ def test_node_set_object_non_res_value_yields_expected_resource_path(godot_proje
         "--value",
         "32,64",
         "--json",
+        code="expected_resource_path",
     )
-
-    err = _assert_operation_error(was_set, "expected_resource_path")
     assert "res://" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -281,11 +237,11 @@ def test_node_set_object_non_res_value_yields_expected_resource_path(godot_proje
 def test_node_set_object_missing_resource_yields_not_a_resource(godot_project):
     # A res:// value that does not load as a Resource (here: no such path) is a
     # DISTINCT not_a_resource — not uncoercible_value; the scene is left untouched.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     scene_path = _scene_with_collision_shape(gda, godot_project)
     before = scene_path.read_text(encoding="utf-8")
 
-    was_set = gda(
+    err = gda.error(
         "node",
         "set",
         "res://main.tscn",
@@ -296,9 +252,8 @@ def test_node_set_object_missing_resource_yields_not_a_resource(godot_project):
         "--value",
         "res://nope.tres",
         "--json",
+        code="not_a_resource",
     )
-
-    err = _assert_operation_error(was_set, "not_a_resource")
     assert "res://nope.tres" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -308,12 +263,12 @@ def test_node_set_non_resource_file_yields_not_a_resource(godot_project):
     # A res:// path that exists but is NOT a resource (a plain text file) also fails
     # not_a_resource — the failure is "does not load as a Resource", not merely
     # "missing path".
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     scene_path = _scene_with_collision_shape(gda, godot_project)
     (godot_project / "notes.txt").write_text("not a resource\n", encoding="utf-8")
     before = scene_path.read_text(encoding="utf-8")
 
-    was_set = gda(
+    err = gda.error(
         "node",
         "set",
         "res://main.tscn",
@@ -324,9 +279,8 @@ def test_node_set_non_resource_file_yields_not_a_resource(godot_project):
         "--value",
         "res://notes.txt",
         "--json",
+        code="not_a_resource",
     )
-
-    err = _assert_operation_error(was_set, "not_a_resource")
     assert "res://notes.txt" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -337,12 +291,12 @@ def test_node_set_script_property_yields_use_script_attach(godot_project):
     # `script attach` (#118) — the one authoritative script-binding path. Setting it
     # returns an ACTIONABLE structured error naming `script attach`, never a second
     # attach entry; the scene is left untouched.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     scene_path = _scene_with_collision_shape(gda, godot_project)
     (godot_project / "foo.gd").write_text("extends Node2D\n", encoding="utf-8")
     before = scene_path.read_text(encoding="utf-8")
 
-    was_set = gda(
+    err = gda.error(
         "node",
         "set",
         "res://main.tscn",
@@ -353,9 +307,8 @@ def test_node_set_script_property_yields_use_script_attach(godot_project):
         "--value",
         "res://foo.gd",
         "--json",
+        code="use_script_attach",
     )
-
-    err = _assert_operation_error(was_set, "use_script_attach")
     assert "script attach" in err["message"]
     assert scene_path.read_text(encoding="utf-8") == before
 
@@ -365,7 +318,7 @@ def test_node_set_value_typed_coercion_is_unchanged(godot_project):
     # Regression: the Object branch must not disturb value-typed coercion — a
     # Vector2 property still coerces from the comma form and round-trips as a JSON
     # number pair (the #55 contract, unchanged by ADR-0033).
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     _scene_with_collision_shape(gda, godot_project)
 
     was_set = gda(
@@ -416,10 +369,13 @@ def test_node_set_script_class_name_typed_property_is_deferred(godot_project):
     # never a misleading resource_type_mismatch — naming the class and the deferral,
     # and leaves the scene untouched. Pins the deferred branch as a checked-in
     # contract (the code is public ABI), dispatching through operations.gd.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     (godot_project / "player_config.gd").write_text(PLAYER_CONFIG_GD, encoding="utf-8")
     (godot_project / "player.gd").write_text(PLAYER_GD, encoding="utf-8")
-    _import_project(godot_project)
+    # A script ``class_name`` only registers in the project's global class list
+    # after a project scan — the realistic precondition for resolving ``Player`` /
+    # ``PlayerConfig`` by class_name.
+    import_project(godot_project)
 
     created = gda(
         "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -443,7 +399,7 @@ def test_node_set_script_class_name_typed_property_is_deferred(godot_project):
     assert cfg.returncode == 0, cfg.stdout + cfg.stderr
     before = (godot_project / "main.tscn").read_text(encoding="utf-8")
 
-    was_set = gda(
+    err = gda.error(
         "node",
         "set",
         "res://main.tscn",
@@ -454,8 +410,7 @@ def test_node_set_script_class_name_typed_property_is_deferred(godot_project):
         "--value",
         "res://cfg.tres",
         "--json",
+        code="unsupported_property_type",
     )
-
-    err = _assert_operation_error(was_set, "unsupported_property_type")
     assert "PlayerConfig" in err["message"]
     assert (godot_project / "main.tscn").read_text(encoding="utf-8") == before

--- a/tests/test_e2e_op_robustness.py
+++ b/tests/test_e2e_op_robustness.py
@@ -13,13 +13,11 @@ import time
 
 import pytest
 
-from gda.binary import resolve_godot_binary
 from gda.errors import Failure, classify_run
 from gda.models import EngineVersion
 from gda.parser import parse_result
 from gda.runner import OPERATIONS_GD, RunResult, SubprocessGodotRunner
-
-GODOT = resolve_godot_binary()
+from tests.support import GODOT
 
 
 @pytest.mark.e2e

--- a/tests/test_e2e_params_json.py
+++ b/tests/test_e2e_params_json.py
@@ -8,15 +8,12 @@ toward this gate.
 """
 
 import json
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
+from tests.support import Gda
 
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
+gda = Gda()
 
 
 @pytest.mark.e2e
@@ -24,20 +21,7 @@ def test_scene_create_via_params_json_creates_the_scene(godot_project):
     scene_path = godot_project / "main.tscn"
     params = json.dumps({"path": str(scene_path), "root_type": "Node2D"})
 
-    created = subprocess.run(
-        [
-            *GDA_CMD,
-            "scene",
-            "create",
-            "--params-json",
-            params,
-            "--json",
-            "--godot",
-            str(GODOT),
-        ],
-        capture_output=True,
-        text=True,
-    )
+    created = gda("scene", "create", "--params-json", params, "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     data = json.loads(created.stdout)
@@ -48,11 +32,7 @@ def test_scene_create_via_params_json_creates_the_scene(godot_project):
     assert scene_path.exists()
 
     # And reads back through the engine — the file is loadable, not just present.
-    got = subprocess.run(
-        [*GDA_CMD, "scene", "get", str(scene_path), "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-    )
+    got = gda("scene", "get", str(scene_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["root"]["type"] == "Node2D"
 
@@ -63,21 +43,7 @@ def test_scene_create_via_params_json_stdin_creates_the_scene(godot_project):
     scene_path = godot_project / "fromstdin.tscn"
     params = json.dumps({"path": str(scene_path), "root_type": "Node2D"})
 
-    created = subprocess.run(
-        [
-            *GDA_CMD,
-            "scene",
-            "create",
-            "--params-json",
-            "-",
-            "--json",
-            "--godot",
-            str(GODOT),
-        ],
-        input=params,
-        capture_output=True,
-        text=True,
-    )
+    created = gda("scene", "create", "--params-json", "-", "--json", stdin=params)
 
     assert created.returncode == 0, created.stdout + created.stderr
     assert json.loads(created.stdout)["root_name"] == "fromstdin"

--- a/tests/test_e2e_perf.py
+++ b/tests/test_e2e_perf.py
@@ -11,28 +11,16 @@ Run e2e SERIALLY; not a fresh empty HOME (Godot first-run). The
 
 import json
 import os
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
+from tests.support import Gda
 
-from tests.support import GDA_CMD
-
-from .conftest import project_godot
-
-GODOT = resolve_godot_binary()
+from .conftest import LIVE_MAIN_TSCN, LIVE_PROJECT_GODOT
 
 # A main scene with a Player Node2D so the launched session has a runtime
 # SceneTree to monitor; Player.position is a Vector2 storage property the property
 # timeline samples each frame. File logging stays disabled via project_godot (#180).
-MAIN_TSCN = (
-    "[gd_scene format=3]\n\n"
-    '[node name="Main" type="Node2D"]\n\n'
-    '[node name="Player" type="Node2D" parent="."]\n'
-)
-PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
-
 # A Player that DECLARES a custom signal and emits it once per _process frame with
 # a single int argument (a monotonically increasing tick). The signal e2e watches
 # this signal over a window and asserts the recorded emissions — exercising the
@@ -60,27 +48,10 @@ pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"
 def test_daemon_serves_a_live_perf_snapshot(tmp_path, daemon_runtime_dir):
     # `perf monitors`: a real daemon -> engine session -> the running game's live
     # Performance counters, snapshotted in one frame (frame-coherent, ADR-0020).
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -105,27 +76,10 @@ def test_daemon_serves_a_property_timeline_over_a_window(tmp_path, daemon_runtim
     # `perf monitor --property --frames N`: the time-windowed multi-frame base
     # (#223) collects one sample per frame across the engine session and returns
     # the whole N-sample timeline in a single blocking call (ADR-0017 one-shot RPC).
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -162,28 +116,11 @@ def test_daemon_serves_a_signal_timeline_over_a_window(tmp_path, daemon_runtime_
     # disconnects on finalize. The Player emits `ticked(n)` once per _process frame,
     # so a window of N frames records emissions carrying the int tick arg — the real
     # get_signal_list / connect / record / disconnect path (#239).
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(SIGNAL_MAIN_TSCN, encoding="utf-8")
     (tmp_path / "player.gd").write_text(SIGNAL_PLAYER_GD, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     try:
         started = run("daemon", "start")
@@ -230,27 +167,10 @@ def test_perf_monitor_missing_node_reports_live_perf_node_not_found(
 ):
     # A path that resolves to no running node is the typed harness op-error,
     # relayed through the daemon (exit-0 sentinel) and mapped by classify_live.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     try:
         assert run("daemon", "start").returncode == 0
@@ -279,12 +199,11 @@ def test_perf_monitors_without_a_daemon_reports_daemon_not_running(tmp_path):
 
     from gda.exit_codes import EXIT_LIVE
 
-    env = {**os.environ, "XDG_RUNTIME_DIR": str(tmp_path / "run")}
-    proc = subprocess.run(
-        [*GDA_CMD, "perf", "monitors", "--project", str(tmp_path), "--json"],
-        capture_output=True,
-        text=True,
-        env=env,
+    proc = Gda(tmp_path, godot=None)(
+        "perf",
+        "monitors",
+        "--json",
+        extra_env={"XDG_RUNTIME_DIR": str(tmp_path / "run")},
     )
 
     assert proc.returncode == EXIT_LIVE, proc.stdout + proc.stderr
@@ -305,8 +224,8 @@ def test_perf_monitors_window_collects_bounded_stats_and_verdicts(
     # 1e6) with one that must fail (fps min 1e6), so `passed` is
     # deterministically false while the command still exits 0 (the verdict is
     # data). The plain snapshot is asserted afterwards on the SAME surface.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
-    (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
     budget = tmp_path / "budget.json"
     budget.write_text(
         '{"node_count": {"stat": "max", "max": 1000000},'
@@ -314,24 +233,7 @@ def test_perf_monitors_window_collects_bounded_stats_and_verdicts(
         encoding="utf-8",
     )
 
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(tmp_path),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=90,
-        )
+    run = Gda(tmp_path, json_output=True)
 
     try:
         assert run("daemon", "start").returncode == 0

--- a/tests/test_e2e_project.py
+++ b/tests/test_e2e_project.py
@@ -12,24 +12,12 @@ the e2e fixture has none, so that surface is exercised as a no-op here.
 """
 
 import json
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
+from tests.support import Gda
 
 from .conftest import project_godot
-
-GODOT = resolve_godot_binary()
-
-
-def _gda(project, *args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [*GDA_CMD, *args, "--project", str(project), "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-    )
 
 
 # An [input] action holding a real InputEventKey Object literal — the exact
@@ -51,7 +39,7 @@ INPUT_ACTION_SECTION = (
 
 @pytest.mark.e2e
 def test_project_info_reports_metadata(godot_project):
-    info = _gda(godot_project, "project", "info", "--json")
+    info = Gda(godot_project)("project", "info", "--json")
 
     assert info.returncode == 0, info.stdout + info.stderr
     data = json.loads(info.stdout)
@@ -69,7 +57,7 @@ def test_project_info_reports_metadata(godot_project):
 
 @pytest.mark.e2e
 def test_project_get_reads_a_setting_as_typed_json(godot_project):
-    got = _gda(godot_project, "project", "get", "application/config/name", "--json")
+    got = Gda(godot_project)("project", "get", "application/config/name", "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     data = json.loads(got.stdout)
@@ -88,7 +76,7 @@ def test_project_get_input_action_projects_a_structured_dictionary(godot_project
         project_godot(extra=INPUT_ACTION_SECTION), encoding="utf-8"
     )
 
-    got = _gda(godot_project, "project", "get", "input/fire", "--json")
+    got = Gda(godot_project)("project", "get", "input/fire", "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     data = json.loads(got.stdout)
@@ -119,7 +107,7 @@ def test_project_get_packed_string_array_setting_projects_a_json_list(godot_proj
         encoding="utf-8",
     )
 
-    got = _gda(godot_project, "project", "get", "gda/tags", "--json")
+    got = Gda(godot_project)("project", "get", "gda/tags", "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     data = json.loads(got.stdout)
@@ -132,8 +120,7 @@ def test_project_set_coerces_persists_and_round_trips_via_get(godot_project):
     # The CLI value is a STRING; the operation coerces it to the setting's declared
     # int type, saves project.godot, and the result reports the coerced int (#55
     # coercion reused). A second get reads it back from the saved file.
-    was_set = _gda(
-        godot_project,
+    was_set = Gda(godot_project)(
         "project",
         "set",
         "display/window/size/viewport_width",
@@ -150,14 +137,14 @@ def test_project_set_coerces_persists_and_round_trips_via_get(godot_project):
     assert set_data["value"] == 1920
 
     # Round-trip: a fresh process reads the persisted value back from project.godot.
-    got = _gda(
-        godot_project, "project", "get", "display/window/size/viewport_width", "--json"
+    got = Gda(godot_project)(
+        "project", "get", "display/window/size/viewport_width", "--json"
     )
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["value"] == 1920
 
     # And project info reflects the saved viewport width.
-    info = _gda(godot_project, "project", "info", "--json")
+    info = Gda(godot_project)("project", "info", "--json")
     assert info.returncode == 0, info.stdout + info.stderr
     assert json.loads(info.stdout)["viewport_width"] == 1920
 
@@ -172,8 +159,7 @@ def test_project_set_preserves_json_container_integer_and_float_types(godot_proj
         encoding="utf-8",
     )
 
-    was_set = _gda(
-        godot_project,
+    was_set = Gda(godot_project)(
         "project",
         "set",
         "gda/stats",
@@ -189,7 +175,7 @@ def test_project_set_preserves_json_container_integer_and_float_types(godot_proj
     assert type(set_value["items"][0]) is int
     assert type(set_value["items"][1]) is float
 
-    got = _gda(godot_project, "project", "get", "gda/stats", "--json")
+    got = Gda(godot_project)("project", "get", "gda/stats", "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     got_value = json.loads(got.stdout)["value"]
     assert type(got_value["a"]) is int
@@ -201,8 +187,7 @@ def test_project_set_preserves_json_container_integer_and_float_types(godot_proj
 @pytest.mark.e2e
 def test_project_set_string_setting_round_trips(godot_project):
     # A String-typed setting takes the CLI value verbatim and round-trips.
-    was_set = _gda(
-        godot_project,
+    was_set = Gda(godot_project)(
         "project",
         "set",
         "application/config/name",
@@ -213,7 +198,7 @@ def test_project_set_string_setting_round_trips(godot_project):
     assert was_set.returncode == 0, was_set.stdout + was_set.stderr
     assert json.loads(was_set.stdout)["value"] == "Renamed Game"
 
-    got = _gda(godot_project, "project", "get", "application/config/name", "--json")
+    got = Gda(godot_project)("project", "get", "application/config/name", "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["value"] == "Renamed Game"
 
@@ -223,7 +208,7 @@ def test_project_list_bare_reports_only_customized_settings(godot_project):
     # A bare list reports only the settings the fixture's project.godot actually
     # writes (customized), each as {setting, type, value, is_default} with
     # is_default false — NOT the hundreds of engine built-in defaults.
-    listed = _gda(godot_project, "project", "list", "--json")
+    listed = Gda(godot_project)("project", "list", "--json")
 
     assert listed.returncode == 0, listed.stdout + listed.stderr
     settings = json.loads(listed.stdout)["settings"]
@@ -248,7 +233,7 @@ def test_project_list_all_includes_engine_defaults(godot_project):
     # --all widens the listing to the engine's built-in defaults too, so a setting
     # the project never customized appears, flagged is_default true, alongside the
     # customized ones (is_default false).
-    listed = _gda(godot_project, "project", "list", "--all", "--json")
+    listed = Gda(godot_project)("project", "list", "--all", "--json")
 
     assert listed.returncode == 0, listed.stdout + listed.stderr
     settings = json.loads(listed.stdout)["settings"]
@@ -273,8 +258,7 @@ def test_project_list_all_includes_engine_defaults(godot_project):
 def test_project_list_section_filters_to_a_prefix_and_composes_with_all(godot_project):
     # --section restricts to keys under a section/ prefix; with --all it scopes the
     # engine defaults to that section too.
-    listed = _gda(
-        godot_project,
+    listed = Gda(godot_project)(
         "project",
         "list",
         "--all",
@@ -299,7 +283,7 @@ def test_project_list_section_filters_to_a_prefix_and_composes_with_all(godot_pr
 def test_project_list_entry_round_trips_through_project_get(godot_project):
     # A listed entry reports the SAME {type, value} projection project get reports
     # for that key — so an agent can list to discover, then get to read one.
-    listed = _gda(godot_project, "project", "list", "--all", "--json")
+    listed = Gda(godot_project)("project", "list", "--all", "--json")
     assert listed.returncode == 0, listed.stdout + listed.stderr
     entry = next(
         e
@@ -307,8 +291,8 @@ def test_project_list_entry_round_trips_through_project_get(godot_project):
         if e["setting"] == "display/window/size/viewport_width"
     )
 
-    got = _gda(
-        godot_project, "project", "get", "display/window/size/viewport_width", "--json"
+    got = Gda(godot_project)(
+        "project", "get", "display/window/size/viewport_width", "--json"
     )
     assert got.returncode == 0, got.stdout + got.stderr
     got_data = json.loads(got.stdout)
@@ -321,12 +305,7 @@ def test_project_list_without_project_is_a_clean_error():
     # Projectless: ProjectSettings would report only the engine's bare defaults,
     # not the agent's project, so it is refused with project_not_found (exit 4),
     # consistent with the rest of the project group.
-    proc = subprocess.run(
-        [*GDA_CMD, "project", "list", "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-        cwd="/tmp",
-    )
+    proc = Gda()("project", "list", "--json", cwd="/tmp")
 
     assert proc.returncode == 4
     err = json.loads(proc.stdout)["error"]
@@ -335,7 +314,7 @@ def test_project_list_without_project_is_a_clean_error():
 
 @pytest.mark.e2e
 def test_project_get_unknown_setting_is_a_clean_error(godot_project):
-    got = _gda(godot_project, "project", "get", "application/bogus/key", "--json")
+    got = Gda(godot_project)("project", "get", "application/bogus/key", "--json")
 
     assert got.returncode == 4
     err = json.loads(got.stdout)["error"]
@@ -348,8 +327,7 @@ def test_project_get_unknown_setting_is_a_clean_error(godot_project):
 def test_project_set_uncoercible_value_is_a_clean_error(godot_project):
     # An int setting cannot take a non-numeric string — uncoercible_value (#55),
     # exit 4, project.godot left untouched.
-    bad = _gda(
-        godot_project,
+    bad = Gda(godot_project)(
         "project",
         "set",
         "display/window/size/viewport_width",
@@ -364,8 +342,8 @@ def test_project_set_uncoercible_value_is_a_clean_error(godot_project):
     assert err["code"] == "uncoercible_value"
 
     # The file was untouched: a subsequent get still returns the original value.
-    got = _gda(
-        godot_project, "project", "get", "display/window/size/viewport_width", "--json"
+    got = Gda(godot_project)(
+        "project", "get", "display/window/size/viewport_width", "--json"
     )
     assert got.returncode == 0, got.stdout + got.stderr
 
@@ -375,8 +353,7 @@ def test_project_add_autoload_registers_persists_and_round_trips(godot_project):
     # A real script to autoload must exist in the project (path_not_found otherwise).
     (godot_project / "global.gd").write_text("extends Node\n", encoding="utf-8")
 
-    added = _gda(
-        godot_project,
+    added = Gda(godot_project)(
         "project",
         "add-autoload",
         "Global",
@@ -391,7 +368,7 @@ def test_project_add_autoload_registers_persists_and_round_trips(godot_project):
     assert add_data["path"] == "*res://global.gd"
 
     # Round-trip: a fresh process reads the autoload back from project.godot via get.
-    got = _gda(godot_project, "project", "get", "autoload/Global", "--json")
+    got = Gda(godot_project)("project", "get", "autoload/Global", "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     got_data = json.loads(got.stdout)
     assert got_data["setting"] == "autoload/Global"
@@ -401,18 +378,18 @@ def test_project_add_autoload_registers_persists_and_round_trips(godot_project):
 @pytest.mark.e2e
 def test_project_remove_autoload_unregisters_and_round_trips(godot_project):
     (godot_project / "global.gd").write_text("extends Node\n", encoding="utf-8")
-    added = _gda(
-        godot_project, "project", "add-autoload", "Global", "res://global.gd", "--json"
+    added = Gda(godot_project)(
+        "project", "add-autoload", "Global", "res://global.gd", "--json"
     )
     assert added.returncode == 0, added.stdout + added.stderr
 
-    removed = _gda(godot_project, "project", "remove-autoload", "Global", "--json")
+    removed = Gda(godot_project)("project", "remove-autoload", "Global", "--json")
     assert removed.returncode == 0, removed.stdout + removed.stderr
     assert json.loads(removed.stdout) == {"name": "Global"}
 
     # Round-trip: the autoload is gone from project.godot — a fresh get reports it
     # as an unknown setting, exit 4.
-    got = _gda(godot_project, "project", "get", "autoload/Global", "--json")
+    got = Gda(godot_project)("project", "get", "autoload/Global", "--json")
     assert got.returncode == 4, got.stdout + got.stderr
     assert json.loads(got.stdout)["error"]["code"] == "unknown_setting"
 
@@ -420,13 +397,13 @@ def test_project_remove_autoload_unregisters_and_round_trips(godot_project):
 @pytest.mark.e2e
 def test_project_add_autoload_duplicate_name_is_a_clean_error(godot_project):
     (godot_project / "global.gd").write_text("extends Node\n", encoding="utf-8")
-    first = _gda(
-        godot_project, "project", "add-autoload", "Global", "res://global.gd", "--json"
+    first = Gda(godot_project)(
+        "project", "add-autoload", "Global", "res://global.gd", "--json"
     )
     assert first.returncode == 0, first.stdout + first.stderr
 
-    dup = _gda(
-        godot_project, "project", "add-autoload", "Global", "res://global.gd", "--json"
+    dup = Gda(godot_project)(
+        "project", "add-autoload", "Global", "res://global.gd", "--json"
     )
     assert dup.returncode == 4
     err = json.loads(dup.stdout)["error"]
@@ -434,7 +411,7 @@ def test_project_add_autoload_duplicate_name_is_a_clean_error(godot_project):
     assert err["code"] == "already_exists"
 
     # The original registration is untouched: a get still reads it back.
-    got = _gda(godot_project, "project", "get", "autoload/Global", "--json")
+    got = Gda(godot_project)("project", "get", "autoload/Global", "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["value"] == "*res://global.gd"
 
@@ -442,8 +419,7 @@ def test_project_add_autoload_duplicate_name_is_a_clean_error(godot_project):
 @pytest.mark.e2e
 def test_project_add_autoload_missing_target_is_a_clean_error(godot_project):
     # The target script/scene does not exist — path_not_found, exit 4, nothing saved.
-    bad = _gda(
-        godot_project,
+    bad = Gda(godot_project)(
         "project",
         "add-autoload",
         "Global",
@@ -457,14 +433,14 @@ def test_project_add_autoload_missing_target_is_a_clean_error(godot_project):
     assert err["code"] == "path_not_found"
 
     # Nothing was registered: a get reports the autoload as unknown.
-    got = _gda(godot_project, "project", "get", "autoload/Global", "--json")
+    got = Gda(godot_project)("project", "get", "autoload/Global", "--json")
     assert got.returncode == 4
     assert json.loads(got.stdout)["error"]["code"] == "unknown_setting"
 
 
 @pytest.mark.e2e
 def test_project_remove_autoload_unknown_name_is_a_clean_error(godot_project):
-    bad = _gda(godot_project, "project", "remove-autoload", "Nonexistent", "--json")
+    bad = Gda(godot_project)("project", "remove-autoload", "Nonexistent", "--json")
 
     assert bad.returncode == 4
     err = json.loads(bad.stdout)["error"]
@@ -491,8 +467,7 @@ def test_project_add_input_action_persists_var_to_str_form_and_reports_keycodes(
     # section with real Object(InputEventKey, ...) literals (issue #380). The
     # stored-value SHAPE via `project get` is deliberately NOT asserted here (the
     # read-side projection of a compound setting is #381, independent).
-    added = _gda(
-        godot_project,
+    added = Gda(godot_project)(
         "project",
         "add-input-action",
         "jump",
@@ -531,8 +506,7 @@ def test_project_add_input_action_persists_var_to_str_form_and_reports_keycodes(
 def test_project_add_input_action_physical_binds_physical_keycode(godot_project):
     # --physical binds the keyboard POSITION: the persisted event carries the
     # keycode in physical_keycode, and the layout keycode stays unset (0).
-    added = _gda(
-        godot_project,
+    added = Gda(godot_project)(
         "project",
         "add-input-action",
         "move_up",
@@ -557,14 +531,14 @@ def test_project_add_input_action_physical_binds_physical_keycode(godot_project)
 
 @pytest.mark.e2e
 def test_project_add_input_action_duplicate_name_is_a_clean_error(godot_project):
-    first = _gda(
-        godot_project, "project", "add-input-action", "fire", "--key", "F", "--json"
+    first = Gda(godot_project)(
+        "project", "add-input-action", "fire", "--key", "F", "--json"
     )
     assert first.returncode == 0, first.stdout + first.stderr
     before = _normalized_project_godot(godot_project)
 
-    dup = _gda(
-        godot_project, "project", "add-input-action", "fire", "--key", "J", "--json"
+    dup = Gda(godot_project)(
+        "project", "add-input-action", "fire", "--key", "J", "--json"
     )
     assert dup.returncode == 4
     err = json.loads(dup.stdout)["error"]
@@ -577,8 +551,7 @@ def test_project_add_input_action_duplicate_name_is_a_clean_error(godot_project)
 
 @pytest.mark.e2e
 def test_project_add_input_action_unknown_key_is_a_clean_error(godot_project):
-    bad = _gda(
-        godot_project,
+    bad = Gda(godot_project)(
         "project",
         "add-input-action",
         "jump",
@@ -599,12 +572,12 @@ def test_project_add_input_action_unknown_key_is_a_clean_error(godot_project):
 
 @pytest.mark.e2e
 def test_project_remove_input_action_unregisters_and_persists(godot_project):
-    added = _gda(
-        godot_project, "project", "add-input-action", "jump", "--key", "J", "--json"
+    added = Gda(godot_project)(
+        "project", "add-input-action", "jump", "--key", "J", "--json"
     )
     assert added.returncode == 0, added.stdout + added.stderr
 
-    removed = _gda(godot_project, "project", "remove-input-action", "jump", "--json")
+    removed = Gda(godot_project)("project", "remove-input-action", "jump", "--json")
     assert removed.returncode == 0, removed.stdout + removed.stderr
     assert json.loads(removed.stdout) == {"name": "jump"}
 
@@ -616,7 +589,7 @@ def test_project_remove_input_action_unregisters_and_persists(godot_project):
 
 @pytest.mark.e2e
 def test_project_remove_input_action_unknown_name_is_a_clean_error(godot_project):
-    bad = _gda(godot_project, "project", "remove-input-action", "nonexistent", "--json")
+    bad = Gda(godot_project)("project", "remove-input-action", "nonexistent", "--json")
 
     assert bad.returncode == 4
     err = json.loads(bad.stdout)["error"]
@@ -629,12 +602,7 @@ def test_project_remove_input_action_unknown_name_is_a_clean_error(godot_project
 def test_project_info_without_project_is_a_clean_error():
     # Projectless: ProjectSettings would report only the engine's bare defaults,
     # not the agent's project, so it is refused with project_not_found.
-    proc = subprocess.run(
-        [*GDA_CMD, "project", "info", "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-        cwd="/tmp",
-    )
+    proc = Gda()("project", "info", "--json", cwd="/tmp")
 
     assert proc.returncode == 4
     err = json.loads(proc.stdout)["error"]

--- a/tests/test_e2e_project_analysis.py
+++ b/tests/test_e2e_project_analysis.py
@@ -14,16 +14,12 @@ acceptance criterion: the same reference graph backs both).
 """
 
 import json
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
+from tests.support import Gda, import_project
 
 from .conftest import project_godot
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
 
 
 # A project.godot with an autoload, a main scene, and an enabled editor plugin —
@@ -140,17 +136,9 @@ def refgraph_project(tmp_path):
     return tmp_path
 
 
-def _gda(project, *args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-        capture_output=True,
-        text=True,
-    )
-
-
 @pytest.mark.e2e
 def test_dependencies_maps_each_scene_to_its_ext_resources(refgraph_project):
-    proc = _gda(refgraph_project, "project", "dependencies", "--json")
+    proc = Gda(refgraph_project)("project", "dependencies", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     data = json.loads(proc.stdout)
@@ -169,8 +157,8 @@ def test_dependencies_maps_each_scene_to_its_ext_resources(refgraph_project):
 
 @pytest.mark.e2e
 def test_find_references_to_a_script_finds_every_referencing_site(refgraph_project):
-    proc = _gda(
-        refgraph_project, "project", "find-references", "res://util.gd", "--json"
+    proc = Gda(refgraph_project)(
+        "project", "find-references", "res://util.gd", "--json"
     )
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
@@ -183,8 +171,8 @@ def test_find_references_to_a_script_finds_every_referencing_site(refgraph_proje
 
 @pytest.mark.e2e
 def test_find_references_to_a_scene_finds_the_ext_resource(refgraph_project):
-    proc = _gda(
-        refgraph_project, "project", "find-references", "res://hero.tscn", "--json"
+    proc = Gda(refgraph_project)(
+        "project", "find-references", "res://hero.tscn", "--json"
     )
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
@@ -197,8 +185,8 @@ def test_find_references_to_a_scene_finds_the_ext_resource(refgraph_project):
 def test_find_references_to_the_main_scene_includes_the_project_level_reference(
     refgraph_project,
 ):
-    proc = _gda(
-        refgraph_project, "project", "find-references", "res://main.tscn", "--json"
+    proc = Gda(refgraph_project)(
+        "project", "find-references", "res://main.tscn", "--json"
     )
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
@@ -209,8 +197,8 @@ def test_find_references_to_the_main_scene_includes_the_project_level_reference(
 
 @pytest.mark.e2e
 def test_find_references_to_an_unreferenced_resource_is_empty(refgraph_project):
-    proc = _gda(
-        refgraph_project, "project", "find-references", "res://orphan.tres", "--json"
+    proc = Gda(refgraph_project)(
+        "project", "find-references", "res://orphan.tres", "--json"
     )
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
@@ -221,7 +209,7 @@ def test_find_references_to_an_unreferenced_resource_is_empty(refgraph_project):
 def test_find_unused_resources_reports_the_orphan_and_is_consistent_with_find_references(
     refgraph_project,
 ):
-    proc = _gda(refgraph_project, "project", "find-unused-resources", "--json")
+    proc = Gda(refgraph_project)("project", "find-unused-resources", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     unused = json.loads(proc.stdout)["unused"]
@@ -238,13 +226,13 @@ def test_find_unused_resources_reports_the_orphan_and_is_consistent_with_find_re
     # find-references for it returns empty, and a referenced one returns non-empty.
     for path in unused:
         refs = json.loads(
-            _gda(refgraph_project, "project", "find-references", path, "--json").stdout
+            Gda(refgraph_project)("project", "find-references", path, "--json").stdout
         )["references"]
         assert refs == [], f"{path} reported unused but has references {refs}"
 
     hero_refs = json.loads(
-        _gda(
-            refgraph_project, "project", "find-references", "res://hero.tscn", "--json"
+        Gda(refgraph_project)(
+            "project", "find-references", "res://hero.tscn", "--json"
         ).stdout
     )["references"]
     assert hero_refs != []  # referenced, hence not in unused
@@ -256,8 +244,8 @@ def test_find_references_skips_decoding_binary_artifacts(refgraph_project):
     # dispatch on extension BEFORE reading, so the binary is never UTF-8-decoded
     # — no engine "Unicode parsing error" on stderr (issue #378) — while the
     # references over the text formats stay byte-for-byte unchanged.
-    proc = _gda(
-        refgraph_project, "project", "find-references", "res://util.gd", "--json"
+    proc = Gda(refgraph_project)(
+        "project", "find-references", "res://util.gd", "--json"
     )
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
@@ -275,7 +263,7 @@ def test_find_unused_resources_skips_decoding_but_keeps_binary_graph_nodes(
     # for DECODING — they stay enumerated as graph nodes, so the unreferenced
     # binary asset (orphan.png) and the build artifact are still unused
     # candidates.
-    proc = _gda(refgraph_project, "project", "find-unused-resources", "--json")
+    proc = Gda(refgraph_project)("project", "find-unused-resources", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     assert "Unicode parsing error" not in proc.stderr, proc.stderr
@@ -286,7 +274,7 @@ def test_find_unused_resources_skips_decoding_but_keeps_binary_graph_nodes(
 
 @pytest.mark.e2e
 def test_statistics_reports_counts_autoloads_and_plugins(refgraph_project):
-    proc = _gda(refgraph_project, "project", "statistics", "--json")
+    proc = Gda(refgraph_project)("project", "statistics", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     data = json.loads(proc.stdout)
@@ -314,8 +302,8 @@ def test_statistics_reports_counts_autoloads_and_plugins(refgraph_project):
 def test_find_references_bad_target_is_invalid_target(refgraph_project):
     # A target that is neither a res:// path nor a registered class_name is a
     # structured invalid_target operation error (exit 4), not an empty result.
-    proc = _gda(
-        refgraph_project, "project", "find-references", "/abs/not/a/target", "--json"
+    proc = Gda(refgraph_project)(
+        "project", "find-references", "/abs/not/a/target", "--json"
     )
 
     assert proc.returncode == 4, proc.stdout + proc.stderr
@@ -370,18 +358,6 @@ func sigh() -> void:
 """
 
 
-def _import_project(project) -> None:
-    # class_name registration lives in the project's global class list, which only
-    # a project scan produces — run the engine's headless import step the way a CI
-    # pipeline would before resolving a find-references target by class_name.
-    imported = subprocess.run(
-        [str(GODOT), "--headless", "--path", str(project), "--import"],
-        capture_output=True,
-        text=True,
-    )
-    assert imported.returncode == 0, imported.stdout + imported.stderr
-
-
 @pytest.fixture
 def classname_project(tmp_path):
     """A project where a class is referenced only by its class_name token."""
@@ -390,7 +366,10 @@ def classname_project(tmp_path):
     (tmp_path / "villain.gd").write_text(VILLAIN_GD, encoding="utf-8")
     (tmp_path / "spawner.gd").write_text(SPAWNER_GD, encoding="utf-8")
     (tmp_path / "lonely.gd").write_text(LONELY_GD, encoding="utf-8")
-    _import_project(tmp_path)
+    # class_name registration lives in the project's global class list, which only
+    # a project scan produces — the precondition for resolving a find-references
+    # target by class_name.
+    import_project(tmp_path)
     return tmp_path
 
 
@@ -402,7 +381,7 @@ def test_find_references_to_a_class_name_excludes_its_own_declaration(
     # `var x: Hero` annotation, Hero.new()) but NEVER hero.gd's own
     # `class_name Hero` declaration line — that is the definition site, not a
     # reference (issue #116 review: false positive).
-    proc = _gda(classname_project, "project", "find-references", "Hero", "--json")
+    proc = Gda(classname_project)("project", "find-references", "Hero", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     data = json.loads(proc.stdout)
@@ -428,7 +407,7 @@ def test_find_references_to_a_class_name_excludes_its_own_declaration(
 def test_find_references_to_an_unreferenced_class_name_is_empty(classname_project):
     # A class declared via class_name that NOTHING consumes returns an empty
     # reference set — its own declaration line must not count as a reference.
-    proc = _gda(classname_project, "project", "find-references", "Lonely", "--json")
+    proc = Gda(classname_project)("project", "find-references", "Lonely", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     assert json.loads(proc.stdout)["references"] == []
@@ -453,7 +432,7 @@ def test_statistics_counts_binary_assets_as_files_but_not_lines(tmp_path):
         b"\x89PNG\r\n\x1a\n" + (b"\n" * 50) + b"\x00\xff\x10binary\n"
     )
 
-    proc = _gda(tmp_path, "project", "statistics", "--json")
+    proc = Gda(tmp_path)("project", "statistics", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     data = json.loads(proc.stdout)
@@ -475,12 +454,7 @@ def test_statistics_counts_binary_assets_as_files_but_not_lines(tmp_path):
 def test_dependencies_without_project_is_project_not_found(tmp_path):
     # Run projectless (no --project, cwd is not a project): the res:// scan has no
     # tree to walk, so it refuses with the registered project_not_found code.
-    proc = subprocess.run(
-        [*GDA_CMD, "project", "dependencies", "--godot", str(GODOT), "--json"],
-        capture_output=True,
-        text=True,
-        cwd=str(tmp_path),
-    )
+    proc = Gda()("project", "dependencies", "--json", cwd=tmp_path)
 
     assert proc.returncode == 4, proc.stdout + proc.stderr
     err = json.loads(proc.stdout)["error"]
@@ -540,9 +514,9 @@ def test_project_walks_agree_on_a_nested_dot_godot_directory(tmp_path):
         CACHED_THING_GD, encoding="utf-8"
     )
 
-    scene_proc = _gda(project, "scene", "list", "--json")
-    script_proc = _gda(project, "script", "list", "--json")
-    stats_proc = _gda(project, "project", "statistics", "--json")
+    scene_proc = Gda(project)("scene", "list", "--json")
+    script_proc = Gda(project)("script", "list", "--json")
+    stats_proc = Gda(project)("project", "statistics", "--json")
 
     assert scene_proc.returncode == 0, scene_proc.stdout + scene_proc.stderr
     assert script_proc.returncode == 0, script_proc.stdout + script_proc.stderr
@@ -566,14 +540,14 @@ def test_project_walks_agree_on_a_nested_dot_godot_directory(tmp_path):
 
     # The class_name index rides the resource walk, so node/resource creation
     # resolves the nested declaration `script list` reports...
-    added = _gda(
-        project, "node", "add", "res://top.tscn", "--type", "NestedThing", "--json"
+    added = Gda(project)(
+        "node", "add", "res://top.tscn", "--type", "NestedThing", "--json"
     )
     assert added.returncode == 0, added.stdout + added.stderr
     assert json.loads(added.stdout)["script_class"] == "NestedThing"
     # ...and still does not resolve one authored into the engine's own cache.
-    cached = _gda(
-        project, "node", "add", "res://top.tscn", "--type", "CachedThing", "--json"
+    cached = Gda(project)(
+        "node", "add", "res://top.tscn", "--type", "CachedThing", "--json"
     )
     assert cached.returncode == 4, cached.stdout + cached.stderr
     assert json.loads(cached.stdout)["error"]["code"] == "invalid_node_type"
@@ -582,11 +556,11 @@ def test_project_walks_agree_on_a_nested_dot_godot_directory(tmp_path):
     # add, which wrote an [ext_resource] to the nested script into
     # `res://top.tscn` — so the nested content is a real reference target here,
     # not just an enumerated path.
-    deps_proc = _gda(project, "project", "dependencies", "--json")
-    refs_proc = _gda(
-        project, "project", "find-references", "res://nested/.godot/hidden.gd", "--json"
+    deps_proc = Gda(project)("project", "dependencies", "--json")
+    refs_proc = Gda(project)(
+        "project", "find-references", "res://nested/.godot/hidden.gd", "--json"
     )
-    unused_proc = _gda(project, "project", "find-unused-resources", "--json")
+    unused_proc = Gda(project)("project", "find-unused-resources", "--json")
 
     assert deps_proc.returncode == 0, deps_proc.stdout + deps_proc.stderr
     assert refs_proc.returncode == 0, refs_proc.stdout + refs_proc.stderr
@@ -759,7 +733,7 @@ def alias_project(tmp_path):
 
 @pytest.mark.e2e
 def test_dependencies_keys_an_aliased_declaration_canonically(alias_project):
-    proc = _gda(alias_project, "project", "dependencies", "--json")
+    proc = Gda(alias_project)("project", "dependencies", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     by_source = {
@@ -796,11 +770,11 @@ def test_dependencies_keys_an_aliased_declaration_canonically(alias_project):
 def test_find_references_matches_an_aliased_declaration_from_a_canonical_query(
     alias_project,
 ):
-    scene = _gda(
-        alias_project, "project", "find-references", "res://leaf.tscn", "--json"
+    scene = Gda(alias_project)(
+        "project", "find-references", "res://leaf.tscn", "--json"
     )
-    script = _gda(
-        alias_project, "project", "find-references", "res://helper.gd", "--json"
+    script = Gda(alias_project)(
+        "project", "find-references", "res://helper.gd", "--json"
     )
 
     assert scene.returncode == 0, scene.stdout + scene.stderr
@@ -819,13 +793,12 @@ def test_find_references_matches_a_relative_declaration(alias_project):
     # the engine loads res://shared/deep.tscn, so a query for that path must find
     # the declaring site. Reported empty before the declaring file's directory was
     # used to anchor the spelling.
-    deep = _gda(
-        alias_project, "project", "find-references", "res://shared/deep.tscn", "--json"
+    deep = Gda(alias_project)(
+        "project", "find-references", "res://shared/deep.tscn", "--json"
     )
     # And the prefix-less relative form, declared `scenes/nested.tscn` from the
     # project root — a spelling with no `..` in it at all.
-    nested = _gda(
-        alias_project,
+    nested = Gda(alias_project)(
         "project",
         "find-references",
         "res://scenes/nested.tscn",
@@ -851,8 +824,7 @@ def test_find_references_matches_a_relative_declaration(alias_project):
 def test_find_references_matches_a_canonical_declaration_from_an_aliased_query(
     alias_project,
 ):
-    proc = _gda(
-        alias_project,
+    proc = Gda(alias_project)(
         "project",
         "find-references",
         "res://sub/../icon.png",
@@ -872,11 +844,11 @@ def test_find_references_matches_a_canonical_declaration_from_an_aliased_query(
 def test_find_references_matches_an_aliased_project_level_entry(alias_project):
     # project.godot is a harvest site too: its main scene and autoloads name a
     # resource by path the way an ext_resource line does.
-    main = _gda(
-        alias_project, "project", "find-references", "res://parent.tscn", "--json"
+    main = Gda(alias_project)(
+        "project", "find-references", "res://parent.tscn", "--json"
     )
-    autoload = _gda(
-        alias_project, "project", "find-references", "res://hud.tscn", "--json"
+    autoload = Gda(alias_project)(
+        "project", "find-references", "res://hud.tscn", "--json"
     )
 
     assert main.returncode == 0, main.stdout + main.stderr
@@ -891,7 +863,7 @@ def test_find_references_matches_an_aliased_project_level_entry(alias_project):
 
 @pytest.mark.e2e
 def test_find_unused_resources_never_lists_an_aliased_reference(alias_project):
-    proc = _gda(alias_project, "project", "find-unused-resources", "--json")
+    proc = Gda(alias_project)("project", "find-unused-resources", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     unused = json.loads(proc.stdout)["unused"]
@@ -915,7 +887,7 @@ def test_find_unused_resources_never_lists_an_aliased_reference(alias_project):
     # exactly "find-references returns empty".
     for path in unused:
         refs = json.loads(
-            _gda(alias_project, "project", "find-references", path, "--json").stdout
+            Gda(alias_project)("project", "find-references", path, "--json").stdout
         )["references"]
         assert refs == [], f"{path} reported unused but has references {refs}"
 
@@ -964,7 +936,7 @@ def one_reader_project(tmp_path):
 def test_dependencies_reads_the_named_path_attribute_not_a_substring(
     one_reader_project,
 ):
-    proc = _gda(one_reader_project, "project", "dependencies", "--json")
+    proc = Gda(one_reader_project)("project", "dependencies", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     by_source = {
@@ -981,11 +953,11 @@ def test_dependencies_reads_the_named_path_attribute_not_a_substring(
 def test_find_references_reads_the_named_path_attribute_not_a_substring(
     one_reader_project,
 ):
-    real = _gda(
-        one_reader_project, "project", "find-references", "res://real.png", "--json"
+    real = Gda(one_reader_project)(
+        "project", "find-references", "res://real.png", "--json"
     )
-    decoy = _gda(
-        one_reader_project, "project", "find-references", "res://decoy.png", "--json"
+    decoy = Gda(one_reader_project)(
+        "project", "find-references", "res://decoy.png", "--json"
     )
 
     assert real.returncode == 0, real.stdout + real.stderr
@@ -1006,7 +978,7 @@ def test_find_references_reads_the_named_path_attribute_not_a_substring(
 def test_find_unused_resources_agrees_with_the_named_path_attribute(
     one_reader_project,
 ):
-    proc = _gda(one_reader_project, "project", "find-unused-resources", "--json")
+    proc = Gda(one_reader_project)("project", "find-unused-resources", "--json")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     unused = json.loads(proc.stdout)["unused"]
@@ -1054,9 +1026,9 @@ def unknown_tag_project(tmp_path):
 def test_an_unknown_section_tag_is_not_an_ext_resource_declaration(
     unknown_tag_project,
 ):
-    deps = _gda(unknown_tag_project, "project", "dependencies", "--json")
-    ghost = _gda(
-        unknown_tag_project, "project", "find-references", "res://ghost.png", "--json"
+    deps = Gda(unknown_tag_project)("project", "dependencies", "--json")
+    ghost = Gda(unknown_tag_project)(
+        "project", "find-references", "res://ghost.png", "--json"
     )
 
     assert deps.returncode == 0, deps.stdout + deps.stderr
@@ -1108,8 +1080,8 @@ def pathless_decl_project(tmp_path):
 def test_find_references_does_not_match_a_directory_through_a_pathless_declaration(
     pathless_decl_project,
 ):
-    found = _gda(
-        pathless_decl_project, "project", "find-references", "res://scenes", "--json"
+    found = Gda(pathless_decl_project)(
+        "project", "find-references", "res://scenes", "--json"
     )
 
     assert found.returncode == 0, found.stdout + found.stderr

--- a/tests/test_e2e_project_walk.py
+++ b/tests/test_e2e_project_walk.py
@@ -27,16 +27,12 @@ universe is the engine's.
 """
 
 import json
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
+from tests.support import Gda
 
 from .conftest import project_godot
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
 
 PROJECT_GODOT = project_godot(name="gda-walk-fixture")
 
@@ -86,28 +82,14 @@ def walk_project(tmp_path):
     return tmp_path
 
 
-def _gda(project, *args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-        capture_output=True,
-        text=True,
-    )
-
-
-def _result(project, *args: str) -> dict:
-    proc = _gda(project, *args, "--json")
-    assert proc.returncode == 0, proc.stdout + proc.stderr
-    return json.loads(proc.stdout)
-
-
 @pytest.mark.e2e
 def test_the_listings_accept_an_extension_in_any_case_as_the_engine_does(walk_project):
     # AC2 (#764): the case-sensitivity drift is resolved case-INSENSITIVELY, on
     # both sides. `Level.TSCN` is a scene to the engine (it loads as a
     # PackedScene, reported below through root_type) so `scene list` reports it;
     # `Widget.GD` was already accepted by the script walk and stays accepted.
-    scenes = {s["path"]: s for s in _result(walk_project, "scene", "list")["scenes"]}
-    scripts = {s["path"] for s in _result(walk_project, "script", "list")["scripts"]}
+    scenes = {s["path"]: s for s in Gda(walk_project).json("scene", "list")["scenes"]}
+    scripts = {s["path"] for s in Gda(walk_project).json("script", "list")["scripts"]}
 
     assert set(scenes) == {"res://main.tscn", "res://Level.TSCN"}
     assert scripts == {"res://helper.gd", "res://Widget.GD"}
@@ -120,7 +102,7 @@ def test_the_listings_accept_an_extension_in_any_case_as_the_engine_does(walk_pr
     # classifies by a lowercased extension, so its counts match the listings.
     # Before this change it counted a scene `scene list` could not see (#712's
     # failure shape, on the acceptance test instead of the descent decision).
-    stats = _result(walk_project, "project", "statistics")
+    stats = Gda(walk_project).json("project", "statistics")
     assert stats["scene_count"] == len(scenes)
     assert stats["script_count"] == len(scripts)
 
@@ -131,7 +113,7 @@ def test_the_two_file_universes_survive_the_shared_traversal(walk_project):
     # file it reaches — including the `.import` sidecar and `project.godot` — while
     # the extension-filtered walk behind the reference graph excludes exactly
     # those, and still sees the leaf asset beside them.
-    stats = _result(walk_project, "project", "statistics")
+    stats = Gda(walk_project).json("project", "statistics")
     by_ext = {e["extension"]: e["files"] for e in stats["by_extension"]}
 
     assert by_ext.get("import") == 1, by_ext  # icon.png.import
@@ -140,10 +122,10 @@ def test_the_two_file_universes_survive_the_shared_traversal(walk_project):
 
     # The filtered universe: the sidecar and the project file are not resources,
     # so they are neither unused-resource candidates nor dependency sources...
-    unused = set(_result(walk_project, "project", "find-unused-resources")["unused"])
+    unused = set(Gda(walk_project).json("project", "find-unused-resources")["unused"])
     sources = {
         d["path"]
-        for d in _result(walk_project, "project", "dependencies")["dependencies"]
+        for d in Gda(walk_project).json("project", "dependencies")["dependencies"]
     }
     excluded = {"res://icon.png.import", "res://project.godot"}
     assert not (unused & excluded), unused
@@ -264,10 +246,9 @@ def _assert_class_name_unresolvable(project, *classes: str) -> None:
     The message half is asserted too, because it is the half that distinguishes
     "no script declares this" from every other ``invalid_node_type``.
     """
-    _result(project, "scene", "create", "res://host.tscn", "--root-type", "Node")
+    Gda(project).json("scene", "create", "res://host.tscn", "--root-type", "Node")
     for name in classes:
-        proc = _gda(
-            project,
+        proc = Gda(project)(
             "node",
             "add",
             "res://host.tscn",
@@ -292,12 +273,12 @@ def _walked_paths(project) -> set[str]:
     The policy is one decision, so the assertions are made against the union: a
     path admitted by any collector is a path the walk admitted.
     """
-    scripts = {s["path"] for s in _result(project, "script", "list")["scripts"]}
-    scenes = {s["path"] for s in _result(project, "scene", "list")["scenes"]}
+    scripts = {s["path"] for s in Gda(project).json("script", "list")["scripts"]}
+    scenes = {s["path"] for s in Gda(project).json("scene", "list")["scenes"]}
     sources = {
-        d["path"] for d in _result(project, "project", "dependencies")["dependencies"]
+        d["path"] for d in Gda(project).json("project", "dependencies")["dependencies"]
     }
-    unused = set(_result(project, "project", "find-unused-resources")["unused"])
+    unused = set(Gda(project).json("project", "find-unused-resources")["unused"])
     return scripts | scenes | sources | unused
 
 
@@ -324,7 +305,7 @@ def test_an_alias_cannot_re_admit_the_engine_cache(symlink_project):
 
     # `project statistics` counts over the unfiltered universe, so it is the
     # collector that would show the cache re-entering as a raw count.
-    stats = _result(symlink_project, "project", "statistics")
+    stats = Gda(symlink_project).json("project", "statistics")
     assert stats["script_count"] == 2, stats  # sub/leaf.gd and vendored/vendored.gd
     assert stats["scene_count"] == 1, stats  # vendored/vendored.tscn — nothing aliased
 
@@ -348,7 +329,9 @@ def test_a_symlink_cycle_terminates_without_fabricated_paths(symlink_project):
 
     # The termination is a rule, not a truncation: the counting collector agrees
     # with the listing rather than reporting the OS limit's leftovers.
-    scripts = [s["path"] for s in _result(symlink_project, "script", "list")["scripts"]]
+    scripts = [
+        s["path"] for s in Gda(symlink_project).json("script", "list")["scripts"]
+    ]
     assert scripts.count("res://sub/leaf.gd") == 1, scripts
 
 
@@ -367,11 +350,10 @@ def test_a_link_to_authored_content_is_still_walked(symlink_project):
     assert "res://vendored/vendored.gd" in walked, walked
     assert "res://vendored/vendored.tscn" in walked, walked
 
-    _result(
-        symlink_project, "scene", "create", "res://host.tscn", "--root-type", "Node"
+    Gda(symlink_project).json(
+        "scene", "create", "res://host.tscn", "--root-type", "Node"
     )
-    added = _result(
-        symlink_project,
+    added = Gda(symlink_project).json(
         "node",
         "add",
         "res://host.tscn",
@@ -495,7 +477,7 @@ def test_the_cache_stays_excluded_under_a_second_spelling_of_its_parent(
         "res://link1/deep_leaf.gd",
     } <= walked, walked
 
-    stats = _result(aliased_spelling_project, "project", "statistics")
+    stats = Gda(aliased_spelling_project).json("project", "statistics")
     assert stats["script_count"] == 3, stats
     assert stats["scene_count"] == 0, stats
 
@@ -514,7 +496,7 @@ def test_a_vendored_checkouts_own_cache_is_not_taken_for_the_projects(
     # `res://.godot`, which is_equivalent then confirmed against the project's own
     # cache — so a nested cache #712 decided to walk was silently hidden.
     scripts = {
-        s["path"] for s in _result(vendored_cache_project, "script", "list")["scripts"]
+        s["path"] for s in Gda(vendored_cache_project).json("script", "list")["scripts"]
     }
 
     assert "res://vendored/x/vendored_sample.gd" in scripts, scripts
@@ -546,7 +528,7 @@ def test_a_cache_alias_is_excluded_however_deep_below_the_cache_it_points(tmp_pa
     (deep / "deep_cache.gd").write_text(ROOT_CACHE_GD, encoding="utf-8")
     (project / "alias_deep").symlink_to(deep, target_is_directory=True)
 
-    scripts = {s["path"] for s in _result(project, "script", "list")["scripts"]}
+    scripts = {s["path"] for s in Gda(project).json("script", "list")["scripts"]}
     assert scripts == {"res://real.gd"}, scripts
     _assert_class_name_unresolvable(project, "RootCacheThing")
 
@@ -689,18 +671,19 @@ def test_the_listings_skip_a_nested_project_and_a_gdignore_directory(
 
     scripts = {
         s["path"]
-        for s in _result(skipped_directory_project, "script", "list")["scripts"]
+        for s in Gda(skipped_directory_project).json("script", "list")["scripts"]
     }
     assert scripts == {"res://outer.gd", "res://duplicate.gd"}, scripts
 
     scenes = {
-        s["path"] for s in _result(skipped_directory_project, "scene", "list")["scenes"]
+        s["path"]
+        for s in Gda(skipped_directory_project).json("scene", "list")["scenes"]
     }
     assert scenes == {"res://outer.tscn"}, scenes
 
     # The unfiltered universe is the one that counts a `project.godot` and the
     # `.gdignore` marker itself, so it is where a re-entry shows up as a raw count.
-    stats = _result(skipped_directory_project, "project", "statistics")
+    stats = Gda(skipped_directory_project).json("project", "statistics")
     by_ext = {e["extension"]: e["files"] for e in stats["by_extension"]}
     assert stats["script_count"] == 2, stats
     assert stats["scene_count"] == 1, stats
@@ -722,15 +705,14 @@ def test_validate_all_and_the_named_target_agree_on_a_nested_projects_script(
     # cascade — while NAMING that file is refused outright by ADR-0006's ownership
     # gate. The walk no longer reaches it, so `--all` reports only what the outer
     # project owns and the refusal stays the one true answer for the nested file.
-    validated = _result(skipped_directory_project, "script", "validate", "--all")
+    validated = Gda(skipped_directory_project).json("script", "validate", "--all")
     assert {s["path"] for s in validated["scripts"]} == {
         "res://outer.gd",
         "res://duplicate.gd",
     }, validated
     assert validated["valid"] is True, validated
 
-    proc = _gda(
-        skipped_directory_project,
+    proc = Gda(skipped_directory_project)(
         "script",
         "validate",
         "res://nested/inner.gd",
@@ -755,8 +737,7 @@ def test_the_class_name_index_follows_the_walk_out_of_a_skipped_directory(
     # ...and a duplicate that existed only because the walk entered the nested
     # project is no longer a duplicate, so a name that reported
     # `ambiguous_class_name` now resolves — to the outer project's declaration.
-    added = _result(
-        skipped_directory_project,
+    added = Gda(skipped_directory_project).json(
         "node",
         "add",
         "res://host.tscn",  # created by the helper above
@@ -772,13 +753,12 @@ def test_the_class_name_index_follows_the_walk_out_of_a_skipped_directory(
     # `find-references` shares the identical resolver, so it agrees: the outer
     # class is a resolvable target, the nested one is not a class at all.
     assert (
-        _result(skipped_directory_project, "project", "find-references", "OuterThing")[
+        Gda(skipped_directory_project).json("project", "find-references", "OuterThing")[
             "target"
         ]
         == "OuterThing"
     )
-    proc = _gda(
-        skipped_directory_project,
+    proc = Gda(skipped_directory_project)(
         "project",
         "find-references",
         "InnerThing",
@@ -798,8 +778,7 @@ def test_the_import_gap_listing_promises_nothing_in_a_skipped_directory(
     # scan skips both marked directories, so their stale sidecars were a promise of
     # work the pass never does. It listed res://ignored/pic.png and
     # res://nested/pic.png before.
-    predicted = _result(
-        skipped_directory_project,
+    predicted = Gda(skipped_directory_project).json(
         "resource",
         "import",
         "res://pic.png",
@@ -948,7 +927,7 @@ def test_an_engine_written_nested_cache_is_skipped_where_an_authored_one_is_walk
     # it is walked, as #712 and #760 decided.
     assert "res://vendored/real.gd" in walked, walked
 
-    stats = _result(marker_reach_project, "project", "statistics")
+    stats = Gda(marker_reach_project).json("project", "statistics")
     by_ext = {e["extension"]: e["files"] for e in stats["by_extension"]}
     assert "gdignore" not in by_ext, by_ext
 
@@ -956,8 +935,7 @@ def test_an_engine_written_nested_cache_is_skipped_where_an_authored_one_is_walk
     # it: the engine-written cache's declaration is gone from the index while the
     # authored one still resolves.
     _assert_class_name_unresolvable(marker_reach_project, "EngineCacheThing")
-    added = _result(
-        marker_reach_project,
+    added = Gda(marker_reach_project).json(
         "node",
         "add",
         "res://host.tscn",  # created by the helper above

--- a/tests/test_e2e_res_containment.py
+++ b/tests/test_e2e_res_containment.py
@@ -28,11 +28,10 @@ import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
 from tests.conftest import project_godot
-from tests.support import GDA_CMD
+from tests.support import GODOT, Gda
 
-GODOT = resolve_godot_binary()
+gda = Gda()
 
 INSIDE_GD = """\
 extends SceneTree
@@ -41,10 +40,6 @@ func _initialize() -> void:
 \tprint("ran")
 \tquit(0)
 """
-
-
-def _run_gda(*args: str) -> subprocess.CompletedProcess:
-    return subprocess.run([*GDA_CMD, *args], capture_output=True, text=True)
 
 
 def _code(proc: subprocess.CompletedProcess) -> "str | None":
@@ -108,36 +103,30 @@ def test_the_three_commands_agree_on_a_res_spelling(
     script = template.format(n="bar.gd", ext=".gd")
     asset = template.format(n="pic.png", ext=".png")
 
-    validate = _run_gda(
+    validate = gda(
         "script",
         "validate",
         script,
         "--project",
         project,
-        "--godot",
-        str(GODOT),
         "--json",
     )
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         script,
         "--project",
         project,
-        "--godot",
-        str(GODOT),
         "--timeout",
         "60",
         "--json",
     )
-    imported = _run_gda(
+    imported = gda(
         "resource",
         "import",
         asset,
         "--project",
         project,
-        "--godot",
-        str(GODOT),
         "--dry-run",
         "--json",
     )
@@ -253,14 +242,12 @@ def test_an_asset_a_nested_project_owns_is_refused_before_the_import_pass(tmp_pa
     (vendor / "pic.png").write_bytes(b"\x89PNG\r\n\x1a\n")
     (outer / "own.png").write_bytes(b"\x89PNG\r\n\x1a\n")
 
-    refused = _run_gda(
+    refused = gda(
         "resource",
         "import",
         "res://vendor/pic.png",
         "--project",
         str(outer),
-        "--godot",
-        str(GODOT),
         "--dry-run",
         "--json",
     )
@@ -269,14 +256,12 @@ def test_an_asset_a_nested_project_owns_is_refused_before_the_import_pass(tmp_pa
     assert error["code"] == "target_outside_project"
     assert error["evidence"]["owning_project"] == str(vendor.resolve())
 
-    accepted = _run_gda(
+    accepted = gda(
         "resource",
         "import",
         "res://own.png",
         "--project",
         str(outer),
-        "--godot",
-        str(GODOT),
         "--dry-run",
         "--json",
     )
@@ -303,14 +288,12 @@ def test_a_script_a_nested_project_owns_is_refused_instead_of_falsely_invalid(tm
     )
 
     # Against its OWN project the verdict is the true one, and stays reachable.
-    owned = _run_gda(
+    owned = gda(
         "script",
         "validate",
         str(inner / "main.gd"),
         "--project",
         str(inner),
-        "--godot",
-        str(GODOT),
         "--json",
     )
     assert owned.returncode == 0, owned.stdout + owned.stderr
@@ -318,14 +301,12 @@ def test_a_script_a_nested_project_owns_is_refused_instead_of_falsely_invalid(tm
 
     # Against the outer one it is refused before the engine runs, and the owner to
     # pass is named in the typed evidence.
-    refused = _run_gda(
+    refused = gda(
         "script",
         "validate",
         str(inner / "main.gd"),
         "--project",
         str(outer),
-        "--godot",
-        str(GODOT),
         "--json",
     )
     assert refused.returncode == 4, refused.stdout + refused.stderr
@@ -351,20 +332,7 @@ def test_a_projectless_call_on_an_owned_script_is_refused(tmp_path):
         'extends Node\n\nconst Dep := preload("res://local_dep.gd")\n', encoding="utf-8"
     )
 
-    refused = subprocess.run(
-        [
-            *GDA_CMD,
-            "script",
-            "validate",
-            "game/main.gd",
-            "--godot",
-            str(GODOT),
-            "--json",
-        ],
-        capture_output=True,
-        text=True,
-        cwd=str(workspace),
-    )
+    refused = gda("script", "validate", "game/main.gd", "--json", cwd=workspace)
 
     assert refused.returncode == 4, refused.stdout + refused.stderr
     error = json.loads(refused.stdout)["error"]
@@ -384,12 +352,7 @@ def test_a_standalone_script_is_still_validated_projectless(tmp_path):
         "extends Node\n\nfunc go() -> int:\n\treturn 1\n", encoding="utf-8"
     )
 
-    proc = subprocess.run(
-        [*GDA_CMD, "script", "validate", "scratch.gd", "--godot", str(GODOT), "--json"],
-        capture_output=True,
-        text=True,
-        cwd=str(tmp_path),
-    )
+    proc = gda("script", "validate", "scratch.gd", "--json", cwd=tmp_path)
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     data = json.loads(proc.stdout)
@@ -443,9 +406,7 @@ def test_the_refusal_states_a_reissue_that_actually_runs(
     # So this reads the two operands OUT of the message and runs them. Nothing here
     # knows the fixture's layout — if the sentence is wrong, the re-issue fails.
     outer = str(owned_target_project)
-    refused = _run_gda(
-        *head, spelling, "--project", outer, "--godot", str(GODOT), *extra, "--json"
-    )
+    refused = gda(*head, spelling, "--project", outer, *extra, "--json")
     assert refused.returncode == 4, refused.stdout + refused.stderr
     error = json.loads(refused.stdout)["error"]
     assert error["code"] == "target_outside_project"
@@ -453,13 +414,11 @@ def test_the_refusal_states_a_reissue_that_actually_runs(
     stated = REISSUE.search(error["message"])
     assert stated is not None, error["message"]
 
-    reissued = _run_gda(
+    reissued = gda(
         *head,
         stated["target"],
         "--project",
         stated["project"],
-        "--godot",
-        str(GODOT),
         *extra,
         "--json",
     )
@@ -468,13 +427,11 @@ def test_the_refusal_states_a_reissue_that_actually_runs(
     # And the half that says WHY the target had to be named beside the project:
     # the same re-issue with the caller's original spelling still fails, so the
     # sentence is not merely decorated with a value the caller already had.
-    stale = _run_gda(
+    stale = gda(
         *head,
         spelling,
         "--project",
         stated["project"],
-        "--godot",
-        str(GODOT),
         *extra,
         "--json",
     )
@@ -498,14 +455,12 @@ def test_the_stated_reissue_survives_a_link_spelled_owner(tmp_path):
     (pkg / "vend.gd").write_text(INSIDE_GD, encoding="utf-8")
     (outer / "addons" / "vendored").symlink_to(pkg, target_is_directory=True)
 
-    refused = _run_gda(
+    refused = gda(
         "script",
         "validate",
         "addons/vendored/vend.gd",
         "--project",
         str(outer),
-        "--godot",
-        str(GODOT),
         "--json",
     )
     assert refused.returncode == 4, refused.stdout + refused.stderr
@@ -513,14 +468,12 @@ def test_the_stated_reissue_survives_a_link_spelled_owner(tmp_path):
     assert stated is not None
     assert stated["target"] == "vend.gd"
 
-    reissued = _run_gda(
+    reissued = gda(
         "script",
         "validate",
         stated["target"],
         "--project",
         stated["project"],
-        "--godot",
-        str(GODOT),
         "--json",
     )
     assert reissued.returncode == 0, reissued.stdout + reissued.stderr

--- a/tests/test_e2e_resource.py
+++ b/tests/test_e2e_resource.py
@@ -23,16 +23,12 @@ modes, are exercised end to end.
 """
 
 import json
-import os
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
+from tests.support import Gda, import_project
 
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
+gda = Gda()
 
 # A plain custom Resource .tres. On import (without a .uid sidecar) it exists as
 # a resource but is NOT assigned a UID in the non-editor reverse cache, so it is
@@ -44,59 +40,12 @@ DATA_TRES = """\
 """
 
 
-def _gda(*args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT)], capture_output=True, text=True
-    )
-
-
-def _import_project(project) -> None:
-    """Run a one-shot headless import so the project's UID cache is written."""
-    subprocess.run(
-        [str(GODOT), "--headless", "--path", str(project), "--import"],
-        capture_output=True,
-        text=True,
-        timeout=120,
-    )
-
-
-def _gda_project(project):
-    """A ``gda`` bound to ``--godot`` and ``--project`` for res:// / UID resolution."""
-
-    def gda(*args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-            capture_output=True,
-            text=True,
-        )
-
-    return gda
-
-
-def _gda_env(extra_env: dict, *args: str) -> subprocess.CompletedProcess:
-    """``_gda`` with extra env vars in the child's environment (issue #226 seam)."""
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-        env={**os.environ, **extra_env},
-    )
-
-
-def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
-    assert proc.returncode == 4, proc.stdout + proc.stderr
-    err = json.loads(proc.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == code
-    return err
-
-
 @pytest.fixture
 def imported_project(godot_project):
     """A project fixture with a script (UID-cached) and a .tres (no cached UID)."""
     (godot_project / "hero.gd").write_text("extends Node\n", encoding="utf-8")
     (godot_project / "data.tres").write_text(DATA_TRES, encoding="utf-8")
-    _import_project(godot_project)
+    import_project(godot_project)
     return godot_project
 
 
@@ -107,7 +56,7 @@ def test_resource_create_then_get_round_trip(godot_project):
     # resource create wrote.
     resource_path = godot_project / "palette.tres"
 
-    created = _gda(
+    created = gda(
         "resource", "create", str(resource_path), "--type", "Gradient", "--json"
     )
 
@@ -119,7 +68,7 @@ def test_resource_create_then_get_round_trip(godot_project):
     # The written file is a real Godot .tres declaring the resource type.
     assert 'type="Gradient"' in resource_path.read_text(encoding="utf-8")
 
-    got = _gda("resource", "get", str(resource_path), "--json")
+    got = gda("resource", "get", str(resource_path), "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     got_data = json.loads(got.stdout)
@@ -140,12 +89,12 @@ def test_resource_get_projects_packed_arrays_as_json_lists(godot_project):
     # list of [r, g, b, a] lists (each Color element re-enters the projection) —
     # not the Variant str() dump.
     resource_path = godot_project / "palette.tres"
-    created = _gda(
+    created = gda(
         "resource", "create", str(resource_path), "--type", "Gradient", "--json"
     )
     assert created.returncode == 0, created.stdout + created.stderr
 
-    got = _gda("resource", "get", str(resource_path), "--json")
+    got = gda("resource", "get", str(resource_path), "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     by_name = {p["name"]: p for p in json.loads(got.stdout)["properties"]}
@@ -165,7 +114,7 @@ def test_resource_create_into_nested_dir_reports_created_dirs(godot_project):
     # outermost to innermost (mirrors scene/script create).
     resource_path = godot_project / "art" / "palettes" / "sunset.tres"
 
-    created = _gda(
+    created = gda(
         "resource", "create", str(resource_path), "--type", "Gradient", "--json"
     )
 
@@ -183,15 +132,21 @@ def test_resource_create_no_clobber_yields_already_exists(godot_project):
     # No-clobber: a create whose target already exists is refused with
     # already_exists, leaving the existing file untouched.
     resource_path = godot_project / "palette.tres"
-    first = _gda(
+    first = gda(
         "resource", "create", str(resource_path), "--type", "Gradient", "--json"
     )
     assert first.returncode == 0, first.stdout + first.stderr
     before = resource_path.read_text(encoding="utf-8")
 
-    second = _gda("resource", "create", str(resource_path), "--type", "Curve", "--json")
-
-    err = _assert_operation_error(second, "already_exists")
+    err = gda.error(
+        "resource",
+        "create",
+        str(resource_path),
+        "--type",
+        "Curve",
+        "--json",
+        code="already_exists",
+    )
     assert str(resource_path) in err["message"]
     # The original file is untouched — the clobber never happened.
     assert resource_path.read_text(encoding="utf-8") == before
@@ -201,11 +156,15 @@ def test_resource_create_no_clobber_yields_already_exists(godot_project):
 def test_resource_create_unknown_type_yields_invalid_resource_type(godot_project):
     resource_path = godot_project / "palette.tres"
 
-    created = _gda(
-        "resource", "create", str(resource_path), "--type", "Bogus", "--json"
+    err = gda.error(
+        "resource",
+        "create",
+        str(resource_path),
+        "--type",
+        "Bogus",
+        "--json",
+        code="invalid_resource_type",
     )
-
-    err = _assert_operation_error(created, "invalid_resource_type")
     assert "Bogus" in err["message"]
     # Nothing was written for the rejected type.
     assert not resource_path.exists()
@@ -217,11 +176,15 @@ def test_resource_create_non_resource_type_yields_invalid_resource_type(godot_pr
     # .tres, so it is refused with the same code as an unknown type.
     resource_path = godot_project / "thing.tres"
 
-    created = _gda(
-        "resource", "create", str(resource_path), "--type", "Node2D", "--json"
+    err = gda.error(
+        "resource",
+        "create",
+        str(resource_path),
+        "--type",
+        "Node2D",
+        "--json",
+        code="invalid_resource_type",
     )
-
-    err = _assert_operation_error(created, "invalid_resource_type")
     assert "Node2D" in err["message"]
     assert not resource_path.exists()
 
@@ -260,10 +223,10 @@ def test_resource_create_by_class_name_round_trips_typed_fields(godot_project):
     # back and reports the exported fields with their declared Godot types and
     # values — create → get IS the round-trip proof for a custom Resource type.
     (godot_project / "panda_stats.gd").write_text(PANDA_STATS_GD, encoding="utf-8")
-    _import_project(godot_project)
+    import_project(godot_project)
     resource_path = godot_project / "panda.tres"
 
-    created = _gda(
+    created = gda(
         "resource",
         "create",
         str(resource_path),
@@ -283,7 +246,7 @@ def test_resource_create_by_class_name_round_trips_typed_fields(godot_project):
     assert resource_path.exists()
     assert 'script_class="PandaStats"' in resource_path.read_text(encoding="utf-8")
 
-    got = _gda(
+    got = gda(
         "resource",
         "get",
         str(resource_path),
@@ -314,9 +277,9 @@ def test_resource_create_by_class_name_round_trips_a_set_via_get(godot_project):
     # persisted value — resource get IS the structured-level proof that set landed
     # on a custom Resource type.
     (godot_project / "panda_stats.gd").write_text(PANDA_STATS_GD, encoding="utf-8")
-    _import_project(godot_project)
+    import_project(godot_project)
     resource_path = godot_project / "panda.tres"
-    created = _gda(
+    created = gda(
         "resource",
         "create",
         str(resource_path),
@@ -328,7 +291,7 @@ def test_resource_create_by_class_name_round_trips_a_set_via_get(godot_project):
     )
     assert created.returncode == 0, created.stdout + created.stderr
 
-    was_set = _gda(
+    was_set = gda(
         "resource",
         "set",
         str(resource_path),
@@ -348,7 +311,7 @@ def test_resource_create_by_class_name_round_trips_a_set_via_get(godot_project):
     assert set_data["type"] == "float"
     assert set_data["value"] == 9.5
 
-    got = _gda(
+    got = gda(
         "resource",
         "get",
         str(resource_path),
@@ -373,9 +336,9 @@ def test_resource_set_preserves_json_container_integer_and_float_types(
     (godot_project / "drop_table_stats.gd").write_text(
         DROP_TABLE_STATS_GD, encoding="utf-8"
     )
-    _import_project(godot_project)
+    import_project(godot_project)
     resource_path = godot_project / "drop_table.tres"
-    created = _gda(
+    created = gda(
         "resource",
         "create",
         str(resource_path),
@@ -387,7 +350,7 @@ def test_resource_set_preserves_json_container_integer_and_float_types(
     )
     assert created.returncode == 0, created.stdout + created.stderr
 
-    was_set = _gda(
+    was_set = gda(
         "resource",
         "set",
         str(resource_path),
@@ -412,7 +375,7 @@ def test_resource_set_preserves_json_container_integer_and_float_types(
     assert '"a": 2.0' not in text
     assert '"b": 2.0' in text
 
-    got = _gda(
+    got = gda(
         "resource",
         "get",
         str(resource_path),
@@ -446,10 +409,10 @@ def test_resource_create_by_non_resource_class_name_yields_invalid_resource_type
     # invalid_resource_type (not uninstantiable_script), with a message naming
     # the script and the real cause rather than "not a registered class_name".
     (godot_project / "widget_node.gd").write_text(WIDGET_NODE_GD, encoding="utf-8")
-    _import_project(godot_project)
+    import_project(godot_project)
     resource_path = godot_project / "widget.tres"
 
-    created = _gda(
+    err = gda.error(
         "resource",
         "create",
         str(resource_path),
@@ -458,9 +421,8 @@ def test_resource_create_by_non_resource_class_name_yields_invalid_resource_type
         "--project",
         str(godot_project),
         "--json",
+        code="invalid_resource_type",
     )
-
-    err = _assert_operation_error(created, "invalid_resource_type")
     assert "WidgetNode" in err["message"]
     assert "not a Resource-derived script" in err["message"]
     assert "widget_node.gd" in err["message"]
@@ -494,11 +456,11 @@ def test_resource_create_by_registered_but_broken_class_name_names_the_script(
     # not the type name. The failure must surface as the distinct
     # uninstantiable_script code naming the script, with nothing written.
     (godot_project / "stats.gd").write_text(STATS_GD, encoding="utf-8")
-    _import_project(godot_project)
+    import_project(godot_project)
     (godot_project / "stats.gd").write_text(BROKEN_STATS_GD, encoding="utf-8")
     resource_path = godot_project / "stats.tres"
 
-    created = _gda(
+    err = gda.error(
         "resource",
         "create",
         str(resource_path),
@@ -507,9 +469,8 @@ def test_resource_create_by_registered_but_broken_class_name_names_the_script(
         "--project",
         str(godot_project),
         "--json",
+        code="uninstantiable_script",
     )
-
-    err = _assert_operation_error(created, "uninstantiable_script")
     assert "Stats" in err["message"]
     assert "stats.gd" in err["message"]
     assert not resource_path.exists()
@@ -541,16 +502,16 @@ def test_resource_create_over_existing_target_refuses_before_constructing(
     (godot_project / "needs_args_stats.gd").write_text(
         NEEDS_ARGS_STATS_GD, encoding="utf-8"
     )
-    _import_project(godot_project)
+    import_project(godot_project)
     resource_path = godot_project / "occupied.tres"
     # Occupy the target first with a plain built-in resource.
-    first = _gda(
+    first = gda(
         "resource", "create", str(resource_path), "--type", "Gradient", "--json"
     )
     assert first.returncode == 0, first.stdout + first.stderr
     before = resource_path.read_text(encoding="utf-8")
 
-    second = _gda(
+    err = gda.error(
         "resource",
         "create",
         str(resource_path),
@@ -559,9 +520,8 @@ def test_resource_create_over_existing_target_refuses_before_constructing(
         "--project",
         str(godot_project),
         "--json",
+        code="already_exists",
     )
-
-    err = _assert_operation_error(second, "already_exists")
     assert str(resource_path) in err["message"]
     # The existing file is untouched — no clobber — and, because the code is
     # already_exists rather than uninstantiable_script, the broken constructor
@@ -573,9 +533,15 @@ def test_resource_create_over_existing_target_refuses_before_constructing(
 def test_resource_create_non_tres_path_yields_invalid_path(godot_project):
     bad_path = godot_project / "palette.txt"
 
-    created = _gda("resource", "create", str(bad_path), "--type", "Gradient", "--json")
-
-    err = _assert_operation_error(created, "invalid_path")
+    err = gda.error(
+        "resource",
+        "create",
+        str(bad_path),
+        "--type",
+        "Gradient",
+        "--json",
+        code="invalid_path",
+    )
     assert ".tres" in err["message"]
     assert not bad_path.exists()
 
@@ -584,9 +550,7 @@ def test_resource_create_non_tres_path_yields_invalid_path(godot_project):
 def test_resource_get_missing_yields_path_not_found(godot_project):
     missing = godot_project / "nope.tres"
 
-    got = _gda("resource", "get", str(missing), "--json")
-
-    err = _assert_operation_error(got, "path_not_found")
+    err = gda.error("resource", "get", str(missing), "--json", code="path_not_found")
     assert str(missing) in err["message"]
 
 
@@ -595,9 +559,7 @@ def test_resource_get_non_tres_path_yields_invalid_path(godot_project):
     bad_path = godot_project / "palette.txt"
     bad_path.write_text("not a resource", encoding="utf-8")
 
-    got = _gda("resource", "get", str(bad_path), "--json")
-
-    err = _assert_operation_error(got, "invalid_path")
+    err = gda.error("resource", "get", str(bad_path), "--json", code="invalid_path")
     assert ".tres" in err["message"]
 
 
@@ -610,12 +572,12 @@ def test_resource_set_coerces_persists_and_round_trips_via_get(godot_project):
     # type, saves the .tres, and get reports the coerced value — resource get IS
     # the structured-level verification that set persisted.
     resource_path = godot_project / "palette.tres"
-    created = _gda(
+    created = gda(
         "resource", "create", str(resource_path), "--type", "Gradient", "--json"
     )
     assert created.returncode == 0, created.stdout + created.stderr
 
-    was_set = _gda(
+    was_set = gda(
         "resource",
         "set",
         str(resource_path),
@@ -634,7 +596,7 @@ def test_resource_set_coerces_persists_and_round_trips_via_get(godot_project):
     assert set_data["type"] == "int"
     assert set_data["value"] == 1
 
-    got = _gda("resource", "get", str(resource_path), "--json")
+    got = gda("resource", "get", str(resource_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     by_name = {p["name"]: p for p in json.loads(got.stdout)["properties"]}
     # Round-trip: get reports the value set persisted to the .tres.
@@ -645,9 +607,9 @@ def test_resource_set_coerces_persists_and_round_trips_via_get(godot_project):
 def test_resource_set_string_property_round_trips(godot_project):
     # A String property coerces trivially and round-trips through get.
     resource_path = godot_project / "palette.tres"
-    _gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
+    gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
 
-    was_set = _gda(
+    was_set = gda(
         "resource",
         "set",
         str(resource_path),
@@ -661,7 +623,7 @@ def test_resource_set_string_property_round_trips(godot_project):
     assert was_set.returncode == 0, was_set.stdout + was_set.stderr
     assert json.loads(was_set.stdout)["type"] == "String"
 
-    got = _gda("resource", "get", str(resource_path), "--json")
+    got = gda("resource", "get", str(resource_path), "--json")
     by_name = {p["name"]: p for p in json.loads(got.stdout)["properties"]}
     assert by_name["resource_name"]["value"] == "Sunset"
 
@@ -675,13 +637,12 @@ def test_resource_set_with_external_edit_in_window_yields_file_changed_externall
     # that window a blind save would clobber the external edit. The production-inert seam
     # (GDA_TEST_PERTURB_BEFORE_SAVE) simulates that edit, and the guard refuses.
     resource_path = godot_project / "palette.tres"
-    created = _gda(
+    created = gda(
         "resource", "create", str(resource_path), "--type", "Gradient", "--json"
     )
     assert created.returncode == 0, created.stdout + created.stderr
 
-    was_set = _gda_env(
-        {"GDA_TEST_PERTURB_BEFORE_SAVE": "1"},
+    err = gda.error(
         "resource",
         "set",
         str(resource_path),
@@ -690,13 +651,13 @@ def test_resource_set_with_external_edit_in_window_yields_file_changed_externall
         "--value",
         "Sunset",
         "--json",
+        extra_env={"GDA_TEST_PERTURB_BEFORE_SAVE": "1"},
+        code="file_changed_externally",
     )
-
-    err = _assert_operation_error(was_set, "file_changed_externally")
     assert str(resource_path) in err["message"]
 
     # The set did NOT land: resource_name is still empty (the default), not "Sunset".
-    got = _gda("resource", "get", str(resource_path), "--json")
+    got = gda("resource", "get", str(resource_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     by_name = {p["name"]: p for p in json.loads(got.stdout)["properties"]}
     assert by_name["resource_name"]["value"] != "Sunset"
@@ -708,9 +669,9 @@ def test_resource_set_unknown_property_is_a_clean_error(godot_project):
     # set edits an existing property; an unknown property is unknown_property,
     # never a silent create — the agent fixes the property name.
     resource_path = godot_project / "palette.tres"
-    _gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
+    gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
 
-    was_set = _gda(
+    err = gda.error(
         "resource",
         "set",
         str(resource_path),
@@ -719,9 +680,8 @@ def test_resource_set_unknown_property_is_a_clean_error(godot_project):
         "--value",
         "1",
         "--json",
+        code="unknown_property",
     )
-
-    err = _assert_operation_error(was_set, "unknown_property")
     assert "bogus_property" in err["message"]
 
 
@@ -730,10 +690,10 @@ def test_resource_set_uncoercible_value_is_a_clean_error(godot_project):
     # An int property cannot take a non-numeric string — uncoercible_value (#55),
     # the .tres left untouched.
     resource_path = godot_project / "palette.tres"
-    _gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
+    gda("resource", "create", str(resource_path), "--type", "Gradient", "--json")
     before = resource_path.read_text(encoding="utf-8")
 
-    was_set = _gda(
+    err = gda.error(
         "resource",
         "set",
         str(resource_path),
@@ -742,9 +702,8 @@ def test_resource_set_uncoercible_value_is_a_clean_error(godot_project):
         "--value",
         "not-a-number",
         "--json",
+        code="uncoercible_value",
     )
-
-    err = _assert_operation_error(was_set, "uncoercible_value")
     assert "not-a-number" in err["message"]
     # The file is untouched — the rejected coercion never wrote.
     assert resource_path.read_text(encoding="utf-8") == before
@@ -754,11 +713,17 @@ def test_resource_set_uncoercible_value_is_a_clean_error(godot_project):
 def test_resource_set_missing_yields_path_not_found(godot_project):
     missing = godot_project / "nope.tres"
 
-    was_set = _gda(
-        "resource", "set", str(missing), "--property", "x", "--value", "1", "--json"
+    err = gda.error(
+        "resource",
+        "set",
+        str(missing),
+        "--property",
+        "x",
+        "--value",
+        "1",
+        "--json",
+        code="path_not_found",
     )
-
-    err = _assert_operation_error(was_set, "path_not_found")
     assert str(missing) in err["message"]
 
 
@@ -767,13 +732,13 @@ def test_resource_delete_removes_file_and_round_trips_against_get(godot_project)
     # create → delete → get: delete removes the .tres and reports what was removed
     # (path + type); a subsequent get is now path_not_found, closing the lifecycle.
     resource_path = godot_project / "palette.tres"
-    created = _gda(
+    created = gda(
         "resource", "create", str(resource_path), "--type", "Gradient", "--json"
     )
     assert created.returncode == 0, created.stdout + created.stderr
     assert resource_path.exists()
 
-    deleted = _gda("resource", "delete", str(resource_path), "--json")
+    deleted = gda("resource", "delete", str(resource_path), "--json")
 
     assert deleted.returncode == 0, deleted.stdout + deleted.stderr
     del_data = json.loads(deleted.stdout)
@@ -783,17 +748,14 @@ def test_resource_delete_removes_file_and_round_trips_against_get(godot_project)
     assert not resource_path.exists()
 
     # Round-trip: get now reports path_not_found — the lifecycle's now-not-found.
-    got = _gda("resource", "get", str(resource_path), "--json")
-    _assert_operation_error(got, "path_not_found")
+    gda.error("resource", "get", str(resource_path), "--json", code="path_not_found")
 
 
 @pytest.mark.e2e
 def test_resource_delete_missing_yields_path_not_found(godot_project):
     missing = godot_project / "nope.tres"
 
-    deleted = _gda("resource", "delete", str(missing), "--json")
-
-    err = _assert_operation_error(deleted, "path_not_found")
+    err = gda.error("resource", "delete", str(missing), "--json", code="path_not_found")
     assert str(missing) in err["message"]
 
 
@@ -802,9 +764,7 @@ def test_resource_delete_non_tres_path_yields_invalid_path(godot_project):
     bad_path = godot_project / "palette.txt"
     bad_path.write_text("not a resource", encoding="utf-8")
 
-    deleted = _gda("resource", "delete", str(bad_path), "--json")
-
-    err = _assert_operation_error(deleted, "invalid_path")
+    err = gda.error("resource", "delete", str(bad_path), "--json", code="invalid_path")
     assert ".tres" in err["message"]
     # The non-.tres file is untouched — the rejected addressing never deleted.
     assert bad_path.exists()
@@ -816,7 +776,7 @@ def test_resource_uid_resolves_both_directions_round_trip(imported_project):
     # same path. This is the bidirectional contract: query a path, get its UID;
     # query that UID, get the path back — proving both directions read one
     # consistent cache.
-    gda = _gda_project(imported_project)
+    gda = Gda(imported_project)
 
     path_to_uid = gda("resource", "uid", "res://hero.gd", "--json")
     assert path_to_uid.returncode == 0, path_to_uid.stdout + path_to_uid.stderr
@@ -838,7 +798,7 @@ def test_resource_uid_resolves_both_directions_round_trip(imported_project):
 @pytest.mark.e2e
 def test_resource_uid_human_output_renders_uid_arrow_path(imported_project):
     # Without --json, a resolved mapping renders as `<uid> -> <path>`.
-    gda = _gda_project(imported_project)
+    gda = Gda(imported_project)
 
     proc = gda("resource", "uid", "res://hero.gd")
 
@@ -850,32 +810,26 @@ def test_resource_uid_human_output_renders_uid_arrow_path(imported_project):
 @pytest.mark.e2e
 def test_resource_uid_unknown_uid_is_unknown_uid(imported_project):
     # A syntactically valid uid:// not in the project's cache is unknown_uid.
-    gda = _gda_project(imported_project)
+    gda = Gda(imported_project)
 
-    proc = gda("resource", "uid", "uid://b00000000000b", "--json")
-
-    _assert_operation_error(proc, "unknown_uid")
+    gda.error("resource", "uid", "uid://b00000000000b", "--json", code="unknown_uid")
 
 
 @pytest.mark.e2e
 def test_resource_uid_invalid_uid_is_invalid_uid(imported_project):
     # A uid:// whose body holds illegal characters fails text_to_id (INVALID_ID),
     # reported as invalid_uid — distinct from a well-formed-but-unknown UID.
-    gda = _gda_project(imported_project)
+    gda = Gda(imported_project)
 
-    proc = gda("resource", "uid", "uid://<invalid>", "--json")
-
-    _assert_operation_error(proc, "invalid_uid")
+    gda.error("resource", "uid", "uid://<invalid>", "--json", code="invalid_uid")
 
 
 @pytest.mark.e2e
 def test_resource_uid_path_not_found_is_path_not_found(imported_project):
     # A res:// path naming no resource is path_not_found.
-    gda = _gda_project(imported_project)
+    gda = Gda(imported_project)
 
-    proc = gda("resource", "uid", "res://missing.tres", "--json")
-
-    _assert_operation_error(proc, "path_not_found")
+    gda.error("resource", "uid", "res://missing.tres", "--json", code="path_not_found")
 
 
 @pytest.mark.e2e
@@ -883,29 +837,15 @@ def test_resource_uid_path_without_uid_is_no_uid_assigned(imported_project):
     # A resource that exists but has no UID in the non-editor reverse cache is
     # no_uid_assigned — distinct from path_not_found (the file is there) and from
     # a UID-direction failure (the query was a path).
-    gda = _gda_project(imported_project)
+    gda = Gda(imported_project)
 
-    proc = gda("resource", "uid", "res://data.tres", "--json")
-
-    _assert_operation_error(proc, "no_uid_assigned")
+    gda.error("resource", "uid", "res://data.tres", "--json", code="no_uid_assigned")
 
 
 @pytest.mark.e2e
 def test_resource_uid_projectless_run_is_project_not_found():
     # Resolution queries the project's UID cache, so a projectless run is refused
     # with project_not_found rather than a misleading "no UID" answer.
-    proc = subprocess.run(
-        [
-            *GDA_CMD,
-            "resource",
-            "uid",
-            "uid://b00000000000b",
-            "--godot",
-            str(GODOT),
-            "--json",
-        ],
-        capture_output=True,
-        text=True,
+    gda.error(
+        "resource", "uid", "uid://b00000000000b", "--json", code="project_not_found"
     )
-
-    _assert_operation_error(proc, "project_not_found")

--- a/tests/test_e2e_resource_import.py
+++ b/tests/test_e2e_resource_import.py
@@ -12,16 +12,14 @@ import hashlib
 import json
 import os
 import struct
-import subprocess
 import zlib
 from pathlib import Path
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
+from tests.support import Gda, import_project
 
-GODOT = resolve_godot_binary()
+from .conftest import project_godot
 
 CHECK_GD = (
     "extends SceneTree\n"
@@ -49,11 +47,7 @@ def _png(path: Path, color: tuple[int, int, int]) -> None:
 
 def _project(tmp_path: Path) -> Path:
     (tmp_path / "project.godot").write_text(
-        "config_version=5\n\n[application]\n\n"
-        'config/name="t668"\n\n[debug]\n\n'
-        "file_logging/enable_file_logging=false\n"
-        "file_logging/enable_file_logging.pc=false\n",
-        encoding="utf-8",
+        project_godot(name="t668"), encoding="utf-8"
     )
     _png(tmp_path / "icon.png", (255, 0, 0))
     (tmp_path / "check.gd").write_text(CHECK_GD, encoding="utf-8")
@@ -63,33 +57,6 @@ def _project(tmp_path: Path) -> Path:
 def _receipt(project: Path, asset: str) -> Path:
     digest = hashlib.md5(f"res://{asset}".encode()).hexdigest()
     return project / ".godot" / "imported" / f"{Path(asset).name}-{digest}.md5"
-
-
-def _native_import(project: Path) -> subprocess.CompletedProcess:
-    """The engine's OWN import pass, no gda in between (native parity)."""
-    return subprocess.run(
-        [str(GODOT), "--headless", "--path", str(project), "--import"],
-        capture_output=True,
-        text=True,
-        timeout=180,
-    )
-
-
-def _gda(project: Path, *args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [
-            *GDA_CMD,
-            *args,
-            "--project",
-            str(project),
-            "--godot",
-            str(GODOT),
-            "--json",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=180,
-    )
 
 
 def _tree(project: Path) -> set[str]:
@@ -104,11 +71,12 @@ def test_import_heals_the_clean_worktree_preload_failure(tmp_path):
     # it succeeds — plus the dry run's zero-write inventory, the classified
     # created files, and the idempotent second run, all on the same project.
     project = _project(tmp_path)
+    gda = Gda(project, json_output=True, timeout=180)
 
     # AC1, the failing half: plain `script run` triggers no import pass, and
     # the clean-worktree load dies.
     before_run = _tree(project)
-    failing = _gda(project, "script", "run", "res://check.gd")
+    failing = gda("script", "run", "res://check.gd")
     assert failing.returncode == 0, failing.stdout + failing.stderr
     assert json.loads(failing.stdout)["exit_status"] == 1
     # `script run` added no import artifacts (the engine writes only its own
@@ -120,7 +88,7 @@ def test_import_heals_the_clean_worktree_preload_failure(tmp_path):
 
     # AC3: the dry run reports the inventory and writes NOTHING.
     before_dry = _tree(project)
-    dry = _gda(project, "resource", "import", "res://icon.png", "--dry-run")
+    dry = gda("resource", "import", "res://icon.png", "--dry-run")
     assert dry.returncode == 0, dry.stdout + dry.stderr
     dry_doc = json.loads(dry.stdout)
     assert dry_doc["dry_run"] is True
@@ -131,7 +99,7 @@ def test_import_heals_the_clean_worktree_preload_failure(tmp_path):
 
     # AC2 + AC4: the real run reports per-asset verdicts, the summary, and
     # every created file classified against the cache root.
-    imported = _gda(project, "resource", "import", "res://icon.png")
+    imported = gda("resource", "import", "res://icon.png")
     assert imported.returncode == 0, imported.stdout + imported.stderr
     doc = json.loads(imported.stdout)
     assert doc["engine_pass"] is True
@@ -151,14 +119,14 @@ def test_import_heals_the_clean_worktree_preload_failure(tmp_path):
     assert doc["summary"]["requested"] == 1
 
     # AC1, the healed half: the same preload now succeeds.
-    healed = _gda(project, "script", "run", "res://check.gd")
+    healed = gda("script", "run", "res://check.gd")
     assert healed.returncode == 0, healed.stdout + healed.stderr
     healed_doc = json.loads(healed.stdout)
     assert healed_doc["exit_status"] == 0
     assert "LOADED" in healed_doc["stdout"]
 
     # Idempotence: the second import is a cache hit and runs NO pass.
-    second = _gda(project, "resource", "import", "res://icon.png")
+    second = gda("resource", "import", "res://icon.png")
     second_doc = json.loads(second.stdout)
     assert second_doc["engine_pass"] is False
     assert second_doc["assets"][0]["status"] == "cached"
@@ -168,8 +136,9 @@ def test_import_heals_the_clean_worktree_preload_failure(tmp_path):
 @pytest.mark.e2e
 def test_a_script_is_engine_decided_not_importable(tmp_path):
     project = _project(tmp_path)
+    gda = Gda(project, json_output=True, timeout=180)
 
-    result = _gda(project, "resource", "import", "res://check.gd")
+    result = gda("resource", "import", "res://check.gd")
 
     assert result.returncode == 0, result.stdout + result.stderr
     doc = json.loads(result.stdout)
@@ -183,9 +152,10 @@ def test_engine_invalid_import_is_failed_not_imported(tmp_path):
     # .png — Godot writes a sidecar with valid=false and no dest_files. gda
     # must report `failed`, never a cache hit or a successful import.
     project = _project(tmp_path)
+    gda = Gda(project, json_output=True, timeout=180)
     (project / "broken.png").write_text("this is not a png", encoding="utf-8")
 
-    result = _gda(project, "resource", "import", "res://broken.png")
+    result = gda("resource", "import", "res://broken.png")
 
     assert result.returncode == 0, result.stdout + result.stderr
     doc = json.loads(result.stdout)
@@ -193,7 +163,7 @@ def test_engine_invalid_import_is_failed_not_imported(tmp_path):
     assert broken["status"] == "failed"
     assert doc["summary"]["failed"] == 1
     # And the verdict is stable: a second run still refuses to call it cached.
-    again = json.loads(_gda(project, "resource", "import", "res://broken.png").stdout)
+    again = json.loads(gda("resource", "import", "res://broken.png").stdout)
     assert again["assets"][0]["status"] == "failed"
 
 
@@ -205,22 +175,19 @@ def test_stale_source_reimports_and_dry_run_lists_project_gaps(tmp_path):
     # pinned: requesting only icon.png, the dry run's project-wide scan lists
     # other.png as something the pass would also import.
     project = _project(tmp_path)
+    gda = Gda(project, json_output=True, timeout=180)
     _png(project / "other.png", (0, 0, 255))
 
-    first = json.loads(_gda(project, "resource", "import", "res://icon.png").stdout)
+    first = json.loads(gda("resource", "import", "res://icon.png").stdout)
     assert first["assets"][0]["status"] == "imported"
 
     # Make icon.png stale (different content, same path).
     _png(project / "icon.png", (0, 255, 0))
-    dry = json.loads(
-        _gda(project, "resource", "import", "res://icon.png", "--dry-run").stdout
-    )
+    dry = json.loads(gda("resource", "import", "res://icon.png", "--dry-run").stdout)
     assert dry["assets"][0]["status"] == "stale"
     assert dry["engine_pass"] is True
 
-    re_imported = json.loads(
-        _gda(project, "resource", "import", "res://icon.png").stdout
-    )
+    re_imported = json.loads(gda("resource", "import", "res://icon.png").stdout)
     assert re_imported["assets"][0]["status"] == "imported"
 
     # The project-gap half: strip other.png's cache, request only icon.png.
@@ -229,9 +196,7 @@ def test_stale_source_reimports_and_dry_run_lists_project_gaps(tmp_path):
     other_sidecar = project / "other.png.import"
     assert other_sidecar.is_file()
     shutil.rmtree(project / ".godot")
-    dry2 = json.loads(
-        _gda(project, "resource", "import", "res://icon.png", "--dry-run").stdout
-    )
+    dry2 = json.loads(gda("resource", "import", "res://icon.png", "--dry-run").stdout)
     assert dry2["assets"][0]["status"] == "stale"
     assert "res://other.png" in dry2["pass_will_also_import"]
 
@@ -244,16 +209,17 @@ def test_alias_sidecar_and_invalid_skip_match_the_engine(tmp_path):
     # - an invalid sidecar is EXCLUDED from pass_will_also_import, and the
     #   pass leaves its bytes untouched (the engine skips failed imports).
     project = _project(tmp_path)
-    first = json.loads(_gda(project, "resource", "import", "res://icon.png").stdout)
+    gda = Gda(project, json_output=True, timeout=180)
+    first = json.loads(gda("resource", "import", "res://icon.png").stdout)
     assert first["assets"][0]["status"] == "imported"
 
     # The invalid neighbor FIRST (its first import runs a project-wide pass;
     # the alias must not exist yet or that pass would heal it prematurely).
     (project / "bad.png").write_text("not a png", encoding="utf-8")
     assert (
-        json.loads(_gda(project, "resource", "import", "res://bad.png").stdout)[
-            "assets"
-        ][0]["status"]
+        json.loads(gda("resource", "import", "res://bad.png").stdout)["assets"][0][
+            "status"
+        ]
         == "failed"
     )
     bad_sidecar_before = (project / "bad.png.import").read_bytes()
@@ -263,13 +229,11 @@ def test_alias_sidecar_and_invalid_skip_match_the_engine(tmp_path):
         (project / "icon.png.import").read_text(encoding="utf-8"), encoding="utf-8"
     )
 
-    dry = json.loads(
-        _gda(project, "resource", "import", "res://alias2.png", "--dry-run").stdout
-    )
+    dry = json.loads(gda("resource", "import", "res://alias2.png", "--dry-run").stdout)
     assert dry["assets"][0]["status"] == "stale"
     assert "res://bad.png" not in dry["pass_will_also_import"]
 
-    real = json.loads(_gda(project, "resource", "import", "res://alias2.png").stdout)
+    real = json.loads(gda("resource", "import", "res://alias2.png").stdout)
     assert real["assets"][0]["status"] == "imported"
     # The engine rewrote the alias's sidecar to its own source/dest paths.
     rewritten = (project / "alias2.png.import").read_text(encoding="utf-8")
@@ -288,7 +252,8 @@ def test_no_destination_sidecar_matches_the_engines_current_verdict(tmp_path):
     # sidecar untouched, and gda agrees: cached, no pass spent, never
     # settled to failed, excluded from the gap prediction.
     project = _project(tmp_path)
-    first = json.loads(_gda(project, "resource", "import", "res://icon.png").stdout)
+    gda = Gda(project, json_output=True, timeout=180)
+    first = json.loads(gda("resource", "import", "res://icon.png").stdout)
     assert first["assets"][0]["status"] == "imported"
 
     sidecar = project / "icon.png.import"
@@ -314,26 +279,22 @@ def test_no_destination_sidecar_matches_the_engines_current_verdict(tmp_path):
     # ...then prove the native verdict the test's name claims: the engine's
     # own pass reaches the full reimport test (the sidecar mtime changed)
     # and still leaves the mutated sidecar byte-identical.
-    native = _native_import(project)
-    assert native.returncode == 0, native.stderr
+    # The engine's OWN import pass, no gda in between (native parity).
+    import_project(project)
     assert sidecar.read_bytes() == mutated
 
-    dry = json.loads(
-        _gda(project, "resource", "import", "res://icon.png", "--dry-run").stdout
-    )
+    dry = json.loads(gda("resource", "import", "res://icon.png", "--dry-run").stdout)
     assert dry["assets"][0]["status"] == "cached"
     assert dry["engine_pass"] is False
 
-    real = json.loads(_gda(project, "resource", "import", "res://icon.png").stdout)
+    real = json.loads(gda("resource", "import", "res://icon.png").stdout)
     assert real["assets"][0]["status"] == "cached"
     assert real["engine_pass"] is False
     assert real["created"] == []
 
     # And a request for a NEW asset must not falsely predict this one.
     _png(project / "fresh.png", (1, 2, 3))
-    gap = json.loads(
-        _gda(project, "resource", "import", "res://fresh.png", "--dry-run").stdout
-    )
+    gap = json.loads(gda("resource", "import", "res://fresh.png", "--dry-run").stdout)
     assert "res://icon.png" not in gap["pass_will_also_import"]
 
 
@@ -344,7 +305,8 @@ def test_malformed_receipt_matches_the_engines_deliberate_skip(tmp_path):
     # loop" branch — no re-import, artifacts untouched. gda must agree:
     # invalid, no pass spent, settled failed without launching the engine.
     project = _project(tmp_path)
-    first = json.loads(_gda(project, "resource", "import", "res://icon.png").stdout)
+    gda = Gda(project, json_output=True, timeout=180)
+    first = json.loads(gda("resource", "import", "res://icon.png").stdout)
     assert first["assets"][0]["status"] == "imported"
 
     sidecar = project / "icon.png.import"
@@ -360,28 +322,24 @@ def test_malformed_receipt_matches_the_engines_deliberate_skip(tmp_path):
     sidecar_bytes = sidecar.read_bytes()
     dest_bytes = dest.read_bytes()
 
-    native = _native_import(project)
-    assert native.returncode == 0, native.stderr
+    # The engine's OWN import pass, no gda in between (native parity).
+    import_project(project)
     assert sidecar.read_bytes() == sidecar_bytes
     assert receipt.read_text(encoding="utf-8") == "source_md5=[\n"
     assert dest.read_bytes() == dest_bytes
 
-    dry = json.loads(
-        _gda(project, "resource", "import", "res://icon.png", "--dry-run").stdout
-    )
+    dry = json.loads(gda("resource", "import", "res://icon.png", "--dry-run").stdout)
     assert dry["assets"][0]["status"] == "invalid"
     assert dry["engine_pass"] is False
 
-    real = json.loads(_gda(project, "resource", "import", "res://icon.png").stdout)
+    real = json.loads(gda("resource", "import", "res://icon.png").stdout)
     assert real["assets"][0]["status"] == "failed"
     assert real["engine_pass"] is False
     assert real["created"] == []
 
     # And another asset's dry run must not predict the skipped one.
     _png(project / "fresh.png", (9, 9, 9))
-    gap = json.loads(
-        _gda(project, "resource", "import", "res://fresh.png", "--dry-run").stdout
-    )
+    gap = json.loads(gda("resource", "import", "res://fresh.png", "--dry-run").stdout)
     assert "res://icon.png" not in gap["pass_will_also_import"]
 
 
@@ -391,7 +349,8 @@ def test_duplicate_receipt_assignments_match_the_engines_last_value(tmp_path):
     # wrong source_md5 followed by the engine-written matching value is still
     # current, so gda must neither spend a pass nor predict neighbor work.
     project = _project(tmp_path)
-    first = json.loads(_gda(project, "resource", "import", "res://icon.png").stdout)
+    gda = Gda(project, json_output=True, timeout=180)
+    first = json.loads(gda("resource", "import", "res://icon.png").stdout)
     assert first["assets"][0]["status"] == "imported"
 
     sidecar = project / "icon.png.import"
@@ -410,22 +369,18 @@ def test_duplicate_receipt_assignments_match_the_engines_last_value(tmp_path):
     receipt_bytes = receipt.read_bytes()
     dest_bytes = dest.read_bytes()
 
-    native = _native_import(project)
-    assert native.returncode == 0, native.stderr
+    # The engine's OWN import pass, no gda in between (native parity).
+    import_project(project)
     assert sidecar.read_bytes() == sidecar_bytes
     assert receipt.read_bytes() == receipt_bytes
     assert dest.read_bytes() == dest_bytes
 
-    dry = json.loads(
-        _gda(project, "resource", "import", "res://icon.png", "--dry-run").stdout
-    )
+    dry = json.loads(gda("resource", "import", "res://icon.png", "--dry-run").stdout)
     assert dry["assets"][0]["status"] == "cached"
     assert dry["engine_pass"] is False
 
     _png(project / "fresh.png", (4, 5, 6))
-    gap = json.loads(
-        _gda(project, "resource", "import", "res://fresh.png", "--dry-run").stdout
-    )
+    gap = json.loads(gda("resource", "import", "res://fresh.png", "--dry-run").stdout)
     assert "res://icon.png" not in gap["pass_will_also_import"]
 
 
@@ -436,7 +391,8 @@ def test_lone_surrogate_receipt_matches_the_engines_deliberate_skip(tmp_path):
     # artifacts untouched — while json.loads would happily decode it. gda must
     # sit on the engine's side: invalid, no pass.
     project = _project(tmp_path)
-    first = json.loads(_gda(project, "resource", "import", "res://icon.png").stdout)
+    gda = Gda(project, json_output=True, timeout=180)
+    first = json.loads(gda("resource", "import", "res://icon.png").stdout)
     assert first["assets"][0]["status"] == "imported"
 
     sidecar = project / "icon.png.import"
@@ -448,19 +404,17 @@ def test_lone_surrogate_receipt_matches_the_engines_deliberate_skip(tmp_path):
     sidecar_bytes = sidecar.read_bytes()
     dest_bytes = dest.read_bytes()
 
-    native = _native_import(project)
-    assert native.returncode == 0, native.stderr
+    # The engine's OWN import pass, no gda in between (native parity).
+    import_project(project)
     assert sidecar.read_bytes() == sidecar_bytes
     assert receipt.read_text(encoding="utf-8") == 'source_md5="\\ud800"\n'
     assert dest.read_bytes() == dest_bytes
 
-    dry = json.loads(
-        _gda(project, "resource", "import", "res://icon.png", "--dry-run").stdout
-    )
+    dry = json.loads(gda("resource", "import", "res://icon.png", "--dry-run").stdout)
     assert dry["assets"][0]["status"] == "invalid"
     assert dry["engine_pass"] is False
 
-    real = json.loads(_gda(project, "resource", "import", "res://icon.png").stdout)
+    real = json.loads(gda("resource", "import", "res://icon.png").stdout)
     assert real["assets"][0]["status"] == "failed"
     assert real["engine_pass"] is False
     assert real["created"] == []

--- a/tests/test_e2e_scene.py
+++ b/tests/test_e2e_scene.py
@@ -8,20 +8,12 @@ structured-level verification of ``scene create``'s effect.
 
 import json
 import os
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
+from tests.support import Gda
 
-GODOT = resolve_godot_binary()
-
-
-def _gda(*args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT)], capture_output=True, text=True
-    )
+gda = Gda()
 
 
 @pytest.mark.e2e
@@ -30,12 +22,7 @@ def test_res_path_round_trip_against_the_project_fixture(godot_project):
     # project fixture, a res:// path resolves against it — proving the fixture
     # is actually handed to the engine (it previously never reached it). The
     # created scene lands inside the project and reads back through res://.
-    def gda(*args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(godot_project)],
-            capture_output=True,
-            text=True,
-        )
+    gda = Gda(godot_project)
 
     created = gda(
         "scene", "create", "res://hero.tscn", "--root-type", "Node2D", "--json"
@@ -53,9 +40,7 @@ def test_res_path_round_trip_against_the_project_fixture(godot_project):
 def test_scene_create_then_get_round_trip(godot_project):
     scene_path = godot_project / "main.tscn"
 
-    created = _gda(
-        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
-    )
+    created = gda("scene", "create", str(scene_path), "--root-type", "Node2D", "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     data = json.loads(created.stdout)
@@ -63,7 +48,7 @@ def test_scene_create_then_get_round_trip(godot_project):
     # The .tscn landed on disk inside the temp project.
     assert scene_path.exists()
 
-    got = _gda("scene", "get", str(scene_path), "--json")
+    got = gda("scene", "get", str(scene_path), "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     tree = json.loads(got.stdout)
@@ -82,7 +67,7 @@ def test_scene_path_containing_end_sentinel_round_trips(godot_project):
     # is not a legal node-name char, so it cannot be derived from this filename.
     scene_path = godot_project / "weird<<<GDA:END>>>name.tscn"
 
-    created = _gda(
+    created = gda(
         "scene",
         "create",
         str(scene_path),
@@ -96,7 +81,7 @@ def test_scene_path_containing_end_sentinel_round_trips(godot_project):
     assert created.returncode == 0, created.stdout + created.stderr
     assert json.loads(created.stdout)["path"] == str(scene_path)
 
-    got = _gda("scene", "get", str(scene_path), "--json")
+    got = gda("scene", "get", str(scene_path), "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     tree = json.loads(got.stdout)
@@ -108,9 +93,7 @@ def test_scene_path_containing_end_sentinel_round_trips(godot_project):
 def test_scene_create_creates_missing_parent_directories(godot_project):
     scene_path = godot_project / "levels" / "demo" / "main.tscn"
 
-    created = _gda(
-        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
-    )
+    created = gda("scene", "create", str(scene_path), "--root-type", "Node2D", "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     data = json.loads(created.stdout)
@@ -120,7 +103,7 @@ def test_scene_create_creates_missing_parent_directories(godot_project):
     ]
     assert scene_path.exists()
 
-    got = _gda("scene", "get", str(scene_path), "--json")
+    got = gda("scene", "get", str(scene_path), "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["root"]["name"] == "main"
@@ -130,22 +113,8 @@ def test_scene_create_creates_missing_parent_directories(godot_project):
 def test_scene_create_creates_relative_parent_directories_against_project(
     godot_project,
 ):
-    created = subprocess.run(
-        [
-            *GDA_CMD,
-            "scene",
-            "create",
-            "demo/main.tscn",
-            "--root-type",
-            "Node2D",
-            "--project",
-            str(godot_project),
-            "--godot",
-            str(GODOT),
-            "--json",
-        ],
-        capture_output=True,
-        text=True,
+    created = Gda(godot_project)(
+        "scene", "create", "demo/main.tscn", "--root-type", "Node2D", "--json"
     )
 
     assert created.returncode == 0, created.stdout + created.stderr
@@ -163,9 +132,7 @@ def test_scene_create_existing_path_yields_already_exists_without_overwriting(
     original = "not a scene\n"
     scene_path.write_text(original, encoding="utf-8")
 
-    created = _gda(
-        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
-    )
+    created = gda("scene", "create", str(scene_path), "--root-type", "Node2D", "--json")
 
     assert created.returncode == 4
     err = json.loads(created.stdout)["error"]
@@ -179,9 +146,7 @@ def test_scene_create_existing_path_yields_already_exists_without_overwriting(
 def test_scene_create_empty_root_name_yields_structured_error(godot_project):
     scene_path = godot_project / ".tscn"
 
-    created = _gda(
-        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
-    )
+    created = gda("scene", "create", str(scene_path), "--root-type", "Node2D", "--json")
 
     assert created.returncode == 4
     err = json.loads(created.stdout)["error"]
@@ -195,7 +160,7 @@ def test_scene_create_empty_root_name_yields_structured_error(godot_project):
 def test_scene_create_rejects_root_name_godot_would_rewrite(godot_project):
     scene_path = godot_project / "bad-name.tscn"
 
-    created = _gda(
+    created = gda(
         "scene",
         "create",
         str(scene_path),
@@ -220,7 +185,7 @@ def test_scene_create_rejects_dotted_default_root_name_but_allows_override(
 ):
     scene_path = godot_project / "level.v2.tscn"
 
-    rejected = _gda(
+    rejected = gda(
         "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
     )
 
@@ -230,7 +195,7 @@ def test_scene_create_rejects_dotted_default_root_name_but_allows_override(
     assert err["code"] == "invalid_root_name"
     assert not scene_path.exists()
 
-    created = _gda(
+    created = gda(
         "scene",
         "create",
         str(scene_path),
@@ -244,7 +209,7 @@ def test_scene_create_rejects_dotted_default_root_name_but_allows_override(
     assert created.returncode == 0, created.stdout + created.stderr
     assert json.loads(created.stdout)["root_name"] == "LevelV2"
 
-    got = _gda("scene", "get", str(scene_path), "--json")
+    got = gda("scene", "get", str(scene_path), "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["root"]["name"] == "LevelV2"
@@ -307,7 +272,7 @@ def test_scene_get_reports_nested_tree(godot_project):
     scene_path = godot_project / "nested.tscn"
     scene_path.write_text(NESTED_TSCN, encoding="utf-8")
 
-    got = _gda("scene", "get", str(scene_path), "--json")
+    got = gda("scene", "get", str(scene_path), "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     root = json.loads(got.stdout)["root"]
@@ -330,7 +295,7 @@ def test_scene_get_marks_instanced_child_and_resolves_its_root_type(godot_projec
     (godot_project / "main.tscn").write_text(
         HOST_WITH_INSTANCED_CHILD_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     got = gda("scene", "get", "res://main.tscn", "--json")
 
@@ -371,7 +336,7 @@ def test_scene_get_reads_the_instance_attribute_by_whole_name(godot_project):
     (godot_project / "main.tscn").write_text(
         HOST_WITH_DECOYED_INSTANCE_ATTR_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     got = gda("scene", "get", "res://main.tscn", "--json")
 
@@ -390,7 +355,7 @@ def test_scene_get_marks_missing_instanced_child_reference(godot_project):
     (godot_project / "main.tscn").write_text(
         HOST_WITH_MISSING_INSTANCED_CHILD_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     got = gda("scene", "get", "res://main.tscn", "--json")
 
@@ -410,7 +375,7 @@ def test_scene_get_missing_file_yields_structured_error_end_to_end(godot_project
     # operation exit code.
     missing = godot_project / "missing.tscn"
 
-    got = _gda("scene", "get", str(missing), "--json")
+    got = gda("scene", "get", str(missing), "--json")
 
     assert got.returncode == 4
     err = json.loads(got.stdout)["error"]
@@ -432,9 +397,7 @@ def test_scene_create_unwritable_directory_yields_structured_save_failed(godot_p
     target = locked / "main.tscn"
     locked.chmod(0o500)
     try:
-        created = _gda(
-            "scene", "create", str(target), "--root-type", "Node2D", "--json"
-        )
+        created = gda("scene", "create", str(target), "--root-type", "Node2D", "--json")
     finally:
         locked.chmod(0o700)
 
@@ -455,7 +418,7 @@ def test_scene_create_unknown_root_type_yields_structured_error_end_to_end(
 ):
     target = godot_project / "bogus.tscn"
 
-    created = _gda("scene", "create", str(target), "--root-type", "NotAClass", "--json")
+    created = gda("scene", "create", str(target), "--root-type", "NotAClass", "--json")
 
     assert created.returncode == 4
     err = json.loads(created.stdout)["error"]
@@ -464,26 +427,13 @@ def test_scene_create_unknown_root_type_yields_structured_error_end_to_end(
     assert not target.exists()
 
 
-def _gda_project(project):
-    """A ``_gda`` bound to ``--project`` for res:// enumeration/resolution."""
-
-    def gda(*args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-            capture_output=True,
-            text=True,
-        )
-
-    return gda
-
-
 @pytest.mark.e2e
 def test_scene_list_enumerates_created_scenes(godot_project):
     # scene list (issue #54) enumerates the project's .tscn scenes by walking
     # res://: two scenes created at different depths both appear, each with its
     # res:// path and the root name/type read from stored state. The listing IS
     # the structured-level verification of what scene create wrote.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     assert (
         gda(
@@ -520,7 +470,7 @@ def test_scene_list_marks_inherited_scene_root_and_resolves_its_type(godot_proje
     (godot_project / "inherited_hud.tscn").write_text(
         INHERITED_HUD_ROOT_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     listed = gda("scene", "list", "--json")
 
@@ -541,7 +491,7 @@ def test_scene_list_enumerates_dot_prefixed_scenes_but_skips_godot_cache(godot_p
     # dot-prefixed entry. The empty-project test already proves res://.godot does
     # not leak; this proves the skip is scoped to res://.godot, not "anything
     # starting with a dot".
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     assert (
         gda(
@@ -589,7 +539,7 @@ def test_scene_list_enumerates_dot_prefixed_scenes_but_skips_godot_cache(godot_p
 def test_scene_list_on_empty_project_is_an_empty_listing(godot_project):
     # A project with no scenes is a valid, empty listing — not an error (the
     # res://.godot import cache must not leak in as a phantom scene).
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     listed = gda("scene", "list", "--json")
 
@@ -602,12 +552,7 @@ def test_scene_list_without_project_yields_project_not_found(tmp_path):
     # scene list cannot enumerate res:// projectless: run from a non-project
     # directory with no --project, it must refuse with the structured
     # project_not_found code rather than return a misleading empty listing.
-    listed = subprocess.run(
-        [*GDA_CMD, "scene", "list", "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-        cwd=str(tmp_path),
-    )
+    listed = gda("scene", "list", "--json", cwd=tmp_path)
 
     assert listed.returncode == 4, listed.stdout + listed.stderr
     err = json.loads(listed.stdout)["error"]
@@ -621,7 +566,7 @@ def test_scene_delete_removes_a_scene_and_names_what_was_removed(godot_project):
     # scene delete (issue #54) removes a scene file and names the removed root.
     # The round-trip verifier: scene list before shows the scene, delete reports
     # the removed root's name/type, and scene list after no longer shows it.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -647,7 +592,7 @@ def test_scene_delete_removes_a_scene_and_names_what_was_removed(godot_project):
 def test_scene_delete_missing_file_yields_path_not_found(godot_project):
     missing = godot_project / "missing.tscn"
 
-    deleted = _gda("scene", "delete", str(missing), "--json")
+    deleted = gda("scene", "delete", str(missing), "--json")
 
     assert deleted.returncode == 4
     err = json.loads(deleted.stdout)["error"]
@@ -664,7 +609,7 @@ def test_scene_delete_refuses_non_scene_file_and_leaves_it_on_disk(godot_project
     notes = godot_project / "notes.txt"
     notes.write_text("not a scene\n", encoding="utf-8")
 
-    deleted = _gda("scene", "delete", str(notes), "--json")
+    deleted = gda("scene", "delete", str(notes), "--json")
 
     assert deleted.returncode == 4
     err = json.loads(deleted.stdout)["error"]

--- a/tests/test_e2e_scene_exports.py
+++ b/tests/test_e2e_scene_exports.py
@@ -12,29 +12,12 @@ The scene is built end-to-end with the real CLI: ``scene create`` →
 """
 
 import json
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
+from tests.support import Gda
 
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
-
-
-def _gda(*args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT)], capture_output=True, text=True
-    )
-
-
-def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
-    assert proc.returncode == 4, proc.stdout + proc.stderr
-    err = json.loads(proc.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == code
-    return err
+gda = Gda()
 
 
 # A script declaring a representative @export surface: a typed scalar with a
@@ -55,15 +38,13 @@ var not_exported: int = 7
 def _build_scene_with_exports(project) -> "tuple":
     """scene create → script create (exports) → script attach to the root."""
     scene_path = project / "main.tscn"
-    created = _gda(
-        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
-    )
+    created = gda("scene", "create", str(scene_path), "--root-type", "Node2D", "--json")
     assert created.returncode == 0, created.stdout + created.stderr
 
     script_path = project / "actor.gd"
     script_path.write_text(EXPORTING_SCRIPT, encoding="utf-8")
 
-    attached = _gda(
+    attached = gda(
         "script",
         "attach",
         str(scene_path),
@@ -87,7 +68,7 @@ def test_scene_get_exports_reports_declared_exports_per_node(godot_project):
     # typed JSON. A plain (non-@export) var is NOT reported.
     scene_path, _ = _build_scene_with_exports(godot_project)
 
-    got = _gda(
+    got = gda(
         "scene",
         "get-exports",
         str(scene_path),
@@ -131,12 +112,10 @@ def test_scene_get_exports_omits_nodes_without_declared_exports(godot_project):
     # not appear: get-exports lists only nodes that actually declare exports. A
     # bare scene (no scripts anywhere) is a valid, empty listing.
     scene_path = godot_project / "bare.tscn"
-    created = _gda(
-        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
-    )
+    created = gda("scene", "create", str(scene_path), "--root-type", "Node2D", "--json")
     assert created.returncode == 0, created.stdout + created.stderr
 
-    got = _gda(
+    got = gda(
         "scene",
         "get-exports",
         str(scene_path),
@@ -157,14 +136,12 @@ def test_scene_get_exports_reports_nested_node_by_path(godot_project):
     # afterwards. The root here carries no script, so only the child is listed —
     # which also pins that a scriptless node is omitted.
     scene_path = godot_project / "main.tscn"
-    created = _gda(
-        "scene", "create", str(scene_path), "--root-type", "Node2D", "--json"
-    )
+    created = gda("scene", "create", str(scene_path), "--root-type", "Node2D", "--json")
     assert created.returncode == 0, created.stdout + created.stderr
     script_path = godot_project / "actor.gd"
     script_path.write_text(EXPORTING_SCRIPT, encoding="utf-8")
 
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(scene_path),
@@ -175,7 +152,7 @@ def test_scene_get_exports_reports_nested_node_by_path(godot_project):
         "--json",
     )
     assert added.returncode == 0, added.stdout + added.stderr
-    attached = _gda(
+    attached = gda(
         "script",
         "attach",
         str(scene_path),
@@ -189,7 +166,7 @@ def test_scene_get_exports_reports_nested_node_by_path(godot_project):
     )
     assert attached.returncode == 0, attached.stdout + attached.stderr
 
-    got = _gda(
+    got = gda(
         "scene",
         "get-exports",
         str(scene_path),
@@ -209,16 +186,15 @@ def test_scene_get_exports_reports_nested_node_by_path(godot_project):
 
 @pytest.mark.e2e
 def test_scene_get_exports_missing_file_yields_path_not_found(godot_project):
-    got = _gda(
+    err = gda.error(
         "scene",
         "get-exports",
         str(godot_project / "nope.tscn"),
         "--project",
         str(godot_project),
         "--json",
+        code="path_not_found",
     )
-
-    err = _assert_operation_error(got, "path_not_found")
     assert "nope.tscn" in err["message"]
 
 
@@ -229,13 +205,12 @@ def test_scene_get_exports_non_scene_file_yields_not_a_scene(godot_project):
     notes = godot_project / "notes.txt"
     notes.write_text("not a scene\n", encoding="utf-8")
 
-    got = _gda(
+    gda.error(
         "scene",
         "get-exports",
         str(notes),
         "--project",
         str(godot_project),
         "--json",
+        code="not_a_scene",
     )
-
-    _assert_operation_error(got, "not_a_scene")

--- a/tests/test_e2e_scene_preflight.py
+++ b/tests/test_e2e_scene_preflight.py
@@ -12,15 +12,11 @@ run, and the verdict has to come back within it.
 """
 
 import json
-import subprocess
 import time
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
+from tests.support import Gda
 
 # printerr, not print: gda's stdout carries only the result object (ADR-0002), so
 # the engine's stdout is consumed by the sentinel parse and never forwarded. Its
@@ -64,17 +60,6 @@ def _scene_tscn(script: str) -> str:
     )
 
 
-def _gda_project(project):
-    def gda(*args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-            capture_output=True,
-            text=True,
-        )
-
-    return gda
-
-
 def _scene(project, name: str, script_name: str, source: str):
     (project / script_name).write_text(source, encoding="utf-8")
     (project / name).write_text(_scene_tscn(script_name), encoding="utf-8")
@@ -83,7 +68,7 @@ def _scene(project, name: str, script_name: str, source: str):
 @pytest.mark.e2e
 def test_a_scene_that_comes_up_cleanly_is_started(godot_project):
     _scene(godot_project, "hero.tscn", "hero.gd", READY_SCRIPT)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     preflighted = gda("scene", "preflight", "res://hero.tscn", "--json")
 
@@ -108,7 +93,7 @@ def test_an_error_raised_in_ready_is_reported_though_the_scene_reached_ready(
     # reaches _ready — and is still broken. `status` reports how far it got, the
     # diagnostics say what went wrong, and `started` requires both.
     _scene(godot_project, "encounter.tscn", "encounter.gd", FAILING_READY_SCRIPT)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     # Static validation passes: every dependency resolves and the script compiles.
     validated = gda("scene", "validate", "res://encounter.tscn", "--json")
@@ -137,7 +122,7 @@ def test_a_scene_whose_ready_never_returns_is_a_timeout_verdict_within_the_bound
     # still comes back — as a SUCCESS carrying status=timeout, because "it did not
     # come up" is the answer this command was asked for.
     _scene(godot_project, "hang.tscn", "hang.gd", BLOCKING_READY_SCRIPT)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     started_at = time.monotonic()
     preflighted = gda(
@@ -179,7 +164,7 @@ def test_a_scene_missing_an_unimported_asset_starts_clean_which_is_why_both_exis
         'texture = ExtResource("1_dot")\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     preflighted = gda("scene", "preflight", "res://main.tscn", "--json")
     assert preflighted.returncode == 0, preflighted.stdout + preflighted.stderr
@@ -198,7 +183,7 @@ def test_a_scene_missing_an_unimported_asset_starts_clean_which_is_why_both_exis
 
 @pytest.mark.e2e
 def test_a_missing_scene_is_refused_not_reported_as_a_verdict(godot_project):
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     preflighted = gda("scene", "preflight", "res://nosuch.tscn", "--json")
 
@@ -253,7 +238,7 @@ def test_a_scene_that_hands_off_in_ready_still_counts_as_started(godot_project):
     # that freed itself in _ready is already gone. Sampling reported this shape as
     # not_ready — a scene that plainly started.
     _scene(godot_project, "splash.tscn", "splash.gd", HANDOFF_READY_SCRIPT)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     preflighted = gda("scene", "preflight", "res://splash.tscn", "--json")
 
@@ -270,7 +255,7 @@ def test_the_frame_window_is_what_catches_a_failure_after_ready(godot_project):
     # one-frame window and fails with the default one, because its error lands on
     # frame five. This is why the window is not simply "wait for ready".
     _scene(godot_project, "late.tscn", "late.gd", LATE_FAILURE_SCRIPT)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     narrow = gda("scene", "preflight", "res://late.tscn", "--frames", "1", "--json")
     assert narrow.returncode == 0, narrow.stdout + narrow.stderr
@@ -305,7 +290,7 @@ def test_a_scene_that_quits_from_ready_still_gets_its_ready_verdict(godot_projec
     # moment the signal lands, so the verdict survives the project's exit instead
     # of being misreported as an operation failure (the pre-#709 behavior).
     _scene(godot_project, "splash.tscn", "splash.gd", QUITTING_READY_SCRIPT)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     preflighted = gda("scene", "preflight", "res://splash.tscn", "--json")
 
@@ -349,7 +334,7 @@ def test_a_push_error_raised_in_ready_is_reported_as_a_startup_diagnostic(
     # `started: true` with EMPTY diagnostics — the phantom-clean start the
     # dogfooding note is about, in the most common shape a project writes it.
     _scene(godot_project, "encounter.tscn", "encounter.gd", PUSH_ERROR_READY_SCRIPT)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     # Static validation passes: the scene's dependencies resolve and it compiles.
     # Only booting it reveals what the project itself thinks of what it found.
@@ -402,7 +387,7 @@ def test_an_engine_error_a_script_triggered_is_not_reported_as_the_projects_own(
     # of the project's diagnostics — the record stays unrecognized, and the
     # verbatim stream is where a reader still finds it.
     _scene(godot_project, "indirect.tscn", "indirect.gd", INDIRECT_ERROR_SCRIPT)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     preflighted = gda("scene", "preflight", "res://indirect.tscn", "--json")
 
@@ -442,7 +427,7 @@ def test_a_refused_script_binding_is_not_a_clean_start(godot_project):
     (godot_project / "badbind.tscn").write_text(
         INCOMPATIBLE_BINDING_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     preflighted = gda("scene", "preflight", "res://badbind.tscn", "--json")
 
@@ -480,7 +465,7 @@ def test_a_non_script_binding_is_not_a_clean_start(godot_project):
     (godot_project / "notascript.tscn").write_text(
         NOT_A_SCRIPT_BINDING_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     preflighted = gda("scene", "preflight", "res://notascript.tscn", "--json")
 
@@ -504,7 +489,7 @@ def test_the_timeout_verdict_carries_the_elapsed_clock_and_the_configured_ceilin
     # exactly what this caller configured, not the 30s default the run did not use.
     # Together they are what tells this scene (stuck) from one that was merely slow.
     _scene(godot_project, "stuck.tscn", "stuck.gd", BLOCKING_READY_SCRIPT)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     preflighted = gda(
         "scene", "preflight", "res://stuck.tscn", "--timeout", "3", "--json"
@@ -526,7 +511,7 @@ def test_a_scene_that_comes_up_carries_no_timeout_evidence(godot_project):
     # absent rather than null or zero. A `ready` verdict is byte-identical to what it
     # was before #787 added the keys.
     _scene(godot_project, "hero.tscn", "hero.gd", READY_SCRIPT)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     preflighted = gda("scene", "preflight", "res://hero.tscn", "--json")
 

--- a/tests/test_e2e_scene_security.py
+++ b/tests/test_e2e_scene_security.py
@@ -32,25 +32,14 @@ The contract pinned (verified on Godot 4.6.3):
 """
 
 import json
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
+from tests.support import Gda
 
 from .conftest import project_godot
 
-GODOT = resolve_godot_binary()
-
-
-def _gda(*args: str, cwd=None) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-        cwd=str(cwd) if cwd is not None else None,
-    )
+gda = Gda()
 
 
 # A root script whose _init has a side effect AND prints a forged result block.
@@ -86,12 +75,7 @@ def test_scene_get_does_not_execute_scene_code(godot_project):
 
     # Run from inside the project so res://evil.gd resolves — the condition
     # under which the script would load and (on the buggy path) execute.
-    proc = subprocess.run(
-        [*GDA_CMD, "scene", "get", "evil.tscn", "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-        cwd=str(godot_project),
-    )
+    proc = gda("scene", "get", "evil.tscn", "--json", cwd=godot_project)
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     tree = json.loads(proc.stdout)
@@ -152,14 +136,14 @@ def test_node_list_does_not_execute_scene_script(godot_project):
     # project code and that is a regression, not an intentional behavior change.
     scene = _plant_spied_scene(godot_project)
 
-    listed = _gda("node", "list", str(scene), "--project", str(godot_project), "--json")
+    listed = gda("node", "list", str(scene), "--project", str(godot_project), "--json")
     assert listed.returncode == 0, listed.stdout + listed.stderr
     tree = json.loads(listed.stdout)["root"]
     # The declared tree is reported (not anything the script could have forged).
     assert (tree["name"], tree["type"], tree["path"]) == ("Root", "Node2D", ".")
     assert tree["children"] == []
 
-    got = _gda("scene", "get", str(scene), "--project", str(godot_project), "--json")
+    got = gda("scene", "get", str(scene), "--project", str(godot_project), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["root"]["name"] == "Root"
 
@@ -180,7 +164,7 @@ def test_node_add_executes_pre_existing_scene_script(godot_project):
     # assertion below should flip to assert the marker file does NOT appear.
     scene = _plant_spied_scene(godot_project)
 
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(scene),
@@ -217,7 +201,7 @@ def test_node_get_executes_pre_existing_scene_script(godot_project):
     # marker file does NOT appear.
     scene = _plant_spied_scene(godot_project)
 
-    got = _gda(
+    got = gda(
         "node",
         "get",
         str(scene),
@@ -276,7 +260,7 @@ def test_node_add_forged_sentinel_from_scene_script_fails_loudly(godot_project):
     (godot_project / "forge.gd").write_text(FORGE_GD, encoding="utf-8")
     (godot_project / "forged.tscn").write_text(FORGED_TSCN, encoding="utf-8")
 
-    added = _gda(
+    added = gda(
         "node",
         "add",
         str(godot_project / "forged.tscn"),
@@ -352,7 +336,7 @@ def test_autoload_runs_on_scene_get(godot_project):
     (godot_project / "autoload.gd").write_text(AUTOLOAD_GD, encoding="utf-8")
     (godot_project / "plain.tscn").write_text(PLAIN_TSCN, encoding="utf-8")
 
-    got = _gda(
+    got = gda(
         "scene",
         "get",
         str(godot_project / "plain.tscn"),

--- a/tests/test_e2e_scene_validate.py
+++ b/tests/test_e2e_scene_validate.py
@@ -14,14 +14,10 @@ compile, through any gda command.
 """
 
 import json
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
+from tests.support import Gda
 
 GOOD_SCRIPT = """\
 extends Node2D
@@ -72,24 +68,13 @@ script = ExtResource("1_broken")
 """
 
 
-def _gda_project(project):
-    def gda(*args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-            capture_output=True,
-            text=True,
-        )
-
-    return gda
-
-
 @pytest.mark.e2e
 def test_a_sound_scene_validates_and_names_the_project_it_resolved_against(
     godot_project,
 ):
     (godot_project / "hero.gd").write_text(GOOD_SCRIPT, encoding="utf-8")
     (godot_project / "hero.tscn").write_text(GOOD_TSCN, encoding="utf-8")
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://hero.tscn", "--json")
 
@@ -106,7 +91,7 @@ def test_missing_dependencies_are_reported_where_scene_get_reports_nothing(
     godot_project,
 ):
     (godot_project / "main.tscn").write_text(MISSING_DEPS_TSCN, encoding="utf-8")
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     # BEFORE (GDA-DF-040): the read succeeds and the tree looks healthy — the missing
     # script and texture leave no trace in it. This is the gap, pinned.
@@ -151,7 +136,7 @@ def test_an_attached_script_that_does_not_compile_is_a_problem_not_a_failure(
 ):
     (godot_project / "broken.gd").write_text(BROKEN_SCRIPT, encoding="utf-8")
     (godot_project / "main.tscn").write_text(BROKEN_SCRIPT_TSCN, encoding="utf-8")
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://main.tscn", "--json")
 
@@ -194,7 +179,7 @@ def test_an_asset_that_was_never_imported_is_unloadable_not_missing(godot_projec
         'texture = ExtResource("1_dot")\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://main.tscn", "--json")
 
@@ -210,7 +195,7 @@ def test_an_asset_that_was_never_imported_is_unloadable_not_missing(godot_projec
 def test_a_missing_scene_is_refused_not_reported_as_invalid(godot_project):
     # The addressing ladder does not fork for validate: what is not there cannot have
     # a verdict, so it is the same path_not_found every other scene command reports.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://nosuch.tscn", "--json")
 
@@ -259,7 +244,7 @@ def test_a_dependency_broken_from_a_sub_resource_is_a_verdict_not_a_refusal(
     # `not_a_scene` about a file that IS a scene — hiding exactly the broken
     # dependency this command exists to report.
     (godot_project / "main.tscn").write_text(SUB_RESOURCE_TSCN, encoding="utf-8")
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://main.tscn", "--json")
 
@@ -283,7 +268,7 @@ def test_a_binary_scene_is_refused_rather_than_reported_valid(godot_project):
     (godot_project / "hero.gd").write_text(GOOD_SCRIPT, encoding="utf-8")
     (godot_project / "hero.tscn").write_text(GOOD_TSCN, encoding="utf-8")
     (godot_project / "save_binary.gd").write_text(SAVE_AS_BINARY_GD, encoding="utf-8")
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     saved = gda("script", "run", "res://save_binary.gd", "--json")
     assert saved.returncode == 0, saved.stdout + saved.stderr
@@ -349,7 +334,7 @@ def test_an_incompatible_script_binding_is_a_problem_not_a_pass(godot_project):
     (godot_project / "badbind.tscn").write_text(
         INCOMPATIBLE_BINDING_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://badbind.tscn", "--json")
 
@@ -367,7 +352,7 @@ def test_an_incompatible_script_binding_is_a_problem_not_a_pass(godot_project):
 @pytest.mark.e2e
 def test_a_broken_embedded_script_is_a_problem_not_a_pass(godot_project):
     (godot_project / "badembed.tscn").write_text(BROKEN_EMBEDDED_TSCN, encoding="utf-8")
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://badembed.tscn", "--json")
 
@@ -420,7 +405,7 @@ def test_a_non_script_resource_declared_as_script_is_a_problem_not_a_pass(
     (godot_project / "notascript.tscn").write_text(
         NOT_A_SCRIPT_BINDING_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://notascript.tscn", "--json")
 
@@ -441,7 +426,7 @@ def test_an_embedded_non_script_bound_as_script_is_a_problem_not_a_pass(
     (godot_project / "embednotascript.tscn").write_text(
         EMBEDDED_NOT_A_SCRIPT_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://embednotascript.tscn", "--json")
 
@@ -464,7 +449,7 @@ def test_a_tscn_that_is_not_a_scene_document_is_refused_not_diagnosed(godot_proj
         "this is not a scene file at all\n",
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://garbage.tscn", "--json")
 
@@ -485,7 +470,7 @@ def test_a_header_that_merely_starts_with_gd_scene_is_still_refused(godot_projec
         "this is not a Godot scene\n",
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://scenery.tscn", "--json")
 
@@ -507,7 +492,7 @@ def test_an_unclosed_gd_scene_header_is_still_refused(godot_project):
         "this is not a Godot scene\n",
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://unclosed.tscn", "--json")
 
@@ -547,7 +532,7 @@ COMPOSED_PARENT_TSCN = """\
 def test_an_instanced_broken_child_makes_the_parent_invalid(godot_project):
     (godot_project / "child.tscn").write_text(COMPOSED_CHILD_TSCN, encoding="utf-8")
     (godot_project / "parent.tscn").write_text(COMPOSED_PARENT_TSCN, encoding="utf-8")
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     # The child's own verdict is the reference answer.
     child = gda("scene", "validate", "res://child.tscn", "--json")
@@ -601,7 +586,7 @@ def test_a_sound_composed_scene_is_still_valid_and_each_file_checked_once(
         '[node name="LeafDirect" parent="." instance=ExtResource("2_leaf")]\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://top.tscn", "--json")
 
@@ -651,7 +636,7 @@ def test_an_instancing_cycle_terminates_with_a_diagnostic(godot_project):
         '[node name="AInstance" parent="." instance=ExtResource("1_a")]\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://a.tscn", "--json")
 
@@ -678,7 +663,7 @@ def test_a_scene_that_instances_itself_is_one_cycle_not_a_hang(godot_project):
         '[node name="Inner2" parent="." instance=ExtResource("1_self")]\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://self.tscn", "--json")
 
@@ -707,7 +692,7 @@ def test_a_missing_sub_scene_is_the_parents_problem_and_not_reported_twice(
         '[node name="Missing" parent="." instance=ExtResource("1_gone")]\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://parent.tscn", "--json")
 
@@ -764,7 +749,7 @@ def test_a_chain_at_the_depth_bound_is_still_fully_validated(godot_project):
     # the verdict is a real one. This is the half that keeps the bound honest: a
     # cap that fires early would turn ordinary compositions into non-answers.
     _write_instance_chain(godot_project, 16)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://s0.tscn", "--json")
 
@@ -779,7 +764,7 @@ def test_past_the_depth_bound_the_walk_stops_and_says_so(godot_project):
     # One level further. The walk stops at the edge into s17 and reports it —
     # rather than answering `valid: true` about a subtree it never looked at.
     _write_instance_chain(godot_project, 17)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://s0.tscn", "--json")
 
@@ -811,7 +796,7 @@ def test_the_bound_does_not_hide_a_break_above_it(godot_project):
         '[node name="Child" parent="." instance=ExtResource("1_c")]\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://s0.tscn", "--json")
 
@@ -860,7 +845,7 @@ def test_a_sub_scene_referenced_as_data_still_breaks_its_owner(godot_project):
     (godot_project / "parent.tscn").write_text(
         DATA_REFERENCE_PARENT_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://parent.tscn", "--json")
 
@@ -901,7 +886,7 @@ def test_a_binary_sub_scene_is_reported_unchecked_not_silently_skipped(godot_pro
     (godot_project / "parent.tscn").write_text(
         BINARY_SUB_SCENE_PARENT_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     saved = gda("script", "run", "res://save_binary.gd", "--json")
     assert saved.returncode == 0, saved.stdout + saved.stderr
     assert (godot_project / "hero.scn").exists(), saved.stdout + saved.stderr
@@ -941,7 +926,7 @@ def test_a_binary_sub_scene_that_does_not_load_is_still_reported_once(godot_proj
     (godot_project / "parent.tscn").write_text(
         BINARY_SUB_SCENE_PARENT_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     saved = gda("script", "run", "res://save_binary.gd", "--json")
     assert saved.returncode == 0, saved.stdout + saved.stderr
     # Removing the script entirely makes the binary resource itself unloadable.
@@ -981,7 +966,7 @@ def test_two_spellings_of_one_sub_scene_are_one_file(godot_project):
         '[node name="B" parent="." instance=ExtResource("2_a")]\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://alias.tscn", "--json")
 
@@ -1050,7 +1035,7 @@ def test_the_depth_verdict_does_not_depend_on_declaration_order(
     # nothing stood behind), while direct-first validated the leaf first and let
     # `visited` swallow the deep edge in silence (`valid: true`).
     _write_cross_boundary_diamond(godot_project, deep_first=deep_first)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://root.tscn", "--json")
 
@@ -1073,7 +1058,7 @@ def test_a_target_no_route_reaches_in_bound_is_still_reported(godot_project):
         '[node name="Deep" parent="." instance=ExtResource("1_deep")]\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://root.tscn", "--json")
 
@@ -1130,7 +1115,7 @@ def test_a_packed_scene_saved_as_a_res_is_reported_not_skipped(godot_project):
     (godot_project / "parent.tscn").write_text(
         RES_SUB_SCENE_PARENT_TSCN, encoding="utf-8"
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     saved = gda("script", "run", "res://save_res.gd", "--json")
     assert saved.returncode == 0, saved.stdout + saved.stderr
     assert (godot_project / "hero_pack.res").exists(), saved.stdout + saved.stderr
@@ -1168,7 +1153,7 @@ def test_a_res_declared_as_something_else_is_still_not_a_scene_edge(godot_projec
         'metadata/thing = ExtResource("1_p")\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://parent.tscn", "--json")
 
@@ -1242,7 +1227,7 @@ def test_a_sound_graph_converging_above_the_bound_is_valid_in_both_orders(
     # `t.tscn`, one edge below it, was reached on the direct-first file and left
     # past the bound on the deep-first one. Same graph, two verdicts.
     _write_ancestor_convergence(godot_project, deep_first=deep_first, break_leaf=False)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://root.tscn", "--json")
 
@@ -1263,7 +1248,7 @@ def test_a_break_below_the_convergence_is_found_in_both_orders(
     # find the break, not merely stop reporting the bound. One problem, the same
     # one, whichever line the root declares first.
     _write_ancestor_convergence(godot_project, deep_first=deep_first, break_leaf=True)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://root.tscn", "--json")
 
@@ -1295,7 +1280,7 @@ def test_a_subtree_only_the_deep_route_reaches_is_still_reported(godot_project):
         '[node name="Deep" parent="." instance=ExtResource("1_deep")]\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://root.tscn", "--json")
 
@@ -1324,7 +1309,7 @@ def test_an_aliased_root_is_the_same_file_as_the_reference_back_to_it(godot_proj
         '[node name="Inner" parent="." instance=ExtResource("2_self")]\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     canonical = gda("scene", "validate", "res://root.tscn", "--json")
     aliased = gda("scene", "validate", "res://./root.tscn", "--json")
@@ -1356,7 +1341,7 @@ def test_an_edge_problem_lists_every_id_that_names_the_target(godot_project):
         '[node name="InnerB" parent="." instance=ExtResource("2_b")]\n',
         encoding="utf-8",
     )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://self.tscn", "--json")
 
@@ -1393,7 +1378,7 @@ def test_a_cycle_below_a_re_expanded_scene_is_reported_once(godot_project):
             '[node name="Child" parent="." instance=ExtResource("1_c")]\n',
             encoding="utf-8",
         )
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://root.tscn", "--json")
 
@@ -1471,7 +1456,7 @@ def test_a_deferred_depth_edge_does_not_suppress_a_later_cycle(
     # reported the cycle (measured on Godot 4.6.3 before the fix). One graph, one
     # verdict — the cycle, attributed to the file that declares the closing edge.
     _write_deferred_cycle(godot_project, deep_first=deep_first)
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://root.tscn", "--json")
 
@@ -1510,7 +1495,7 @@ script = ExtResource("1_gone")
 @pytest.mark.e2e
 def test_a_problem_names_the_node_a_whole_name_header_read_finds(godot_project):
     (godot_project / "main.tscn").write_text(DECOY_ATTR_TSCN, encoding="utf-8")
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     validated = gda("scene", "validate", "res://main.tscn", "--json")
 

--- a/tests/test_e2e_screen.py
+++ b/tests/test_e2e_screen.py
@@ -44,7 +44,12 @@ MAIN_TSCN = (
     "color = Color(0.2, 0.6, 0.9, 1)\n"
 )
 
-pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
+pytestmark = [
+    pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"),
+    # The windowed captures share the host display: one worker under xdist's
+    # `--dist loadgroup`, so two windowed sessions never compete for it (#818).
+    pytest.mark.xdist_group("windowed"),
+]
 
 # A WINDOWED engine session needs a usable host DisplayServer. This is NOT a
 # "macOS always has one" assumption: headless macOS (SSH / CI / sandbox) has no

--- a/tests/test_e2e_screen.py
+++ b/tests/test_e2e_screen.py
@@ -21,16 +21,12 @@ within the `sun_path` limit.
 
 import json
 import os
-import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD, assert_windowed_ok
+from tests.support import Gda, assert_windowed_ok
 
-from .conftest import project_godot
-
-GODOT = resolve_godot_binary()
+from .conftest import LIVE_PROJECT_GODOT, project_godot
 
 # The PNG magic the written capture must start with — the proof it is a real,
 # decodable image (not an empty/placeholder buffer).
@@ -47,7 +43,6 @@ MAIN_TSCN = (
     "offset_bottom = 150.0\n"
     "color = Color(0.2, 0.6, 0.9, 1)\n"
 )
-PROJECT_GODOT = project_godot(extra='run/main_scene="res://main.tscn"')
 
 pytestmark = pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX")
 
@@ -69,23 +64,8 @@ _needs_display = pytest.mark.usefixtures("windowed_host")
 
 
 def _scaffold(tmp_path):
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(MAIN_TSCN, encoding="utf-8")
-
-
-def _runner(gda, tmp_path):
-    env = {**os.environ}
-
-    def run(*args):
-        return subprocess.run(
-            [*gda, *args, "--project", str(tmp_path), "--godot", str(GODOT), "--json"],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=120,
-        )
-
-    return run
 
 
 @pytest.mark.e2e
@@ -94,7 +74,7 @@ def test_windowed_daemon_captures_a_single_viewport_frame(tmp_path, daemon_runti
     # `daemon start --windowed` -> a WINDOWED engine session -> `screen capture`
     # writes a real PNG of the running viewport (magic + dims > 0).
     _scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out = tmp_path / "shot.png"
 
     try:
@@ -147,7 +127,7 @@ def test_windowed_daemon_captures_a_single_viewport_frame(tmp_path, daemon_runti
 def test_windowed_daemon_inline_embeds_the_base64(tmp_path, daemon_runtime_dir):
     # `screen capture --inline` additionally embeds the base64 PNG in the reply.
     _scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out = tmp_path / "shot.png"
 
     try:
@@ -182,12 +162,12 @@ def test_capture_receipt_reports_the_scene_uid_the_project_provides(
     # whose FILE HEADER carries a uid (as every editor-authored scene does)
     # reports it — read from the header itself, no `.godot/` cache needed. The
     # uid-less arm is the single-frame test above.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.tscn").write_text(
         f'{header}\n\n[node name="Main" type="Node2D"]\n',
         encoding="utf-8",
     )
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out = tmp_path / "shot.png"
 
     try:
@@ -208,7 +188,7 @@ def test_capture_receipt_names_the_launched_scene_after_a_scene_switch(
     # #660's authoritative semantics (#746 review Spec 1): the receipt's scene
     # fields are the LAUNCHED scene — a session launch fact — so a game that
     # switches scenes mid-session still receipts under the scene it launched.
-    (tmp_path / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
     (tmp_path / "main.gd").write_text(
         "extends Node2D\n"
         "var _frames := 0\n"
@@ -229,7 +209,7 @@ def test_capture_receipt_names_the_launched_scene_after_a_scene_switch(
         '[gd_scene format=3]\n\n[node name="Other" type="Node2D"]\n',
         encoding="utf-8",
     )
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out = tmp_path / "shot.png"
 
     try:
@@ -255,7 +235,7 @@ def test_windowed_daemon_captures_a_frame_window(tmp_path, daemon_runtime_dir):
     # 3 viewport frames over the engine session and returns them in one blocking
     # call; the CLI writes one PNG per frame (path-only).
     _scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out_dir = tmp_path / "frames"
 
     try:
@@ -302,7 +282,7 @@ def test_ninety_frame_capture_completes_with_a_structured_envelope(
     # they establish correlation, not the specific cap. The --summary envelope
     # below stays well under any such limit either way.
     _scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out_dir = tmp_path / "frames"
 
     try:
@@ -353,7 +333,7 @@ def test_headless_session_reports_live_display_unavailable(
     # capture` there is refused with the typed live_display_unavailable (the
     # self-revealing remediation: start --windowed). No file is written.
     _scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out = tmp_path / "shot.png"
 
     try:
@@ -376,7 +356,7 @@ def test_screen_capture_with_no_daemon_reports_daemon_not_running(
     # No daemon started: `screen capture` is the attach-or-fail daemon_not_running
     # (ADR-0017), the same typed error every live op reports with no daemon.
     _scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
 
     cap = run("screen", "capture", "--output", str(tmp_path / "shot.png"))
 
@@ -549,7 +529,7 @@ def test_await_predicate_captures_the_matched_frames_pixels_repeatedly(
     # decoded PNG must show the MATCHED frame's presentation — not the frame
     # before it — on REPEATED captures in one session.
     _predicate_scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
 
     try:
         assert_windowed_ok(run("daemon", "start", "--windowed"))
@@ -579,7 +559,7 @@ def test_await_predicate_that_never_holds_is_the_typed_error(
     # after the declared frame bound — in ~a third of a second, not a timeout —
     # and writes no file.
     _predicate_scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out = tmp_path / "never.png"
 
     try:
@@ -605,7 +585,7 @@ def test_await_events_capture_an_input_triggered_transient(
     # press triggers cannot be missed by a second CLI round trip; the declared
     # release fires before the reply, so no key is left held.
     _predicate_scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out = tmp_path / "flash.png"
 
     try:
@@ -638,7 +618,7 @@ def test_early_match_still_fires_every_scheduled_release(tmp_path, daemon_runtim
     # mouse-button phase, and an action are each verified released afterwards,
     # so no input state leaks into later live operations.
     _predicate_scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
 
     cases = [
         (
@@ -686,7 +666,7 @@ def test_unmet_predicate_error_path_still_fires_every_event(
     # schema/model parity, #743 second re-review) and still fires during the
     # drain, so the reply arrives only after it.
     _predicate_scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out = tmp_path / "never.png"
 
     try:
@@ -717,7 +697,7 @@ def test_predicate_resolution_never_reads_the_property(tmp_path, daemon_runtime_
     # so a scripted getter runs EXACTLY once per sampled frame — frames_waited+1
     # times in total, no pre-read, no re-read at capture.
     _predicate_scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out = tmp_path / "probe.png"
 
     try:
@@ -741,7 +721,7 @@ def test_input_written_state_is_captured_with_its_own_presentation(
     # writes is observed one boundary LATER, together with its own
     # presentation — so the decoded pixels show the matched visual.
     _predicate_scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
 
     try:
         assert_windowed_ok(run("daemon", "start", "--windowed"))
@@ -775,7 +755,7 @@ def test_late_event_failure_is_the_reply_and_writes_no_file(
     # scheduled event FAILS — the reply is that typed failure, no file is
     # written, and the later declared release still drains (no held action).
     _predicate_scaffold(tmp_path)
-    run = _runner(GDA_CMD, tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=120)
     out = tmp_path / "late.png"
 
     try:

--- a/tests/test_e2e_script.py
+++ b/tests/test_e2e_script.py
@@ -14,51 +14,12 @@ import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
 from gda.runner import OPERATIONS_GD
-
-from tests.support import GDA_CMD
+from tests.support import GODOT, Gda, assert_operation_error
 
 from .conftest import project_godot
 
-GODOT = resolve_godot_binary()
-
-
-def _gda(*args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT)], capture_output=True, text=True
-    )
-
-
-def _gda_project(project):
-    """A ``_gda`` bound to ``--project`` for res:// enumeration/resolution."""
-
-    def gda(*args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT), "--project", str(project)],
-            capture_output=True,
-            text=True,
-        )
-
-    return gda
-
-
-def _gda_env(extra_env: dict, *args: str) -> subprocess.CompletedProcess:
-    """``_gda`` with extra env vars in the child's environment (issue #226 seam)."""
-    return subprocess.run(
-        [*GDA_CMD, *args, "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-        env={**os.environ, **extra_env},
-    )
-
-
-def _assert_operation_error(proc: subprocess.CompletedProcess, code: str) -> dict:
-    assert proc.returncode == 4, proc.stdout + proc.stderr
-    err = json.loads(proc.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == code
-    return err
+gda = Gda()
 
 
 @pytest.mark.e2e
@@ -67,7 +28,7 @@ def test_script_create_default_template_then_get_round_trip(godot_project):
     # source on disk IS what get reports — the round-trip proves the write.
     script_path = godot_project / "actor.gd"
 
-    created = _gda("script", "create", str(script_path), "--json")
+    created = gda("script", "create", str(script_path), "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     data = json.loads(created.stdout)
@@ -76,7 +37,7 @@ def test_script_create_default_template_then_get_round_trip(godot_project):
     assert data["class_name"] is None
     assert script_path.exists()
 
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     got_data = json.loads(got.stdout)
@@ -93,14 +54,12 @@ def test_script_create_with_extends_parameterizes_the_template(godot_project):
     # --root-type), and get reports it back from the parsed source.
     script_path = godot_project / "sprite.gd"
 
-    created = _gda(
-        "script", "create", str(script_path), "--extends", "Node2D", "--json"
-    )
+    created = gda("script", "create", str(script_path), "--extends", "Node2D", "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     assert json.loads(created.stdout)["extends"] == "Node2D"
 
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["extends"] == "Node2D"
 
@@ -115,14 +74,14 @@ def test_script_create_with_content_round_trips_verbatim_source_and_metadata(
     script_path = godot_project / "hero.gd"
     source = "class_name Hero\nextends Node2D\n\nvar speed := 100\n"
 
-    created = _gda("script", "create", str(script_path), "--content", source, "--json")
+    created = gda("script", "create", str(script_path), "--content", source, "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     create_data = json.loads(created.stdout)
     assert create_data["class_name"] == "Hero"
     assert create_data["extends"] == "Node2D"
 
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     got_data = json.loads(got.stdout)
@@ -136,8 +95,7 @@ def test_script_create_resolves_res_path_against_the_project(godot_project):
     # Script-file addressing via res:// resolves against --project, exactly like
     # scene create (issue #32): the script lands inside the project and reads
     # back through res://.
-    def gda(*args: str) -> subprocess.CompletedProcess:
-        return _gda(*args, "--project", str(godot_project))
+    gda = Gda(godot_project)
 
     created = gda("script", "create", "res://hero.gd", "--extends", "Node2D", "--json")
 
@@ -155,7 +113,7 @@ def test_script_create_creates_missing_parent_directories(godot_project):
     # in created_dirs from outermost to innermost.
     script_path = godot_project / "actors" / "enemies" / "goblin.gd"
 
-    created = _gda("script", "create", str(script_path), "--json")
+    created = gda("script", "create", str(script_path), "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     assert script_path.exists()
@@ -172,14 +130,18 @@ def test_script_create_existing_path_yields_already_exists_without_overwriting(
     # No-clobber: a second create on the same path is refused with already_exists
     # and the original content is left untouched.
     script_path = godot_project / "hero.gd"
-    _gda("script", "create", str(script_path), "--extends", "Node2D", "--json")
+    gda("script", "create", str(script_path), "--extends", "Node2D", "--json")
     before = script_path.read_text(encoding="utf-8")
 
-    again = _gda(
-        "script", "create", str(script_path), "--extends", "Sprite2D", "--json"
+    err = gda.error(
+        "script",
+        "create",
+        str(script_path),
+        "--extends",
+        "Sprite2D",
+        "--json",
+        code="already_exists",
     )
-
-    err = _assert_operation_error(again, "already_exists")
     assert str(script_path) in err["message"]
     assert script_path.read_text(encoding="utf-8") == before
 
@@ -190,9 +152,7 @@ def test_script_create_wrong_extension_yields_invalid_path(godot_project):
     # written.
     target = godot_project / "notes.txt"
 
-    created = _gda("script", "create", str(target), "--json")
-
-    err = _assert_operation_error(created, "invalid_path")
+    err = gda.error("script", "create", str(target), "--json", code="invalid_path")
     assert ".gd" in err["message"]
     assert str(target) in err["message"]
     assert not target.exists()
@@ -206,9 +166,7 @@ def test_script_create_cs_extension_is_refused(godot_project):
     # opaque text.
     target = godot_project / "Player.cs"
 
-    created = _gda("script", "create", str(target), "--json")
-
-    err = _assert_operation_error(created, "invalid_path")
+    err = gda.error("script", "create", str(target), "--json", code="invalid_path")
     assert ".gd" in err["message"]
     assert str(target) in err["message"]
     assert not target.exists()
@@ -218,9 +176,7 @@ def test_script_create_cs_extension_is_refused(godot_project):
 def test_script_get_missing_file_yields_path_not_found(godot_project):
     missing = godot_project / "nope.gd"
 
-    got = _gda("script", "get", str(missing), "--json")
-
-    err = _assert_operation_error(got, "path_not_found")
+    err = gda.error("script", "get", str(missing), "--json", code="path_not_found")
     assert str(missing) in err["message"]
 
 
@@ -237,11 +193,11 @@ def test_script_get_unreadable_file_is_path_not_found_not_empty_source(godot_pro
     locked.write_text("extends Node\n", encoding="utf-8")
     locked.chmod(0o000)
     try:
-        got = _gda("script", "get", str(locked), "--json")
+        got = gda("script", "get", str(locked), "--json")
     finally:
         locked.chmod(0o600)
 
-    err = _assert_operation_error(got, "path_not_found")
+    err = assert_operation_error(got, "path_not_found")
     assert str(locked) in err["message"]
     assert "could not be read" in err["message"]
 
@@ -251,9 +207,7 @@ def test_script_get_wrong_extension_yields_invalid_path(godot_project):
     notes = godot_project / "notes.txt"
     notes.write_text("not a script\n", encoding="utf-8")
 
-    got = _gda("script", "get", str(notes), "--json")
-
-    err = _assert_operation_error(got, "invalid_path")
+    err = gda.error("script", "get", str(notes), "--json", code="invalid_path")
     assert ".gd" in err["message"]
     assert str(notes) in err["message"]
 
@@ -267,12 +221,12 @@ def test_script_create_then_get_preserves_a_path_containing_the_end_sentinel(
     # sentinel must round-trip, not truncate into a parse error.
     script_path = godot_project / "weird<<<GDA:END>>>name.gd"
 
-    created = _gda("script", "create", str(script_path), "--json")
+    created = gda("script", "create", str(script_path), "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     assert json.loads(created.stdout)["path"] == str(script_path)
 
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["source"] == "extends Node\n"
 
@@ -294,14 +248,14 @@ def test_script_get_parses_metadata_past_a_leading_annotation_header(godot_proje
         "\tpass\n"
     )
 
-    created = _gda("script", "create", str(script_path), "--content", source, "--json")
+    created = gda("script", "create", str(script_path), "--content", source, "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     create_data = json.loads(created.stdout)
     assert create_data["class_name"] == "Widget"
     assert create_data["extends"] == "Control"
 
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     got_data = json.loads(got.stdout)
     assert got_data["class_name"] == "Widget"
@@ -321,14 +275,14 @@ def test_script_get_does_not_mistake_declaration_shaped_body_text_for_metadata(
         'extends Node\n\nvar doc := """\nclass_name Injected\nextends Injected\n"""\n'
     )
 
-    created = _gda("script", "create", str(script_path), "--content", source, "--json")
+    created = gda("script", "create", str(script_path), "--content", source, "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     create_data = json.loads(created.stdout)
     assert create_data["extends"] == "Node"
     assert create_data["class_name"] is None
 
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     got_data = json.loads(got.stdout)
     assert got_data["source"] == source
@@ -345,12 +299,12 @@ def test_script_get_keeps_a_quoted_base_class_path_intact(godot_project):
     script_path = godot_project / "derived.gd"
     source = 'extends "res://weapons/a#b.gd"\n'
 
-    created = _gda("script", "create", str(script_path), "--content", source, "--json")
+    created = gda("script", "create", str(script_path), "--content", source, "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     assert json.loads(created.stdout)["extends"] == '"res://weapons/a#b.gd"'
 
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["extends"] == '"res://weapons/a#b.gd"'
 
@@ -361,7 +315,7 @@ def test_script_list_enumerates_created_scripts(godot_project):
     # res://: two scripts created at different depths both appear, each with its
     # res:// path and the class_name/extends parsed from raw source. The listing
     # IS the structured-level verification of what script create wrote.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     assert (
         gda(
@@ -396,7 +350,7 @@ def test_script_list_enumerates_created_scripts(godot_project):
 def test_script_list_on_empty_project_is_an_empty_listing(godot_project):
     # A project with no scripts is a valid, empty listing — not an error (the
     # res://.godot import cache must not leak in as a phantom script).
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
     listed = gda("script", "list", "--json")
 
@@ -409,14 +363,8 @@ def test_script_list_without_project_yields_project_not_found(tmp_path):
     # script list cannot enumerate res:// projectless: run from a non-project
     # directory with no --project, it must refuse with the structured
     # project_not_found code rather than return a misleading empty listing.
-    listed = subprocess.run(
-        [*GDA_CMD, "script", "list", "--json", "--godot", str(GODOT)],
-        capture_output=True,
-        text=True,
-        cwd=str(tmp_path),
-    )
+    err = gda.error("script", "list", "--json", cwd=tmp_path, code="project_not_found")
 
-    err = _assert_operation_error(listed, "project_not_found")
     assert "--project" in err["message"]
 
 
@@ -426,7 +374,7 @@ def test_script_delete_removes_a_script_and_names_what_was_removed(godot_project
     # script's metadata. The round-trip verifier: script list before shows the
     # script, delete reports the removed class_name/extends, and script list
     # after no longer shows it.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "script",
@@ -459,9 +407,7 @@ def test_script_delete_removes_a_script_and_names_what_was_removed(godot_project
 def test_script_delete_missing_file_yields_path_not_found(godot_project):
     missing = godot_project / "nope.gd"
 
-    deleted = _gda("script", "delete", str(missing), "--json")
-
-    err = _assert_operation_error(deleted, "path_not_found")
+    err = gda.error("script", "delete", str(missing), "--json", code="path_not_found")
     assert str(missing) in err["message"]
 
 
@@ -473,9 +419,7 @@ def test_script_delete_wrong_extension_yields_invalid_path_and_leaves_it(godot_p
     notes = godot_project / "notes.txt"
     notes.write_text("not a script\n", encoding="utf-8")
 
-    deleted = _gda("script", "delete", str(notes), "--json")
-
-    err = _assert_operation_error(deleted, "invalid_path")
+    err = gda.error("script", "delete", str(notes), "--json", code="invalid_path")
     assert ".gd" in err["message"]
     assert str(notes) in err["message"]
     # The non-script file survives the refusal.
@@ -489,7 +433,7 @@ def test_script_set_search_replace_edits_in_place_and_round_trips_via_get(
     # search-replace mode (issue #118): every literal occurrence of --search is
     # replaced with --replace; script get round-trips the edited source on disk.
     script_path = godot_project / "hero.gd"
-    _gda(
+    gda(
         "script",
         "create",
         str(script_path),
@@ -498,7 +442,7 @@ def test_script_set_search_replace_edits_in_place_and_round_trips_via_get(
         "--json",
     )
 
-    edited = _gda(
+    edited = gda(
         "script",
         "set",
         str(script_path),
@@ -511,7 +455,7 @@ def test_script_set_search_replace_edits_in_place_and_round_trips_via_get(
 
     assert edited.returncode == 0, edited.stdout + edited.stderr
     assert json.loads(edited.stdout)["extends"] == "Node2D"
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     # Both occurrences replaced; the edited source IS what get reports.
     assert json.loads(got.stdout)["source"] == "extends Node2D\nvar a := Node2D\n"
@@ -529,7 +473,7 @@ def test_script_set_with_external_edit_in_window_yields_file_changed_externally(
     # blind write would clobber the external edit. The production-inert seam
     # (GDA_TEST_PERTURB_BEFORE_SAVE) simulates that edit, and the guard refuses.
     script_path = godot_project / "hero.gd"
-    _gda(
+    gda(
         "script",
         "create",
         str(script_path),
@@ -538,8 +482,7 @@ def test_script_set_with_external_edit_in_window_yields_file_changed_externally(
         "--json",
     )
 
-    edited = _gda_env(
-        {"GDA_TEST_PERTURB_BEFORE_SAVE": "1"},
+    err = gda.error(
         "script",
         "set",
         str(script_path),
@@ -548,9 +491,9 @@ def test_script_set_with_external_edit_in_window_yields_file_changed_externally(
         "--replace",
         "2",
         "--json",
+        extra_env={"GDA_TEST_PERTURB_BEFORE_SAVE": "1"},
+        code="file_changed_externally",
     )
-
-    err = _assert_operation_error(edited, "file_changed_externally")
     assert str(script_path) in err["message"]
 
     # The edit did NOT land: the original "var a := 1" is still present (the seam only
@@ -564,7 +507,7 @@ def test_script_set_line_range_replaces_the_span_and_round_trips_via_get(godot_p
     # line-range mode: replace lines 2..3 (1-based, inclusive) with new content;
     # the rest of the file is untouched. Lines are the parts split on "\n".
     script_path = godot_project / "actor.gd"
-    _gda(
+    gda(
         "script",
         "create",
         str(script_path),
@@ -573,7 +516,7 @@ def test_script_set_line_range_replaces_the_span_and_round_trips_via_get(godot_p
         "--json",
     )
 
-    edited = _gda(
+    edited = gda(
         "script",
         "set",
         str(script_path),
@@ -587,7 +530,7 @@ def test_script_set_line_range_replaces_the_span_and_round_trips_via_get(godot_p
     )
 
     assert edited.returncode == 0, edited.stdout + edited.stderr
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
     assert got.returncode == 0, got.stdout + got.stderr
     assert json.loads(got.stdout)["source"] == (
         "extends Node\nvar x := 9\nfunc f(): pass\n"
@@ -598,7 +541,7 @@ def test_script_set_line_range_replaces_the_span_and_round_trips_via_get(godot_p
 def test_script_set_line_range_defaults_end_to_start_for_a_single_line(godot_project):
     # --end-line defaults to --start-line: a single-line replace.
     script_path = godot_project / "single.gd"
-    _gda(
+    gda(
         "script",
         "create",
         str(script_path),
@@ -607,7 +550,7 @@ def test_script_set_line_range_defaults_end_to_start_for_a_single_line(godot_pro
         "--json",
     )
 
-    edited = _gda(
+    edited = gda(
         "script",
         "set",
         str(script_path),
@@ -619,7 +562,7 @@ def test_script_set_line_range_defaults_end_to_start_for_a_single_line(godot_pro
     )
 
     assert edited.returncode == 0, edited.stdout + edited.stderr
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
     assert json.loads(got.stdout)["source"] == "extends Node\nvar a := 99\nvar b := 2\n"
 
 
@@ -631,7 +574,7 @@ def test_script_set_line_range_preserves_crlf_line_endings(godot_project):
     script_path = godot_project / "crlf.gd"
     script_path.write_bytes(b"extends Node\r\nvar a := 1\r\nvar b := 2\r\n")
 
-    edited = _gda(
+    edited = gda(
         "script",
         "set",
         str(script_path),
@@ -653,16 +596,16 @@ def test_script_set_full_overwrites_the_whole_file_and_round_trips_via_get(
 ):
     # full mode: --content with no --start-line overwrites the entire file.
     script_path = godot_project / "full.gd"
-    _gda("script", "create", str(script_path), "--content", "extends Node\n", "--json")
+    gda("script", "create", str(script_path), "--content", "extends Node\n", "--json")
 
     new_source = "class_name Hero\nextends Node2D\n\nvar speed := 100\n"
-    edited = _gda("script", "set", str(script_path), "--content", new_source, "--json")
+    edited = gda("script", "set", str(script_path), "--content", new_source, "--json")
 
     assert edited.returncode == 0, edited.stdout + edited.stderr
     data = json.loads(edited.stdout)
     assert data["class_name"] == "Hero"
     assert data["extends"] == "Node2D"
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
     assert json.loads(got.stdout)["source"] == new_source
 
 
@@ -671,10 +614,10 @@ def test_script_set_no_search_match_is_refused_and_leaves_file_untouched(godot_p
     # A search string the source does not contain is refused with no_search_match
     # and the file is left exactly as it was — the edit landed nowhere.
     script_path = godot_project / "hero.gd"
-    _gda("script", "create", str(script_path), "--content", "extends Node\n", "--json")
+    gda("script", "create", str(script_path), "--content", "extends Node\n", "--json")
     before = script_path.read_text(encoding="utf-8")
 
-    edited = _gda(
+    gda.error(
         "script",
         "set",
         str(script_path),
@@ -683,9 +626,8 @@ def test_script_set_no_search_match_is_refused_and_leaves_file_untouched(godot_p
         "--replace",
         "Node2D",
         "--json",
+        code="no_search_match",
     )
-
-    _assert_operation_error(edited, "no_search_match")
     assert script_path.read_text(encoding="utf-8") == before
 
 
@@ -696,7 +638,7 @@ def test_script_set_out_of_bounds_line_range_is_refused_and_leaves_file_untouche
     # A line range past the file's bounds is refused with invalid_line_range and
     # the file is left untouched.
     script_path = godot_project / "hero.gd"
-    _gda(
+    gda(
         "script",
         "create",
         str(script_path),
@@ -706,7 +648,7 @@ def test_script_set_out_of_bounds_line_range_is_refused_and_leaves_file_untouche
     )
     before = script_path.read_text(encoding="utf-8")
 
-    edited = _gda(
+    gda.error(
         "script",
         "set",
         str(script_path),
@@ -715,9 +657,8 @@ def test_script_set_out_of_bounds_line_range_is_refused_and_leaves_file_untouche
         "--content",
         "var x := 0",
         "--json",
+        code="invalid_line_range",
     )
-
-    _assert_operation_error(edited, "invalid_line_range")
     assert script_path.read_text(encoding="utf-8") == before
 
 
@@ -727,11 +668,15 @@ def test_script_set_missing_file_yields_path_not_found(godot_project):
     # silent create.
     missing = godot_project / "nope.gd"
 
-    edited = _gda(
-        "script", "set", str(missing), "--content", "extends Node\n", "--json"
+    err = gda.error(
+        "script",
+        "set",
+        str(missing),
+        "--content",
+        "extends Node\n",
+        "--json",
+        code="path_not_found",
     )
-
-    err = _assert_operation_error(edited, "path_not_found")
     assert str(missing) in err["message"]
     assert not missing.exists()
 
@@ -749,7 +694,7 @@ def test_script_validate_valid_script_reports_valid_true_no_diagnostics(godot_pr
     # lives in one, so validating it without naming it is now refused. The genuinely
     # projectless arm — a loose `.gd` no project.godot claims — is
     # `tests/test_e2e_res_containment.py`.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     script_path = godot_project / "ok.gd"
     gda(
         "script",
@@ -778,7 +723,7 @@ def test_script_validate_accepts_both_path_forms(godot_project, form):
     # (see tests/test_e2e_script_run.py). Pinned here so the shared representation is
     # a guarded contract on BOTH commands rather than an accident of this build —
     # the property that lets an agent address a script once and use it for either.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     (godot_project / "ok.gd").write_text("extends Node\n", encoding="utf-8")
 
     validated = gda("script", "validate", form, "--json")
@@ -795,7 +740,7 @@ def test_script_validate_broken_script_is_success_with_a_real_diagnostic(godot_p
     # op (exit 0) reporting valid=false, and at least one diagnostic with a real
     # `line` and non-empty `message` — proving the stderr-parsing regex against
     # the REAL engine output, not a fixture.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     script_path = godot_project / "broken.gd"
     # `var x =` with no initializer is a parse error the engine reports on its line.
     gda(
@@ -833,7 +778,7 @@ def test_script_validate_relative_preload_resolves_at_the_real_res_path(godot_pr
     # so the dependent script is valid=true under --project — not a false negative
     # from compiling an anonymous in-memory GDScript that has no res:// location to
     # resolve the relative reference against.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "script",
@@ -876,7 +821,7 @@ def test_script_validate_broken_script_under_project_still_reports_diagnostics(
     # reporting valid=false, and the stderr-parsed line/message diagnostic still
     # works under --project (the reload frame now names the real res:// path, which
     # the diagnostics parser pairs exactly as before).
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     # `var x =` with no initializer is a parse error the engine reports on its line.
     assert (
         gda(
@@ -912,11 +857,9 @@ def test_script_validate_missing_file_yields_path_not_found(godot_project):
     # project context first, which is a different (and equally true) verdict.
     missing = godot_project / "nope.gd"
 
-    validated = _gda_project(godot_project)(
-        "script", "validate", str(missing), "--json"
+    err = Gda(godot_project).error(
+        "script", "validate", str(missing), "--json", code="path_not_found"
     )
-
-    err = _assert_operation_error(validated, "path_not_found")
     assert str(missing) in err["message"]
 
 
@@ -925,9 +868,9 @@ def test_script_validate_wrong_extension_yields_invalid_path(godot_project):
     notes = godot_project / "notes.txt"
     notes.write_text("not a script\n", encoding="utf-8")
 
-    validated = _gda_project(godot_project)("script", "validate", str(notes), "--json")
-
-    err = _assert_operation_error(validated, "invalid_path")
+    err = Gda(godot_project).error(
+        "script", "validate", str(notes), "--json", code="invalid_path"
+    )
     assert ".gd" in err["message"]
 
 
@@ -965,7 +908,7 @@ def test_script_validate_batch_uses_one_engine_launch_for_every_script(tmp_path)
     # dispatch is one process. Three occurrences would be the pre-#663 behaviour
     # (one launch per script) passing every other assertion here.
     project = _batch_project(tmp_path)
-    gda = _gda_project(project)
+    gda = Gda(project)
 
     validated = gda(
         "script", "validate", "res://a.gd", "res://bad.gd", "res://c.gd", "--json"
@@ -999,7 +942,7 @@ def test_script_validate_all_validates_every_script_in_the_project(tmp_path):
     # the same shape, so an agent can screen a whole project in one launch without
     # first listing its scripts.
     project = _batch_project(tmp_path)
-    gda = _gda_project(project)
+    gda = Gda(project)
 
     validated = gda("script", "validate", "--all", "--json")
 
@@ -1026,7 +969,7 @@ def test_script_validate_batch_reports_a_repeated_path_once_per_occurrence(tmp_p
     # — is exactly what a fake runner cannot vouch for. It must, because gda
     # promises entry i corresponds to argument i and so never deduplicates.
     project = _batch_project(tmp_path)
-    gda = _gda_project(project)
+    gda = Gda(project)
 
     validated = gda(
         "script", "validate", "res://bad.gd", "res://a.gd", "res://bad.gd", "--json"
@@ -1073,7 +1016,7 @@ def test_script_validate_all_enumerates_a_nested_dot_godot_directory(tmp_path):
     (project / ".godot" / "engine_cache.gd").write_text(
         "extends Node\n\nvar y =\n", encoding="utf-8"
     )
-    gda = _gda_project(project)
+    gda = Gda(project)
 
     validated = gda("script", "validate", "--all", "--json")
 
@@ -1108,7 +1051,7 @@ def test_script_validate_all_on_a_project_with_no_scripts_is_vacuously_valid(tmp
         project_godot("gda-e2e-bare"), encoding="utf-8"
     )
 
-    validated = _gda_project(project)("script", "validate", "--all", "--json")
+    validated = Gda(project)("script", "validate", "--all", "--json")
 
     assert validated.returncode == 0, validated.stdout + validated.stderr
     data = json.loads(validated.stdout)
@@ -1126,7 +1069,7 @@ def test_script_validate_refuses_a_batch_that_spans_two_projects(tmp_path):
     project = _batch_project(tmp_path)
     _, other_project, outsider = _nested_project_script(tmp_path / "elsewhere")
 
-    validated = _gda(
+    validated = gda(
         "script",
         "validate",
         str(project / "a.gd"),
@@ -1136,7 +1079,7 @@ def test_script_validate_refuses_a_batch_that_spans_two_projects(tmp_path):
         "--json",
     )
 
-    err = _assert_operation_error(validated, "target_outside_project")
+    err = assert_operation_error(validated, "target_outside_project")
     assert str(outsider) in err["message"]
     assert str(project) in err["message"]
     assert other_project.exists()
@@ -1192,28 +1135,15 @@ def test_script_validate_from_an_ancestor_is_refused_and_names_the_owner(tmp_pat
     # as before.
     workspace, project, script = _nested_project_script(tmp_path)
 
-    from_ancestor = subprocess.run(
-        [
-            *GDA_CMD,
-            "script",
-            "validate",
-            "game/deck.gd",
-            "--godot",
-            str(GODOT),
-            "--json",
-        ],
-        capture_output=True,
-        text=True,
-        cwd=workspace,
-    )
+    from_ancestor = gda("script", "validate", "game/deck.gd", "--json", cwd=workspace)
 
-    _assert_operation_error(from_ancestor, "target_outside_project")
+    assert_operation_error(from_ancestor, "target_outside_project")
     evidence = json.loads(from_ancestor.stdout)["error"]["evidence"]
     assert evidence["owning_project"] == str(project.resolve())
     # No engine ran, so the false cascade does not exist to be misread.
     assert '"valid"' not in from_ancestor.stdout
 
-    with_owning_project = _gda(
+    with_owning_project = gda(
         "script", "validate", str(script), "--project", str(project), "--json"
     )
 
@@ -1240,11 +1170,11 @@ def test_script_validate_refuses_a_script_outside_the_resolved_project(tmp_path)
         project_godot("gda-e2e-other"), encoding="utf-8"
     )
 
-    validated = _gda(
+    validated = gda(
         "script", "validate", str(script), "--project", str(other), "--json"
     )
 
-    err = _assert_operation_error(validated, "target_outside_project")
+    err = assert_operation_error(validated, "target_outside_project")
     assert str(script) in err["message"]
     assert str(other) in err["message"]
     # Refused BEFORE parsing: no engine ran, so no diagnostic about the file.
@@ -1288,7 +1218,7 @@ def test_script_validate_accepts_a_file_symlinked_into_the_project(tmp_path):
     (project / "addons" / "cardlib").symlink_to(library, target_is_directory=True)
     through_the_link = project / "addons" / "cardlib" / "deck.gd"
 
-    validated = _gda(
+    validated = gda(
         "script", "validate", str(through_the_link), "--project", str(project), "--json"
     )
 
@@ -1299,16 +1229,15 @@ def test_script_validate_accepts_a_file_symlinked_into_the_project(tmp_path):
     assert data["project_root"] == str(project)
 
     # Same file, outside spelling: outside under both readings, so still refused.
-    from_outside = _gda(
+    gda.error(
         "script",
         "validate",
         str(library / "deck.gd"),
         "--project",
         str(project),
         "--json",
+        code="target_outside_project",
     )
-
-    _assert_operation_error(from_outside, "target_outside_project")
 
 
 @pytest.mark.e2e
@@ -1331,13 +1260,7 @@ def test_script_validate_relative_target_from_an_ancestor_cwd_agrees_with_the_en
         "extends Node\n\nfunc top() -> int:\n\treturn 3\n", encoding="utf-8"
     )
 
-    def from_workspace(*args: str) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [*GDA_CMD, *args, "--godot", str(GODOT)],
-            capture_output=True,
-            text=True,
-            cwd=tmp_path,
-        )
+    from_workspace = Gda(cwd=tmp_path)
 
     argv = from_workspace(
         "script", "validate", "deck.gd", "--project", "game", "--json"
@@ -1383,7 +1306,7 @@ def test_script_validate_refuses_a_symlink_dot_dot_pivot_out_of_the_project(tmp_
     )
     (project / "pivot").symlink_to(outside / "deep", target_is_directory=True)
 
-    validated = _gda(
+    validated = gda(
         "script",
         "validate",
         str(project / "pivot" / ".." / "deck.gd"),
@@ -1392,7 +1315,7 @@ def test_script_validate_refuses_a_symlink_dot_dot_pivot_out_of_the_project(tmp_
         "--json",
     )
 
-    err = _assert_operation_error(validated, "target_outside_project")
+    err = assert_operation_error(validated, "target_outside_project")
     # The refusal names where the target REALLY is, not the collapsed spelling.
     assert str((outside / "deck.gd").resolve()) in err["message"]
     # Nothing was compiled: no verdict, and no engine diagnostic about the file.
@@ -1418,11 +1341,11 @@ def test_script_validate_refuses_an_outside_path_that_merely_contains_a_scheme(
         "extends Node\n\nfunc scheme_secret() -> int:\n\treturn 7\n", encoding="utf-8"
     )
 
-    validated = _gda(
+    validated = gda(
         "script", "validate", f"{odd}//deck.gd", "--project", str(project), "--json"
     )
 
-    _assert_operation_error(validated, "target_outside_project")
+    assert_operation_error(validated, "target_outside_project")
     assert '"valid"' not in validated.stdout
 
 
@@ -1435,7 +1358,7 @@ def test_script_attach_binds_script_to_node_and_scene_references_it(godot_projec
     # attaches a .gd, and saves. Verify by reading the saved .tscn back: the
     # script path now appears as an ext_resource the node references, the result
     # echoes the script's class_name, and the scene still re-loads (node list).
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1483,7 +1406,7 @@ def test_script_attach_binds_script_to_node_and_scene_references_it(godot_projec
 def test_script_attach_to_a_descendant_node(godot_project):
     # Attach addresses the node by the #53 node path: a descendant, not just the
     # root. The script lands on that exact node.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1530,7 +1453,7 @@ def test_script_attach_to_a_descendant_node(godot_project):
 @pytest.mark.e2e
 def test_script_attach_no_class_name_echoes_null_class_name(godot_project):
     # A script with no class_name attaches fine and the result carries null.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node", "--json"
@@ -1566,7 +1489,7 @@ def test_script_attach_non_compiling_script_yields_script_compile_failed(godot_p
     # saves no script), so attach must refuse with script_compile_failed rather
     # than report a phantom success over a scene with nothing attached. The scene
     # is left untouched.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1588,7 +1511,7 @@ def test_script_attach_non_compiling_script_yields_script_compile_failed(godot_p
     )
     before = (godot_project / "main.tscn").read_text(encoding="utf-8")
 
-    attached = gda(
+    err = gda.error(
         "script",
         "attach",
         "res://main.tscn",
@@ -1597,9 +1520,8 @@ def test_script_attach_non_compiling_script_yields_script_compile_failed(godot_p
         "--script",
         "res://broken.gd",
         "--json",
+        code="script_compile_failed",
     )
-
-    err = _assert_operation_error(attached, "script_compile_failed")
     assert "broken.gd" in err["message"]
     # The refusal leaves the scene exactly as it was — no half-applied mutation.
     assert (godot_project / "main.tscn").read_text(encoding="utf-8") == before
@@ -1612,7 +1534,7 @@ def test_script_attach_missing_preload_target_yields_missing_dependency(
     # A missing preload target is a dependency-ordering problem, not generic
     # prose-only compile stderr: the structured error names the missing res://
     # path, and the scene is left untouched.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1632,7 +1554,7 @@ def test_script_attach_missing_preload_target_yields_missing_dependency(
     )
     before = (godot_project / "main.tscn").read_text(encoding="utf-8")
 
-    attached = gda(
+    err = gda.error(
         "script",
         "attach",
         "res://main.tscn",
@@ -1641,9 +1563,8 @@ def test_script_attach_missing_preload_target_yields_missing_dependency(
         "--script",
         "res://enemy.gd",
         "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(attached, "missing_dependency")
     assert "res://missing_projectile.tscn" in err["message"]
     assert "res://enemy.gd" in err["message"]
     assert (godot_project / "main.tscn").read_text(encoding="utf-8") == before
@@ -1656,7 +1577,7 @@ def test_script_attach_ignores_preload_mentions_in_comments_and_strings(
     # The missing-preload gate must follow executable GDScript syntax, not the
     # project reference graph's raw text scan. Mentioning future assets in comments
     # or string literals is not a preload dependency and must not block attach.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1706,7 +1627,7 @@ def test_script_attach_multiline_missing_preload_target_yields_missing_dependenc
     # A valid preload call may split the opening paren and string literal across
     # lines. It should still get the same stable missing_dependency result as the
     # single-line form.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1735,7 +1656,7 @@ def test_script_attach_multiline_missing_preload_target_yields_missing_dependenc
     )
     before = (godot_project / "main.tscn").read_text(encoding="utf-8")
 
-    attached = gda(
+    err = gda.error(
         "script",
         "attach",
         "res://main.tscn",
@@ -1744,9 +1665,8 @@ def test_script_attach_multiline_missing_preload_target_yields_missing_dependenc
         "--script",
         "res://enemy.gd",
         "--json",
+        code="missing_dependency",
     )
-
-    err = _assert_operation_error(attached, "missing_dependency")
     assert "res://missing_projectile.tscn" in err["message"]
     assert "res://enemy.gd" in err["message"]
     assert (godot_project / "main.tscn").read_text(encoding="utf-8") == before
@@ -1762,7 +1682,7 @@ def test_script_attach_incompatible_node_type_yields_incompatible_script_type(
     # incompatible_script_type — not script_compile_failed — so the agent fixes
     # the node/script pairing rather than chasing a non-existent syntax error. The
     # scene is left untouched.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1779,7 +1699,7 @@ def test_script_attach_incompatible_node_type_yields_incompatible_script_type(
     )
     before = (godot_project / "main.tscn").read_text(encoding="utf-8")
 
-    attached = gda(
+    err = gda.error(
         "script",
         "attach",
         "res://main.tscn",
@@ -1788,9 +1708,8 @@ def test_script_attach_incompatible_node_type_yields_incompatible_script_type(
         "--script",
         "res://spatial.gd",
         "--json",
+        code="incompatible_script_type",
     )
-
-    err = _assert_operation_error(attached, "incompatible_script_type")
     assert "Node3D" in err["message"]
     assert "Node2D" in err["message"]
     # The refusal leaves the scene untouched.
@@ -1799,7 +1718,7 @@ def test_script_attach_incompatible_node_type_yields_incompatible_script_type(
 
 @pytest.mark.e2e
 def test_script_attach_missing_script_yields_path_not_found(godot_project):
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1807,7 +1726,7 @@ def test_script_attach_missing_script_yields_path_not_found(godot_project):
         == 0
     )
 
-    attached = gda(
+    err = gda.error(
         "script",
         "attach",
         "res://main.tscn",
@@ -1816,15 +1735,14 @@ def test_script_attach_missing_script_yields_path_not_found(godot_project):
         "--script",
         "res://nope.gd",
         "--json",
+        code="path_not_found",
     )
-
-    err = _assert_operation_error(attached, "path_not_found")
     assert "nope.gd" in err["message"]
 
 
 @pytest.mark.e2e
 def test_script_attach_wrong_script_extension_yields_invalid_path(godot_project):
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1833,7 +1751,7 @@ def test_script_attach_wrong_script_extension_yields_invalid_path(godot_project)
     )
     (godot_project / "notes.txt").write_text("not a script\n", encoding="utf-8")
 
-    attached = gda(
+    err = gda.error(
         "script",
         "attach",
         "res://main.tscn",
@@ -1842,9 +1760,8 @@ def test_script_attach_wrong_script_extension_yields_invalid_path(godot_project)
         "--script",
         "res://notes.txt",
         "--json",
+        code="invalid_path",
     )
-
-    err = _assert_operation_error(attached, "invalid_path")
     assert ".gd" in err["message"]
 
 
@@ -1852,7 +1769,7 @@ def test_script_attach_wrong_script_extension_yields_invalid_path(godot_project)
 def test_script_attach_missing_node_yields_node_not_found_and_leaves_scene(
     godot_project,
 ):
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1867,7 +1784,7 @@ def test_script_attach_missing_node_yields_node_not_found_and_leaves_scene(
     )
     before = (godot_project / "main.tscn").read_text(encoding="utf-8")
 
-    attached = gda(
+    err = gda.error(
         "script",
         "attach",
         "res://main.tscn",
@@ -1876,9 +1793,8 @@ def test_script_attach_missing_node_yields_node_not_found_and_leaves_scene(
         "--script",
         "res://hero.gd",
         "--json",
+        code="node_not_found",
     )
-
-    err = _assert_operation_error(attached, "node_not_found")
     assert "Bogus" in err["message"]
     # The refusal leaves the scene untouched.
     assert (godot_project / "main.tscn").read_text(encoding="utf-8") == before
@@ -1886,7 +1802,7 @@ def test_script_attach_missing_node_yields_node_not_found_and_leaves_scene(
 
 @pytest.mark.e2e
 def test_script_attach_missing_scene_yields_path_not_found(godot_project):
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "script", "create", "res://hero.gd", "--extends", "Node2D", "--json"
@@ -1894,7 +1810,7 @@ def test_script_attach_missing_scene_yields_path_not_found(godot_project):
         == 0
     )
 
-    attached = gda(
+    err = gda.error(
         "script",
         "attach",
         "res://missing.tscn",
@@ -1903,9 +1819,8 @@ def test_script_attach_missing_scene_yields_path_not_found(godot_project):
         "--script",
         "res://hero.gd",
         "--json",
+        code="path_not_found",
     )
-
-    err = _assert_operation_error(attached, "path_not_found")
     assert "missing.tscn" in err["message"]
 
 
@@ -1913,7 +1828,7 @@ def test_script_attach_missing_scene_yields_path_not_found(godot_project):
 def test_script_attach_no_prior_script_reports_null_replaced_script(godot_project):
     # attach is overwrite-and-report (issue #132): a node with no prior script is
     # bound and replaced_script is null — the signal that nothing was displaced.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -1949,7 +1864,7 @@ def test_script_attach_overwrites_and_reports_the_displaced_script(godot_project
     # would strand the node) but no longer hides the displacement: replaced_script
     # names the prior script's res:// path verbatim. The overwrite is real — the
     # saved .tscn now references the NEW script and no longer the old one.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
     assert (
         gda(
             "scene", "create", "res://main.tscn", "--root-type", "Node2D", "--json"
@@ -2020,9 +1935,9 @@ def test_script_attach_both_scene_and_script_missing_reports_the_scene_first(
     # primary subject (the scene loads + node exists) is validated before the
     # secondary input (the --script arg), one invariant with no exceptions. Before
     # the reorder this surfaced the script's path_not_found and masked the scene.
-    gda = _gda_project(godot_project)
+    gda = Gda(godot_project)
 
-    attached = gda(
+    err = gda.error(
         "script",
         "attach",
         "res://missing.tscn",
@@ -2031,9 +1946,8 @@ def test_script_attach_both_scene_and_script_missing_reports_the_scene_first(
         "--script",
         "res://also_missing.gd",
         "--json",
+        code="path_not_found",
     )
-
-    err = _assert_operation_error(attached, "path_not_found")
     # The reported failure names the SCENE, not the script.
     assert "missing.tscn" in err["message"]
     assert "also_missing.gd" not in err["message"]
@@ -2047,7 +1961,7 @@ def test_script_create_empty_content_round_trips_as_empty_source(godot_project):
     # metadata.
     script_path = godot_project / "empty.gd"
 
-    created = _gda("script", "create", str(script_path), "--content", "", "--json")
+    created = gda("script", "create", str(script_path), "--content", "", "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     create_data = json.loads(created.stdout)
@@ -2055,7 +1969,7 @@ def test_script_create_empty_content_round_trips_as_empty_source(godot_project):
     assert create_data["extends"] is None
     assert script_path.read_text(encoding="utf-8") == ""
 
-    got = _gda("script", "get", str(script_path), "--json")
+    got = gda("script", "get", str(script_path), "--json")
 
     assert got.returncode == 0, got.stdout + got.stderr
     got_data = json.loads(got.stdout)
@@ -2231,6 +2145,7 @@ def _run_harness(project, harness: str = _ATTACH_DROP_HARNESS) -> str:
         ],
         capture_output=True,
         text=True,
+        timeout=120,
     )
     marker_begin, marker_end = "<<<HARNESS>>>", "<<<END>>>"
     out = proc.stdout

--- a/tests/test_e2e_script_run.py
+++ b/tests/test_e2e_script_run.py
@@ -64,16 +64,14 @@ headless one-shot script controls its own exit code.
 """
 
 import json
-import subprocess
 import time
 from pathlib import Path
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-from tests.support import GDA_CMD
+from tests.support import Gda
 
-GODOT = resolve_godot_binary()
+gda = Gda()
 
 # A standalone headless script: do work in _initialize, then quit with a chosen
 # code. `extends SceneTree` makes the script the main loop, the pattern a
@@ -157,40 +155,18 @@ func _initialize() -> void:
 """
 
 
-def _run_gda(*args: str, retry: bool = False) -> subprocess.CompletedProcess:
-    """Invoke ``gda <args>`` as a subprocess (this checkout's editable gda, ADR-0011).
-
-    ``retry`` re-runs once on a transient ``engine_crashed`` — a shared-``user://``
-    log race under parallel e2e (not a gda bug; the race was fixed in #180) — so a
-    happy path does not flake.
-    """
-    for attempt in range(2 if retry else 1):
-        proc = subprocess.run([*GDA_CMD, *args], capture_output=True, text=True)
-        if not retry or proc.returncode == 0:
-            return proc
-        try:
-            code = json.loads(proc.stdout)["error"]["code"]
-        except (ValueError, KeyError, TypeError):
-            return proc
-        if code != "engine_crashed":
-            return proc
-    return proc
-
-
 @pytest.mark.e2e
 def test_script_run_passes_a_clean_run_through(godot_project):
     # Happy path: a script that quit(0) → SUCCESS carrying exit_status 0 and the
     # script's printed line read back from stdout.
     (godot_project / "hello.gd").write_text(HELLO_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://hello.gd",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
         retry=True,
     )
@@ -210,14 +186,12 @@ def test_script_run_non_zero_quit_is_success_not_a_gda_failure(godot_project):
     # the non-zero code and the message are DATA the agent reads, not a gda error.
     (godot_project / "fail.gd").write_text(FAIL_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://fail.gd",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
         retry=True,
     )
@@ -238,14 +212,12 @@ def test_script_run_accepts_both_path_forms(godot_project, form):
     # `script validate` and `script run`.
     (godot_project / "hello.gd").write_text(HELLO_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         form,
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
         retry=True,
     )
@@ -265,14 +237,12 @@ def test_script_run_absolute_path_is_invalid_path(godot_project):
     # invalid_path decided BEFORE any launch — an explicit ABI edge (ADR-0031).
     (godot_project / "hello.gd").write_text(HELLO_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         str(godot_project / "hello.gd"),  # absolute, even though it EXISTS
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -310,14 +280,12 @@ def test_script_run_non_project_scoped_paths_are_refused_before_launch(
     # engine against `res://user:/x.gd`, an address the caller never typed. The
     # upward escapes moved to the containment arm below with #763 — same refusal,
     # same pre-launch timing, the shared code.
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         script,
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -351,14 +319,12 @@ def test_script_run_escapes_are_the_shared_containment_refusal(godot_project, sc
     # project, which is the ADR-0009 widening ADR-0031 cites as its reason for
     # refusing absolute paths. #763 keeps the refusal and moves it onto the code
     # every command reports this condition under.
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         script,
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -379,14 +345,12 @@ def test_script_run_does_not_overreject_unicode_spaces_godot_preserves(
     # so the request must launch and reach the ordinary entry-load verdict rather
     # than fail pre-launch as invalid_path.
     script = f"res://missing.gd{suffix}"
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         script,
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -403,12 +367,7 @@ def test_script_run_without_a_project_is_project_not_found(tmp_path):
     projectless = tmp_path / "empty"
     projectless.mkdir()
 
-    run = subprocess.run(
-        [*GDA_CMD, "script", "run", "res://hello.gd", "--godot", str(GODOT), "--json"],
-        capture_output=True,
-        text=True,
-        cwd=str(projectless),
-    )
+    run = gda("script", "run", "res://hello.gd", "--json", cwd=projectless)
 
     assert run.returncode == 4, run.stdout + run.stderr
     err = json.loads(run.stdout)["error"]
@@ -421,14 +380,12 @@ def test_script_run_missing_script_is_script_not_found(godot_project):
     # GDA-DF-032 against the REAL engine: Godot exits 0 for a res:// script that does
     # not exist, printing the load errors to stderr only. The verdict must come from
     # that stderr — a structured failure, never {"exit_status": 0}.
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://no-such-script.gd",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -459,14 +416,12 @@ def test_script_run_parse_error_dependency_is_script_compile_failed(godot_projec
     (godot_project / "suite.gd").write_text(BAD_DEPENDENCY_GD, encoding="utf-8")
     (godot_project / "broken_dep.gd").write_text(BROKEN_DEP_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://suite.gd",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -510,14 +465,12 @@ def test_script_run_runtime_error_is_a_success_carrying_diagnostics(godot_projec
     # in stderr prose: it is a classified diagnostic an agent can branch on.
     (godot_project / "runtime_error.gd").write_text(RUNTIME_ERROR_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://runtime_error.gd",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
         retry=True,
     )
@@ -557,14 +510,12 @@ def test_script_run_missing_entry_verdict_survives_path_aliasing(
     # identity restores the specific verdict for every spelling.
     (godot_project / "sub").mkdir(exist_ok=True)
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         spelling,
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -598,14 +549,12 @@ def test_script_run_compile_failed_verdict_survives_path_aliasing(
     (godot_project / "suite.gd").write_text(BAD_DEPENDENCY_GD, encoding="utf-8")
     (godot_project / "broken_dep.gd").write_text(BROKEN_DEP_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         spelling,
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -626,14 +575,12 @@ def test_script_run_runtime_resource_load_failure_is_a_success_with_diagnostics(
         RUNTIME_RESOURCE_LOAD_GD, encoding="utf-8"
     )
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://runtime_load.gd",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
         retry=True,
     )
@@ -657,15 +604,13 @@ def test_script_run_strict_fails_on_an_explicit_non_zero_quit(godot_project):
     # parsing the JSON.
     (godot_project / "fail.gd").write_text(FAIL_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://fail.gd",
         "--strict",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -697,15 +642,13 @@ def test_script_run_strict_envelope_carries_the_suites_stdout(godot_project):
     # a CI caller that only gets an exit code and an empty diagnostics learns nothing.
     (godot_project / "suite_fail.gd").write_text(FAILING_SUITE_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://suite_fail.gd",
         "--strict",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -731,15 +674,13 @@ def test_script_run_strict_leaves_a_passing_script_a_success(godot_project):
     # success, so a CI step can pass --strict unconditionally.
     (godot_project / "hello.gd").write_text(HELLO_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://hello.gd",
         "--strict",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
         retry=True,
     )
@@ -757,15 +698,8 @@ def test_script_run_unlaunchable_binary_is_binary_not_found(godot_project):
     # GDScript-mirrored code.
     (godot_project / "hello.gd").write_text(HELLO_GD, encoding="utf-8")
 
-    run = _run_gda(
-        "script",
-        "run",
-        "res://hello.gd",
-        "--project",
-        str(godot_project),
-        "--godot",
-        str(godot_project / "no-such-godot"),
-        "--json",
+    run = Gda(godot=godot_project / "no-such-godot")(
+        "script", "run", "res://hello.gd", "--project", str(godot_project), "--json"
     )
 
     assert run.returncode == 127, run.stdout + run.stderr
@@ -823,7 +757,7 @@ def test_script_run_returns_the_captured_error_of_an_aborted_run(godot_project):
     (godot_project / "aborts.gd").write_text(ABORTS_BEFORE_QUIT_GD, encoding="utf-8")
 
     started = time.monotonic()
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://aborts.gd",
@@ -833,8 +767,6 @@ def test_script_run_returns_the_captured_error_of_an_aborted_run(godot_project):
         "60",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
     elapsed = time.monotonic() - started
@@ -863,7 +795,7 @@ def test_script_run_timeout_returns_partial_output_elapsed_and_a_phase(godot_pro
     # a silent hang. No marker is declared here, so this is the plain timeout path.
     (godot_project / "slow.gd").write_text(SLOW_BUT_HEALTHY_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://slow.gd",
@@ -871,8 +803,6 @@ def test_script_run_timeout_returns_partial_output_elapsed_and_a_phase(godot_pro
         "4",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -904,7 +834,7 @@ def test_script_run_without_a_marker_waits_out_the_timeout_but_still_captures(
     (godot_project / "aborts.gd").write_text(ABORTS_BEFORE_QUIT_GD, encoding="utf-8")
 
     started = time.monotonic()
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://aborts.gd",
@@ -912,8 +842,6 @@ def test_script_run_without_a_marker_waits_out_the_timeout_but_still_captures(
         "5",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
     elapsed = time.monotonic() - started
@@ -993,7 +921,7 @@ def test_script_run_ends_a_silent_survivor_by_the_declared_contract(godot_projec
     (godot_project / "survivor.gd").write_text(QUIET_SURVIVOR_GD, encoding="utf-8")
 
     started = time.monotonic()
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://survivor.gd",
@@ -1003,8 +931,6 @@ def test_script_run_ends_a_silent_survivor_by_the_declared_contract(godot_projec
         "60",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
     elapsed = time.monotonic() - started
@@ -1027,7 +953,7 @@ def test_script_run_leaves_the_same_survivor_alone_without_a_marker(godot_projec
     # gda must not judge.
     (godot_project / "survivor.gd").write_text(QUIET_SURVIVOR_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://survivor.gd",
@@ -1035,8 +961,6 @@ def test_script_run_leaves_the_same_survivor_alone_without_a_marker(godot_projec
         "60",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -1059,7 +983,7 @@ def test_script_run_spares_a_survivor_that_prints_progress(godot_project):
     # satisfiable by a quiet-working script, not a trap.
     (godot_project / "progress.gd").write_text(PROGRESS_SURVIVOR_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://progress.gd",
@@ -1069,8 +993,6 @@ def test_script_run_spares_a_survivor_that_prints_progress(godot_project):
         "60",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
     )
 
@@ -1091,7 +1013,7 @@ def test_script_run_abort_still_lands_within_its_stated_bound(godot_project):
     (godot_project / "aborts.gd").write_text(ABORTS_BEFORE_QUIT_GD, encoding="utf-8")
 
     started = time.monotonic()
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://aborts.gd",
@@ -1101,9 +1023,11 @@ def test_script_run_abort_still_lands_within_its_stated_bound(godot_project):
         "120",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
+        # The engine ceiling (120s) sits above the spawn's default bound; a
+        # regressed abort must reach the assertion below with its message, not
+        # die as a TimeoutExpired at 90s.
+        timeout=150,
     )
     elapsed = time.monotonic() - started
 
@@ -1133,14 +1057,12 @@ def test_script_run_stdout_above_the_cap_truncates_and_spills(godot_project):
 
     (godot_project / "big.gd").write_text(BIG_PRINTER_GD, encoding="utf-8")
 
-    run = _run_gda(
+    run = gda(
         "script",
         "run",
         "res://big.gd",
         "--project",
         str(godot_project),
-        "--godot",
-        str(GODOT),
         "--json",
         retry=True,
     )

--- a/tests/test_e2e_user_data.py
+++ b/tests/test_e2e_user_data.py
@@ -44,11 +44,8 @@ from pathlib import Path
 
 import pytest
 
-from gda.binary import resolve_godot_binary
 from gda.runner import data_path_env, engine_data_path
-from tests.support import GDA_CMD
-
-GODOT = resolve_godot_binary()
+from tests.support import GDA_CMD, GODOT, Gda
 
 # A project whose file logging is at the ENGINE DEFAULT (on for desktop), i.e. what
 # a real user project looks like — see the module docstring.
@@ -161,10 +158,6 @@ def _env(home: Path, **extra: str) -> dict:
     return {**os.environ, "HOME": str(home), "GDA_GODOT": str(GODOT), **extra}
 
 
-def _run_gda(*args: str, env: dict) -> subprocess.CompletedProcess:
-    return subprocess.run([*GDA_CMD, *args], capture_output=True, text=True, env=env)
-
-
 @pytest.mark.e2e
 def test_control_unprotected_launch_really_does_die_on_the_restriction(
     restricted_home, logging_project
@@ -185,6 +178,7 @@ def test_control_unprotected_launch_really_does_die_on_the_restriction(
         capture_output=True,
         text=True,
         env=_env(home),
+        timeout=120,
     )
 
     assert MARKER not in proc.stdout, (
@@ -204,14 +198,13 @@ def test_script_validate_completes_under_a_read_only_app_data_dir(
     # restriction really do kill an unprotected launch.
     home, _ = restricted_home
 
-    run = _run_gda(
+    run = Gda(godot=None, env=_env(home))(
         "script",
         "validate",
         str(logging_project / "hello.gd"),
         "--project",
         str(logging_project),
         "--json",
-        env=_env(home),
     )
 
     assert run.returncode == 0, run.stdout + run.stderr
@@ -227,14 +220,13 @@ def test_script_run_completes_under_a_read_only_app_data_dir(
 ):
     home, _ = restricted_home
 
-    run = _run_gda(
+    run = Gda(godot=None, env=_env(home))(
         "script",
         "run",
         "res://hello.gd",
         "--project",
         str(logging_project),
         "--json",
-        env=_env(home),
     )
 
     assert run.returncode == 0, run.stdout + run.stderr
@@ -254,10 +246,9 @@ def test_unwritable_log_target_is_a_typed_environment_error(
     # typed environment code before the engine starts — never a signal-11 backtrace.
     home, data_path = restricted_home
 
-    run = _run_gda(
+    run = Gda(godot=None, env=_env(home, GDA_USER_DATA_ROOT=str(data_path / "denied")))(
         "info",
         "--json",
-        env=_env(home, GDA_USER_DATA_ROOT=str(data_path / "denied")),
     )
 
     assert run.returncode == 127, run.stdout + run.stderr
@@ -301,7 +292,7 @@ def test_a_root_whose_derived_data_path_is_blocked_is_refused(
     blocker.parent.mkdir(parents=True, exist_ok=True)
     blocker.write_text("not a directory", encoding="utf-8")
 
-    run = _run_gda(
+    run = Gda(godot=None, env={**os.environ, "GDA_GODOT": str(GODOT)})(
         "--user-data-root",
         str(root),
         "script",
@@ -310,7 +301,6 @@ def test_a_root_whose_derived_data_path_is_blocked_is_refused(
         "--project",
         str(logging_project),
         "--json",
-        env={**os.environ, "GDA_GODOT": str(GODOT)},
     )
 
     assert run.returncode == 127, run.stdout + run.stderr
@@ -336,7 +326,7 @@ def test_user_data_root_makes_user_writable_again(restricted_home, logging_proje
     home, _ = restricted_home
     root = logging_project.parent / "udr"
 
-    run = _run_gda(
+    run = Gda(godot=None, env=_env(home))(
         "--user-data-root",
         str(root),
         "script",
@@ -345,7 +335,6 @@ def test_user_data_root_makes_user_writable_again(restricted_home, logging_proje
         "--project",
         str(logging_project),
         "--json",
-        env=_env(home),
     )
 
     assert run.returncode == 0, run.stdout + run.stderr
@@ -394,7 +383,7 @@ def test_concurrent_invocations_never_touch_the_shared_rotated_log(
     ]
     # communicate() before returncode: draining the pipes is what lets each child
     # exit, so waiting first can deadlock on a full pipe buffer.
-    results = [(*p.communicate(), p.returncode) for p in procs]
+    results = [(*p.communicate(timeout=120), p.returncode) for p in procs]
 
     for out, err, code in results:
         assert code == 0, out + err
@@ -429,22 +418,15 @@ def test_relative_root_on_the_sentinel_channel_lands_under_gda_cwd(
     workdir = tmp_path / "workdir"
     workdir.mkdir()
 
-    run = subprocess.run(
-        [
-            *GDA_CMD,
-            "--user-data-root",
-            "./rel",
-            "script",
-            "validate",
-            str(logging_project / "hello.gd"),
-            "--project",
-            str(logging_project),
-            "--json",
-        ],
-        capture_output=True,
-        text=True,
-        cwd=str(workdir),
-        env={**os.environ, "GDA_GODOT": str(GODOT)},
+    run = Gda(godot=None, env={**os.environ, "GDA_GODOT": str(GODOT)}, cwd=workdir)(
+        "--user-data-root",
+        "./rel",
+        "script",
+        "validate",
+        str(logging_project / "hello.gd"),
+        "--project",
+        str(logging_project),
+        "--json",
     )
 
     assert run.returncode == 0, run.stdout + run.stderr
@@ -470,27 +452,20 @@ def test_relative_root_on_the_export_channel_lands_under_gda_cwd(
     workdir.mkdir()
     artifact = logging_project / "dist" / "packed.pck"
 
-    run = subprocess.run(
-        [
-            *GDA_CMD,
-            "--user-data-root",
-            "./rel",
-            "export",
-            "run",
-            "--preset",
-            "Linux/X11",
-            "--mode",
-            "pack",
-            "--output",
-            str(artifact),
-            "--project",
-            str(logging_project),
-            "--json",
-        ],
-        capture_output=True,
-        text=True,
-        cwd=str(workdir),
-        env={**os.environ, "GDA_GODOT": str(GODOT)},
+    run = Gda(godot=None, env={**os.environ, "GDA_GODOT": str(GODOT)}, cwd=workdir)(
+        "--user-data-root",
+        "./rel",
+        "export",
+        "run",
+        "--preset",
+        "Linux/X11",
+        "--mode",
+        "pack",
+        "--output",
+        str(artifact),
+        "--project",
+        str(logging_project),
+        "--json",
     )
 
     assert run.returncode == 0, run.stdout + run.stderr

--- a/tests/test_e2e_write_value_fidelity.py
+++ b/tests/test_e2e_write_value_fidelity.py
@@ -33,12 +33,10 @@ import subprocess
 
 import pytest
 
-from gda.binary import resolve_godot_binary
-
 from tests.live_number_corpus import LIVE_NUMBER_CORPUS, value_bits
-from tests.support import GDA_CMD
+from tests.support import GODOT, Gda
 
-GODOT = resolve_godot_binary()
+from .conftest import LIVE_PROJECT_GODOT
 
 
 # --- the policy, expressed independently of the GDScript that implements it ----
@@ -324,26 +322,6 @@ WRITE_CASES = [
 ]
 
 
-def _headless_runner(project):
-    def run(*args):
-        return subprocess.run(
-            [
-                *GDA_CMD,
-                *args,
-                "--project",
-                str(project),
-                "--godot",
-                str(GODOT),
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=180,
-        )
-
-    return run
-
-
 @pytest.fixture
 def probe_project(godot_project):
     (godot_project / "probe.gd").write_text(PROBE_GD, encoding="utf-8")
@@ -360,7 +338,7 @@ def test_node_set_refuses_a_literal_the_parser_destroys(probe_project):
     rewritten with it.
     """
     scene = probe_project / "main.tscn"
-    run = _headless_runner(probe_project)
+    run = Gda(probe_project, json_output=True, timeout=180)
 
     for literal, refused, note in WRITE_CASES:
         before = scene.read_text(encoding="utf-8")
@@ -407,7 +385,7 @@ def test_node_set_refuses_a_literal_the_parser_destroys(probe_project):
 def test_the_refusal_is_narrow_and_names_its_remedy(probe_project):
     """It refuses a LOSS, not a magnitude, and tells the caller what to type instead."""
     scene = probe_project / "main.tscn"
-    run = _headless_runner(probe_project)
+    run = Gda(probe_project, json_output=True, timeout=180)
 
     # A value that is not a number at all keeps the message it always had: the
     # fidelity note must not relabel an ordinary coercion failure.
@@ -555,7 +533,7 @@ def test_node_set_refuses_a_destroyed_number_inside_a_container(probe_project):
     scalar, alive on the one path its per-component walk could not reach.
     """
     scene = probe_project / "main.tscn"
-    run = _headless_runner(probe_project)
+    run = Gda(probe_project, json_output=True, timeout=180)
 
     for prop, value, note in CONTAINER_REFUSED:
         before = scene.read_text(encoding="utf-8")
@@ -639,7 +617,7 @@ def test_the_note_explains_only_the_refusal_it_diagnosed(probe_project):
     `test_node_set_refuses_a_destroyed_number_inside_a_container`.)
     """
     scene = probe_project / "main.tscn"
-    run = _headless_runner(probe_project)
+    run = Gda(probe_project, json_output=True, timeout=180)
 
     def message(*args):
         result = run("node", "set", str(scene), "--node", ".", *args)
@@ -707,7 +685,7 @@ def test_project_set_shares_the_refusal(probe_project):
         + '\n[gda]\n\nprobe/value=1.5\nprobe/dict={"a": 1.0}\nprobe/arr=[1.0]\n',
         encoding="utf-8",
     )
-    run = _headless_runner(probe_project)
+    run = Gda(probe_project, json_output=True, timeout=180)
 
     refused = run(
         "project", "set", "gda/probe/value", "--value", "0.000000000000000001"
@@ -760,7 +738,7 @@ def test_resource_set_shares_the_refusal(probe_project):
     (probe_project / "probe_res.gd").write_text(RESOURCE_PROBE_GD, encoding="utf-8")
     resource = probe_project / "probe.tres"
     resource.write_text(RESOURCE_PROBE_TRES, encoding="utf-8")
-    run = _headless_runner(probe_project)
+    run = Gda(probe_project, json_output=True, timeout=180)
 
     # The scalar rule first, so a container failure below cannot be a `resource
     # set` that never had the rule at all.
@@ -796,8 +774,8 @@ def test_resource_set_shares_the_refusal(probe_project):
 
 # --- the command tier: live `game set` through a real daemon -------------------
 
-LIVE_MAIN_GD = 'extends Node2D\n\nvar v := 1.5\nvar n := 0\nvar d := {"seed": 1.0}\nvar a := [1.0]\n'
-LIVE_MAIN_TSCN = (
+SET_MAIN_GD = 'extends Node2D\n\nvar v := 1.5\nvar n := 0\nvar d := {"seed": 1.0}\nvar a := [1.0]\n'
+SET_MAIN_TSCN = (
     "[gd_scene load_steps=2 format=3]\n\n"
     '[ext_resource type="Script" path="res://live_main.gd" id="1"]\n\n'
     '[node name="Main" type="Node2D"]\n'
@@ -818,15 +796,11 @@ def test_game_set_refuses_the_same_literals_against_a_real_daemon(
     This is why the block is mirrored, and why it is exercised through a real
     session rather than trusted to the drift test.
     """
-    from .conftest import project_godot
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(SET_MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "live_main.gd").write_text(SET_MAIN_GD, encoding="utf-8")
 
-    (tmp_path / "project.godot").write_text(
-        project_godot(extra='run/main_scene="res://main.tscn"'), encoding="utf-8"
-    )
-    (tmp_path / "main.tscn").write_text(LIVE_MAIN_TSCN, encoding="utf-8")
-    (tmp_path / "live_main.gd").write_text(LIVE_MAIN_GD, encoding="utf-8")
-
-    run = _headless_runner(tmp_path)
+    run = Gda(tmp_path, json_output=True, timeout=180)
     try:
         assert run("daemon", "start").returncode == 0
 

--- a/tests/test_export_commands.py
+++ b/tests/test_export_commands.py
@@ -17,8 +17,9 @@ from gda.runner import RunResult
 from tests.support import (
     EXPORT_GET_RESULT as GET_RESULT,
     EXPORT_LIST_RESULT as LIST_RESULT,
-    FakeRunner,
-    inject_runner,
+    invoke_cli,
+    minimal_project,
+    recording_runner,
     sentinel,
 )
 
@@ -27,14 +28,12 @@ def test_export_list_json_enumerates_presets_and_exit_zero(monkeypatch, tmp_path
     # export list enumerates the resolved project's export presets (issue #114):
     # each entry carries its index, name, platform, and runnable flag, read
     # cheaply from export_presets.cfg.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(LIST_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["export", "list", "--project", str(tmp_path), "--json"]
+    minimal_project(tmp_path)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["export", "list", "--project", str(tmp_path), "--json"],
+        stdout=sentinel(LIST_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -52,23 +51,17 @@ def test_export_list_json_enumerates_presets_and_exit_zero(monkeypatch, tmp_path
 def test_export_list_passes_resolved_project_to_the_runner(monkeypatch, tmp_path):
     # export list reads export_presets.cfg in the resolved project, so --project
     # must reach the runner (which hands it to the engine as --path, issue #32).
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    seen: dict = {}
-
-    def record(binary, project):
-        seen["project"] = project
-        return FakeRunner(
-            RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
-        )
-
-    monkeypatch.setattr("gda.dispatch.make_runner", record)
+    minimal_project(tmp_path)
+    projects = recording_runner(
+        monkeypatch, RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(
         app, ["export", "list", "--project", str(tmp_path), "--json"]
     )
 
     assert result.exit_code == 0
-    assert seen["project"] == tmp_path
+    assert projects[0] == tmp_path
 
 
 def test_export_get_json_reports_preset_details_and_template_status(monkeypatch):
@@ -76,10 +69,11 @@ def test_export_get_json_reports_preset_details_and_template_status(monkeypatch)
     # (issue #114): the preset is addressed by --preset (its display name), and
     # the result carries templates_installed/templates_version so an agent can
     # check readiness before an export run.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(GET_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(app, ["export", "get", "--preset", "Web", "--json"])
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["export", "get", "--preset", "Web", "--json"],
+        stdout=sentinel(GET_RESULT),
+    )
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -95,11 +89,9 @@ def test_export_get_json_reports_preset_details_and_template_status(monkeypatch)
 def test_export_get_missing_preset_flag_is_a_usage_error(monkeypatch):
     # --preset is required: export get always needs a preset to address. Its
     # absence is a usage error (exit 2) that fires before any dispatch.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch, ["export", "get", "--json"], stdout=sentinel(GET_RESULT)
     )
-
-    result = CliRunner().invoke(app, ["export", "get", "--json"])
 
     assert result.exit_code == 2
     assert fake.calls == []
@@ -110,10 +102,11 @@ def test_export_get_templates_missing_rides_through_false(monkeypatch):
     # templates_installed=false rides through to the result so the agent knows it
     # must install templates before an export run.
     payload = {**GET_RESULT, "templates_installed": False, "export_path": ""}
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(payload)
-    inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(app, ["export", "get", "--preset", "Web", "--json"])
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["export", "get", "--preset", "Web", "--json"],
+        stdout=sentinel(payload),
+    )
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)

--- a/tests/test_export_errors.py
+++ b/tests/test_export_errors.py
@@ -9,39 +9,19 @@ group mints two new codes for the modes that had no existing code
 ``project_not_found`` for the projectless mode.
 """
 
-import json
-
-from typer.testing import CliRunner
-
-from gda.cli import app
-from gda.runner import RunResult
-from tests.support import error_sentinel, inject_runner
+from tests.support import assert_operation_error, operation_error_invoker
 
 
-def _invoke_export_list(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: export-list\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, ["export", "list", "--json"])
+_export_list = operation_error_invoker(
+    ["export", "list", "--json"],
+    "export-list",
+)
 
 
-def _invoke_export_get(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: export-get\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, ["export", "get", "--preset", "Web", "--json"])
+_export_get = operation_error_invoker(
+    ["export", "get", "--preset", "Web", "--json"],
+    "export-get",
+)
 
 
 def test_export_list_no_export_presets_maps_to_export_presets_not_found(monkeypatch):
@@ -49,19 +29,19 @@ def test_export_list_no_export_presets_maps_to_export_presets_not_found(monkeypa
     # this is the new export_presets_not_found code (distinct from a generic
     # missing-path), so an agent knows the project defines no presets rather than
     # mistaking it for an empty listing.
-    result = _invoke_export_list(
+    result = _export_list(
         monkeypatch,
         "export_presets_not_found",
         "project has no export_presets.cfg; no export presets are defined",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "export_presets_not_found"
-    assert "export_presets.cfg" in err["message"]
     # The raw stderr still rides along as diagnostics (ADR-0002).
-    assert err["diagnostics"] == "gda: running operation: export-list\n"
+    assert_operation_error(
+        result,
+        "export_presets_not_found",
+        "export_presets.cfg",
+        diagnostics="gda: running operation: export-list\n",
+    )
 
 
 def test_export_list_without_project_reuses_stable_project_not_found_code(monkeypatch):
@@ -69,59 +49,48 @@ def test_export_list_without_project_reuses_stable_project_not_found_code(monkey
     # projectless: with no resolvable project, the operation reuses the registered
     # project_not_found code (the same one scene/script list use) so an agent
     # knows to pass --project rather than retry.
-    result = _invoke_export_list(
+    result = _export_list(
         monkeypatch,
         "project_not_found",
         "export list requires a Godot project; none was resolved — pass --project",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "project_not_found"
-    assert "--project" in err["message"]
+    assert_operation_error(result, "project_not_found", "--project")
 
 
 def test_export_get_unknown_preset_maps_to_export_preset_not_found(monkeypatch):
     # A preset name not present in export_presets.cfg is the new
     # export_preset_not_found code, so an agent branches on the unknown-preset
     # mode (and re-lists to find the real names) without parsing prose.
-    result = _invoke_export_get(
+    result = _export_get(
         monkeypatch, "export_preset_not_found", "no export preset named: Web"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "export_preset_not_found"
-    assert "Web" in err["message"]
-    assert err["diagnostics"] == "gda: running operation: export-get\n"
+    assert_operation_error(
+        result,
+        "export_preset_not_found",
+        "Web",
+        diagnostics="gda: running operation: export-get\n",
+    )
 
 
 def test_export_get_no_export_presets_maps_to_export_presets_not_found(monkeypatch):
     # export get over a project with no export_presets.cfg reports the same
     # export_presets_not_found mode as export list — there is nothing to address.
-    result = _invoke_export_get(
+    result = _export_get(
         monkeypatch,
         "export_presets_not_found",
         "project has no export_presets.cfg; no export presets are defined",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "export_presets_not_found"
+    assert_operation_error(result, "export_presets_not_found")
 
 
 def test_export_get_without_project_reuses_stable_project_not_found_code(monkeypatch):
-    result = _invoke_export_get(
+    result = _export_get(
         monkeypatch,
         "project_not_found",
         "export get requires a Godot project; none was resolved — pass --project",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "project_not_found"
-    assert "--project" in err["message"]
+    assert_operation_error(result, "project_not_found", "--project")

--- a/tests/test_export_run_commands.py
+++ b/tests/test_export_run_commands.py
@@ -33,8 +33,11 @@ from typer.testing import CliRunner
 from gda.cli import app
 from gda.runner import RunResult
 from tests.support import (
+    ENGINE_BANNER,
     FakeExportRunner,
-    FakeRunner,
+    inject_runner,
+    invoke_cli,
+    minimal_project,
     plain_text,
     sentinel,
 )
@@ -52,15 +55,9 @@ GET_RESULT = {
 
 def _inject(monkeypatch, *, get=GET_RESULT, export=None):
     """Wire both seams: the sentinel runner for export-get, the export runner."""
-    get_runner = FakeRunner(
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n" + sentinel(get),
-            stderr="",
-            exit_code=0,
-        )
-    )
-    monkeypatch.setattr(
-        "gda.dispatch.make_runner", lambda binary, project=None: get_runner
+    get_runner = inject_runner(
+        monkeypatch,
+        RunResult(stdout=ENGINE_BANNER + sentinel(get), stderr="", exit_code=0),
     )
     if export is None:
         export = RunResult(stdout="", stderr="", exit_code=0)
@@ -84,7 +81,7 @@ def test_export_run_params_json_drives_the_native_export_runner(monkeypatch, tmp
     # sentinel pipeline. --params-json (ADR-0015) must drive that SAME recipe, so
     # the export runner is actually invoked — a regression guard against the
     # generic dispatch hook routing it through the wrong (sentinel) path.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     _, export_runner = _inject(monkeypatch)
 
     result = CliRunner().invoke(
@@ -114,7 +111,7 @@ def test_export_run_json_reports_configured_path_and_exit_zero(monkeypatch, tmp_
     # acceptance behavior) and reports the result (preset, platform, mode,
     # output_path, warnings) as typed JSON. The mode is always release in #121; an
     # agent's template-readiness check via export get is now also gda's preflight.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     _, export_runner = _inject(monkeypatch)
 
     result = CliRunner().invoke(
@@ -149,7 +146,7 @@ def test_export_run_json_reports_configured_path_and_exit_zero(monkeypatch, tmp_
 def test_export_run_json_keeps_native_progress_on_stderr(monkeypatch, tmp_path):
     # issue #431: the native export phase gets a progress line, but JSON stdout
     # remains exactly one machine-readable result object.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     _, export_runner = _inject(monkeypatch)
 
     result = CliRunner().invoke(
@@ -187,7 +184,7 @@ def test_export_run_default_mode_is_release(monkeypatch, tmp_path):
     # #170 adds --mode but keeps release the default: omitting --mode runs the
     # native --export-release invocation and reports mode == "release", the #121
     # behavior preserved.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     _, export_runner = _inject(monkeypatch)
 
     result = CliRunner().invoke(
@@ -214,7 +211,7 @@ def test_export_run_mode_selects_export_flavor(monkeypatch, tmp_path):
     # --mode (issue #170) selects the export flavor, reflected in BOTH the native
     # invocation (the mode string the runner is asked to export) and the result's
     # `mode` field. Each of debug/pack flows end-to-end through the pipeline.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     for mode in ("debug", "pack"):
         _, export_runner = _inject(monkeypatch)
 
@@ -245,7 +242,7 @@ def test_export_run_mode_selects_export_flavor(monkeypatch, tmp_path):
 def test_export_run_rejects_unknown_mode(monkeypatch, tmp_path):
     # --mode is a closed set (release/debug/pack); an unrecognized value is a
     # Typer usage error (exit 2) and spawns no engine.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
 
     def _boom(*args, **kwargs):
         raise AssertionError("a rejected --mode must not spawn any engine")
@@ -275,7 +272,7 @@ def test_export_run_output_overrides_configured_path(monkeypatch, tmp_path):
     # native export is driven to the override, NOT the configured "build/game.x86_64",
     # and the result's output_path reports the effective destination.
     monkeypatch.chdir(tmp_path)
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     _, export_runner = _inject(monkeypatch)
 
     result = CliRunner().invoke(
@@ -309,7 +306,7 @@ def test_export_run_relative_output_resolves_against_invoker_cwd(monkeypatch, tm
     # reaches Godot. The JSON result reports the same absolute artifact path.
     project = tmp_path / "project"
     project.mkdir()
-    (project / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(project)
     invoker_cwd = tmp_path / "caller"
     invoker_cwd.mkdir()
     monkeypatch.chdir(invoker_cwd)
@@ -344,7 +341,7 @@ def test_export_run_output_expands_leading_tilde(monkeypatch, tmp_path):
     # the artifact lands in $HOME, not a literal "~" directory.
     home = tmp_path / "home"
     monkeypatch.setenv("HOME", str(home))
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     _, export_runner = _inject(monkeypatch)
 
     result = CliRunner().invoke(
@@ -376,7 +373,7 @@ def test_export_run_output_overrides_unset_configured_path(monkeypatch, tmp_path
     # is empty: the export_path_unset preflight no longer fires (there IS a place to
     # write), and the export runs to the override.
     monkeypatch.chdir(tmp_path)
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     get = {**GET_RESULT, "export_path": ""}
     _, export_runner = _inject(monkeypatch, get=get)
 
@@ -407,7 +404,7 @@ def test_export_run_surfaces_advisory_warnings(monkeypatch, tmp_path):
     # A clean export (exit 0) that still emits engine WARNING lines surfaces them
     # advisorily on the success result (ADR-0002: stderr is advisory for success),
     # not as a failure — the export succeeded.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     _inject(
         monkeypatch,
         export=RunResult(
@@ -451,7 +448,7 @@ def test_export_run_missing_templates_is_structured_preflight(monkeypatch, tmp_p
     # templates_installed=False, so gda fails with export_templates_missing BEFORE
     # spawning any native export — no stderr string-matching (ADR-0002), no native
     # run. The message names the templates_version the agent must install.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     get = {
         **GET_RESULT,
         "templates_installed": False,
@@ -487,7 +484,7 @@ def test_export_run_pack_skips_template_preflight_when_missing(monkeypatch, tmp_
     # templates_installed=False, pack must NOT emit export_templates_missing — it
     # proceeds straight to the native runner. (release/debug, which DO need
     # templates, still fail fast — asserted by the parametric test below.)
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     get = {
         **GET_RESULT,
         "templates_installed": False,
@@ -523,7 +520,7 @@ def test_export_run_release_debug_still_require_templates_when_missing(
     # The counterpart guard: release and debug DO need platform templates, so with
     # templates_installed=False they still fail fast with export_templates_missing
     # before any native run — only pack is exempt (#170).
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     for mode in ("release", "debug"):
         get = {
             **GET_RESULT,
@@ -557,7 +554,7 @@ def test_export_run_release_debug_still_require_templates_when_missing(
 def test_export_run_generic_failure_is_structured(monkeypatch, tmp_path):
     # A non-zero export with no recognized stderr signature is the generic
     # export_failed code; the engine's stderr is preserved as diagnostics.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     _inject(
         monkeypatch,
         export=RunResult(
@@ -589,7 +586,7 @@ def test_export_run_unset_path_is_structured(monkeypatch, tmp_path):
     # A preset whose configured export_path is empty is the export_path_unset
     # failure — reported BEFORE the native export runs (no --output to fall back
     # on; that override is deferred to #170).
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     get = {**GET_RESULT, "export_path": ""}
     _, export_runner = _inject(monkeypatch, get=get)
 
@@ -615,32 +612,19 @@ def test_export_run_unset_path_is_structured(monkeypatch, tmp_path):
 def test_export_run_unknown_preset_reuses_export_get_error(monkeypatch, tmp_path):
     # An unknown preset surfaces export-get's clean export_preset_not_found,
     # reused verbatim — and no native export is attempted.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    get_runner = FakeRunner(
-        RunResult(
-            stdout=sentinel(
-                {
-                    "error": {
-                        "code": "export_preset_not_found",
-                        "message": "no such preset",
-                    }
-                }
-            ),
-            stderr="",
-            exit_code=4,
-        )
-    )
-    monkeypatch.setattr(
-        "gda.dispatch.make_runner", lambda binary, project=None: get_runner
-    )
+    minimal_project(tmp_path)
     export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
     monkeypatch.setattr(
         "gda.dispatch.make_export_runner", lambda binary, project=None: export_runner
     )
 
-    result = CliRunner().invoke(
-        app,
+    result, _ = invoke_cli(
+        monkeypatch,
         ["export", "run", "--preset", "Nope", "--project", str(tmp_path), "--json"],
+        stdout=sentinel(
+            {"error": {"code": "export_preset_not_found", "message": "no such preset"}}
+        ),
+        exit_code=4,
     )
 
     assert result.exit_code == 4
@@ -699,7 +683,7 @@ def test_export_run_help_documents_output_resolution():
 
 def test_export_run_human_output_echoes_artifact(monkeypatch, tmp_path):
     # Without --json the command renders a human line naming the artifact.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     _inject(monkeypatch)
 
     result = CliRunner().invoke(

--- a/tests/test_export_run_operation.py
+++ b/tests/test_export_run_operation.py
@@ -31,7 +31,13 @@ from gda.errors import Failure
 from gda.execution import ExecutionKind
 from gda.harness.install import install_harness, uninstall_harness
 from gda.runner import RunResult
-from tests.support import FakeExportRunner, FakeRunner, error_sentinel, sentinel
+from tests.support import (
+    ENGINE_BANNER,
+    FakeExportRunner,
+    FakeRunner,
+    error_sentinel,
+    sentinel,
+)
 
 
 def test_export_run_command_is_the_native_export_channel():
@@ -58,7 +64,7 @@ def _get_runner(get=GET_RESULT) -> FakeRunner:
     """A FakeRunner that returns ``get`` wrapped in an ADR-0002 success sentinel."""
     return FakeRunner(
         RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n" + sentinel(get),
+            stdout=ENGINE_BANNER + sentinel(get),
             stderr="",
             exit_code=0,
         )

--- a/tests/test_game_commands.py
+++ b/tests/test_game_commands.py
@@ -25,12 +25,8 @@ from tests.support import (
     inject_live_runner,
     panel_text,
     sentinel,
+    minimal_project,
 )
-
-
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
 
 
 def test_game_tree_emits_runtime_tree_json_through_the_live_channel(
@@ -42,7 +38,7 @@ def test_game_tree_emits_runtime_tree_json_through_the_live_channel(
     )
 
     result = CliRunner().invoke(
-        app, ["game", "tree", "--project", str(_project(tmp_path)), "--json"]
+        app, ["game", "tree", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -59,7 +55,7 @@ def test_game_tree_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_pa
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
 
     result = CliRunner().invoke(
-        app, ["game", "tree", "--project", str(_project(tmp_path)), "--json"]
+        app, ["game", "tree", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
@@ -95,7 +91,7 @@ def test_game_tree_on_non_unix_reports_live_unsupported_platform(monkeypatch, tm
     monkeypatch.setattr("gda.live_runner._is_unix", lambda: False)
 
     result = CliRunner().invoke(
-        app, ["game", "tree", "--project", str(_project(tmp_path)), "--json"]
+        app, ["game", "tree", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code != 0, result.stdout
@@ -120,7 +116,7 @@ def test_game_get_emits_runtime_properties_through_the_live_channel(
             "get",
             "/root/Main/Player",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -157,7 +153,7 @@ def test_game_get_passes_the_property_filter_through_the_live_channel(
             "--property",
             "position",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -196,7 +192,7 @@ def test_game_get_threads_the_texture_digest_opt_in(monkeypatch, tmp_path):
             "sprite_texture",
             "--texture-digest",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -265,7 +261,7 @@ def test_game_get_missing_node_reports_live_node_not_found(monkeypatch, tmp_path
             "get",
             "/root/Main/Ghost",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -295,7 +291,7 @@ def test_game_get_unknown_property_reports_live_unknown_property(monkeypatch, tm
             "--property",
             "nope",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -316,7 +312,7 @@ def test_game_get_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_pat
             "get",
             "/root/Main/Player",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -352,7 +348,7 @@ def test_game_rect_emits_rendered_control_rect_through_the_live_channel(
             "rect",
             "/root/Main/HUD/Stats",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -380,7 +376,7 @@ def test_game_rect_non_control_reports_live_not_control(monkeypatch, tmp_path):
             "rect",
             "/root/Main/Player",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -408,7 +404,7 @@ def test_game_rect_missing_node_reports_live_node_not_found(monkeypatch, tmp_pat
             "rect",
             "/root/Main/Ghost",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -441,7 +437,7 @@ def test_game_set_mutates_and_echoes_coerced_value_through_the_live_channel(
             "--value",
             "10,20",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -484,7 +480,7 @@ def test_game_set_missing_node_reports_live_node_not_found(monkeypatch, tmp_path
             "--value",
             "1,2",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -516,7 +512,7 @@ def test_game_set_unknown_property_reports_live_unknown_property(monkeypatch, tm
             "--value",
             "1",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -550,7 +546,7 @@ def test_game_set_uncoercible_value_reports_live_uncoercible_value(
             "--value",
             "not-a-vector",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -575,7 +571,7 @@ def test_game_set_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_pat
             "--value",
             "1,2",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -617,7 +613,7 @@ def test_game_call_invokes_the_method_and_projects_its_return(monkeypatch, tmp_p
             "--method",
             "qa_current_state_contract",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -662,7 +658,7 @@ def test_game_call_threads_json_args_as_values(monkeypatch, tmp_path):
             "--args",
             '[2, "peak", {"deep": [1]}]',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -700,7 +696,7 @@ def test_game_call_non_json_args_is_refused_before_the_wire(monkeypatch, tmp_pat
             "--args",
             "not json",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -731,7 +727,7 @@ def test_game_call_undeclared_method_reports_not_allowlisted(monkeypatch, tmp_pa
             "--method",
             "undeclared_secret",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -763,7 +759,7 @@ def test_game_call_distinguishes_missing_from_undeclared_and_bad_args(
                 "--method",
                 "whatever",
                 "--project",
-                str(_project(tmp_path)),
+                str(minimal_project(tmp_path)),
                 "--json",
             ],
         )
@@ -788,7 +784,7 @@ def test_game_call_human_render_names_the_method_and_value(monkeypatch, tmp_path
             "--method",
             "qa_current_state_contract",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
         ],
     )
 
@@ -903,7 +899,7 @@ def test_game_call_refuses_non_finite_args_on_both_paths(monkeypatch, tmp_path):
     # bound, gets live_timeout, and the session is retired (state lost). The
     # params model is the one authority both paths share (ADR-0015), so both
     # are refused structurally, before the wire.
-    project = str(_project(tmp_path))
+    project = str(minimal_project(tmp_path))
     for argv in (
         ["--method", "m", "--args", "[NaN]"],
         ["--method", "m", "--args", '[{"deep": [Infinity]}]'],
@@ -962,7 +958,7 @@ def test_game_call_accepts_finite_nested_json_args(monkeypatch, tmp_path):
             "--args",
             '[1, 2.5, {"a": [3.5, "x"]}]',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -973,7 +969,7 @@ def test_game_call_accepts_finite_nested_json_args(monkeypatch, tmp_path):
 
 def test_game_call_accepts_large_finite_float_args_on_both_paths(monkeypatch, tmp_path):
     """High-range floats already are binary64 and do not inherit the int bound."""
-    project = str(_project(tmp_path))
+    project = str(minimal_project(tmp_path))
     expected = [1e17, 2.5e17, {"deep": [1e300]}]
 
     invocations = (
@@ -1018,7 +1014,7 @@ def test_game_call_refuses_integers_beyond_the_exact_json_range(monkeypatch, tmp
     # nested positions are covered; the boundary value still rides through.
     from gda.commands.game import MAX_EXACT_JSON_INT
 
-    project = str(_project(tmp_path))
+    project = str(minimal_project(tmp_path))
     for argv in (
         ["--method", "m", "--args", f"[{MAX_EXACT_JSON_INT + 2}]"],
         ["--method", "m", "--args", f"[-{MAX_EXACT_JSON_INT + 2}]"],

--- a/tests/test_human_failure_output.py
+++ b/tests/test_human_failure_output.py
@@ -40,7 +40,13 @@ from gda.models import (
 from gda.render import render_failure
 from gda.runner import LaunchFailure, RunResult, TimeoutBound
 from gda.script_errors import ScriptError, ScriptErrorKind
-from tests.support import error_sentinel, inject_runner, sentinel
+from tests.support import (
+    error_sentinel,
+    inject_runner,
+    invoke_cli,
+    minimal_project,
+    sentinel,
+)
 
 
 def _error(**overrides) -> GdaError:
@@ -302,6 +308,9 @@ def test_a_human_invocation_gets_the_lines_and_never_the_envelope(monkeypatch):
     # End to end through the real CLI: no `--json`, so the failure arrives as text.
     # `gda info` with a hung runner is the fast engine-free fixture that carries
     # typed evidence as well as prose.
+    # Staged as a whole raw run, not through `invoke_cli`: the LAUNCH FAILURE
+    # this run carries is the input under test, and the invoker stages only the
+    # three canned streams.
     inject_runner(
         monkeypatch,
         RunResult(
@@ -328,6 +337,9 @@ def test_the_same_failure_under_json_is_the_envelope_and_nothing_else(monkeypatc
     # The scope-defining half, at the CLI: `--json` must be exactly what it was —
     # ONE line, the model's own `exclude_none` dump, with no rendered text anywhere
     # near it.
+    # Staged as a whole raw run, not through `invoke_cli`: the LAUNCH FAILURE
+    # this run carries is the input under test, and the invoker stages only the
+    # three canned streams.
     inject_runner(
         monkeypatch,
         RunResult(
@@ -360,9 +372,7 @@ def test_a_raw_stderr_failure_reaches_a_human_once_not_twice(monkeypatch):
     # emission point when the bytes are identical, so a human reads ONE copy, on
     # the channel the layout owns.
     raw = "Godot Engine v4.6.stable\nERROR: the operation said no\n"
-    inject_runner(monkeypatch, RunResult(stdout="", stderr=raw, exit_code=1))
-
-    result = CliRunner().invoke(app, ["info"])
+    result, _ = invoke_cli(monkeypatch, ["info"], stderr=raw, exit_code=1)
 
     assert result.exit_code == EXIT_OPERATION
     assert result.stdout.startswith("error: operation_failed (operation)\n")
@@ -375,9 +385,7 @@ def test_the_same_raw_failure_under_json_keeps_its_stderr_tee(monkeypatch):
     # The scope boundary: `--json`'s streams are exactly what they were — the
     # envelope alone on stdout, the child's stderr forwarded in full.
     raw = "Godot Engine v4.6.stable\nERROR: the operation said no\n"
-    inject_runner(monkeypatch, RunResult(stdout="", stderr=raw, exit_code=1))
-
-    result = CliRunner().invoke(app, ["info", "--json"])
+    result, _ = invoke_cli(monkeypatch, ["info", "--json"], stderr=raw, exit_code=1)
 
     assert result.exit_code == EXIT_OPERATION
     assert json.loads(result.stdout)["error"]["code"] == "operation_failed"
@@ -389,6 +397,9 @@ def test_a_capped_diagnostics_failure_keeps_the_full_stderr_tee(monkeypatch):
     # COMPOSED tail-capped capture, not the raw stream, so its tee — the only
     # complete copy — survives for a human too.
     raw = "Godot Engine v4.6.stable\n"
+    # Staged as a whole raw run, not through `invoke_cli`: the LAUNCH FAILURE
+    # this run carries is the input under test, and the invoker stages only the
+    # three canned streams.
     inject_runner(
         monkeypatch,
         RunResult(
@@ -461,12 +472,6 @@ def test_a_usage_refusal_without_json_is_rendered_by_the_same_one_renderer():
 # passed the whole suite. One CLI case each closes that, all four engine-free.
 
 
-def _project(tmp_path):
-    """The minimum that makes a directory a Godot project (ADR-0006)."""
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
-
-
 def test_an_unresolvable_project_is_refused_in_lines_on_the_dispatch_tail(tmp_path):
     # `dispatch._resolve_project_or_fail`, the shared project-resolution point: it
     # refuses BEFORE any command runs, so the flag is the one the tail carries down.
@@ -493,7 +498,7 @@ def test_a_recipe_failure_is_refused_in_lines_too(monkeypatch, tmp_path):
             "--output",
             str(tmp_path / "shot.png"),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
         ],
     )
 
@@ -515,7 +520,7 @@ def test_the_params_json_conflict_is_refused_in_lines(tmp_path):
             '{"path": "res://a.tscn", "root_type": "Node2D"}',
             "res://b.tscn",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
         ],
     )
 
@@ -536,7 +541,7 @@ def test_an_invalid_params_json_object_is_refused_in_lines(tmp_path):
             "--params-json",
             "{}",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
         ],
     )
 
@@ -578,7 +583,7 @@ def _preflight(tmp_path, *extra: str):
             "preflight",
             "res://nope.tscn",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             *extra,
         ],
     )

--- a/tests/test_human_output.py
+++ b/tests/test_human_output.py
@@ -22,11 +22,8 @@ These run engine-free (FakeRunner) under ``-m "not e2e"``.
 """
 
 import pytest
-from typer.testing import CliRunner
 
-from gda.cli import app
-from gda.runner import RunResult
-from tests.support import inject_runner, sentinel
+from tests.support import invoke_cli, sentinel
 
 # Each case: (id, argv-without-`--json`, success-payload, expected-stdout-text).
 # The payload is wrapped in the result sentinel as operations.gd emits it; the
@@ -498,11 +495,7 @@ def test_human_mode_cli_output_is_exactly_the_rendered_text(
     # with a fake runner, and assert the exact stdout: the renderer's text plus
     # the single trailing newline typer.echo adds. This pins #139's render
     # dispatch + #140's gda.render end-to-end, per command.
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(app, argv)
+    result, _ = invoke_cli(monkeypatch, argv, stdout=sentinel(payload))
 
     assert result.exit_code == 0
     assert result.stdout == expected + "\n"

--- a/tests/test_info_command.py
+++ b/tests/test_info_command.py
@@ -6,19 +6,24 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import RunResult
-from tests.support import FakeRunner, VERSION_INFO, inject_runner, sentinel
+from tests.support import (
+    VERSION_INFO,
+    assert_operation_error,
+    invoke_cli,
+    minimal_project,
+    recording_runner,
+    sentinel,
+)
 
 
 def test_info_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
     # Engine banner / warnings around the sentinel, plus diagnostics on stderr.
-    stdout = "Godot Engine v4.6.3.stable.official\nWARNING: benign\n" + sentinel(
-        VERSION_INFO
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["info", "--json"],
+        stdout="WARNING: benign\n" + sentinel(VERSION_INFO),
+        stderr="engine diagnostic\n",
     )
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(app, ["info", "--json"])
 
     assert result.exit_code == 0
     # stdout carries ONLY the result payload — a single valid JSON object.
@@ -35,19 +40,6 @@ def test_info_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
 # --- `gda info --project`: accepted, validated, never inherited (#670) ---------
 
 
-def _record_project(monkeypatch, result: RunResult) -> list:
-    """Swap the runner seam for one that records the project it was built with."""
-    fake = FakeRunner(result)
-    projects: list = []
-
-    def factory(binary, project=None):
-        projects.append(project)
-        return fake
-
-    monkeypatch.setattr("gda.dispatch.make_runner", factory)
-    return projects
-
-
 def _ok(monkeypatch) -> RunResult:
     return RunResult(stdout=sentinel(VERSION_INFO), stderr="", exit_code=0)
 
@@ -58,9 +50,8 @@ def test_info_accepts_an_explicit_project_and_runs_against_it(monkeypatch, tmp_p
     # and honoured the way every other command honours it — handed to the engine as
     # its project (ADR-0006).
     project = tmp_path / "game"
-    project.mkdir()
-    (project / "project.godot").write_text("")
-    projects = _record_project(monkeypatch, _ok(monkeypatch))
+    minimal_project(project)
+    projects = recording_runner(monkeypatch, _ok(monkeypatch))
 
     result = CliRunner().invoke(app, ["info", "--project", str(project), "--json"])
 
@@ -72,12 +63,11 @@ def test_info_accepts_an_explicit_project_and_runs_against_it(monkeypatch, tmp_p
 def test_info_refuses_an_explicit_project_that_is_not_one(monkeypatch, tmp_path):
     # Validated, not merely accepted: a `--project` that names no Godot project is the
     # ordinary structured refusal, not a silent run against the wrong root.
-    _record_project(monkeypatch, _ok(monkeypatch))
+    recording_runner(monkeypatch, _ok(monkeypatch))
 
     result = CliRunner().invoke(app, ["info", "--project", str(tmp_path), "--json"])
 
-    assert result.exit_code == 4, result.stdout
-    assert json.loads(result.stdout)["error"]["code"] == "project_not_found"
+    assert_operation_error(result, "project_not_found")
 
 
 def test_info_ignores_an_inherited_project_context(monkeypatch, tmp_path):
@@ -85,7 +75,7 @@ def test_info_ignores_an_inherited_project_context(monkeypatch, tmp_path):
     # a stale $GDA_PROJECT in the shell would otherwise break the one command an agent
     # runs to find out whether anything works at all (#357's rule, same reasoning).
     monkeypatch.setenv("GDA_PROJECT", str(tmp_path / "gone"))
-    projects = _record_project(monkeypatch, _ok(monkeypatch))
+    projects = recording_runner(monkeypatch, _ok(monkeypatch))
 
     result = CliRunner().invoke(app, ["info", "--json"])
 
@@ -95,14 +85,13 @@ def test_info_ignores_an_inherited_project_context(monkeypatch, tmp_path):
 
 def test_the_params_json_path_validates_the_project_the_same_way(monkeypatch, tmp_path):
     # ADR-0015 parity: the form gda-mcp dispatches must refuse identically.
-    _record_project(monkeypatch, _ok(monkeypatch))
+    recording_runner(monkeypatch, _ok(monkeypatch))
 
     result = CliRunner().invoke(
         app, ["info", "--params-json", "{}", "--project", str(tmp_path), "--json"]
     )
 
-    assert result.exit_code == 4, result.stdout
-    assert json.loads(result.stdout)["error"]["code"] == "project_not_found"
+    assert_operation_error(result, "project_not_found")
 
 
 def test_the_project_option_is_not_an_operation_param(monkeypatch):

--- a/tests/test_info_errors.py
+++ b/tests/test_info_errors.py
@@ -15,7 +15,7 @@ from typer.testing import CliRunner
 from gda.cli import app
 from gda.runner import LaunchFailure, RunResult, TimeoutBound
 from tests.support import inject_runner as _inject
-from tests.support import raw_sentinel, sentinel
+from tests.support import assert_operation_error, raw_sentinel, sentinel
 
 
 def test_binary_not_found_maps_to_environment_error(monkeypatch):
@@ -88,10 +88,7 @@ def test_operation_failure_maps_to_operation_error_distinct_from_environment(
 
     result = CliRunner().invoke(app, ["info", "--json"])
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "operation_failed"
+    assert_operation_error(result, "operation_failed")
     assert "unknown operation" in result.stderr
 
 
@@ -108,12 +105,8 @@ def test_engine_signal_crash_maps_to_operation_error_distinct_from_clean_exit(
 
     result = CliRunner().invoke(app, ["info", "--json"])
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "engine_crashed"
     # The signal number is surfaced for diagnosis.
-    assert "11" in err["message"]
+    assert_operation_error(result, "engine_crashed", "11")
 
 
 def test_missing_sentinel_maps_to_parse_error_distinct_from_operation(monkeypatch):

--- a/tests/test_input_commands.py
+++ b/tests/test_input_commands.py
@@ -30,12 +30,8 @@ from tests.support import (
     error_sentinel,
     inject_live_runner,
     sentinel,
+    minimal_project,
 )
-
-
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
 
 
 # --- input key (single-frame) -------------------------------------------------
@@ -48,7 +44,15 @@ def test_input_key_injects_a_key_event_through_the_live_channel(monkeypatch, tmp
     )
 
     result = CliRunner().invoke(
-        app, ["input", "key", "Right", "--project", str(_project(tmp_path)), "--json"]
+        app,
+        [
+            "input",
+            "key",
+            "Right",
+            "--project",
+            str(minimal_project(tmp_path)),
+            "--json",
+        ],
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -81,7 +85,7 @@ def test_input_key_threads_modifiers_and_released(monkeypatch, tmp_path):
             "ctrl",
             "--released",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -105,7 +109,8 @@ def test_input_key_unresolvable_name_reports_live_invalid_key(monkeypatch, tmp_p
     )
 
     result = CliRunner().invoke(
-        app, ["input", "key", "Nope", "--project", str(_project(tmp_path)), "--json"]
+        app,
+        ["input", "key", "Nope", "--project", str(minimal_project(tmp_path)), "--json"],
     )
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
@@ -118,7 +123,15 @@ def test_input_key_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_pa
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
 
     result = CliRunner().invoke(
-        app, ["input", "key", "Right", "--project", str(_project(tmp_path)), "--json"]
+        app,
+        [
+            "input",
+            "key",
+            "Right",
+            "--project",
+            str(minimal_project(tmp_path)),
+            "--json",
+        ],
     )
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
@@ -158,7 +171,7 @@ def test_input_mouse_click_injects_the_whole_gesture_through_the_live_channel(
             "right",
             "--double",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -236,7 +249,7 @@ def test_input_mouse_move_injects_a_motion_through_the_live_channel(
             "50",
             "60",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -262,7 +275,7 @@ def test_input_mouse_click_default_button_is_left(monkeypatch, tmp_path):
             "1",
             "2",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -287,7 +300,7 @@ def test_input_mouse_click_unknown_button_argv_is_a_usage_error(monkeypatch, tmp
             "--button",
             "scroll",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -314,7 +327,14 @@ def test_input_action_presses_an_action_through_the_live_channel(monkeypatch, tm
 
     result = CliRunner().invoke(
         app,
-        ["input", "action", "jump", "--project", str(_project(tmp_path)), "--json"],
+        [
+            "input",
+            "action",
+            "jump",
+            "--project",
+            str(minimal_project(tmp_path)),
+            "--json",
+        ],
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -341,7 +361,7 @@ def test_input_action_release_and_strength_are_threaded(monkeypatch, tmp_path):
             "--strength",
             "0.5",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -362,7 +382,15 @@ def test_input_action_unknown_action_reports_live_unknown_action(monkeypatch, tm
     )
 
     result = CliRunner().invoke(
-        app, ["input", "action", "nope", "--project", str(_project(tmp_path)), "--json"]
+        app,
+        [
+            "input",
+            "action",
+            "nope",
+            "--project",
+            str(minimal_project(tmp_path)),
+            "--json",
+        ],
     )
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
@@ -386,7 +414,7 @@ def test_input_action_strength_over_range_argv_is_a_usage_error(monkeypatch, tmp
             "--strength",
             "2.0",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -419,7 +447,7 @@ def test_input_tap_key_dispatches_the_press_hold_release_window(monkeypatch, tmp
             "--key",
             "Right",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -473,7 +501,7 @@ def test_input_tap_action_threads_strength_and_frame_counts(monkeypatch, tmp_pat
             "--settle-frames",
             "0",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -506,7 +534,7 @@ def test_input_tap_requires_exactly_one_target(monkeypatch, tmp_path):
 
     neither = CliRunner().invoke(
         app,
-        ["input", "tap", "--project", str(_project(tmp_path)), "--json"],
+        ["input", "tap", "--project", str(minimal_project(tmp_path)), "--json"],
     )
     both = CliRunner().invoke(
         app,
@@ -518,7 +546,7 @@ def test_input_tap_requires_exactly_one_target(monkeypatch, tmp_path):
             "--action",
             "jump",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -547,7 +575,7 @@ def test_input_tap_rejects_the_other_targets_fields(monkeypatch, tmp_path):
             "--modifiers",
             "shift",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -561,7 +589,7 @@ def test_input_tap_rejects_the_other_targets_fields(monkeypatch, tmp_path):
             "--strength",
             "0.5",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -593,7 +621,7 @@ def test_input_tap_window_is_bounded_to_the_shared_ceiling(monkeypatch, tmp_path
             "--settle-frames",
             "0",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -621,7 +649,7 @@ def test_input_tap_hold_frames_zero_is_a_usage_error(monkeypatch, tmp_path):
             "--hold-frames",
             "0",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -672,7 +700,7 @@ def test_input_tap_omitted_action_strength_is_normalized_model_side(
             "--action",
             "jump",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -684,7 +712,7 @@ def test_input_tap_omitted_action_strength_is_normalized_model_side(
             "--params-json",
             '{"action": "jump"}',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -705,7 +733,7 @@ def test_input_tap_omitted_action_strength_is_normalized_model_side(
             "--key",
             "Right",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -775,7 +803,7 @@ def test_malformed_tap_reply_is_a_contract_violation(monkeypatch, tmp_path):
                 "--key",
                 "Right",
                 "--project",
-                str(_project(tmp_path)),
+                str(minimal_project(tmp_path)),
                 "--json",
             ],
         )
@@ -799,7 +827,7 @@ def test_malformed_click_reply_is_a_contract_violation(monkeypatch, tmp_path):
                 "1",
                 "2",
                 "--project",
-                str(_project(tmp_path)),
+                str(minimal_project(tmp_path)),
                 "--json",
             ],
         )
@@ -829,7 +857,7 @@ def test_malformed_mouse_move_reply_is_a_contract_violation(monkeypatch, tmp_pat
                 "1",
                 "2",
                 "--project",
-                str(_project(tmp_path)),
+                str(minimal_project(tmp_path)),
                 "--json",
             ],
         )
@@ -863,7 +891,7 @@ def test_input_sequence_injects_events_across_frames_through_the_live_channel(
             "--events",
             json.dumps(events),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -917,7 +945,7 @@ def test_input_sequence_physics_frame_offsets_dispatch_through_the_live_channel(
             "--events",
             json.dumps(events),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -963,7 +991,7 @@ def test_input_sequence_accepts_mouse_button_press_move_release(monkeypatch, tmp
             "--events",
             json.dumps(events),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -997,7 +1025,7 @@ def test_input_sequence_with_no_daemon_reports_daemon_not_running(
             "--events",
             json.dumps([{"type": "key", "key": "Right"}]),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1029,7 +1057,7 @@ def test_input_sequence_invalid_event_spec_reports_the_typed_error(
             "--events",
             json.dumps([{"type": "key", "key": "Right"}]),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1054,7 +1082,7 @@ def test_input_sequence_non_json_events_argv_is_a_usage_error(monkeypatch, tmp_p
             "--events",
             "not json",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1077,7 +1105,7 @@ def test_input_sequence_empty_events_argv_is_a_usage_error(monkeypatch, tmp_path
             "--events",
             "[]",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1102,7 +1130,7 @@ def test_input_sequence_malformed_event_argv_is_a_usage_error(monkeypatch, tmp_p
             "--events",
             json.dumps([{"type": "key", "frame": 0}]),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1129,7 +1157,7 @@ def test_input_sequence_over_window_frame_argv_is_a_usage_error(monkeypatch, tmp
             "--events",
             json.dumps([{"type": "key", "key": "Right", "frame": 999999}]),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1162,7 +1190,7 @@ def test_input_sequence_over_window_physics_frame_argv_is_a_usage_error(
                 ]
             ),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1196,7 +1224,7 @@ def test_input_sequence_mixed_process_and_physics_clocks_argv_is_a_usage_error(
                 ]
             ),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1223,7 +1251,7 @@ def test_input_sequence_at_the_window_boundary_argv_is_accepted(monkeypatch, tmp
                 [{"type": "key", "key": "Right", "frame": MAX_WINDOW_FRAMES - 1}]
             ),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1298,7 +1326,7 @@ def test_input_key_params_json_bad_modifier_is_invalid_params(monkeypatch, tmp_p
             "--params-json",
             '{"key": "A", "modifiers": ["control"]}',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1323,7 +1351,7 @@ def test_input_action_params_json_strength_over_range_is_invalid_params(
             "--params-json",
             '{"action": "jump", "strength": 2.0}',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1348,7 +1376,7 @@ def test_input_sequence_params_json_empty_events_is_invalid_params(
             "--params-json",
             '{"events": []}',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1373,7 +1401,7 @@ def test_input_sequence_params_json_malformed_event_is_invalid_params(
             "--params-json",
             '{"events": [{"type": "mouse_click", "x": 1.0}]}',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1398,7 +1426,7 @@ def test_input_sequence_params_json_mouse_button_without_phase_is_invalid_params
             "--params-json",
             '{"events": [{"type": "mouse_button", "x": 1.0, "y": 2.0}]}',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1426,7 +1454,7 @@ def test_input_sequence_params_json_mouse_button_conflicting_phase_is_invalid_pa
                 '"pressed": true, "release": true}]}'
             ),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1454,7 +1482,7 @@ def test_input_sequence_params_json_mouse_button_pressed_false_is_invalid_params
                 '"pressed": false}]}'
             ),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1479,7 +1507,7 @@ def test_input_sequence_params_json_pressed_on_mouse_move_is_invalid_params(
             "--params-json",
             '{"events": [{"type": "mouse_move", "x": 1.0, "y": 2.0, "pressed": true}]}',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1507,7 +1535,7 @@ def test_input_sequence_params_json_over_window_frame_is_invalid_params(
             "--params-json",
             json.dumps({"events": [{"type": "key", "key": "Right", "frame": 999999}]}),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1543,7 +1571,7 @@ def test_input_sequence_params_json_mixed_clock_fields_is_invalid_params(
                 }
             ),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1576,7 +1604,7 @@ def test_input_sequence_params_json_at_the_window_boundary_dispatches(
                 }
             ),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1626,7 +1654,7 @@ def test_input_sequence_params_json_physics_frame_dispatches(monkeypatch, tmp_pa
                 }
             ),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1653,7 +1681,7 @@ def test_input_key_params_json_dispatches_like_argv(monkeypatch, tmp_path):
             "--params-json",
             '{"key": "Right", "modifiers": ["shift"]}',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1778,7 +1806,7 @@ def _reject(monkeypatch, tmp_path, event: dict) -> str:
             "--params-json",
             json.dumps({"events": [event]}),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1941,7 +1969,7 @@ def test_an_explicit_null_button_still_means_the_left_button(monkeypatch, tmp_pa
             "--events",
             json.dumps(events),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )

--- a/tests/test_json_flag_acceptance.py
+++ b/tests/test_json_flag_acceptance.py
@@ -36,11 +36,10 @@ from typer.testing import CliRunner
 from gda.cli import app
 from gda.commands.meta import read_skill_text
 from gda.headless import adopt_group_json
-from gda.runner import RunResult
 from tests.support import (
     SCENE_GET_RESULT,
     GDA_CMD,
-    inject_runner,
+    invoke_cli,
     panel_text,
     plain_text,
     sentinel,
@@ -137,18 +136,16 @@ def test_both_spellings_together_are_not_a_conflict():
 def test_root_json_reaches_a_domain_command(monkeypatch):
     # Not just the meta commands: the inherited flag rides the shared sentinel
     # dispatch tail, so a domain command emits its JSON result too.
-    inject_runner(
+    root_spelling, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCENE_GET_RESULT), stderr="", exit_code=0),
+        ["--json", "scene", "get", "/tmp/x.tscn"],
+        stdout=sentinel(SCENE_GET_RESULT),
     )
-    root_spelling = CliRunner().invoke(app, ["--json", "scene", "get", "/tmp/x.tscn"])
 
-    inject_runner(
+    command_spelling, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCENE_GET_RESULT), stderr="", exit_code=0),
-    )
-    command_spelling = CliRunner().invoke(
-        app, ["scene", "get", "/tmp/x.tscn", "--json"]
+        ["scene", "get", "/tmp/x.tscn", "--json"],
+        stdout=sentinel(SCENE_GET_RESULT),
     )
 
     assert root_spelling.exit_code == 0, root_spelling.stdout
@@ -176,11 +173,7 @@ def _scene_get(monkeypatch, args: list[str]):
     default: a flag that parsed but did not reach the command would show up here as
     that text, which is the failure mode acceptance alone would hide.
     """
-    inject_runner(
-        monkeypatch,
-        RunResult(stdout=sentinel(SCENE_GET_RESULT), stderr="", exit_code=0),
-    )
-    return CliRunner().invoke(app, args)
+    return invoke_cli(monkeypatch, args, stdout=sentinel(SCENE_GET_RESULT))[0]
 
 
 def test_group_json_is_equivalent_to_the_commands_own_json(monkeypatch):

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -90,7 +90,9 @@ def _fake_engine(tmp_path: Path, body: str) -> Path:
     return script
 
 
-def _fast_fake_engine(tmp_path: Path, stdout_line: str, stderr_line: str) -> Path:
+def _fast_fake_engine(
+    tmp_path: Path, stdout_line: str, stderr_line: str, marker: Path | None = None
+) -> Path:
     """A ``/bin/sh`` stand-in, kept for WALL-CLOCK SPEED, not correctness (#728).
 
     Diverges from ``_fake_engine`` on purpose: that one pays a fresh Python
@@ -109,6 +111,11 @@ def _fast_fake_engine(tmp_path: Path, stdout_line: str, stderr_line: str) -> Pat
     passed in. ``printf`` with a literal ``'%s\\n'`` format leaves the
     (``shlex.quote``-escaped, so shell-syntax-safe) argument untouched.
 
+    ``marker``, when given, is a file the stand-in creates AFTER both lines are
+    written — the observation channel a test without a watch needs to hold the
+    runner's clock until the output is guaranteed to be in the pipe (#824, see
+    ``_clock_held_until_written``).
+
     It always ``sleep``s afterward, past any timeout this suite uses, via
     ``exec`` — not a trailing background job. Without ``exec`` SIGTERM only
     ends the shell; the orphaned ``sleep`` keeps the captured pipe open and
@@ -118,20 +125,71 @@ def _fast_fake_engine(tmp_path: Path, stdout_line: str, stderr_line: str) -> Pat
     script = tmp_path / "fast-fake-engine"
     out = shlex.quote(stdout_line)
     err = shlex.quote(stderr_line)
+    touch = f": > {shlex.quote(str(marker))}\n" if marker is not None else ""
     script.write_text(
-        f"#!/bin/sh\nprintf '%s\\n' {out}\nprintf '%s\\n' {err} 1>&2\nexec sleep 30\n",
+        f"#!/bin/sh\nprintf '%s\\n' {out}\nprintf '%s\\n' {err} 1>&2\n{touch}exec sleep 30\n",
         encoding="utf-8",
     )
     script.chmod(0o755)
     return script
 
 
-def test_timeout_synthesizes_a_result_that_keeps_what_the_run_produced(tmp_path):
+def _clock_held_until_written(
+    monkeypatch, marker: Path, *, settle_polls: int = 5, then: float = 1.5
+) -> None:
+    """Make the runner's poll loop see NO time pass until ``marker`` exists (#824).
+
+    The #728 technique for a launch that has no watch to observe the capture
+    through: the stand-in touches ``marker`` after its two ``printf``s, and the
+    clock the runner reads reports 0.0 until the marker exists AND it has been
+    read ``settle_polls`` more times — one read per poll for a watchless launch
+    (a watch's abort deliberation adds a second read), so this is proof that
+    the run kept polling past its output rather than ending on it — then jumps
+    to ``then``, past the ceiling its callers use, so the deadline "elapses"
+    only once the output is guaranteed to be in the pipe. Racing a REAL 1.0s
+    ceiling against the child's first write failed under xdist contention (10
+    of 12 runs with the timing modules concentrated on four workers). A
+    real-time safety ceiling turns a loop that never ends into a loud
+    assertion, not a hung suite. The loop's real cadence is untouched: it
+    comes from ``proc.wait(timeout=...)`` on the subprocess module's own
+    clock, which this binding does not reach; ``sleep`` is kept real only so
+    the stand-in module stays faithful.
+    """
+    real_monotonic = time.monotonic
+    real_deadline = real_monotonic() + 15.0
+    polls_after_written = 0
+
+    def fake_monotonic() -> float:
+        nonlocal polls_after_written
+        if real_monotonic() > real_deadline:
+            raise AssertionError(
+                "safety ceiling: launch did not finish within 15s "
+                f"(marker exists: {marker.exists()})"
+            )
+        if not marker.exists():
+            return 0.0
+        polls_after_written += 1
+        return then if polls_after_written > settle_polls else 0.0
+
+    monkeypatch.setattr(
+        runner,
+        "time",
+        SimpleNamespace(monotonic=fake_monotonic, sleep=time.sleep),
+    )
+
+
+def test_timeout_synthesizes_a_result_that_keeps_what_the_run_produced(
+    monkeypatch, tmp_path
+):
     # The bound gda puts on a hung engine, and the evidence it comes back with. The
     # run below writes to both streams and then never returns; `launch` ends it at
     # the ceiling and reports what it had already read — the whole of #714, which
-    # replaced a capture that discarded exactly this.
-    engine = _fast_fake_engine(tmp_path, "BOOTED", "wedged")
+    # replaced a capture that discarded exactly this. The ceiling elapses on the
+    # held clock only after the child has written (#824): the real 1.0s used to
+    # race the child's first line under load.
+    marker = tmp_path / "written"
+    engine = _fast_fake_engine(tmp_path, "BOOTED", "wedged", marker=marker)
+    _clock_held_until_written(monkeypatch, marker)
 
     result = launch(engine, ["--version"], cwd=None, timeout=1.0)
 
@@ -142,7 +200,8 @@ def test_timeout_synthesizes_a_result_that_keeps_what_the_run_produced(tmp_path)
     # No gda prose in either stream: the classifier composes the sentence from the
     # bound below, so mixing one in would corrupt the evidence.
     assert "timed out" not in result.stderr
-    # The caller's own ceiling is what ended it, and the clock says so.
+    # The caller's own ceiling is what ended it, and the clock the loop read says
+    # so (the real wall clock is pinned by test_streaming_measures_the_elapsed_wall_clock).
     assert result.elapsed_seconds is not None
     assert 1.0 <= result.elapsed_seconds < 3.0
     # Default label: the sentinel channel's launch is just "Godot".
@@ -506,25 +565,30 @@ def test_streaming_maps_a_missing_binary_to_the_same_not_found_result():
     assert streamed.stderr == buffered.stderr
 
 
-def test_a_watchless_launch_streams_and_never_ends_a_run_early(tmp_path):
+def test_a_watchless_launch_streams_and_never_ends_a_run_early(monkeypatch, tmp_path):
     # The pairing that makes ``watch`` POLICY rather than strategy (#714): a launch
     # WITHOUT one still captures and still times itself, and the only thing it gives
     # up is the early abort. Both halves are asserted against the same engine, so a
     # regression that made the no-watch path buffered again — or one that let it end
-    # a run on its own — fails here.
-    engine = _fast_fake_engine(tmp_path, "written and kept", "and this too")
+    # a run on its own — fails here. The clock is held until the child has written
+    # (#824), so neither half races the child's first line.
+    marker = tmp_path / "written"
+    engine = _fast_fake_engine(
+        tmp_path, "written and kept", "and this too", marker=marker
+    )
+    _clock_held_until_written(monkeypatch, marker)
 
-    started = time.monotonic()
     result = launch(engine, [], cwd=None, timeout=1.0, timeout_label="Godot export")
-    waited = time.monotonic() - started
 
     assert result.launch_failure is LaunchFailure.TIMEOUT
     assert result.stdout == "written and kept\n"
     assert result.stderr == "and this too\n"
-    assert result.elapsed_seconds is not None
     assert result.timeout_bound == TimeoutBound("Godot export", 1.0)
-    # It waited out the ceiling rather than ending early on the output it saw.
-    assert waited >= 1.0
+    # It waited out the ceiling rather than ending early on the output it saw: the
+    # held clock reaches 1.0 only after the loop polled past the written output,
+    # so a run that ended on that output would report an elapsed of 0.0.
+    assert result.elapsed_seconds is not None
+    assert result.elapsed_seconds >= 1.0
 
 
 def _capture_popen(monkeypatch) -> list:

--- a/tests/test_live_contract_guards.py
+++ b/tests/test_live_contract_guards.py
@@ -16,6 +16,7 @@ descriptors off the LIVE Typer tree — the same authority ``gda.surface`` walks
 so they stay correct wherever the descriptors and result models physically live.
 """
 
+import functools
 import json
 import math
 import re
@@ -157,13 +158,20 @@ def _live_operations() -> set[str]:
     return {d.operation for d in _descriptors() if d.kind is ExecutionKind.LIVE}
 
 
-def _live_leaves():
-    """Every LIVE leaf as ``(name, descriptor)``, read off the live Typer tree."""
+@functools.cache
+def _live_leaves() -> "tuple[tuple[str, Any], ...]":
+    """Every LIVE leaf as ``(name, descriptor)``, read off the live Typer tree ONCE.
+
+    The tree is immutable for the process, so the walk is memoized (#815); the
+    tuple keeps the callers' ``for name, descriptor in _live_leaves()`` shape.
+    """
     root = typer.main.get_command(app)
+    leaves = []
     for name, command in _leaf_commands(root, []):
         descriptor = getattr(command, "gda_command", None)
         if descriptor is not None and descriptor.kind is ExecutionKind.LIVE:
-            yield name, descriptor
+            leaves.append((name, descriptor))
+    return tuple(leaves)
 
 
 def test_relayed_live_params_models_carry_the_wire_number_policy():

--- a/tests/test_live_contract_guards.py
+++ b/tests/test_live_contract_guards.py
@@ -40,6 +40,7 @@ from gda.runner import RunResult
 from tests.support import (
     PNG_1X1_B64,
     inject_live_runner,
+    minimal_project,
     panel_text,
     screen_capture_reply,
     sentinel,
@@ -626,7 +627,7 @@ def test_the_classify_path_hands_back_the_engines_own_floats(monkeypatch, tmp_pa
     # values Godot's DEFAULT writer would have lost (1e-300 flattens, and
     # 3.141592653589793 loses its last digits), so the assertion would also fail
     # if anything CLI-side re-rendered the value.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(tmp_path)
     reply = {
         "path": "/root/Main/Player",
         "name": "Player",

--- a/tests/test_logger_commands.py
+++ b/tests/test_logger_commands.py
@@ -21,12 +21,8 @@ from tests.support import (
     error_sentinel,
     inject_live_runner,
     sentinel,
+    minimal_project,
 )
-
-
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
 
 
 def test_logger_tail_emits_structured_records_json_through_the_live_channel(
@@ -38,7 +34,7 @@ def test_logger_tail_emits_structured_records_json_through_the_live_channel(
     )
 
     result = CliRunner().invoke(
-        app, ["logger", "tail", "--project", str(_project(tmp_path)), "--json"]
+        app, ["logger", "tail", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -67,7 +63,7 @@ def test_logger_tail_passes_level_and_limit_through(monkeypatch, tmp_path):
             "--limit",
             "5",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -87,7 +83,15 @@ def test_logger_tail_raw_passes_raw_flag_and_returns_verbatim_info_records(
     )
 
     result = CliRunner().invoke(
-        app, ["logger", "tail", "--raw", "--project", str(_project(tmp_path)), "--json"]
+        app,
+        [
+            "logger",
+            "tail",
+            "--raw",
+            "--project",
+            str(minimal_project(tmp_path)),
+            "--json",
+        ],
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -113,7 +117,7 @@ def test_logger_tail_rejects_a_non_positive_limit_on_the_argv_path(tmp_path):
                 "--limit",
                 bad,
                 "--project",
-                str(_project(tmp_path)),
+                str(minimal_project(tmp_path)),
                 "--json",
             ],
         )
@@ -130,7 +134,7 @@ def test_logger_tail_rejects_an_unknown_level_on_the_argv_path(tmp_path):
             "--level",
             "trace",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -144,7 +148,7 @@ def test_logger_tail_human_output_renders_records(monkeypatch, tmp_path):
     )
 
     result = CliRunner().invoke(
-        app, ["logger", "tail", "--project", str(_project(tmp_path))]
+        app, ["logger", "tail", "--project", str(minimal_project(tmp_path))]
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -161,7 +165,7 @@ def test_logger_tail_raw_human_output_renders_lines(monkeypatch, tmp_path):
     )
 
     result = CliRunner().invoke(
-        app, ["logger", "tail", "--raw", "--project", str(_project(tmp_path))]
+        app, ["logger", "tail", "--raw", "--project", str(minimal_project(tmp_path))]
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -173,7 +177,7 @@ def test_logger_tail_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
 
     result = CliRunner().invoke(
-        app, ["logger", "tail", "--project", str(_project(tmp_path)), "--json"]
+        app, ["logger", "tail", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
@@ -193,7 +197,7 @@ def test_logger_tail_log_unavailable_is_a_typed_live_error(monkeypatch, tmp_path
     )
 
     result = CliRunner().invoke(
-        app, ["logger", "tail", "--project", str(_project(tmp_path)), "--json"]
+        app, ["logger", "tail", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
@@ -214,7 +218,7 @@ def test_logger_tail_params_json_rejects_a_non_positive_limit_as_invalid_params(
                 "--params-json",
                 json.dumps({"limit": bad}),
                 "--project",
-                str(_project(tmp_path)),
+                str(minimal_project(tmp_path)),
                 "--json",
             ],
         )

--- a/tests/test_mcp_project_context.py
+++ b/tests/test_mcp_project_context.py
@@ -10,17 +10,11 @@ ADR-0014 / #194 acceptance criterion).
 from pathlib import Path
 
 from gda.mcp.project_context import resolve_project_dir
-
-
-def _project(dir_path: Path) -> Path:
-    """Mark ``dir_path`` a Godot project (a ``project.godot`` is all that counts)."""
-    dir_path.mkdir(parents=True, exist_ok=True)
-    (dir_path / "project.godot").write_text("", encoding="utf-8")
-    return dir_path
+from tests.support import minimal_project
 
 
 def test_gda_project_env_resolves_to_that_project(tmp_path):
-    proj = _project(tmp_path)
+    proj = minimal_project(tmp_path)
     result = resolve_project_dir(
         env={"GDA_PROJECT": str(proj)}, roots=[], cwd=Path("/nonexistent")
     )
@@ -28,13 +22,13 @@ def test_gda_project_env_resolves_to_that_project(tmp_path):
 
 
 def test_root_resolves_when_gda_project_unset(tmp_path):
-    proj = _project(tmp_path)
+    proj = minimal_project(tmp_path)
     result = resolve_project_dir(env={}, roots=[str(proj)], cwd=Path("/nonexistent"))
     assert result == proj
 
 
 def test_cwd_used_when_it_is_a_project_and_nothing_else_resolves(tmp_path):
-    proj = _project(tmp_path)
+    proj = minimal_project(tmp_path)
     result = resolve_project_dir(env={}, roots=[], cwd=proj)
     assert result == proj
 
@@ -42,8 +36,8 @@ def test_cwd_used_when_it_is_a_project_and_nothing_else_resolves(tmp_path):
 def test_first_valid_root_wins_invalid_roots_skipped(tmp_path):
     not_a_project = tmp_path / "plain"
     not_a_project.mkdir()
-    proj = _project(tmp_path / "game")
-    later = _project(tmp_path / "other")
+    proj = minimal_project(tmp_path / "game")
+    later = minimal_project(tmp_path / "other")
     result = resolve_project_dir(
         env={},
         roots=[str(not_a_project), str(proj), str(later)],
@@ -60,8 +54,8 @@ def test_nothing_resolves_to_none(tmp_path):
 
 
 def test_gda_project_takes_precedence_over_root(tmp_path):
-    pinned = _project(tmp_path / "pinned")
-    root = _project(tmp_path / "root")
+    pinned = minimal_project(tmp_path / "pinned")
+    root = minimal_project(tmp_path / "root")
     result = resolve_project_dir(
         env={"GDA_PROJECT": str(pinned)}, roots=[str(root)], cwd=Path("/nonexistent")
     )
@@ -75,7 +69,7 @@ def test_invalid_gda_project_does_not_fall_through_to_root(tmp_path):
     # GDA_PROJECT and surfaces its own typed error for project-taking commands.
     bad = tmp_path / "not-a-project"
     bad.mkdir()
-    valid_root = _project(tmp_path / "game")
+    valid_root = minimal_project(tmp_path / "game")
     result = resolve_project_dir(
         env={"GDA_PROJECT": str(bad)},
         roots=[str(valid_root)],

--- a/tests/test_mcp_project_injection.py
+++ b/tests/test_mcp_project_injection.py
@@ -12,7 +12,6 @@ engine-free. The real MCP -> gda -> engine chain is the L4 e2e gate.
 
 import json
 import sys
-from pathlib import Path
 
 from gda.mcp.runner import SubprocessGdaRunner
 from gda.mcp.server import build_server, dispatch
@@ -24,14 +23,7 @@ from tests.mcp_support import (
     roots_changed_call,
     schema_then,
 )
-from tests.support import SCENE_CREATE_RESULT
-
-
-def _project(dir_path: Path) -> Path:
-    """Mark ``dir_path`` a Godot project (a ``project.godot`` is all that counts)."""
-    dir_path.mkdir(parents=True, exist_ok=True)
-    (dir_path / "project.godot").write_text("", encoding="utf-8")
-    return dir_path
+from tests.support import SCENE_CREATE_RESULT, minimal_project
 
 
 def test_no_tool_inputschema_carries_a_project_field():
@@ -88,7 +80,7 @@ def test_server_resolves_gda_project_env_and_injects_it_on_dispatch(
 ):
     # The full env -> resolve -> inject glue: GDA_PROJECT points at a real project,
     # so every tool call dispatches gda against it (here observed at the seam).
-    proj = _project(tmp_path)
+    proj = minimal_project(tmp_path)
     monkeypatch.setenv("GDA_PROJECT", str(proj))
     runner = FakeGdaRunner(
         schema_then(lambda args, stdin: gda_result(json.dumps(SCENE_CREATE_RESULT)))
@@ -109,7 +101,7 @@ def _scene_create_runner():
 
 def test_client_root_resolves_project_when_gda_project_unset(tmp_path, monkeypatch):
     monkeypatch.delenv("GDA_PROJECT", raising=False)
-    proj = _project(tmp_path / "game")
+    proj = minimal_project(tmp_path / "game")
     runner = _scene_create_runner()
     server = build_server(runner)
 
@@ -125,8 +117,8 @@ def test_client_root_resolves_project_when_gda_project_unset(tmp_path, monkeypat
 
 
 def test_gda_project_env_beats_client_roots(tmp_path, monkeypatch):
-    pinned = _project(tmp_path / "pinned")
-    other = _project(tmp_path / "other")
+    pinned = minimal_project(tmp_path / "pinned")
+    other = minimal_project(tmp_path / "other")
     monkeypatch.setenv("GDA_PROJECT", str(pinned))
     runner = _scene_create_runner()
     server = build_server(runner)
@@ -146,7 +138,7 @@ def test_invalid_client_roots_skipped_first_valid_used(tmp_path, monkeypatch):
     monkeypatch.delenv("GDA_PROJECT", raising=False)
     not_a_project = tmp_path / "plain"
     not_a_project.mkdir()
-    proj = _project(tmp_path / "game")
+    proj = minimal_project(tmp_path / "game")
     runner = _scene_create_runner()
     server = build_server(runner)
 
@@ -169,8 +161,8 @@ def test_project_is_snapshotted_on_first_call_then_cached(tmp_path, monkeypatch)
     # snapshot. (Re-resolution on a roots/list_changed notification — a different
     # trigger — is exercised by the two tests below.)
     monkeypatch.delenv("GDA_PROJECT", raising=False)
-    first = _project(tmp_path / "first")
-    second = _project(tmp_path / "second")
+    first = minimal_project(tmp_path / "first")
+    second = minimal_project(tmp_path / "second")
     runner = _scene_create_runner()
     server = build_server(runner)
 
@@ -196,8 +188,8 @@ def test_roots_list_changed_reresolves_to_the_new_active_project(tmp_path, monke
     # gda-mcp invalidates its cached project so the NEXT tool call re-runs the
     # ADR-0014 precedence against the now-current roots.
     monkeypatch.delenv("GDA_PROJECT", raising=False)
-    first = _project(tmp_path / "first")
-    second = _project(tmp_path / "second")
+    first = minimal_project(tmp_path / "first")
+    second = minimal_project(tmp_path / "second")
     runner = _scene_create_runner()
     server = build_server(runner)
 
@@ -216,8 +208,8 @@ def test_roots_list_changed_reresolves_to_the_new_active_project(tmp_path, monke
 def test_roots_list_changed_does_not_override_pinned_gda_project(tmp_path, monkeypatch):
     # #209: an explicitly pinned GDA_PROJECT wins regardless of a roots change —
     # resolve_project_dir reads env first, so re-resolution returns the pin.
-    pinned = _project(tmp_path / "pinned")
-    other = _project(tmp_path / "other")
+    pinned = minimal_project(tmp_path / "pinned")
+    other = minimal_project(tmp_path / "other")
     monkeypatch.setenv("GDA_PROJECT", str(pinned))
     runner = _scene_create_runner()
     server = build_server(runner)
@@ -261,7 +253,7 @@ def test_stateless_connection_degrades_to_no_project_without_error(
     # projectless (no NoBackChannelError escapes the server), landing on the
     # env→cwd tail of the ADR-0014 precedence.
     monkeypatch.delenv("GDA_PROJECT", raising=False)
-    unreachable = _project(tmp_path / "game")
+    unreachable = minimal_project(tmp_path / "game")
     runner = _scene_create_runner()
     server = build_server(runner)
 
@@ -282,7 +274,7 @@ def test_gda_project_env_resolves_on_stateless_connection(tmp_path, monkeypatch)
     # ADR-0039 promotes GDA_PROJECT to the durable anchor: on a 2026-07-28
     # connection (no roots signal at all) the env pin must keep resolving exactly
     # as it does for legacy clients.
-    proj = _project(tmp_path)
+    proj = minimal_project(tmp_path)
     monkeypatch.setenv("GDA_PROJECT", str(proj))
     runner = _scene_create_runner()
     server = build_server(runner)

--- a/tests/test_node_commands.py
+++ b/tests/test_node_commands.py
@@ -8,10 +8,7 @@ parse → typed model → JSON — with canned engine output, no real Godot.
 
 import json
 
-from typer.testing import CliRunner
 
-from gda.cli import app
-from gda.runner import RunResult
 from tests.support import (
     NODE_ADD_RESULT as ADD_RESULT,
     NODE_CONNECT_RESULT as CONNECT_RESULT,
@@ -21,7 +18,7 @@ from tests.support import (
     NODE_MOVE_RESULT as MOVE_RESULT,
     NODE_REMOVE_RESULT as REMOVE_RESULT,
     NODE_SET_RESULT as SET_RESULT,
-    inject_runner,
+    invoke_cli,
     sentinel,
 )
 
@@ -46,11 +43,8 @@ def test_node_add_instance_json_dispatches_instance_param_and_echoes_source(
     # carries the instance path instead of a type, the name defaults to the
     # instanced scene's filename stem (model-side, ADR-0015), and the result
     # echoes the instanced res:// path alongside the resolved root type.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(ADD_INSTANCE_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "node",
             "add",
@@ -59,6 +53,7 @@ def test_node_add_instance_json_dispatches_instance_param_and_echoes_source(
             "res://hud.tscn",
             "--json",
         ],
+        stdout=sentinel(ADD_INSTANCE_RESULT),
     )
 
     assert result.exit_code == 0
@@ -87,12 +82,8 @@ def test_node_add_type_and_instance_together_is_a_usage_error(monkeypatch):
     # them is a usage error (exit 2) that fires before any dispatch — the
     # engine is never reached. The rule lives model-side (ADR-0015), so the
     # --params-json path surfaces the same violation as invalid_params.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(ADD_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "node",
             "add",
@@ -103,6 +94,7 @@ def test_node_add_type_and_instance_together_is_a_usage_error(monkeypatch):
             "res://hud.tscn",
             "--json",
         ],
+        stdout=sentinel(ADD_RESULT),
     )
 
     assert result.exit_code == 2
@@ -112,11 +104,11 @@ def test_node_add_type_and_instance_together_is_a_usage_error(monkeypatch):
 def test_node_add_without_type_or_instance_is_a_usage_error(monkeypatch):
     # No mode at all is a usage error too: add always needs exactly one of
     # --type/--instance.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(ADD_RESULT), stderr="", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["node", "add", "/tmp/proj/main.tscn", "--json"],
+        stdout=sentinel(ADD_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["node", "add", "/tmp/proj/main.tscn", "--json"])
 
     assert result.exit_code == 2
     assert fake.calls == []
@@ -124,13 +116,8 @@ def test_node_add_without_type_or_instance_is_a_usage_error(monkeypatch):
 
 def test_node_add_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
     # Engine banner noise around the sentinel, diagnostics on stderr (ADR-0002).
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(ADD_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "node",
             "add",
@@ -143,6 +130,8 @@ def test_node_add_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
             "Hero",
             "--json",
         ],
+        stdout=sentinel(ADD_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -177,10 +166,8 @@ def test_node_add_index_dispatches_destination_index(monkeypatch):
     # operation owns range validation because the valid upper bound depends on
     # the resolved parent at runtime.
     stdout = sentinel({**ADD_RESULT, "path": "Level", "name": "Level"})
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "node",
             "add",
@@ -193,6 +180,7 @@ def test_node_add_index_dispatches_destination_index(monkeypatch):
             "1",
             "--json",
         ],
+        stdout=stdout,
     )
 
     assert result.exit_code == 0
@@ -215,10 +203,11 @@ def test_node_list_json_emits_node_tree_with_paths_and_exit_zero(monkeypatch):
     # node list is the node-group verifier (issue #53): it reports the scene's
     # tree like scene get, but each node carries its node path — the address an
     # agent feeds back into node add's --parent.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(LIST_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(app, ["node", "list", "/tmp/proj/main.tscn", "--json"])
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["node", "list", "/tmp/proj/main.tscn", "--json"],
+        stdout=sentinel(LIST_RESULT),
+    )
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -235,11 +224,10 @@ def test_node_get_json_emits_typed_properties_and_exit_zero(monkeypatch):
     # node get is the read half of issue #55: it loads a scene and reports the
     # addressed node's properties as typed JSON — the read an agent verifies a
     # `set` against.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(GET_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["node", "get", "/tmp/proj/main.tscn", "--node", "Hero", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["node", "get", "/tmp/proj/main.tscn", "--node", "Hero", "--json"],
+        stdout=sentinel(GET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -261,10 +249,8 @@ def test_node_set_json_echoes_the_coerced_property_and_exit_zero(monkeypatch):
     # to the property's declared type, saves, and echoes the coerced property —
     # the result an agent asserts (and which round-trips via node get).
     stdout = sentinel(SET_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "node",
             "set",
@@ -277,6 +263,7 @@ def test_node_set_json_echoes_the_coerced_property_and_exit_zero(monkeypatch):
             "3,4",
             "--json",
         ],
+        stdout=stdout,
     )
 
     assert result.exit_code == 0
@@ -305,11 +292,10 @@ def test_node_remove_json_echoes_the_removed_node_and_exit_zero(monkeypatch):
     # node remove is the first structural edit (issue #56): it deletes a node
     # and its subtree, echoing the removed node's address/name/type — the result
     # an agent asserts. The node is addressed by node path, dispatched by name.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(REMOVE_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["node", "remove", "/tmp/proj/main.tscn", "--node", "Hero", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["node", "remove", "/tmp/proj/main.tscn", "--node", "Hero", "--json"],
+        stdout=sentinel(REMOVE_RESULT),
     )
 
     assert result.exit_code == 0
@@ -325,11 +311,10 @@ def test_node_duplicate_json_echoes_the_new_copy_and_exit_zero(monkeypatch):
     # node duplicate (issue #56) copies a node and its subtree under the source's
     # own parent with a fresh name, echoing the source and the new copy's
     # address/name/type — the result an agent feeds back into other node commands.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(DUPLICATE_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["node", "duplicate", "/tmp/proj/main.tscn", "--node", "Hero", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["node", "duplicate", "/tmp/proj/main.tscn", "--node", "Hero", "--json"],
+        stdout=sentinel(DUPLICATE_RESULT),
     )
 
     assert result.exit_code == 0
@@ -346,11 +331,8 @@ def test_node_move_json_echoes_the_reparented_node_and_exit_zero(monkeypatch):
     # echoing the source, the new parent, and the node's new address — the
     # result an agent feeds back into other node commands. Both node paths are
     # passed through as raw strings; the operation resolves them.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(MOVE_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "node",
             "move",
@@ -361,6 +343,7 @@ def test_node_move_json_echoes_the_reparented_node_and_exit_zero(monkeypatch):
             "Enemies",
             "--json",
         ],
+        stdout=sentinel(MOVE_RESULT),
     )
 
     assert result.exit_code == 0
@@ -384,11 +367,8 @@ def test_node_move_index_dispatches_destination_index(monkeypatch):
     # Issue #415: `node move --index` requests the moved node's final 0-based
     # sibling position under --to. The operation validates the range after it
     # resolves the source and destination parents.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(MOVE_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "node",
             "move",
@@ -401,6 +381,7 @@ def test_node_move_index_dispatches_destination_index(monkeypatch):
             "1",
             "--json",
         ],
+        stdout=sentinel(MOVE_RESULT),
     )
 
     assert result.exit_code == 0
@@ -422,11 +403,10 @@ def test_node_add_defaults_parent_to_root_and_name_to_type(monkeypatch):
     # scene root ('.'), and omitting --name names the node after its type —
     # mirroring how the Godot editor names a freshly added node.
     stdout = sentinel({**ADD_RESULT, "path": "Sprite2D", "name": "Sprite2D"})
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         ["node", "add", "/tmp/proj/main.tscn", "--type", "Sprite2D", "--json"],
+        stdout=stdout,
     )
 
     assert result.exit_code == 0
@@ -450,11 +430,8 @@ def test_node_connect_signal_json_dispatches_the_four_part_connection(monkeypatc
     # parts are addressed by --from/--signal/--to/--method; the wire param key
     # for the source is `from` (matching the .tscn [connection] key), since
     # `from` is a Python keyword only at the model layer.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(CONNECT_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "node",
             "connect-signal",
@@ -469,6 +446,7 @@ def test_node_connect_signal_json_dispatches_the_four_part_connection(monkeypatc
             "on_timeout",
             "--json",
         ],
+        stdout=sentinel(CONNECT_RESULT),
     )
 
     assert result.exit_code == 0
@@ -494,10 +472,8 @@ def test_node_disconnect_signal_json_dispatches_the_four_part_connection(monkeyp
     # node disconnect-signal is the unwire half of issue #57: same four-part
     # addressing, dispatched by its own operation name.
     stdout = sentinel(CONNECT_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "node",
             "disconnect-signal",
@@ -512,6 +488,7 @@ def test_node_disconnect_signal_json_dispatches_the_four_part_connection(monkeyp
             "on_timeout",
             "--json",
         ],
+        stdout=stdout,
     )
 
     assert result.exit_code == 0
@@ -535,12 +512,8 @@ def test_node_connect_signal_requires_all_four_connection_flags(monkeypatch):
     # The four connection flags are mandatory (no sensible default for any part
     # of a connection): omitting one is a usage error (exit 2), surfaced before
     # any engine path so no Godot process is spawned.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(CONNECT_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "node",
             "connect-signal",
@@ -554,6 +527,7 @@ def test_node_connect_signal_requires_all_four_connection_flags(monkeypatch):
             # --method omitted
             "--json",
         ],
+        stdout=sentinel(CONNECT_RESULT),
     )
 
     assert result.exit_code == 2

--- a/tests/test_node_errors.py
+++ b/tests/test_node_errors.py
@@ -6,46 +6,28 @@ registered operation codes (ADR-0002) — exit 4 for the operation category,
 finer stable codes so an agent can branch on the mode without parsing prose.
 """
 
-import json
+from tests.support import assert_operation_error, operation_error_invoker
 
-from typer.testing import CliRunner
-
-from gda.cli import app
-from gda.runner import RunResult
-from tests.support import error_sentinel, inject_runner
-
-
-def _invoke_node_add(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: node-add\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app,
-        ["node", "add", "/x/main.tscn", "--type", "Sprite2D", "--json"],
-    )
+_node_add = operation_error_invoker(
+    ["node", "add", "/x/main.tscn", "--type", "Sprite2D", "--json"], "node-add"
+)
 
 
 def test_node_add_bad_parent_maps_to_stable_parent_not_found_code(monkeypatch):
     # The scene exists but the requested parent node path resolves to nothing —
     # a new node-group code, distinct from the file-level path_not_found, so an
     # agent knows to fix the node path, not the scene path.
-    result = _invoke_node_add(
+    result = _node_add(
         monkeypatch, "parent_not_found", "parent node not found in scene: Bogus/Path"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "parent_not_found"
-    assert "Bogus/Path" in err["message"]
     # The raw stderr still rides along as diagnostics (ADR-0002).
-    assert err["diagnostics"] == "gda: running operation: node-add\n"
+    assert_operation_error(
+        result,
+        "parent_not_found",
+        "Bogus/Path",
+        diagnostics="gda: running operation: node-add\n",
+    )
 
 
 def test_node_add_non_canonical_parent_maps_to_stable_parent_not_found_code(
@@ -58,57 +40,39 @@ def test_node_add_non_canonical_parent_maps_to_stable_parent_not_found_code(
     # nothing — with a message naming the canonical form. Mapping pin: the
     # envelope rides through the same parent_not_found path as a missing
     # canonical parent.
-    result = _invoke_node_add(
+    result = _node_add(
         monkeypatch,
         "parent_not_found",
         "non-canonical parent path: A/.. — address the parent exactly as "
         "node list reports it: '.' for the root, 'A/B' for a descendant",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "parent_not_found"
-    assert "A/.." in err["message"]
+    err = assert_operation_error(result, "parent_not_found", "A/..")
     assert "non-canonical" in err["message"]
 
 
 def test_node_add_unknown_type_maps_to_stable_invalid_node_type_code(monkeypatch):
-    result = _invoke_node_add(
+    result = _node_add(
         monkeypatch,
         "invalid_node_type",
         "not an instantiable Node class or registered class_name: Foo",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "invalid_node_type"
-    assert "Foo" in err["message"]
+    assert_operation_error(result, "invalid_node_type", "Foo")
 
 
 def test_node_add_name_collision_maps_to_stable_duplicate_node_name_code(monkeypatch):
-    result = _invoke_node_add(
+    result = _node_add(
         monkeypatch, "duplicate_node_name", "parent already has a child named: Hero"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "duplicate_node_name"
-    assert "Hero" in err["message"]
+    assert_operation_error(result, "duplicate_node_name", "Hero")
 
 
 def test_node_add_bad_name_maps_to_stable_invalid_node_name_code(monkeypatch):
-    result = _invoke_node_add(
-        monkeypatch, "invalid_node_name", "invalid name: Bad%Name"
-    )
+    result = _node_add(monkeypatch, "invalid_node_name", "invalid name: Bad%Name")
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "invalid_node_name"
-    assert "Bad%Name" in err["message"]
+    assert_operation_error(result, "invalid_node_name", "Bad%Name")
 
 
 def test_node_add_vanished_instance_maps_to_stable_missing_dependency_code(monkeypatch):
@@ -116,18 +80,14 @@ def test_node_add_vanished_instance_maps_to_stable_missing_dependency_code(monke
     # would lose the whole instance on re-save; the refusal surfaces as the
     # registered missing_dependency code so an agent knows to fix the scene's
     # dependencies or its project context rather than retry the add.
-    result = _invoke_node_add(
+    result = _node_add(
         monkeypatch,
         "missing_dependency",
         "scene nodes vanished on load (unresolvable instanced sub-scene?): "
         "ChildInstance — re-saving would silently drop them",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "missing_dependency"
-    assert "ChildInstance" in err["message"]
+    assert_operation_error(result, "missing_dependency", "ChildInstance")
 
 
 def test_node_add_substituted_class_maps_to_stable_missing_dependency_code(monkeypatch):
@@ -135,7 +95,7 @@ def test_node_add_substituted_class_maps_to_stable_missing_dependency_code(monke
     # run materializes as a substitute node, so a re-save would rewrite its
     # type. The refusal reuses missing_dependency — an unavailable class IS a
     # missing dependency (extension/module), the same agent fix applies.
-    result = _invoke_node_add(
+    result = _node_add(
         monkeypatch,
         "missing_dependency",
         "scene nodes vanished or degraded on load: "
@@ -143,11 +103,9 @@ def test_node_add_substituted_class_maps_to_stable_missing_dependency_code(monke
         "re-saving would silently drop or downgrade them",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "missing_dependency"
-    assert "declared TotallyMissingClass, materialized Node" in err["message"]
+    assert_operation_error(
+        result, "missing_dependency", "declared TotallyMissingClass, materialized Node"
+    )
 
 
 def test_node_add_broken_class_name_maps_to_stable_uninstantiable_script_code(
@@ -157,74 +115,46 @@ def test_node_add_broken_class_name_maps_to_stable_uninstantiable_script_code(
     # script broke after registration is a script problem, not an unknown type.
     # The refusal surfaces as the registered uninstantiable_script code so an
     # agent knows to repair the script rather than the type name.
-    result = _invoke_node_add(
+    result = _node_add(
         monkeypatch,
         "uninstantiable_script",
         "registered class_name Hero script cannot be instantiated: "
         "res://hero.gd — it no longer compiles; see diagnostics",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "uninstantiable_script"
-    assert "res://hero.gd" in err["message"]
+    assert_operation_error(result, "uninstantiable_script", "res://hero.gd")
 
 
 def test_node_add_missing_scene_reuses_stable_path_not_found_code(monkeypatch):
     # The scene-file-level failure reuses the registered scene code: the
     # node group introduces no parallel code for the same mode.
-    result = _invoke_node_add(
+    result = _node_add(
         monkeypatch, "path_not_found", "scene file does not exist: /x/main.tscn"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/main.tscn" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/main.tscn")
 
 
-def _invoke_node_get(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: node-get\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app, ["node", "get", "/x/main.tscn", "--node", "Bogus", "--json"]
-    )
+_node_get = operation_error_invoker(
+    ["node", "get", "/x/main.tscn", "--node", "Bogus", "--json"], "node-get"
+)
 
 
-def _invoke_node_set(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: node-set\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app,
-        [
-            "node",
-            "set",
-            "/x/main.tscn",
-            "--node",
-            "Hero",
-            "--property",
-            "position",
-            "--value",
-            "3,4",
-            "--json",
-        ],
-    )
+_node_set = operation_error_invoker(
+    [
+        "node",
+        "set",
+        "/x/main.tscn",
+        "--node",
+        "Hero",
+        "--property",
+        "position",
+        "--value",
+        "3,4",
+        "--json",
+    ],
+    "node-set",
+)
 
 
 def test_node_get_missing_node_maps_to_stable_node_not_found_code(monkeypatch):
@@ -232,60 +162,41 @@ def test_node_get_missing_node_maps_to_stable_node_not_found_code(monkeypatch):
     # distinct from the file-level path_not_found and from node add's
     # parent_not_found, so an agent knows the node, not the file or parent, is
     # the thing that's missing.
-    result = _invoke_node_get(
-        monkeypatch, "node_not_found", "node not found in scene: Bogus"
-    )
+    result = _node_get(monkeypatch, "node_not_found", "node not found in scene: Bogus")
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "node_not_found"
-    assert "Bogus" in err["message"]
+    assert_operation_error(result, "node_not_found", "Bogus")
 
 
 def test_node_set_missing_node_maps_to_stable_node_not_found_code(monkeypatch):
-    result = _invoke_node_set(
-        monkeypatch, "node_not_found", "node not found in scene: Hero"
-    )
+    result = _node_set(monkeypatch, "node_not_found", "node not found in scene: Hero")
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "node_not_found"
-    assert "Hero" in err["message"]
+    assert_operation_error(result, "node_not_found", "Hero")
 
 
 def test_node_set_unknown_property_maps_to_stable_unknown_property_code(monkeypatch):
     # issue #55: setting a property the node does not declare is a clean
     # unknown_property error, so an agent can branch on a typo'd or absent
     # property name rather than parsing prose.
-    result = _invoke_node_set(
+    result = _node_set(
         monkeypatch,
         "unknown_property",
         "node Hero has no settable property: positon",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "unknown_property"
-    assert "positon" in err["message"]
+    assert_operation_error(result, "unknown_property", "positon")
 
 
 def test_node_set_uncoercible_value_maps_to_stable_uncoercible_value_code(monkeypatch):
     # issue #55's type-coercion contract: a value that cannot be coerced to the
     # property's declared Godot type is a clean uncoercible_value error naming
     # the value, the target type, and the property — never a silent wrong value.
-    result = _invoke_node_set(
+    result = _node_set(
         monkeypatch,
         "uncoercible_value",
         'cannot coerce value "nope" to Vector2 for property position on node Hero',
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "uncoercible_value"
-    assert "Vector2" in err["message"]
+    assert_operation_error(result, "uncoercible_value", "Vector2")
 
 
 def test_node_set_missing_dependency_maps_to_stable_missing_dependency_code(
@@ -295,145 +206,104 @@ def test_node_set_missing_dependency_maps_to_stable_missing_dependency_code(
     # (issue #64) via the shared mutate-entry: a scene whose instance vanishes
     # on load is refused with missing_dependency, the same as node add, leaving
     # the file untouched rather than dropping the instance on re-save.
-    result = _invoke_node_set(
+    result = _node_set(
         monkeypatch,
         "missing_dependency",
         "scene nodes vanished or degraded on load: ChildInstance (vanished) — "
         "re-saving would silently drop or downgrade them",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "missing_dependency"
-    assert "ChildInstance" in err["message"]
+    assert_operation_error(result, "missing_dependency", "ChildInstance")
 
 
 def test_node_get_missing_scene_reuses_stable_path_not_found_code(monkeypatch):
-    result = _invoke_node_get(
+    result = _node_get(
         monkeypatch, "path_not_found", "scene file does not exist: /x/main.tscn"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "path_not_found"
-    assert "/x/main.tscn" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/main.tscn")
 
 
-def _invoke_node_remove(monkeypatch, code: str, message: str, node: str = "Hero"):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: node-remove\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app, ["node", "remove", "/x/main.tscn", "--node", node, "--json"]
-    )
+_node_remove = operation_error_invoker(
+    lambda node="Hero": ["node", "remove", "/x/main.tscn", "--node", node, "--json"],
+    "node-remove",
+)
 
 
 def test_node_remove_missing_node_maps_to_stable_node_not_found_code(monkeypatch):
     # issue #56: removing a node path that resolves to nothing reuses the
     # node-group's node_not_found code — the same mode node get / node set
     # report, so an agent branches on a missing node without a parallel code.
-    result = _invoke_node_remove(
+    result = _node_remove(
         monkeypatch, "node_not_found", "node not found in scene: Bogus", node="Bogus"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "node_not_found"
-    assert "Bogus" in err["message"]
+    assert_operation_error(result, "node_not_found", "Bogus")
 
 
 def test_node_remove_root_maps_to_stable_cannot_target_root_code(monkeypatch):
     # issue #56: removing the scene root is refused with the new structural-edit
     # code cannot_target_root — the root has no parent to be removed from, so
     # the agent learns to delete the scene file rather than retry the removal.
-    result = _invoke_node_remove(
+    result = _node_remove(
         monkeypatch,
         "cannot_target_root",
         "cannot remove the scene root: . — the root has no parent to be removed from",
         node=".",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "cannot_target_root"
-    assert "root" in err["message"]
+    assert_operation_error(result, "cannot_target_root", "root")
 
 
-def _invoke_node_duplicate(monkeypatch, code: str, message: str, node: str = "Hero"):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: node-duplicate\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app, ["node", "duplicate", "/x/main.tscn", "--node", node, "--json"]
-    )
+_node_duplicate = operation_error_invoker(
+    lambda node="Hero": ["node", "duplicate", "/x/main.tscn", "--node", node, "--json"],
+    "node-duplicate",
+)
 
 
 def test_node_duplicate_missing_node_maps_to_stable_node_not_found_code(monkeypatch):
     # issue #56: duplicating a node path that resolves to nothing reuses the
     # node-group's node_not_found code.
-    result = _invoke_node_duplicate(
+    result = _node_duplicate(
         monkeypatch, "node_not_found", "node not found in scene: Bogus", node="Bogus"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "node_not_found"
-    assert "Bogus" in err["message"]
+    assert_operation_error(result, "node_not_found", "Bogus")
 
 
 def test_node_duplicate_root_maps_to_stable_cannot_target_root_code(monkeypatch):
     # issue #56: the scene root has no parent to host a sibling copy, so
     # duplicating '.' reuses the shared cannot_target_root code.
-    result = _invoke_node_duplicate(
+    result = _node_duplicate(
         monkeypatch,
         "cannot_target_root",
         "cannot duplicate the scene root: . — the root has no parent to host a sibling copy",
         node=".",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "cannot_target_root"
-    assert "root" in err["message"]
+    assert_operation_error(result, "cannot_target_root", "root")
 
 
-def _invoke_node_move(
-    monkeypatch, code: str, message: str, node: str = "Hero", to: str = "Enemies"
-):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: node-move\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app,
-        ["node", "move", "/x/main.tscn", "--node", node, "--to", to, "--json"],
-    )
+_node_move = operation_error_invoker(
+    lambda node="Hero", to="Enemies": [
+        "node",
+        "move",
+        "/x/main.tscn",
+        "--node",
+        node,
+        "--to",
+        to,
+        "--json",
+    ],
+    "node-move",
+)
 
 
 def test_node_move_cyclic_target_maps_to_stable_cyclic_target_code(monkeypatch):
     # issue #56: moving a node under its own descendant would detach the subtree
     # from the scene. The refusal surfaces as the new cyclic_target code so an
     # agent branches on the cyclic mistake rather than parsing prose.
-    result = _invoke_node_move(
+    result = _node_move(
         monkeypatch,
         "cyclic_target",
         "cyclic move target: A/B is the moved node A or one of its descendants",
@@ -441,129 +311,93 @@ def test_node_move_cyclic_target_maps_to_stable_cyclic_target_code(monkeypatch):
         to="A/B",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "cyclic_target"
-    assert "A/B" in err["message"]
+    assert_operation_error(result, "cyclic_target", "A/B")
 
 
 def test_node_move_missing_target_maps_to_stable_parent_not_found_code(monkeypatch):
     # An invalid move target reuses the node group's parent_not_found code (the
     # same code node add reports for a bad --parent).
-    result = _invoke_node_move(
+    result = _node_move(
         monkeypatch,
         "parent_not_found",
         "target parent node not found in scene: Bogus",
         to="Bogus",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "parent_not_found"
-    assert "Bogus" in err["message"]
+    assert_operation_error(result, "parent_not_found", "Bogus")
 
 
 def test_node_move_name_collision_maps_to_stable_duplicate_node_name_code(monkeypatch):
     # A name collision at the destination reuses duplicate_node_name.
-    result = _invoke_node_move(
+    result = _node_move(
         monkeypatch,
         "duplicate_node_name",
         "target Enemies already has a child named: Hero",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "duplicate_node_name"
-    assert "Hero" in err["message"]
+    assert_operation_error(result, "duplicate_node_name", "Hero")
 
 
 def test_node_move_missing_node_maps_to_stable_node_not_found_code(monkeypatch):
-    result = _invoke_node_move(
+    result = _node_move(
         monkeypatch, "node_not_found", "node not found in scene: Bogus", node="Bogus"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "node_not_found"
-    assert "Bogus" in err["message"]
+    assert_operation_error(result, "node_not_found", "Bogus")
 
 
 def test_node_move_root_maps_to_stable_cannot_target_root_code(monkeypatch):
     # Moving the scene root is refused with cannot_target_root — the root has no
     # parent to be reparented out of.
-    result = _invoke_node_move(
+    result = _node_move(
         monkeypatch,
         "cannot_target_root",
         "cannot move the scene root: . — the root has no parent to be reparented out of",
         node=".",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "cannot_target_root"
-    assert "root" in err["message"]
+    assert_operation_error(result, "cannot_target_root", "root")
 
 
 # --- node connect-signal / disconnect-signal (issue #57) ---
 
 
-def _invoke_connect_signal(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: node-connect-signal\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app,
-        [
-            "node",
-            "connect-signal",
-            "/x/main.tscn",
-            "--from",
-            "Emitter",
-            "--signal",
-            "timeout",
-            "--to",
-            "Receiver",
-            "--method",
-            "on_timeout",
-            "--json",
-        ],
-    )
+_connect_signal = operation_error_invoker(
+    [
+        "node",
+        "connect-signal",
+        "/x/main.tscn",
+        "--from",
+        "Emitter",
+        "--signal",
+        "timeout",
+        "--to",
+        "Receiver",
+        "--method",
+        "on_timeout",
+        "--json",
+    ],
+    "node-connect-signal",
+)
 
 
-def _invoke_disconnect_signal(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: node-disconnect-signal\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app,
-        [
-            "node",
-            "disconnect-signal",
-            "/x/main.tscn",
-            "--from",
-            "Emitter",
-            "--signal",
-            "timeout",
-            "--to",
-            "Receiver",
-            "--method",
-            "on_timeout",
-            "--json",
-        ],
-    )
+_disconnect_signal = operation_error_invoker(
+    [
+        "node",
+        "disconnect-signal",
+        "/x/main.tscn",
+        "--from",
+        "Emitter",
+        "--signal",
+        "timeout",
+        "--to",
+        "Receiver",
+        "--method",
+        "on_timeout",
+        "--json",
+    ],
+    "node-disconnect-signal",
+)
 
 
 def test_connect_signal_missing_signal_maps_to_stable_signal_not_found_code(
@@ -572,40 +406,30 @@ def test_connect_signal_missing_signal_maps_to_stable_signal_not_found_code(
     # issue #57's design decision: the signal MUST exist on the source node — a
     # typo or wrong node is a clean signal_not_found error, so an agent branches
     # on a bad signal name rather than parsing prose.
-    result = _invoke_connect_signal(
+    result = _connect_signal(
         monkeypatch, "signal_not_found", "source node Emitter has no signal: timoeut"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "signal_not_found"
-    assert "timoeut" in err["message"]
+    assert_operation_error(result, "signal_not_found", "timoeut")
 
 
 def test_connect_signal_missing_source_node_reuses_node_not_found_code(monkeypatch):
     # The source node path resolving to nothing reuses the node group's
     # node_not_found code (issue #55) — the node group introduces no parallel
     # code for the same mode.
-    result = _invoke_connect_signal(
+    result = _connect_signal(
         monkeypatch, "node_not_found", "source node not found in scene: Emitter"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "node_not_found"
-    assert "Emitter" in err["message"]
+    assert_operation_error(result, "node_not_found", "Emitter")
 
 
 def test_connect_signal_missing_target_node_reuses_node_not_found_code(monkeypatch):
-    result = _invoke_connect_signal(
+    result = _connect_signal(
         monkeypatch, "node_not_found", "target node not found in scene: Receiver"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "node_not_found"
-    assert "Receiver" in err["message"]
+    assert_operation_error(result, "node_not_found", "Receiver")
 
 
 def test_connect_signal_already_connected_maps_to_stable_already_connected_code(
@@ -615,17 +439,13 @@ def test_connect_signal_already_connected_maps_to_stable_already_connected_code(
     # already_connected error rather than a silent no-op or a noisy engine
     # ERR_INVALID_PARAMETER — so an agent can tell "already there" apart from
     # "newly wired".
-    result = _invoke_connect_signal(
+    result = _connect_signal(
         monkeypatch,
         "already_connected",
         "Emitter.timeout is already connected to Receiver.on_timeout",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "already_connected"
-    assert "on_timeout" in err["message"]
+    assert_operation_error(result, "already_connected", "on_timeout")
 
 
 def test_disconnect_signal_absent_connection_maps_to_connection_not_found_code(
@@ -634,53 +454,39 @@ def test_disconnect_signal_absent_connection_maps_to_connection_not_found_code(
     # issue #57's acceptance: disconnecting a connection that does not exist is a
     # clean connection_not_found error, not a silent success — so an agent knows
     # the unwiring had nothing to remove.
-    result = _invoke_disconnect_signal(
+    result = _disconnect_signal(
         monkeypatch,
         "connection_not_found",
         "no such connection: Emitter.timeout -> Receiver.on_timeout",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "connection_not_found"
-    assert "Emitter.timeout" in err["message"]
+    assert_operation_error(result, "connection_not_found", "Emitter.timeout")
 
 
 def test_disconnect_signal_missing_signal_maps_to_signal_not_found_code(monkeypatch):
     # A missing source signal on disconnect is signal_not_found, symmetric with
     # connect-signal and the documented contract (issue #57 review) — it is not
     # collapsed into connection_not_found.
-    result = _invoke_disconnect_signal(
+    result = _disconnect_signal(
         monkeypatch,
         "signal_not_found",
         "source node Emitter has no signal: timoeut",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "signal_not_found"
-    assert "timoeut" in err["message"]
+    assert_operation_error(result, "signal_not_found", "timoeut")
 
 
 def test_disconnect_signal_missing_node_reuses_node_not_found_code(monkeypatch):
-    result = _invoke_disconnect_signal(
+    result = _disconnect_signal(
         monkeypatch, "node_not_found", "source node not found in scene: Emitter"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "node_not_found"
-    assert "Emitter" in err["message"]
+    assert_operation_error(result, "node_not_found", "Emitter")
 
 
 def test_connect_signal_missing_scene_reuses_path_not_found_code(monkeypatch):
-    result = _invoke_connect_signal(
+    result = _connect_signal(
         monkeypatch, "path_not_found", "scene file does not exist: /x/main.tscn"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "path_not_found"
-    assert "/x/main.tscn" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/main.tscn")

--- a/tests/test_params_json.py
+++ b/tests/test_params_json.py
@@ -16,7 +16,6 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.commands.script import ScriptSetMode
-from gda.runner import RunResult
 from tests.support import (
     NODE_ADD_RESULT,
     NODE_GET_RESULT,
@@ -26,7 +25,8 @@ from tests.support import (
     SCRIPT_CREATE_RESULT,
     SCRIPT_SET_RESULT,
     SHADER_CREATE_RESULT,
-    inject_runner,
+    invoke_cli,
+    minimal_project,
     sentinel,
 )
 
@@ -36,19 +36,15 @@ def test_scene_create_params_json_dispatches_like_argv(monkeypatch):
     # through the SAME runner seam as the argv path, applying the same
     # normalization (~ expanded, root_name derived from the filename). Proves the
     # central mechanism end-to-end and the argv/JSON parity in one shot.
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCENE_CREATE_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "scene",
             "create",
             "--params-json",
             '{"path": "~/proj/main.tscn", "root_type": "Node2D"}',
         ],
+        stdout=sentinel(SCENE_CREATE_RESULT),
     )
 
     assert result.exit_code == 0, result.stdout
@@ -70,13 +66,8 @@ def test_params_json_conflicting_with_individual_args_is_a_structured_usage_erro
     # Mutual exclusivity (ADR-0015): --params-json alongside an individual arg is a
     # registered usage_error (ADR-0002), emitted as a structured GdaError envelope
     # on a non-zero exit — never an ad-hoc message.
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCENE_CREATE_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "scene",
             "create",
@@ -85,6 +76,7 @@ def test_params_json_conflicting_with_individual_args_is_a_structured_usage_erro
             '{"path": "/tmp/proj/main.tscn", "root_type": "Node2D"}',
             "--json",
         ],
+        stdout=sentinel(SCENE_CREATE_RESULT),
     )
 
     assert result.exit_code != 0
@@ -95,13 +87,10 @@ def test_params_json_conflicting_with_individual_args_is_a_structured_usage_erro
 
 def test_invalid_json_params_is_a_structured_error(monkeypatch):
     # Malformed JSON → a registered invalid_params GdaError, not a traceback.
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCENE_CREATE_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["scene", "create", "--params-json", "{not json", "--json"]
+        ["scene", "create", "--params-json", "{not json", "--json"],
+        stdout=sentinel(SCENE_CREATE_RESULT),
     )
 
     assert result.exit_code != 0
@@ -112,13 +101,8 @@ def test_invalid_json_params_is_a_structured_error(monkeypatch):
 
 def test_schema_invalid_params_object_is_a_structured_error(monkeypatch):
     # Valid JSON but missing a required field (root_type) → invalid_params.
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCENE_CREATE_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "scene",
             "create",
@@ -126,6 +110,7 @@ def test_schema_invalid_params_object_is_a_structured_error(monkeypatch):
             '{"path": "/tmp/proj/main.tscn"}',
             "--json",
         ],
+        stdout=sentinel(SCENE_CREATE_RESULT),
     )
 
     assert result.exit_code != 0
@@ -159,13 +144,8 @@ def test_schema_takes_precedence_over_params_json(monkeypatch):
 def test_json_output_composes_with_params_json(monkeypatch):
     # --json (a result projection) composes with --params-json (an input source):
     # the success result is emitted as a single JSON object.
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCENE_CREATE_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "scene",
             "create",
@@ -173,6 +153,7 @@ def test_json_output_composes_with_params_json(monkeypatch):
             '{"path": "/tmp/proj/main.tscn", "root_type": "Node2D"}',
             "--json",
         ],
+        stdout=sentinel(SCENE_CREATE_RESULT),
     )
 
     assert result.exit_code == 0, result.stdout
@@ -184,15 +165,11 @@ def test_json_output_composes_with_params_json(monkeypatch):
 def test_params_json_dash_reads_the_object_from_stdin(monkeypatch):
     # `--params-json -` reads the JSON object from stdin, so large payloads
     # (script/shader content) avoid argv length limits (ADR-0015).
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCENE_CREATE_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         ["scene", "create", "--params-json", "-"],
-        input='{"path": "/tmp/proj/level.tscn", "root_type": "Node2D"}',
+        stdout=sentinel(SCENE_CREATE_RESULT),
+        stdin='{"path": "/tmp/proj/level.tscn", "root_type": "Node2D"}',
     )
 
     assert result.exit_code == 0, result.stdout
@@ -217,13 +194,8 @@ def test_wrong_typed_path_is_a_structured_error_not_a_traceback(monkeypatch):
     # A non-string NormalizedPath value must surface as structured invalid_params,
     # not a TypeError traceback: NormalizedPath uses AfterValidator, so the value is
     # validated as a str FIRST (ADR-0015). Regression for the BeforeValidator crash.
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCENE_CREATE_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "scene",
             "create",
@@ -231,6 +203,7 @@ def test_wrong_typed_path_is_a_structured_error_not_a_traceback(monkeypatch):
             '{"path": 123, "root_type": "Node2D"}',
             "--json",
         ],
+        stdout=sentinel(SCENE_CREATE_RESULT),
     )
 
     assert result.exit_code != 0
@@ -242,18 +215,15 @@ def test_wrong_typed_path_is_a_structured_error_not_a_traceback(monkeypatch):
 def test_node_add_params_json_derives_default_name_like_argv(monkeypatch):
     # Parity: omitting name derives it from the type model-side, exactly like the
     # argv path (which used to do this in the CLI body).
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(NODE_ADD_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "node",
             "add",
             "--params-json",
             '{"path": "/tmp/proj/main.tscn", "type": "Sprite2D"}',
         ],
+        stdout=sentinel(NODE_ADD_RESULT),
     )
 
     assert result.exit_code == 0, result.stdout
@@ -265,13 +235,8 @@ def test_node_add_params_json_derives_default_name_like_argv(monkeypatch):
 def test_script_create_params_json_rejects_content_and_extends(monkeypatch):
     # The content/extends mutual exclusivity is enforced model-side, so
     # --params-json cannot bypass it (it is rejected, not silently resolved).
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCRIPT_CREATE_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "script",
             "create",
@@ -279,6 +244,7 @@ def test_script_create_params_json_rejects_content_and_extends(monkeypatch):
             '{"path": "/tmp/proj/hero.gd", "content": "extends Node\\n", "extends_type": "Node2D"}',
             "--json",
         ],
+        stdout=sentinel(SCRIPT_CREATE_RESULT),
     )
 
     assert result.exit_code != 0
@@ -286,13 +252,8 @@ def test_script_create_params_json_rejects_content_and_extends(monkeypatch):
 
 
 def test_shader_create_params_json_rejects_content_and_shader_type(monkeypatch):
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SHADER_CREATE_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "shader",
             "create",
@@ -300,6 +261,7 @@ def test_shader_create_params_json_rejects_content_and_shader_type(monkeypatch):
             '{"path": "/tmp/proj/wave.gdshader", "content": "shader_type spatial;", "shader_type": "spatial"}',
             "--json",
         ],
+        stdout=sentinel(SHADER_CREATE_RESULT),
     )
 
     assert result.exit_code != 0
@@ -309,13 +271,8 @@ def test_shader_create_params_json_rejects_content_and_shader_type(monkeypatch):
 def test_script_set_params_json_rejects_inconsistent_edit_fields(monkeypatch):
     # The edit-mode rule is enforced model-side: a half-specified mode (search
     # without replace) is invalid_params via --params-json, not a silent dispatch.
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCRIPT_SET_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "script",
             "set",
@@ -323,6 +280,7 @@ def test_script_set_params_json_rejects_inconsistent_edit_fields(monkeypatch):
             '{"path": "/tmp/proj/hero.gd", "search": "a"}',
             "--json",
         ],
+        stdout=sentinel(SCRIPT_SET_RESULT),
     )
 
     assert result.exit_code != 0
@@ -398,19 +356,15 @@ def test_perf_monitor_params_json_rejects_frames_below_range(monkeypatch):
 def test_script_set_params_json_derives_mode_like_argv(monkeypatch):
     # Parity: the edit mode is derived from the supplied fields model-side, so a
     # --params-json caller need not (and should not) supply it.
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(SCRIPT_SET_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "script",
             "set",
             "--params-json",
             '{"path": "/tmp/proj/hero.gd", "content": "extends Node\\n"}',
         ],
+        stdout=sentinel(SCRIPT_SET_RESULT),
     )
 
     assert result.exit_code == 0, result.stdout
@@ -553,26 +507,7 @@ def test_an_unexpandable_tilde_is_structured_on_a_sibling_command(
     # `invalid_path`), but structured either way, which is what the contract requires.
     # Both channels, because the argv body builds the params model DIRECTLY: a
     # normalizer that raised would still crash here even though --params-json caught it.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout=sentinel(
-                {
-                    "valid": True,
-                    "scripts": [
-                        {
-                            "path": _UNEXPANDABLE,
-                            "valid": True,
-                            "error_string": None,
-                        }
-                    ],
-                }
-            ),
-            stderr="",
-            exit_code=0,
-        ),
-    )
+    minimal_project(tmp_path)
     argv = ["script", "validate"]
     argv += (
         [_UNEXPANDABLE]
@@ -580,7 +515,18 @@ def test_an_unexpandable_tilde_is_structured_on_a_sibling_command(
         else ["--params-json", json.dumps({"paths": [_UNEXPANDABLE]})]
     )
 
-    result = CliRunner().invoke(app, [*argv, "--project", str(tmp_path), "--json"])
+    result, _ = invoke_cli(
+        monkeypatch,
+        [*argv, "--project", str(tmp_path), "--json"],
+        stdout=sentinel(
+            {
+                "valid": True,
+                "scripts": [
+                    {"path": _UNEXPANDABLE, "valid": True, "error_string": None}
+                ],
+            }
+        ),
+    )
 
     assert "Traceback" not in (result.stderr or ""), result.stderr
     assert result.exception is None or result.exit_code != 1, result.exception
@@ -600,16 +546,12 @@ def test_argv_and_params_json_dispatch_identically(
     # logical input (a `~/…` path that normalization must expand), dispatch the
     # IDENTICAL (operation, params) call. Proves argv ≡ JSON parity and catches
     # any path-bearing field that did not get NormalizedPath.
-    argv_fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(canned), stderr="", exit_code=0)
-    )
-    CliRunner().invoke(app, argv)
+    _, argv_fake = invoke_cli(monkeypatch, argv, stdout=sentinel(canned))
 
-    json_fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(canned), stderr="", exit_code=0)
-    )
-    CliRunner().invoke(
-        app, [argv[0], argv[1], "--params-json", json.dumps(params_object)]
+    _, json_fake = invoke_cli(
+        monkeypatch,
+        [argv[0], argv[1], "--params-json", json.dumps(params_object)],
+        stdout=sentinel(canned),
     )
 
     assert argv_fake.calls == json_fake.calls, case_id

--- a/tests/test_perf_commands.py
+++ b/tests/test_perf_commands.py
@@ -27,12 +27,8 @@ from tests.support import (
     perf_sample_reply_all_monitors,
     plain_text,
     sentinel,
+    minimal_project,
 )
-
-
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
 
 
 # --- perf monitors (single-frame snapshot) ------------------------------------
@@ -45,7 +41,7 @@ def test_perf_monitors_emits_a_snapshot_through_the_live_channel(monkeypatch, tm
     )
 
     result = CliRunner().invoke(
-        app, ["perf", "monitors", "--project", str(_project(tmp_path)), "--json"]
+        app, ["perf", "monitors", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -63,7 +59,7 @@ def test_perf_monitors_with_no_daemon_reports_daemon_not_running(monkeypatch, tm
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
 
     result = CliRunner().invoke(
-        app, ["perf", "monitors", "--project", str(_project(tmp_path)), "--json"]
+        app, ["perf", "monitors", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code == EXIT_LIVE, result.stdout + result.stderr
@@ -101,7 +97,7 @@ def test_perf_monitors_on_non_unix_reports_live_unsupported_platform(
     monkeypatch.setattr("gda.live_runner._is_unix", lambda: False)
 
     result = CliRunner().invoke(
-        app, ["perf", "monitors", "--project", str(_project(tmp_path)), "--json"]
+        app, ["perf", "monitors", "--project", str(minimal_project(tmp_path)), "--json"]
     )
 
     assert result.exit_code != 0, result.stdout
@@ -132,7 +128,7 @@ def test_perf_monitor_property_emits_a_timeline_through_the_live_channel(
             "--frames",
             "3",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -176,7 +172,7 @@ def test_perf_monitor_signal_records_emissions_through_the_live_channel(
             "--frames",
             "3",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -217,7 +213,7 @@ def test_perf_monitor_default_frame_count_is_threaded(monkeypatch, tmp_path):
             "--property",
             "position",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -249,7 +245,7 @@ def test_perf_monitor_missing_node_reports_live_perf_node_not_found(
             "--property",
             "position",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -283,7 +279,7 @@ def test_perf_monitor_unknown_property_reports_live_perf_property_not_found(
             "--property",
             "nope",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -313,7 +309,7 @@ def test_perf_monitor_unknown_signal_reports_live_perf_signal_not_found(
             "--signal",
             "nope",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -334,7 +330,7 @@ def test_perf_monitor_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp
             "--property",
             "position",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -370,7 +366,7 @@ def test_perf_monitor_argv_both_selectors_is_a_usage_error(monkeypatch, tmp_path
             "--signal",
             "hit",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -394,7 +390,7 @@ def test_perf_monitor_argv_no_selector_is_a_usage_error(monkeypatch, tmp_path):
             "monitor",
             "/root/Main/Player",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -422,7 +418,7 @@ def test_perf_monitor_argv_frames_over_range_is_a_usage_error(monkeypatch, tmp_p
             "--frames",
             "601",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -466,7 +462,7 @@ def _window(tmp_path, *args):
             "monitors",
             *args,
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -609,7 +605,7 @@ def test_perf_monitors_selection_and_budget_require_frames(monkeypatch, tmp_path
             "--params-json",
             '{"monitors": ["fps"]}',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -641,7 +637,7 @@ def test_perf_monitors_window_unknown_monitor_is_rejected_before_dispatch(
             "--params-json",
             '{"frames": 5, "monitors": ["fpss"]}',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -845,7 +841,7 @@ def test_perf_monitors_budget_path_expands_a_literal_tilde(monkeypatch, tmp_path
             '{"frames": 5, "monitors": ["fps", "draw_calls"], '
             '"budget": "~/budget.json"}',
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )

--- a/tests/test_project_analysis_commands.py
+++ b/tests/test_project_analysis_commands.py
@@ -9,27 +9,24 @@ parse → typed model → JSON — with canned engine output, no real Godot.
 
 import json
 
-from typer.testing import CliRunner
 
-from gda.cli import app
-from gda.runner import RunResult
 from tests.support import (
     DEPENDENCIES_RESULT,
     FIND_REFERENCES_RESULT,
     STATISTICS_RESULT,
     UNUSED_RESULT,
-    inject_runner,
+    invoke_cli,
     sentinel,
 )
 
 
 def test_dependencies_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(DEPENDENCIES_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["project", "dependencies", "--json"],
+        stdout=sentinel(DEPENDENCIES_RESULT),
+        stderr="engine diagnostic\n",
     )
-
-    result = CliRunner().invoke(app, ["project", "dependencies", "--json"])
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -41,12 +38,9 @@ def test_dependencies_json_maps_success_to_json_object_and_exit_zero(monkeypatch
 
 
 def test_dependencies_human_output_lists_each_scene_and_its_deps(monkeypatch):
-    inject_runner(
-        monkeypatch,
-        RunResult(stdout=sentinel(DEPENDENCIES_RESULT), stderr="", exit_code=0),
+    result, _ = invoke_cli(
+        monkeypatch, ["project", "dependencies"], stdout=sentinel(DEPENDENCIES_RESULT)
     )
-
-    result = CliRunner().invoke(app, ["project", "dependencies"])
 
     assert result.exit_code == 0
     assert "res://main.tscn" in result.stdout
@@ -55,10 +49,10 @@ def test_dependencies_human_output_lists_each_scene_and_its_deps(monkeypatch):
 
 def test_find_references_passes_target_param(monkeypatch):
     stdout = sentinel(FIND_REFERENCES_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["project", "find-references", "res://hero.gd", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["project", "find-references", "res://hero.gd", "--json"],
+        stdout=stdout,
     )
 
     assert result.exit_code == 0
@@ -73,27 +67,22 @@ def test_find_references_passes_target_param(monkeypatch):
 def test_find_references_normalizes_filesystem_target_but_not_res_path(monkeypatch):
     # A res:// virtual path passes through untouched (the engine resolves it);
     # a class_name target (no '://') is left as-is too, not treated as a file.
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=sentinel({"target": "Hero", "references": []}),
-            stderr="",
-            exit_code=0,
-        ),
+        ["project", "find-references", "Hero", "--json"],
+        stdout=sentinel({"target": "Hero", "references": []}),
     )
-
-    result = CliRunner().invoke(app, ["project", "find-references", "Hero", "--json"])
 
     assert result.exit_code == 0
     assert fake.calls == [("project-find-references", {"target": "Hero"})]
 
 
 def test_find_unused_resources_json(monkeypatch):
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(UNUSED_RESULT), stderr="", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["project", "find-unused-resources", "--json"],
+        stdout=sentinel(UNUSED_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["project", "find-unused-resources", "--json"])
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -102,12 +91,11 @@ def test_find_unused_resources_json(monkeypatch):
 
 
 def test_statistics_json(monkeypatch):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(STATISTICS_RESULT), stderr="", exit_code=0),
+        ["project", "statistics", "--json"],
+        stdout=sentinel(STATISTICS_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["project", "statistics", "--json"])
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -118,12 +106,9 @@ def test_statistics_json(monkeypatch):
 
 
 def test_statistics_human_output_summarizes_counts(monkeypatch):
-    inject_runner(
-        monkeypatch,
-        RunResult(stdout=sentinel(STATISTICS_RESULT), stderr="", exit_code=0),
+    result, _ = invoke_cli(
+        monkeypatch, ["project", "statistics"], stdout=sentinel(STATISTICS_RESULT)
     )
-
-    result = CliRunner().invoke(app, ["project", "statistics"])
 
     assert result.exit_code == 0
     assert "5" in result.stdout  # total files

--- a/tests/test_project_analysis_errors.py
+++ b/tests/test_project_analysis_errors.py
@@ -8,106 +8,66 @@ agent branches on the mode without parsing prose. The project group reuses
 and mints ``invalid_target`` for a bad find-references target.
 """
 
-import json
-
-from typer.testing import CliRunner
-
-from gda.cli import app
-from gda.runner import RunResult
-from tests.support import error_sentinel, inject_runner
-
-
-def _assert_structured_operation_error(result, code: str) -> None:
-    assert result.exit_code == 4, result.stdout
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == code
+from tests.support import assert_operation_error, invoke_operation_error
 
 
 def test_dependencies_without_project_is_project_not_found(monkeypatch):
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(
-                "project_not_found",
-                "project dependencies requires a Godot project; none was resolved",
-            ),
-            stderr="gda: running operation: project-dependencies\n",
-            exit_code=1,
-        ),
+        ["project", "dependencies", "--json"],
+        "project_not_found",
+        "project dependencies requires a Godot project; none was resolved",
+        "project-dependencies",
     )
 
-    result = CliRunner().invoke(app, ["project", "dependencies", "--json"])
-
-    _assert_structured_operation_error(result, "project_not_found")
+    assert_operation_error(result, "project_not_found")
 
 
 def test_find_unused_without_project_is_project_not_found(monkeypatch):
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout=error_sentinel("project_not_found", "no project resolved"),
-            stderr="",
-            exit_code=1,
-        ),
+        ["project", "find-unused-resources", "--json"],
+        "project_not_found",
+        "no project resolved",
+        "project-find-unused-resources",
     )
 
-    result = CliRunner().invoke(app, ["project", "find-unused-resources", "--json"])
-
-    _assert_structured_operation_error(result, "project_not_found")
+    assert_operation_error(result, "project_not_found")
 
 
 def test_statistics_without_project_is_project_not_found(monkeypatch):
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout=error_sentinel("project_not_found", "no project resolved"),
-            stderr="",
-            exit_code=1,
-        ),
+        ["project", "statistics", "--json"],
+        "project_not_found",
+        "no project resolved",
+        "project-statistics",
     )
 
-    result = CliRunner().invoke(app, ["project", "statistics", "--json"])
-
-    _assert_structured_operation_error(result, "project_not_found")
+    assert_operation_error(result, "project_not_found")
 
 
 def test_find_references_without_project_is_project_not_found(monkeypatch):
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout=error_sentinel("project_not_found", "no project resolved"),
-            stderr="",
-            exit_code=1,
-        ),
+        ["project", "find-references", "res://hero.gd", "--json"],
+        "project_not_found",
+        "no project resolved",
+        "project-find-references",
     )
 
-    result = CliRunner().invoke(
-        app, ["project", "find-references", "res://hero.gd", "--json"]
-    )
-
-    _assert_structured_operation_error(result, "project_not_found")
+    assert_operation_error(result, "project_not_found")
 
 
 def test_find_references_bad_target_is_invalid_target(monkeypatch):
     # A bad find-references target (empty, or not a res:// path / class_name)
     # surfaces as the registered invalid_target operation code.
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(
-                "invalid_target",
-                "find-references target is not a res:// path or class_name: /abs/path",
-            ),
-            stderr="gda: running operation: project-find-references\n",
-            exit_code=1,
-        ),
+        ["project", "find-references", "/abs/path", "--json"],
+        "invalid_target",
+        "find-references target is not a res:// path or class_name: /abs/path",
+        "project-find-references",
     )
 
-    result = CliRunner().invoke(
-        app, ["project", "find-references", "/abs/path", "--json"]
-    )
-
-    _assert_structured_operation_error(result, "invalid_target")
+    assert_operation_error(result, "invalid_target")

--- a/tests/test_project_commands.py
+++ b/tests/test_project_commands.py
@@ -32,8 +32,7 @@ from gda.commands.project import (
     ProjectSetResult,
 )
 from gda.models import GdaErrorEnvelope
-from gda.runner import RunResult
-from tests.support import VERSION_INFO, FakeRunner, inject_runner, sentinel
+from tests.support import VERSION_INFO, invoke_cli, sentinel
 
 INFO_RESULT = {
     "name": "My Game",
@@ -78,12 +77,12 @@ LIST_RESULT = {
 
 def test_project_info_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
     # Engine banner noise around the sentinel, diagnostics on stderr (ADR-0002).
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(INFO_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["project", "info", "--json"],
+        stdout=sentinel(INFO_RESULT),
+        stderr="engine diagnostic\n",
     )
-
-    result = CliRunner().invoke(app, ["project", "info", "--json"])
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -99,11 +98,9 @@ def test_project_info_json_maps_success_to_json_object_and_exit_zero(monkeypatch
 
 
 def test_project_info_human_output_is_a_readable_block(monkeypatch):
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(INFO_RESULT), stderr="", exit_code=0)
+    result, _ = invoke_cli(
+        monkeypatch, ["project", "info"], stdout=sentinel(INFO_RESULT)
     )
-
-    result = CliRunner().invoke(app, ["project", "info"])
 
     assert result.exit_code == 0
     assert "name: My Game" in result.stdout
@@ -115,11 +112,7 @@ def test_project_info_human_output_is_a_readable_block(monkeypatch):
 def test_project_info_human_output_shows_none_for_empty_main_scene(monkeypatch):
     # A new project has no main scene; the human block names that explicitly.
     payload = {**INFO_RESULT, "main_scene": ""}
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(app, ["project", "info"])
+    result, _ = invoke_cli(monkeypatch, ["project", "info"], stdout=sentinel(payload))
 
     assert result.exit_code == 0
     assert "main_scene: (none)" in result.stdout
@@ -129,12 +122,10 @@ def test_project_info_human_output_shows_none_for_empty_main_scene(monkeypatch):
 
 
 def test_project_get_dispatches_setting_param_and_reports_typed_value(monkeypatch):
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["project", "get", "application/config/name", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["project", "get", "application/config/name", "--json"],
+        stdout=sentinel(GET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -145,11 +136,11 @@ def test_project_get_dispatches_setting_param_and_reports_typed_value(monkeypatc
 
 
 def test_project_get_human_output_is_setting_type_value(monkeypatch):
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0)
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["project", "get", "application/config/name"],
+        stdout=sentinel(GET_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["project", "get", "application/config/name"])
 
     assert result.exit_code == 0
     assert result.stdout.strip() == 'application/config/name (String) = "My Game"'
@@ -159,11 +150,9 @@ def test_project_get_carries_packed_value_projection(monkeypatch):
     # A packed-type setting (e.g. a Vector2-ish value) is carried as a JSON list,
     # the same projection node get reports — so get / set round-trip the shape.
     payload = {"setting": "some/vec", "type": "Vector2", "value": [10.0, 20.0]}
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    result, _ = invoke_cli(
+        monkeypatch, ["project", "get", "some/vec", "--json"], stdout=sentinel(payload)
     )
-
-    result = CliRunner().invoke(app, ["project", "get", "some/vec", "--json"])
 
     assert result.exit_code == 0
     assert json.loads(result.stdout)["value"] == [10.0, 20.0]
@@ -179,11 +168,11 @@ def test_project_get_carries_compound_value_projection_untouched(monkeypatch):
         "events": [{"type": "InputEventKey", "keycode": 74, "pressed": False}],
     }
     payload = {"setting": "input/fire", "type": "Dictionary", "value": value}
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["project", "get", "input/fire", "--json"],
+        stdout=sentinel(payload),
     )
-
-    result = CliRunner().invoke(app, ["project", "get", "input/fire", "--json"])
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -197,12 +186,8 @@ def test_project_get_carries_compound_value_projection_untouched(monkeypatch):
 
 
 def test_project_set_dispatches_setting_and_value_and_round_trips(monkeypatch):
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "project",
             "set",
@@ -211,6 +196,7 @@ def test_project_set_dispatches_setting_and_value_and_round_trips(monkeypatch):
             "1920",
             "--json",
         ],
+        stdout=sentinel(SET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -230,12 +216,10 @@ def test_project_set_dispatches_setting_and_value_and_round_trips(monkeypatch):
 
 
 def test_project_set_human_output_is_set_setting_type_value(monkeypatch):
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["project", "set", "display/window/size/viewport_width", "--value", "1920"]
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["project", "set", "display/window/size/viewport_width", "--value", "1920"],
+        stdout=sentinel(SET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -247,10 +231,11 @@ def test_project_set_human_output_is_set_setting_type_value(monkeypatch):
 def test_project_set_requires_value(monkeypatch):
     # --value is required: a set with no value is a usage error (exit 2), not a
     # silent no-op or an empty write.
-    fake = FakeRunner(RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0))
-    monkeypatch.setattr("gda.dispatch.make_runner", lambda binary, project=None: fake)
-
-    result = CliRunner().invoke(app, ["project", "set", "application/config/name"])
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["project", "set", "application/config/name"],
+        stdout=sentinel(SET_RESULT),
+    )
 
     assert result.exit_code == 2
     assert fake.calls == []
@@ -262,11 +247,9 @@ def test_project_set_requires_value(monkeypatch):
 def test_project_list_bare_dispatches_customized_scope_and_maps_entries(monkeypatch):
     # A bare list lists only customized settings: include_defaults defaults False,
     # section None. Each entry rides through as {setting, type, value, is_default}.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch, ["project", "list", "--json"], stdout=sentinel(LIST_RESULT)
     )
-
-    result = CliRunner().invoke(app, ["project", "list", "--json"])
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -279,11 +262,11 @@ def test_project_list_bare_dispatches_customized_scope_and_maps_entries(monkeypa
 def test_project_list_all_flag_widens_scope_to_engine_defaults(monkeypatch):
     # --all sets include_defaults True so the engine's built-in defaults are listed
     # too, not just the project's customized settings.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["project", "list", "--all", "--json"],
+        stdout=sentinel(LIST_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["project", "list", "--all", "--json"])
 
     assert result.exit_code == 0
     assert fake.calls == [("project-list", {"include_defaults": True, "section": None})]
@@ -292,12 +275,10 @@ def test_project_list_all_flag_widens_scope_to_engine_defaults(monkeypatch):
 def test_project_list_section_filter_rides_through_as_a_param(monkeypatch):
     # --section restricts the listing to keys under a section/ prefix; it composes
     # with --all (both ride through as operation params).
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["project", "list", "--all", "--section", "application/", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["project", "list", "--all", "--section", "application/", "--json"],
+        stdout=sentinel(LIST_RESULT),
     )
 
     assert result.exit_code == 0
@@ -307,11 +288,9 @@ def test_project_list_section_filter_rides_through_as_a_param(monkeypatch):
 
 
 def test_project_list_human_output_lines_settings_and_marks_defaults(monkeypatch):
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
+    result, _ = invoke_cli(
+        monkeypatch, ["project", "list"], stdout=sentinel(LIST_RESULT)
     )
-
-    result = CliRunner().invoke(app, ["project", "list"])
 
     assert result.exit_code == 0
     lines = result.stdout.strip().splitlines()
@@ -321,12 +300,9 @@ def test_project_list_human_output_lines_settings_and_marks_defaults(monkeypatch
 
 
 def test_project_list_human_output_names_an_empty_listing(monkeypatch):
-    inject_runner(
-        monkeypatch,
-        RunResult(stdout=sentinel({"settings": []}), stderr="", exit_code=0),
+    result, _ = invoke_cli(
+        monkeypatch, ["project", "list"], stdout=sentinel({"settings": []})
     )
-
-    result = CliRunner().invoke(app, ["project", "list"])
 
     assert result.exit_code == 0
     assert result.stdout.strip() == "(no settings)"
@@ -346,14 +322,10 @@ REMOVE_AUTOLOAD_RESULT = {
 
 
 def test_project_add_autoload_dispatches_name_and_path_and_reports_result(monkeypatch):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(ADD_AUTOLOAD_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         ["project", "add-autoload", "Global", "res://global.gd", "--json"],
+        stdout=sentinel(ADD_AUTOLOAD_RESULT),
     )
 
     assert result.exit_code == 0
@@ -369,13 +341,10 @@ def test_project_add_autoload_dispatches_name_and_path_and_reports_result(monkey
 
 
 def test_project_add_autoload_human_output_names_the_registered_autoload(monkeypatch):
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(ADD_AUTOLOAD_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["project", "add-autoload", "Global", "res://global.gd"]
+        ["project", "add-autoload", "Global", "res://global.gd"],
+        stdout=sentinel(ADD_AUTOLOAD_RESULT),
     )
 
     assert result.exit_code == 0
@@ -386,12 +355,11 @@ def test_project_add_autoload_human_output_names_the_registered_autoload(monkeyp
 
 
 def test_project_remove_autoload_dispatches_name_and_reports_result(monkeypatch):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(REMOVE_AUTOLOAD_RESULT), stderr="", exit_code=0),
+        ["project", "remove-autoload", "Global", "--json"],
+        stdout=sentinel(REMOVE_AUTOLOAD_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["project", "remove-autoload", "Global", "--json"])
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -402,12 +370,11 @@ def test_project_remove_autoload_dispatches_name_and_reports_result(monkeypatch)
 def test_project_remove_autoload_human_output_names_the_unregistered_autoload(
     monkeypatch,
 ):
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(REMOVE_AUTOLOAD_RESULT), stderr="", exit_code=0),
+        ["project", "remove-autoload", "Global"],
+        stdout=sentinel(REMOVE_AUTOLOAD_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["project", "remove-autoload", "Global"])
 
     assert result.exit_code == 0
     assert result.stdout.strip() == "removed autoload Global"
@@ -433,13 +400,8 @@ REMOVE_INPUT_ACTION_RESULT = {
 def test_project_add_input_action_dispatches_full_params_and_reports_result(
     monkeypatch,
 ):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(ADD_INPUT_ACTION_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "project",
             "add-input-action",
@@ -450,6 +412,7 @@ def test_project_add_input_action_dispatches_full_params_and_reports_result(
             "Space",
             "--json",
         ],
+        stdout=sentinel(ADD_INPUT_ACTION_RESULT),
     )
 
     assert result.exit_code == 0
@@ -481,13 +444,8 @@ def test_project_add_input_action_dispatches_full_params_and_reports_result(
 def test_project_add_input_action_dispatches_deadzone_and_physical_overrides(
     monkeypatch,
 ):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(ADD_INPUT_ACTION_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "project",
             "add-input-action",
@@ -499,6 +457,7 @@ def test_project_add_input_action_dispatches_deadzone_and_physical_overrides(
             "--physical",
             "--json",
         ],
+        stdout=sentinel(ADD_INPUT_ACTION_RESULT),
     )
 
     assert result.exit_code == 0
@@ -513,12 +472,11 @@ def test_project_add_input_action_dispatches_deadzone_and_physical_overrides(
 def test_project_add_input_action_requires_at_least_one_key(monkeypatch):
     # --key is required: an add with no keys is a usage error (exit 2), not a
     # dispatch of an empty key list.
-    fake = FakeRunner(
-        RunResult(stdout=sentinel(ADD_INPUT_ACTION_RESULT), stderr="", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["project", "add-input-action", "jump"],
+        stdout=sentinel(ADD_INPUT_ACTION_RESULT),
     )
-    monkeypatch.setattr("gda.dispatch.make_runner", lambda binary, project=None: fake)
-
-    result = CliRunner().invoke(app, ["project", "add-input-action", "jump"])
 
     assert result.exit_code == 2
     assert fake.calls == []
@@ -527,14 +485,10 @@ def test_project_add_input_action_requires_at_least_one_key(monkeypatch):
 def test_project_add_input_action_rejects_out_of_range_deadzone(monkeypatch):
     # The deadzone bounds (0..1, the editor slider's) are validated model-side
     # (ADR-0015) and surface as a clean usage error before any dispatch.
-    fake = FakeRunner(
-        RunResult(stdout=sentinel(ADD_INPUT_ACTION_RESULT), stderr="", exit_code=0)
-    )
-    monkeypatch.setattr("gda.dispatch.make_runner", lambda binary, project=None: fake)
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         ["project", "add-input-action", "jump", "--key", "J", "--deadzone", "1.5"],
+        stdout=sentinel(ADD_INPUT_ACTION_RESULT),
     )
 
     assert result.exit_code == 2
@@ -542,13 +496,10 @@ def test_project_add_input_action_rejects_out_of_range_deadzone(monkeypatch):
 
 
 def test_project_add_input_action_human_output_lists_resolved_bindings(monkeypatch):
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(ADD_INPUT_ACTION_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["project", "add-input-action", "jump", "--key", "J", "--key", "Space"]
+        ["project", "add-input-action", "jump", "--key", "J", "--key", "Space"],
+        stdout=sentinel(ADD_INPUT_ACTION_RESULT),
     )
 
     assert result.exit_code == 0
@@ -564,12 +515,10 @@ def test_project_add_input_action_human_output_marks_physical_bindings(monkeypat
         "deadzone": 0.5,
         "events": [{"kind": "key", "key": "J", "keycode": 74, "physical": True}],
     }
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["project", "add-input-action", "jump", "--key", "J", "--physical"]
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["project", "add-input-action", "jump", "--key", "J", "--physical"],
+        stdout=sentinel(payload),
     )
 
     assert result.exit_code == 0
@@ -583,13 +532,10 @@ def test_project_add_input_action_human_output_marks_physical_bindings(monkeypat
 
 
 def test_project_remove_input_action_dispatches_name_and_reports_result(monkeypatch):
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(REMOVE_INPUT_ACTION_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["project", "remove-input-action", "jump", "--json"]
+        ["project", "remove-input-action", "jump", "--json"],
+        stdout=sentinel(REMOVE_INPUT_ACTION_RESULT),
     )
 
     assert result.exit_code == 0
@@ -600,12 +546,11 @@ def test_project_remove_input_action_dispatches_name_and_reports_result(monkeypa
 def test_project_remove_input_action_human_output_names_the_removed_action(
     monkeypatch,
 ):
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(REMOVE_INPUT_ACTION_RESULT), stderr="", exit_code=0),
+        ["project", "remove-input-action", "jump"],
+        stdout=sentinel(REMOVE_INPUT_ACTION_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["project", "remove-input-action", "jump"])
 
     assert result.exit_code == 0
     assert result.stdout.strip() == "removed input action jump"

--- a/tests/test_project_errors.py
+++ b/tests/test_project_errors.py
@@ -6,67 +6,44 @@ registered operation codes (ADR-0002) — exit 4 for the operation category, fin
 stable codes so an agent branches on the mode without parsing prose.
 """
 
-import json
-
-from typer.testing import CliRunner
-
-from gda.cli import app
-from gda.runner import RunResult
-from tests.support import error_sentinel, inject_runner
-
-
-def _invoke(monkeypatch, args, code, message, stderr="gda: running operation\n"):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr=stderr,
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, args)
+from tests.support import assert_operation_error, invoke_operation_error
 
 
 def test_project_info_without_project_maps_to_project_not_found(monkeypatch):
     # project info reads ProjectSettings, so a projectless run would report only
     # the engine's bare defaults — refused with project_not_found instead.
-    result = _invoke(
+    result = invoke_operation_error(
         monkeypatch,
         ["project", "info", "--json"],
         "project_not_found",
         "project info requires a Godot project; none was resolved",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "project_not_found"
-    assert "Godot project" in err["message"]
-    assert err["diagnostics"] == "gda: running operation\n"
+    assert_operation_error(
+        result,
+        "project_not_found",
+        "Godot project",
+        diagnostics="gda: running operation\n",
+    )
 
 
 def test_project_get_unknown_setting_maps_to_stable_unknown_setting_code(monkeypatch):
     # A typo'd / absent setting key is unknown_setting, distinct from a setting
     # genuinely holding null — the agent fixes the key, not the value.
-    result = _invoke(
+    result = invoke_operation_error(
         monkeypatch,
         ["project", "get", "application/bogus/key", "--json"],
         "unknown_setting",
         "project setting not found: application/bogus/key",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "unknown_setting"
-    assert "application/bogus/key" in err["message"]
+    assert_operation_error(result, "unknown_setting", "application/bogus/key")
 
 
 def test_project_set_unknown_setting_maps_to_stable_unknown_setting_code(monkeypatch):
     # set edits an existing setting; an unknown key is unknown_setting, never a
     # silent create.
-    result = _invoke(
+    result = invoke_operation_error(
         monkeypatch,
         ["project", "set", "application/bogus/key", "--value", "1", "--json"],
         "unknown_setting",
@@ -74,10 +51,7 @@ def test_project_set_unknown_setting_maps_to_stable_unknown_setting_code(monkeyp
         "existing setting; it never creates one",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "unknown_setting"
-    assert "never creates" in err["message"]
+    assert_operation_error(result, "unknown_setting", "never creates")
 
 
 def test_project_set_uncoercible_value_maps_to_stable_uncoercible_value_code(
@@ -85,7 +59,7 @@ def test_project_set_uncoercible_value_maps_to_stable_uncoercible_value_code(
 ):
     # A value that cannot be coerced to the setting's declared type reuses the
     # node-set #55 code: uncoercible_value (exit 4, project.godot untouched).
-    result = _invoke(
+    result = invoke_operation_error(
         monkeypatch,
         [
             "project",
@@ -100,8 +74,4 @@ def test_project_set_uncoercible_value_maps_to_stable_uncoercible_value_code(
         "display/window/size/viewport_width",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "uncoercible_value"
-    assert "not-a-number" in err["message"]
+    assert_operation_error(result, "uncoercible_value", "not-a-number")

--- a/tests/test_resource_commands.py
+++ b/tests/test_resource_commands.py
@@ -26,8 +26,9 @@ from tests.support import (
     PATH_TO_UID_RESULT,
     UID,
     UID_TO_PATH_RESULT,
-    FakeRunner,
-    inject_runner,
+    invoke_cli,
+    minimal_project,
+    recording_runner,
     sentinel,
 )
 
@@ -36,13 +37,8 @@ from tests.support import (
 
 
 def test_resource_set_dispatches_path_property_value_and_round_trips(monkeypatch):
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(SET_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "resource",
             "set",
@@ -53,6 +49,8 @@ def test_resource_set_dispatches_path_property_value_and_round_trips(monkeypatch
             "1",
             "--json",
         ],
+        stdout=sentinel(SET_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -78,12 +76,8 @@ def test_resource_set_dispatches_path_property_value_and_round_trips(monkeypatch
 
 
 def test_resource_set_human_output_is_set_path_property_type_value(monkeypatch):
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, _ = invoke_cli(
+        monkeypatch,
         [
             "resource",
             "set",
@@ -93,6 +87,7 @@ def test_resource_set_human_output_is_set_path_property_type_value(monkeypatch):
             "--value",
             "1",
         ],
+        stdout=sentinel(SET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -105,11 +100,10 @@ def test_resource_set_human_output_is_set_path_property_type_value(monkeypatch):
 def test_resource_set_requires_value(monkeypatch):
     # --value is required: a set with no value is a usage error (exit 2), not a
     # silent no-op or an empty write.
-    fake = FakeRunner(RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0))
-    monkeypatch.setattr("gda.dispatch.make_runner", lambda binary, project=None: fake)
-
-    result = CliRunner().invoke(
-        app, ["resource", "set", "/tmp/proj/palette.tres", "--property", "x"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["resource", "set", "/tmp/proj/palette.tres", "--property", "x"],
+        stdout=sentinel(SET_RESULT),
     )
 
     assert result.exit_code == 2
@@ -117,11 +111,8 @@ def test_resource_set_requires_value(monkeypatch):
 
 
 def test_resource_set_expands_user_home_in_filesystem_path(monkeypatch):
-    fake = FakeRunner(RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0))
-    monkeypatch.setattr("gda.dispatch.make_runner", lambda binary, project=None: fake)
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "resource",
             "set",
@@ -132,6 +123,7 @@ def test_resource_set_expands_user_home_in_filesystem_path(monkeypatch):
             "1",
             "--json",
         ],
+        stdout=sentinel(SET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -144,13 +136,11 @@ def test_resource_set_expands_user_home_in_filesystem_path(monkeypatch):
 
 
 def test_resource_delete_dispatches_path_and_reports_removed(monkeypatch):
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(DELETE_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["resource", "delete", "/tmp/proj/palette.tres", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["resource", "delete", "/tmp/proj/palette.tres", "--json"],
+        stdout=sentinel(DELETE_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -163,22 +153,21 @@ def test_resource_delete_dispatches_path_and_reports_removed(monkeypatch):
 
 
 def test_resource_delete_human_output_names_path_and_type(monkeypatch):
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(DELETE_RESULT), stderr="", exit_code=0)
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["resource", "delete", "/tmp/proj/palette.tres"],
+        stdout=sentinel(DELETE_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["resource", "delete", "/tmp/proj/palette.tres"])
 
     assert result.exit_code == 0
     assert result.stdout.strip() == "deleted /tmp/proj/palette.tres (Gradient)"
 
 
 def test_resource_delete_res_path_passes_through_untouched(monkeypatch):
-    fake = FakeRunner(RunResult(stdout=sentinel(DELETE_RESULT), stderr="", exit_code=0))
-    monkeypatch.setattr("gda.dispatch.make_runner", lambda binary, project=None: fake)
-
-    result = CliRunner().invoke(
-        app, ["resource", "delete", "res://palette.tres", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["resource", "delete", "res://palette.tres", "--json"],
+        stdout=sentinel(DELETE_RESULT),
     )
 
     assert result.exit_code == 0
@@ -187,13 +176,8 @@ def test_resource_delete_res_path_passes_through_untouched(monkeypatch):
 
 def test_resource_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
     # Engine banner noise around the sentinel, diagnostics on stderr (ADR-0002).
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(CREATE_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "resource",
             "create",
@@ -202,6 +186,8 @@ def test_resource_create_json_maps_success_to_json_object_and_exit_zero(monkeypa
             "Gradient",
             "--json",
         ],
+        stdout=sentinel(CREATE_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -219,12 +205,10 @@ def test_resource_create_json_maps_success_to_json_object_and_exit_zero(monkeypa
 
 
 def test_resource_create_human_output_reports_path_and_type(monkeypatch):
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(CREATE_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["resource", "create", "/tmp/proj/palette.tres", "--type", "Gradient"]
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["resource", "create", "/tmp/proj/palette.tres", "--type", "Gradient"],
+        stdout=sentinel(CREATE_RESULT),
     )
 
     assert result.exit_code == 0
@@ -234,11 +218,10 @@ def test_resource_create_human_output_reports_path_and_type(monkeypatch):
 
 
 def test_resource_get_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(GET_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["resource", "get", "/tmp/proj/palette.tres", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["resource", "get", "/tmp/proj/palette.tres", "--json"],
+        stdout=sentinel(GET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -253,11 +236,11 @@ def test_resource_get_json_maps_success_to_json_object_and_exit_zero(monkeypatch
 
 
 def test_resource_get_human_output_lists_typed_properties(monkeypatch):
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0)
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["resource", "get", "/tmp/proj/palette.tres"],
+        stdout=sentinel(GET_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["resource", "get", "/tmp/proj/palette.tres"])
 
     assert result.exit_code == 0
     # The header names the resource and its type; each property is a typed line.
@@ -268,11 +251,10 @@ def test_resource_get_human_output_lists_typed_properties(monkeypatch):
 def test_resource_create_expands_user_home_in_filesystem_path(monkeypatch):
     # A filesystem path gets ~ expanded at the CLI layer (issue #32); res://
     # virtual paths pass through untouched. Exercise the expansion seam.
-    fake = FakeRunner(RunResult(stdout=sentinel(CREATE_RESULT), stderr="", exit_code=0))
-    monkeypatch.setattr("gda.dispatch.make_runner", lambda binary, project=None: fake)
-
-    result = CliRunner().invoke(
-        app, ["resource", "create", "~/palette.tres", "--type", "Gradient", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["resource", "create", "~/palette.tres", "--type", "Gradient", "--json"],
+        stdout=sentinel(CREATE_RESULT),
     )
 
     assert result.exit_code == 0
@@ -282,11 +264,10 @@ def test_resource_create_expands_user_home_in_filesystem_path(monkeypatch):
 
 
 def test_resource_get_res_path_passes_through_untouched(monkeypatch):
-    fake = FakeRunner(RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0))
-    monkeypatch.setattr("gda.dispatch.make_runner", lambda binary, project=None: fake)
-
-    result = CliRunner().invoke(
-        app, ["resource", "get", "res://palette.tres", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["resource", "get", "res://palette.tres", "--json"],
+        stdout=sentinel(GET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -296,14 +277,12 @@ def test_resource_get_res_path_passes_through_untouched(monkeypatch):
 def test_resource_uid_resolves_uid_to_path_json_and_exit_zero(monkeypatch, tmp_path):
     # Given a uid://, the command reports the res:// path it resolves to. Engine
     # banner noise around the sentinel, diagnostics on stderr (ADR-0002).
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(UID_TO_PATH_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["resource", "uid", UID, "--project", str(tmp_path), "--json"]
+    minimal_project(tmp_path)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["resource", "uid", UID, "--project", str(tmp_path), "--json"],
+        stdout=sentinel(UID_TO_PATH_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -320,12 +299,11 @@ def test_resource_uid_resolves_uid_to_path_json_and_exit_zero(monkeypatch, tmp_p
 def test_resource_uid_resolves_path_to_uid_json_and_exit_zero(monkeypatch, tmp_path):
     # Given a res:// path, the command reports its assigned uid://. The result is
     # the same shape; only `queried` distinguishes which side was the target.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(PATH_TO_UID_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["resource", "uid", PATH, "--project", str(tmp_path), "--json"]
+    minimal_project(tmp_path)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["resource", "uid", PATH, "--project", str(tmp_path), "--json"],
+        stdout=sentinel(PATH_TO_UID_RESULT),
     )
 
     assert result.exit_code == 0
@@ -340,36 +318,28 @@ def test_resource_uid_resolves_path_to_uid_json_and_exit_zero(monkeypatch, tmp_p
 def test_resource_uid_passes_resolved_project_to_the_runner(monkeypatch, tmp_path):
     # Resolution queries the project's UID cache, so --project must reach the
     # runner (which hands it to the engine as --path, issue #32).
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    seen: dict = {}
-
-    def record(binary, project):
-        seen["project"] = project
-        return FakeRunner(
-            RunResult(stdout=sentinel(UID_TO_PATH_RESULT), stderr="", exit_code=0)
-        )
-
-    monkeypatch.setattr("gda.dispatch.make_runner", record)
+    minimal_project(tmp_path)
+    projects = recording_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(UID_TO_PATH_RESULT), stderr="", exit_code=0),
+    )
 
     result = CliRunner().invoke(
         app, ["resource", "uid", UID, "--project", str(tmp_path), "--json"]
     )
 
     assert result.exit_code == 0
-    assert seen["project"] == tmp_path
+    assert projects[0] == tmp_path
 
 
 def test_resource_uid_expands_tilde_for_a_filesystem_target(monkeypatch, tmp_path):
     # A filesystem path target gets ~ expanded at the CLI layer so a literal ~
     # works without a shell (issue #32); a uid:// / res:// target is untouched.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    fake = inject_runner(
+    minimal_project(tmp_path)
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(PATH_TO_UID_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["resource", "uid", "~/data.tres", "--project", str(tmp_path), "--json"]
+        ["resource", "uid", "~/data.tres", "--project", str(tmp_path), "--json"],
+        stdout=sentinel(PATH_TO_UID_RESULT),
     )
 
     assert result.exit_code == 0
@@ -386,14 +356,11 @@ def test_resource_uid_expands_tilde_for_a_filesystem_target(monkeypatch, tmp_pat
 def test_resource_uid_human_output_renders_uid_arrow_path(monkeypatch, tmp_path):
     # Without --json, a resolved mapping renders as `<uid> -> <path>`, the same
     # for both directions since the result shape is identical.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    inject_runner(
+    minimal_project(tmp_path)
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(UID_TO_PATH_RESULT), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["resource", "uid", UID, "--project", str(tmp_path)]
+        ["resource", "uid", UID, "--project", str(tmp_path)],
+        stdout=sentinel(UID_TO_PATH_RESULT),
     )
 
     assert result.exit_code == 0

--- a/tests/test_resource_errors.py
+++ b/tests/test_resource_errors.py
@@ -17,58 +17,36 @@ malformed ``uid://`` adds ``invalid_uid``, and a projectless run reuses the
 shared ``project_not_found``.
 """
 
-import json
-
-from typer.testing import CliRunner
-
-from gda.cli import app
-from gda.runner import RunResult
-from tests.support import error_sentinel, inject_runner
+from tests.support import assert_operation_error, operation_error_invoker
 
 
-def _invoke_resource_create(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: resource-create\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app, ["resource", "create", "/x/palette.tres", "--type", "Gradient", "--json"]
-    )
+_resource_create = operation_error_invoker(
+    ["resource", "create", "/x/palette.tres", "--type", "Gradient", "--json"],
+    "resource-create",
+)
 
 
-def _invoke_resource_get(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: resource-get\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, ["resource", "get", "/x/palette.tres", "--json"])
+_resource_get = operation_error_invoker(
+    ["resource", "get", "/x/palette.tres", "--json"],
+    "resource-get",
+)
 
 
 def test_resource_create_collision_reuses_stable_already_exists_code(monkeypatch):
     # No-clobber: a create whose target already exists reuses the registered
     # already_exists code (the same one scene/script create use), leaving the
     # file untouched — the resource group mints no parallel collision code.
-    result = _invoke_resource_create(
+    result = _resource_create(
         monkeypatch, "already_exists", "resource target already exists: /x/palette.tres"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "already_exists"
-    assert "/x/palette.tres" in err["message"]
     # The raw stderr still rides along as diagnostics (ADR-0002).
-    assert err["diagnostics"] == "gda: running operation: resource-create\n"
+    assert_operation_error(
+        result,
+        "already_exists",
+        "/x/palette.tres",
+        diagnostics="gda: running operation: resource-create\n",
+    )
 
 
 def test_resource_create_invalid_type_yields_invalid_resource_type(monkeypatch):
@@ -76,248 +54,200 @@ def test_resource_create_invalid_type_yields_invalid_resource_type(monkeypatch):
     # refuses it with the resource group's own invalid_resource_type code —
     # parallel to scene create's invalid_root_type and node add's
     # invalid_node_type, but for the Resource hierarchy.
-    result = _invoke_resource_create(
+    result = _resource_create(
         monkeypatch,
         "invalid_resource_type",
         "not an instantiable Resource class: Bogus",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "invalid_resource_type"
-    assert "Bogus" in err["message"]
+    assert_operation_error(result, "invalid_resource_type", "Bogus")
 
 
 def test_resource_create_non_tres_path_yields_invalid_path(monkeypatch):
-    result = _invoke_resource_create(
+    result = _resource_create(
         monkeypatch, "invalid_path", "resource path must end in .tres: /x/palette.txt"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "invalid_path"
+    assert_operation_error(result, "invalid_path")
 
 
 def test_resource_get_missing_yields_path_not_found(monkeypatch):
     # A get on a path with no resource file reuses the registered path_not_found
     # code (the same one scene/script get use for a missing file).
-    result = _invoke_resource_get(
+    result = _resource_get(
         monkeypatch, "path_not_found", "resource file does not exist: /x/palette.tres"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/palette.tres" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/palette.tres")
 
 
-def _invoke_resource_set(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: resource-set\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app,
-        [
-            "resource",
-            "set",
-            "/x/palette.tres",
-            "--property",
-            "interpolation_mode",
-            "--value",
-            "1",
-            "--json",
-        ],
-    )
+_resource_set = operation_error_invoker(
+    [
+        "resource",
+        "set",
+        "/x/palette.tres",
+        "--property",
+        "interpolation_mode",
+        "--value",
+        "1",
+        "--json",
+    ],
+    "resource-set",
+)
 
 
-def _invoke_resource_delete(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: resource-delete\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, ["resource", "delete", "/x/palette.tres", "--json"])
+_resource_delete = operation_error_invoker(
+    ["resource", "delete", "/x/palette.tres", "--json"],
+    "resource-delete",
+)
 
 
 def test_resource_set_unknown_property_yields_unknown_property(monkeypatch):
     # set edits an existing property; an unknown property is unknown_property
     # (the same #55 code node set uses), never a silent create.
-    result = _invoke_resource_set(
+    result = _resource_set(
         monkeypatch,
         "unknown_property",
         "resource /x/palette.tres has no settable property: bogus",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "unknown_property"
-    assert "bogus" in err["message"]
-    assert err["diagnostics"] == "gda: running operation: resource-set\n"
+    assert_operation_error(
+        result,
+        "unknown_property",
+        "bogus",
+        diagnostics="gda: running operation: resource-set\n",
+    )
 
 
 def test_resource_set_uncoercible_value_yields_uncoercible_value(monkeypatch):
     # A value that cannot be coerced to the property's declared type reuses the
     # node-set #55 code: uncoercible_value (exit 4, the .tres untouched).
-    result = _invoke_resource_set(
+    result = _resource_set(
         monkeypatch,
         "uncoercible_value",
         "cannot coerce value not-a-number to int for property "
         "interpolation_mode on resource /x/palette.tres",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "uncoercible_value"
-    assert "not-a-number" in err["message"]
+    assert_operation_error(result, "uncoercible_value", "not-a-number")
 
 
 def test_resource_set_missing_yields_path_not_found(monkeypatch):
     # A set on a path with no resource file reuses the registered path_not_found
     # code (the same one resource get uses for a missing file).
-    result = _invoke_resource_set(
+    result = _resource_set(
         monkeypatch, "path_not_found", "resource file does not exist: /x/palette.tres"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "path_not_found"
-    assert "/x/palette.tres" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/palette.tres")
 
 
 def test_resource_set_non_tres_path_yields_invalid_path(monkeypatch):
-    result = _invoke_resource_set(
+    result = _resource_set(
         monkeypatch, "invalid_path", "resource path must end in .tres: /x/palette.txt"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "invalid_path"
+    assert_operation_error(result, "invalid_path")
 
 
 def test_resource_delete_missing_yields_path_not_found(monkeypatch):
     # A delete on a path with no resource file reuses path_not_found, so the
     # lifecycle's now-not-found is the same code a fresh get would report.
-    result = _invoke_resource_delete(
+    result = _resource_delete(
         monkeypatch, "path_not_found", "resource file does not exist: /x/palette.tres"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/palette.tres" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/palette.tres")
 
 
 def test_resource_delete_non_tres_path_yields_invalid_path(monkeypatch):
-    result = _invoke_resource_delete(
+    result = _resource_delete(
         monkeypatch, "invalid_path", "resource path must end in .tres: /x/palette.txt"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "invalid_path"
+    assert_operation_error(result, "invalid_path")
 
 
-def _invoke_resource_uid(monkeypatch, code: str, message: str, target: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: resource-uid\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, ["resource", "uid", target, "--json"])
+_resource_uid = operation_error_invoker(
+    lambda target: ["resource", "uid", target, "--json"],
+    "resource-uid",
+)
 
 
-def _assert_operation_error(result, code: str, needle: str) -> dict:
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == code
-    assert needle in err["message"]
-    # The raw stderr still rides along as diagnostics (ADR-0002).
-    assert err["diagnostics"] == "gda: running operation: resource-uid\n"
-    return err
+# The raw stderr still rides along as diagnostics (ADR-0002). Every resource uid
+# test checks it, so the notice is named here and passed at each call site rather
+# than hidden inside a helper's default.
+_UID_NOTICE = "gda: running operation: resource-uid\n"
 
 
 def test_resource_uid_unknown_uid_is_structured_error(monkeypatch):
     # A well-formed uid:// absent from the project's UID cache is unknown_uid —
     # the agent learns the UID is unregistered, not that the syntax was wrong.
-    result = _invoke_resource_uid(
+    result = _resource_uid(
         monkeypatch,
         "unknown_uid",
         "UID is not registered in the project's UID cache: uid://abc",
-        "uid://abc",
+        target="uid://abc",
     )
 
-    _assert_operation_error(result, "unknown_uid", "uid://abc")
+    assert_operation_error(result, "unknown_uid", "uid://abc", diagnostics=_UID_NOTICE)
 
 
 def test_resource_uid_invalid_uid_is_structured_error(monkeypatch):
     # A syntactically malformed uid:// (engine text_to_id == INVALID_ID) is
     # invalid_uid — distinct from an unknown-but-well-formed UID.
-    result = _invoke_resource_uid(
+    result = _resource_uid(
         monkeypatch,
         "invalid_uid",
         "not a valid resource UID: uid://!!!",
-        "uid://!!!",
+        target="uid://!!!",
     )
 
-    _assert_operation_error(result, "invalid_uid", "uid://!!!")
+    assert_operation_error(result, "invalid_uid", "uid://!!!", diagnostics=_UID_NOTICE)
 
 
 def test_resource_uid_path_not_found_is_structured_error(monkeypatch):
     # A res:// path naming no resource is path_not_found — the same registered
     # code the file groups use, not a parallel resource-specific code.
-    result = _invoke_resource_uid(
+    result = _resource_uid(
         monkeypatch,
         "path_not_found",
         "no resource at path: res://missing.tres",
-        "res://missing.tres",
+        target="res://missing.tres",
     )
 
-    _assert_operation_error(result, "path_not_found", "res://missing.tres")
+    assert_operation_error(
+        result, "path_not_found", "res://missing.tres", diagnostics=_UID_NOTICE
+    )
 
 
 def test_resource_uid_no_uid_assigned_is_structured_error(monkeypatch):
     # A resource that exists but carries no UID in the cache is no_uid_assigned —
     # distinct from path_not_found (the file is there) and from a UID-direction
     # failure (the query was a path).
-    result = _invoke_resource_uid(
+    result = _resource_uid(
         monkeypatch,
         "no_uid_assigned",
         "resource has no UID assigned in the project's UID cache: res://plain.txt",
-        "res://plain.txt",
+        target="res://plain.txt",
     )
 
-    _assert_operation_error(result, "no_uid_assigned", "res://plain.txt")
+    assert_operation_error(
+        result, "no_uid_assigned", "res://plain.txt", diagnostics=_UID_NOTICE
+    )
 
 
 def test_resource_uid_projectless_run_is_project_not_found(monkeypatch):
     # Resolution queries the project's UID cache, so a projectless run has no
     # cache to query — refused with the shared project_not_found rather than a
     # misleading "no UID" answer.
-    result = _invoke_resource_uid(
+    result = _resource_uid(
         monkeypatch,
         "project_not_found",
         "resource uid requires a Godot project; none was resolved",
-        "uid://abc",
+        target="uid://abc",
     )
 
-    _assert_operation_error(result, "project_not_found", "requires a Godot project")
+    assert_operation_error(
+        result, "project_not_found", "requires a Godot project", diagnostics=_UID_NOTICE
+    )

--- a/tests/test_resource_import_commands.py
+++ b/tests/test_resource_import_commands.py
@@ -18,14 +18,16 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import LaunchFailure, RunResult, TimeoutBound
+from tests.support import minimal_project
 
 runner_cli = CliRunner()
 
 
 def _project(tmp_path: Path) -> Path:
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    (tmp_path / "icon.png").write_bytes(b"\x89PNG fake bytes")
-    return tmp_path
+    """The shared minimum, plus the one asset the import pass has to see."""
+    project = minimal_project(tmp_path)
+    (project / "icon.png").write_bytes(b"\x89PNG fake bytes")
+    return project
 
 
 def _sidecar(
@@ -741,9 +743,7 @@ def test_an_asset_a_nested_project_owns_is_refused_before_the_pass(tmp_path):
     # `not_importable`, while `--dry-run` predicted a sidecar that would never
     # appear. It now refuses up front and names the project that CAN import it.
     project = _project(tmp_path)
-    nested = project / "vendor"
-    nested.mkdir()
-    (nested / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    nested = minimal_project(project / "vendor")
     (nested / "pic.png").write_bytes(b"\x89PNG")
 
     data = json.loads(_run(project, "res://vendor/pic.png", "--dry-run").stdout)

--- a/tests/test_scene_commands.py
+++ b/tests/test_scene_commands.py
@@ -16,22 +16,20 @@ from tests.support import (
     SCENE_DELETE_RESULT as DELETE_RESULT,
     SCENE_GET_RESULT as GET_RESULT,
     SCENE_LIST_RESULT as LIST_RESULT,
-    FakeRunner,
-    inject_runner,
+    invoke_cli,
+    minimal_project,
+    recording_runner,
     sentinel,
 )
 
 
 def test_scene_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
     # Engine banner noise around the sentinel, diagnostics on stderr (ADR-0002).
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(CREATE_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         ["scene", "create", "/tmp/proj/main.tscn", "--root-type", "Node2D", "--json"],
+        stdout=sentinel(CREATE_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -59,10 +57,8 @@ def test_scene_create_accepts_explicit_root_name(monkeypatch):
     stdout = sentinel(
         {**CREATE_RESULT, "path": "/tmp/proj/level.v2.tscn", "root_name": "LevelV2"}
     )
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "scene",
             "create",
@@ -73,6 +69,7 @@ def test_scene_create_accepts_explicit_root_name(monkeypatch):
             "LevelV2",
             "--json",
         ],
+        stdout=stdout,
     )
 
     assert result.exit_code == 0
@@ -90,10 +87,11 @@ def test_scene_create_accepts_explicit_root_name(monkeypatch):
 
 
 def test_scene_get_json_emits_structured_node_tree_and_exit_zero(monkeypatch):
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(GET_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(app, ["scene", "get", "/tmp/proj/main.tscn", "--json"])
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["scene", "get", "/tmp/proj/main.tscn", "--json"],
+        stdout=sentinel(GET_RESULT),
+    )
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -108,33 +106,27 @@ def test_scene_get_json_emits_structured_node_tree_and_exit_zero(monkeypatch):
 def test_scene_get_passes_resolved_project_to_the_runner(monkeypatch, tmp_path):
     # --project resolves to a project dir and is handed to the runner (which
     # turns it into the engine's --path so res:// resolves there, issue #32).
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    seen: dict = {}
-
-    def record(binary, project):
-        seen["project"] = project
-        return FakeRunner(
-            RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0)
-        )
-
-    monkeypatch.setattr("gda.dispatch.make_runner", record)
+    minimal_project(tmp_path)
+    projects = recording_runner(
+        monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(
         app, ["scene", "get", "res://main.tscn", "--project", str(tmp_path), "--json"]
     )
 
     assert result.exit_code == 0
-    assert seen["project"] == tmp_path
+    assert projects[0] == tmp_path
 
 
 def test_scene_get_expands_user_home_in_filesystem_path_but_not_res(monkeypatch):
     # Path normalization lives at the CLI layer (issue #32): a filesystem path
     # gets ~ expanded; an engine-resolved res:// path passes through untouched.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(GET_RESULT), stderr="", exit_code=0)
+    _, fake = invoke_cli(
+        monkeypatch,
+        ["scene", "get", "~/game/main.tscn", "--json"],
+        stdout=sentinel(GET_RESULT),
     )
-
-    CliRunner().invoke(app, ["scene", "get", "~/game/main.tscn", "--json"])
     assert "~" not in fake.calls[0][1]["path"]
     assert fake.calls[0][1]["path"].endswith("/game/main.tscn")
 
@@ -191,13 +183,11 @@ def test_scene_get_exports_json_emits_per_node_exports_and_exit_zero(monkeypatch
     # scene get-exports loads a scene and reports, per node (by node path), the
     # @export properties its attached script declares (issue #58): each export's
     # name, declared type, hint/hint_string, and value as typed JSON.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(GET_EXPORTS_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["scene", "get-exports", "/tmp/proj/main.tscn", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["scene", "get-exports", "/tmp/proj/main.tscn", "--json"],
+        stdout=sentinel(GET_EXPORTS_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -224,12 +214,11 @@ def test_scene_get_exports_expands_user_home_in_filesystem_path_but_not_res(
 ):
     # Path normalization at the CLI layer (issue #32) applies to get-exports too:
     # a filesystem path gets ~ expanded; a res:// path passes through untouched.
-    fake = inject_runner(
+    _, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(GET_EXPORTS_RESULT), stderr="", exit_code=0),
+        ["scene", "get-exports", "~/game/main.tscn", "--json"],
+        stdout=sentinel(GET_EXPORTS_RESULT),
     )
-
-    CliRunner().invoke(app, ["scene", "get-exports", "~/game/main.tscn", "--json"])
     assert "~" not in fake.calls[0][1]["path"]
     assert fake.calls[0][1]["path"].endswith("/game/main.tscn")
 
@@ -242,10 +231,10 @@ def test_scene_get_exports_empty_scene_is_a_valid_empty_listing(monkeypatch):
     # A scene with no exported variables anywhere is a successful, empty listing
     # (nodes == []), not a failure.
     stdout = sentinel({"path": "/tmp/proj/bare.tscn", "nodes": []})
-    inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["scene", "get-exports", "/tmp/proj/bare.tscn", "--json"]
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["scene", "get-exports", "/tmp/proj/bare.tscn", "--json"],
+        stdout=stdout,
     )
 
     assert result.exit_code == 0
@@ -256,12 +245,11 @@ def test_scene_list_json_enumerates_project_scenes_and_exit_zero(monkeypatch, tm
     # scene list enumerates the resolved project's .tscn files (issue #54):
     # each entry carries its res:// path plus the root name/type read cheaply
     # from the scene's stored state.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(LIST_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["scene", "list", "--project", str(tmp_path), "--json"]
+    minimal_project(tmp_path)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["scene", "list", "--project", str(tmp_path), "--json"],
+        stdout=sentinel(LIST_RESULT),
     )
 
     assert result.exit_code == 0
@@ -280,36 +268,28 @@ def test_scene_list_json_enumerates_project_scenes_and_exit_zero(monkeypatch, tm
 def test_scene_list_passes_resolved_project_to_the_runner(monkeypatch, tmp_path):
     # scene list enumerates res:// in the resolved project, so --project must
     # reach the runner (which hands it to the engine as --path, issue #32).
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    seen: dict = {}
-
-    def record(binary, project):
-        seen["project"] = project
-        return FakeRunner(
-            RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
-        )
-
-    monkeypatch.setattr("gda.dispatch.make_runner", record)
+    minimal_project(tmp_path)
+    projects = recording_runner(
+        monkeypatch, RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(
         app, ["scene", "list", "--project", str(tmp_path), "--json"]
     )
 
     assert result.exit_code == 0
-    assert seen["project"] == tmp_path
+    assert projects[0] == tmp_path
 
 
 def test_scene_delete_json_reports_what_was_removed_and_exit_zero(monkeypatch):
     # scene delete removes a scene file and names what it deleted (issue #54):
     # the path plus the removed scene's root name/type, so the result names the
     # content, not just the file.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(DELETE_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["scene", "delete", "/tmp/proj/old.tscn", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["scene", "delete", "/tmp/proj/old.tscn", "--json"],
+        stdout=sentinel(DELETE_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -326,11 +306,11 @@ def test_scene_delete_json_reports_what_was_removed_and_exit_zero(monkeypatch):
 def test_scene_delete_expands_user_home_in_filesystem_path_but_not_res(monkeypatch):
     # Path normalization at the CLI layer (issue #32) applies to delete too: a
     # filesystem path gets ~ expanded; a res:// path passes through untouched.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(DELETE_RESULT), stderr="", exit_code=0)
+    _, fake = invoke_cli(
+        monkeypatch,
+        ["scene", "delete", "~/game/old.tscn", "--json"],
+        stdout=sentinel(DELETE_RESULT),
     )
-
-    CliRunner().invoke(app, ["scene", "delete", "~/game/old.tscn", "--json"])
     assert "~" not in fake.calls[0][1]["path"]
     assert fake.calls[0][1]["path"].endswith("/game/old.tscn")
 

--- a/tests/test_scene_errors.py
+++ b/tests/test_scene_errors.py
@@ -13,131 +13,91 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import LaunchFailure, RunResult
-from tests.support import error_sentinel, inject_runner
+from tests.support import (
+    assert_operation_error,
+    inject_runner,
+    invoke_cli,
+    invoke_operation_error,
+)
 
 
 def test_scene_get_missing_file_maps_to_stable_path_not_found_code(monkeypatch):
     # The operation found no file at the target path and reported a structured
     # failure: exit 4 (operation category), but a finer stable code than the
     # generic operation_failed so an agent can react to the mode specifically.
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(
-                "path_not_found", "scene file does not exist: /x/missing.tscn"
-            ),
-            stderr="gda: running operation: scene-get\n",
-            exit_code=1,
-        ),
+        ["scene", "get", "/x/missing.tscn", "--json"],
+        "path_not_found",
+        "scene file does not exist: /x/missing.tscn",
+        "scene-get",
     )
 
-    result = CliRunner().invoke(app, ["scene", "get", "/x/missing.tscn", "--json"])
-
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/missing.tscn" in err["message"]
     # The raw stderr still rides along as diagnostics (ADR-0002).
-    assert err["diagnostics"] == "gda: running operation: scene-get\n"
+    assert_operation_error(
+        result,
+        "path_not_found",
+        "/x/missing.tscn",
+        diagnostics="gda: running operation: scene-get\n",
+    )
 
 
 def test_scene_get_unloadable_file_maps_to_stable_not_a_scene_code(monkeypatch):
     # The file exists but Godot cannot load it as a PackedScene — distinct
     # stable code, same operation category and exit code.
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout=error_sentinel(
-                "not_a_scene", "failed to load as a scene: /x/notes.txt"
-            ),
-            stderr="",
-            exit_code=1,
-        ),
+        ["scene", "get", "/x/notes.txt", "--json"],
+        "not_a_scene",
+        "failed to load as a scene: /x/notes.txt",
+        "scene-get",
     )
 
-    result = CliRunner().invoke(app, ["scene", "get", "/x/notes.txt", "--json"])
-
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "not_a_scene"
+    assert_operation_error(result, "not_a_scene")
 
 
 def test_scene_get_exports_missing_file_maps_to_stable_path_not_found_code(monkeypatch):
     # scene get-exports reuses the shared load-failure ladder (issue #58): a
     # target that does not exist is the file-level path_not_found, exit 4, so an
     # agent can tell "no such scene" apart from other get-exports failures.
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(
-                "path_not_found", "scene file does not exist: /x/missing.tscn"
-            ),
-            stderr="gda: running operation: scene-get-exports\n",
-            exit_code=1,
-        ),
+        ["scene", "get-exports", "/x/missing.tscn", "--json"],
+        "path_not_found",
+        "scene file does not exist: /x/missing.tscn",
+        "scene-get-exports",
     )
 
-    result = CliRunner().invoke(
-        app, ["scene", "get-exports", "/x/missing.tscn", "--json"]
-    )
-
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/missing.tscn" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/missing.tscn")
 
 
 def test_scene_get_exports_unloadable_file_maps_to_stable_not_a_scene_code(monkeypatch):
     # The file exists but Godot cannot load it as a PackedScene — get-exports
     # reuses the same stable not_a_scene code scene get / delete report, so a
     # stray non-scene file is refused rather than mis-handled (issue #58).
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout=error_sentinel(
-                "not_a_scene", "failed to load as a scene: /x/notes.txt"
-            ),
-            stderr="",
-            exit_code=1,
-        ),
+        ["scene", "get-exports", "/x/notes.txt", "--json"],
+        "not_a_scene",
+        "failed to load as a scene: /x/notes.txt",
+        "scene-get-exports",
     )
 
-    result = CliRunner().invoke(app, ["scene", "get-exports", "/x/notes.txt", "--json"])
-
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "not_a_scene"
+    assert_operation_error(result, "not_a_scene")
 
 
 def test_scene_create_unknown_root_type_maps_to_stable_invalid_root_type_code(
     monkeypatch,
 ):
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout=error_sentinel(
-                "invalid_root_type", "not an instantiable Node class: Foo"
-            ),
-            stderr="",
-            exit_code=1,
-        ),
+        ["scene", "create", "/x/main.tscn", "--root-type", "Foo", "--json"],
+        "invalid_root_type",
+        "not an instantiable Node class: Foo",
+        "scene-create",
     )
 
-    result = CliRunner().invoke(
-        app, ["scene", "create", "/x/main.tscn", "--root-type", "Foo", "--json"]
-    )
-
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "invalid_root_type"
-    assert "Foo" in err["message"]
+    assert_operation_error(result, "invalid_root_type", "Foo")
 
 
 def test_scene_create_save_failure_maps_to_stable_save_failed_code(monkeypatch):
@@ -145,39 +105,27 @@ def test_scene_create_save_failure_maps_to_stable_save_failed_code(monkeypatch):
     # read-only filesystem): the structured error envelope maps to the stable
     # save_failed code so an agent can tell "fix the destination" apart from
     # "fix the request" (issue #35).
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout=error_sentinel(
-                "save_failed",
-                "failed to save scene to /x/demo/main.tscn: Can't open",
-            ),
-            stderr="",
-            exit_code=1,
-        ),
+        ["scene", "create", "/x/demo/main.tscn", "--root-type", "Node2D", "--json"],
+        "save_failed",
+        "failed to save scene to /x/demo/main.tscn: Can't open",
+        "scene-create",
     )
 
-    result = CliRunner().invoke(
-        app, ["scene", "create", "/x/demo/main.tscn", "--root-type", "Node2D", "--json"]
-    )
-
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "save_failed"
-    assert "/x/demo/main.tscn" in err["message"]
+    assert_operation_error(result, "save_failed", "/x/demo/main.tscn")
 
 
 def test_scene_get_broken_sentinel_maps_to_parse_error(monkeypatch):
     # Exit 0 but no result sentinel: the structured-output contract (ADR-0002)
     # was violated — the shared parse classification applies to scene commands
     # exactly as it does to info.
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout="no sentinel here\n", stderr="", exit_code=0),
+        ["scene", "get", "/x/main.tscn", "--json"],
+        stdout="no sentinel here\n",
+        banner=False,
     )
-
-    result = CliRunner().invoke(app, ["scene", "get", "/x/main.tscn", "--json"])
 
     assert result.exit_code == 5
     err = json.loads(result.stdout)["error"]
@@ -189,47 +137,30 @@ def test_scene_delete_missing_file_maps_to_stable_path_not_found_code(monkeypatc
     # scene delete reuses the shared load-failure ladder (issue #54): a target
     # that does not exist is the file-level path_not_found, exit 4, so an agent
     # can tell "no such scene" apart from other delete failures.
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout=error_sentinel(
-                "path_not_found", "scene file does not exist: /x/missing.tscn"
-            ),
-            stderr="",
-            exit_code=1,
-        ),
+        ["scene", "delete", "/x/missing.tscn", "--json"],
+        "path_not_found",
+        "scene file does not exist: /x/missing.tscn",
+        "scene-delete",
     )
 
-    result = CliRunner().invoke(app, ["scene", "delete", "/x/missing.tscn", "--json"])
-
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/missing.tscn" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/missing.tscn")
 
 
 def test_scene_delete_non_scene_file_maps_to_stable_not_a_scene_code(monkeypatch):
     # delete refuses a target that is not loadable as a scene (issue #54): the
     # safety boundary is that delete only removes things that load as a
     # PackedScene, so a stray file is not_a_scene rather than silently deleted.
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout=error_sentinel(
-                "not_a_scene", "failed to load as a scene: /x/notes.txt"
-            ),
-            stderr="",
-            exit_code=1,
-        ),
+        ["scene", "delete", "/x/notes.txt", "--json"],
+        "not_a_scene",
+        "failed to load as a scene: /x/notes.txt",
+        "scene-delete",
     )
 
-    result = CliRunner().invoke(app, ["scene", "delete", "/x/notes.txt", "--json"])
-
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "not_a_scene"
+    assert_operation_error(result, "not_a_scene")
 
 
 def test_scene_delete_unlink_failure_maps_to_stable_delete_failed_code(monkeypatch):
@@ -239,25 +170,15 @@ def test_scene_delete_unlink_failure_maps_to_stable_delete_failed_code(monkeypat
     # than reusing save_failed (whose contract is "a scene could not be packed or
     # saved"). An agent can then tell "deletion was blocked" apart from "writing
     # the scene failed".
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout=error_sentinel(
-                "delete_failed",
-                "failed to delete scene /x/main.tscn: Permission denied",
-            ),
-            stderr="",
-            exit_code=1,
-        ),
+        ["scene", "delete", "/x/main.tscn", "--json"],
+        "delete_failed",
+        "failed to delete scene /x/main.tscn: Permission denied",
+        "scene-delete",
     )
 
-    result = CliRunner().invoke(app, ["scene", "delete", "/x/main.tscn", "--json"])
-
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "delete_failed"
-    assert "/x/main.tscn" in err["message"]
+    assert_operation_error(result, "delete_failed", "/x/main.tscn")
 
 
 def test_scene_list_without_project_maps_to_stable_project_not_found_code(monkeypatch):
@@ -265,30 +186,23 @@ def test_scene_list_without_project_maps_to_stable_project_not_found_code(monkey
     # (issue #54): with no resolvable project, the operation reports the new
     # project_not_found code — a finer mode than the generic operation_failed so
     # an agent knows to pass --project rather than retry.
-    inject_runner(
+    result = invoke_operation_error(
         monkeypatch,
-        RunResult(
-            stdout=error_sentinel(
-                "project_not_found",
-                "scene list requires a Godot project; none was resolved — pass --project",
-            ),
-            stderr="",
-            exit_code=1,
-        ),
+        ["scene", "list", "--json"],
+        "project_not_found",
+        "scene list requires a Godot project; none was resolved — pass --project",
+        "scene-list",
     )
 
-    result = CliRunner().invoke(app, ["scene", "list", "--json"])
-
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "project_not_found"
-    assert "--project" in err["message"]
+    assert_operation_error(result, "project_not_found", "--project")
 
 
 def test_scene_create_missing_binary_maps_to_environment_error(monkeypatch):
     # The runner's synthetic exit 127 flows through the same shared environment
     # branch for scene commands as for info.
+    # Staged as a whole raw run, not through `invoke_cli`: the LAUNCH FAILURE
+    # this run carries is the input under test, and the invoker stages only the
+    # three canned streams.
     inject_runner(
         monkeypatch,
         RunResult(

--- a/tests/test_scene_preflight_commands.py
+++ b/tests/test_scene_preflight_commands.py
@@ -20,7 +20,7 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import LaunchFailure, RunResult, TimeoutBound
-from tests.support import sentinel
+from tests.support import assert_operation_error, minimal_project, sentinel
 
 READY = sentinel({"path": "res://main.tscn", "status": "ready"})
 
@@ -44,13 +44,8 @@ def _patch_launch(monkeypatch, result: RunResult) -> list:
     return calls
 
 
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
-
-
 def test_a_clean_start_is_ready_and_started(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout=READY, stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -83,7 +78,7 @@ def test_a_script_error_during_startup_is_reported_though_the_scene_reached_read
     # THE DISTINCTION the issue asks for: "compiles and loads" is not "reaches _ready
     # without script errors". The engine says ready; the stderr says otherwise, so
     # `started` is false while `status` still reports how far the boot got.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch, RunResult(stdout=READY, stderr=READY_STDERR, exit_code=0)
     )
@@ -116,7 +111,7 @@ def test_a_run_gda_ends_at_the_bound_is_a_timeout_verdict_not_an_envelope(
     # anything, so the bound is gda's. The answer is still the verdict the caller
     # asked for — "it did not start" — carrying what the engine had already printed,
     # which the streaming capture is what preserves.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -153,7 +148,7 @@ def test_a_run_gda_ends_at_the_bound_is_a_timeout_verdict_not_an_envelope(
 def test_a_missing_binary_is_still_an_error_envelope(monkeypatch, tmp_path):
     # Only the SCENE's fate is a verdict. An environment failure is not about the
     # scene at all, so it stays the shared envelope every channel reports.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -176,7 +171,7 @@ def test_a_missing_binary_is_still_an_error_envelope(monkeypatch, tmp_path):
 def test_an_operation_refusal_survives_the_recipe(monkeypatch, tmp_path):
     # The op's own structured refusals still classify normally: a scene that cannot
     # be instantiated at all is a dependency failure, not a startup verdict.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     payload = sentinel(
         {
             "error": {
@@ -192,12 +187,11 @@ def test_an_operation_refusal_survives_the_recipe(monkeypatch, tmp_path):
         ["scene", "preflight", "res://main.tscn", "--project", str(project), "--json"],
     )
 
-    assert result.exit_code == 4, result.stdout + result.stderr
-    assert json.loads(result.stdout)["error"]["code"] == "missing_dependency"
+    assert_operation_error(result, "missing_dependency")
 
 
 def test_frames_and_timeout_reach_the_launch_through_params_json(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout=READY, stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -221,7 +215,7 @@ def test_frames_and_timeout_reach_the_launch_through_params_json(monkeypatch, tm
 
 @pytest.mark.parametrize("frames", ["0", "-1"])
 def test_a_non_positive_frame_budget_is_a_usage_error(monkeypatch, tmp_path, frames):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout=READY, stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -242,7 +236,7 @@ def test_a_non_positive_frame_budget_is_a_usage_error(monkeypatch, tmp_path, fra
 
 
 def test_a_non_positive_timeout_is_a_usage_error(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout=READY, stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -263,7 +257,7 @@ def test_a_non_positive_timeout_is_a_usage_error(monkeypatch, tmp_path):
 
 
 def test_human_output_leads_with_the_verdict(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch, RunResult(stdout=READY, stderr=READY_STDERR, exit_code=0)
     )
@@ -287,7 +281,7 @@ def test_an_engine_reported_not_ready_projects_as_a_failed_start(monkeypatch, tm
     # The verdict gda cannot produce on a healthy engine but must still project
     # faithfully: readiness is settled before the first observed frame, so a
     # not_ready payload means the propagation never reached the scene at all.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -312,7 +306,7 @@ def test_an_unknown_status_is_a_contract_violation_not_a_verdict(monkeypatch, tm
     # The closed enum is the contract: a payload gda does not understand is a parse
     # failure, never a guess. This is what keeps the GDScript/Python mirror honest at
     # runtime as well as in the pinning test.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -336,7 +330,7 @@ def test_a_timeout_outranks_a_sentinel_that_arrived_before_it(monkeypatch, tmp_p
     # over whatever the partial capture happens to contain. A sentinel in a timed-out
     # capture is not the engine's final answer — the run never finished — and reading
     # it would report a scene as started that gda had just killed.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -368,7 +362,7 @@ def test_this_channel_declares_no_watch_which_is_what_keeps_aborted_unreachable(
     # watch, and ABORTED is unreachable here. The invariant is an argument the launch
     # does NOT get: adding a policy watch later fails this test rather than silently
     # degrading an abort into a contract_violation.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout=READY, stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -395,7 +389,7 @@ def test_params_json_refuses_the_same_bounds_argv_does(monkeypatch, tmp_path, pa
     # argv as a usage error, --params-json as the structured invalid_params. An
     # infinite ceiling is refused because it would never be reached, leaving the run
     # gda promised to bound unbounded.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout=READY, stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -411,8 +405,7 @@ def test_params_json_refuses_the_same_bounds_argv_does(monkeypatch, tmp_path, pa
         ],
     )
 
-    assert result.exit_code == 4, result.stdout + result.stderr
-    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+    assert_operation_error(result, "invalid_params")
     assert calls == []
 
 
@@ -424,7 +417,7 @@ def test_a_project_that_quits_the_engine_is_not_blamed_on_gdas_contract(
     # then exits cleanly with no sentinel, which the shared classifier reads as gda's
     # own output contract being violated. That sends the reader to debug gda for
     # something the project did, so this channel names the real cause instead.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(stdout="Godot Engine v4.6.3\n", stderr="quitting\n", exit_code=0),
@@ -449,7 +442,7 @@ def test_a_quit_after_the_readiness_evidence_keeps_the_ready_verdict(
     # already printed readiness as its own evidence line. That run has a startup
     # verdict — the scene plainly came up — so it is reported as ready, not as an
     # operation failure.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -477,7 +470,7 @@ def test_a_quit_after_readiness_still_combines_the_captured_diagnostics(
     # `started` keeps both halves of the contract on the synthesized verdict too:
     # readiness is proven by the evidence line, and a recognized error captured
     # before the quit still gates a clean start.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -510,7 +503,7 @@ def test_a_payload_that_died_without_reporting_is_still_the_generic_failure(
     # payload quits with a code that DEFAULTS to failure, so every way it can end
     # without emitting exits non-zero — and stays the generic operation_failed rather
     # than being mislabelled as the project's own quit.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(stdout="", stderr="SCRIPT ERROR: in the payload\n", exit_code=1),
@@ -533,7 +526,7 @@ def test_a_begun_but_unterminated_sentinel_stays_a_parse_failure(monkeypatch, tm
     # marker here: a payload that STARTED a result and did not finish one has not
     # been quit out from under — it emitted something gda cannot read. Reported as
     # the parse failure it is, not as the project's own quit.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -560,7 +553,7 @@ def test_a_timeout_verdict_carries_the_elapsed_clock_and_the_ceiling_it_reached(
     # fraction over a tight ceiling from one that was stuck for an hour (GDA-DF-032,
     # reintroduced for this one channel). The evidence is now on the verdict, in the
     # same two words the other timeout surfaces use.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -605,7 +598,7 @@ def test_the_ceiling_is_read_off_the_launch_rather_than_re_derived_from_the_para
     # same fact from the params it happened to pass in. Production keeps the two
     # equal; the divergence here is test-only, and it is what makes the source of
     # the number observable at all.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -643,7 +636,7 @@ def test_an_unmeasured_timeout_reports_the_ceiling_instead_of_claiming_zero(
     # Reporting 0.0 would read as "ended instantly" — the opposite of what happened —
     # so each number degrades to the truthful value the caller's own ceiling
     # guarantees: gda ended this run AT that ceiling, so it ran at least that long.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -695,7 +688,7 @@ def test_a_non_timeout_verdict_omits_the_evidence_keys_entirely(
     # exactly the bytes it always did. The keys are OMITTED rather than serialized as
     # null — gda's omitted-never-null convention (cf. gda.provenance) — because a
     # null would claim a measurement that does not apply to a run nobody bounded.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(monkeypatch, raw)
 
     result = CliRunner().invoke(
@@ -714,7 +707,7 @@ def test_the_human_timeout_verdict_states_both_numbers_too(monkeypatch, tmp_path
     # The rendered output carries the same evidence as the JSON: an agent reading the
     # human channel must not have to re-run with --json to learn whether the scene
     # was slow or stuck.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch,
         RunResult(
@@ -750,7 +743,7 @@ def test_the_human_render_of_a_non_timeout_verdict_gains_no_evidence_line(
 ):
     # The same invariance on the human channel: a verdict with nothing to report
     # reports nothing, rather than a line of blanks or zeros.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(
         monkeypatch, RunResult(stdout=READY, stderr=READY_STDERR, exit_code=0)
     )

--- a/tests/test_scene_validate_commands.py
+++ b/tests/test_scene_validate_commands.py
@@ -15,8 +15,12 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.commands.scene import SceneProblemKind, SceneStartupStatus
-from gda.runner import RunResult
-from tests.support import inject_runner, sentinel
+from tests.support import (
+    assert_operation_error,
+    invoke_cli,
+    minimal_project,
+    sentinel,
+)
 
 # One invalid verdict as the engine reports it: the op's own payload, WITHOUT the
 # project_root the CLI adds afterwards.
@@ -72,20 +76,12 @@ COMPOSED_PAYLOAD = {
 VALID_PAYLOAD = {"path": "res://main.tscn", "valid": True, "problems": []}
 
 
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
-
-
 def test_valid_scene_reports_the_verdict_and_exits_zero(monkeypatch, tmp_path):
-    project = _project(tmp_path)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(VALID_PAYLOAD), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    project = minimal_project(tmp_path)
+    result, fake = invoke_cli(
+        monkeypatch,
         ["scene", "validate", "res://main.tscn", "--project", str(project), "--json"],
+        stdout=sentinel(VALID_PAYLOAD),
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -105,14 +101,11 @@ def test_invalid_scene_is_a_successful_operation_with_problems(monkeypatch, tmp_
     # THE CRUX: an invalid scene exits 0 with valid=false — the verdict is read from
     # the result, never from the process status (the script validate contract, applied
     # to scenes).
-    project = _project(tmp_path)
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(INVALID_PAYLOAD), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    project = minimal_project(tmp_path)
+    result, _ = invoke_cli(
+        monkeypatch,
         ["scene", "validate", "res://main.tscn", "--project", str(project), "--json"],
+        stdout=sentinel(INVALID_PAYLOAD),
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -134,24 +127,20 @@ def test_projectless_run_reports_a_null_project_root(monkeypatch, tmp_path):
     # present so an agent reads it unconditionally.
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("GDA_PROJECT", raising=False)
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(VALID_PAYLOAD), stderr="", exit_code=0)
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["scene", "validate", "/tmp/loose.tscn", "--json"],
+        stdout=sentinel(VALID_PAYLOAD),
     )
-
-    result = CliRunner().invoke(app, ["scene", "validate", "/tmp/loose.tscn", "--json"])
 
     assert result.exit_code == 0, result.stdout + result.stderr
     assert json.loads(result.stdout)["project_root"] is None
 
 
 def test_params_json_drives_the_same_recipe(monkeypatch, tmp_path):
-    project = _project(tmp_path)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(VALID_PAYLOAD), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    project = minimal_project(tmp_path)
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "scene",
             "validate",
@@ -161,6 +150,7 @@ def test_params_json_drives_the_same_recipe(monkeypatch, tmp_path):
             str(project),
             "--json",
         ],
+        stdout=sentinel(VALID_PAYLOAD),
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -169,13 +159,11 @@ def test_params_json_drives_the_same_recipe(monkeypatch, tmp_path):
 
 
 def test_human_output_leads_with_the_verdict_then_the_evidence(monkeypatch, tmp_path):
-    project = _project(tmp_path)
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(INVALID_PAYLOAD), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["scene", "validate", "res://main.tscn", "--project", str(project)]
+    project = minimal_project(tmp_path)
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["scene", "validate", "res://main.tscn", "--project", str(project)],
+        stdout=sentinel(INVALID_PAYLOAD),
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -196,15 +184,11 @@ def test_a_composed_verdict_attributes_each_problem_to_the_scene_it_was_found_in
     # both live in `child.tscn`. Without `scene` an agent reads them as the
     # parent's, and each problem's `nodes` — relative to the scene that owns
     # them — resolve against the wrong tree.
-    project = _project(tmp_path)
-    inject_runner(
+    project = minimal_project(tmp_path)
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(COMPOSED_PAYLOAD), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         ["scene", "validate", "res://parent.tscn", "--project", str(project), "--json"],
+        stdout=sentinel(COMPOSED_PAYLOAD),
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -220,14 +204,11 @@ def test_a_composed_verdict_attributes_each_problem_to_the_scene_it_was_found_in
 
 
 def test_human_output_names_the_sub_scene_a_problem_was_found_in(monkeypatch, tmp_path):
-    project = _project(tmp_path)
-    inject_runner(
+    project = minimal_project(tmp_path)
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=sentinel(COMPOSED_PAYLOAD), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["scene", "validate", "res://parent.tscn", "--project", str(project)]
+        ["scene", "validate", "res://parent.tscn", "--project", str(project)],
+        stdout=sentinel(COMPOSED_PAYLOAD),
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -245,13 +226,11 @@ def test_human_output_stays_silent_about_the_scene_the_command_was_given(
 ):
     # The `in` line is attribution, not decoration: an ordinary single-file verdict
     # would only be made longer by repeating the path already in its headline.
-    project = _project(tmp_path)
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(INVALID_PAYLOAD), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["scene", "validate", "res://main.tscn", "--project", str(project)]
+    project = minimal_project(tmp_path)
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["scene", "validate", "res://main.tscn", "--project", str(project)],
+        stdout=sentinel(INVALID_PAYLOAD),
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
@@ -261,21 +240,18 @@ def test_human_output_stays_silent_about_the_scene_the_command_was_given(
 def test_an_operation_failure_is_still_an_error_envelope(monkeypatch, tmp_path):
     # The shared addressing ladder does not fork for validate: a missing file is a
     # refusal, not a verdict.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     payload = {
         "error": {"code": "path_not_found", "message": "scene file does not exist"}
     }
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=1)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, _ = invoke_cli(
+        monkeypatch,
         ["scene", "validate", "res://gone.tscn", "--project", str(project), "--json"],
+        stdout=sentinel(payload),
+        exit_code=1,
     )
 
-    assert result.exit_code == 4, result.stdout + result.stderr
-    assert json.loads(result.stdout)["error"]["code"] == "path_not_found"
+    assert_operation_error(result, "path_not_found")
 
 
 # --- The cross-language enum contract (#664) --------------------------------
@@ -326,9 +302,7 @@ def test_the_rendered_help_keeps_the_bracketed_scene_file_tokens():
     # style tags, so an unescaped docstring RENDERS without them — the published
     # help read "no complete  header" (#720 recheck ×2). Pin the rendered output,
     # not the source: the escape is load-bearing.
-    from typer.testing import CliRunner
 
-    from gda.cli import app
     from tests.support import plain_text
 
     result = CliRunner().invoke(app, ["scene", "validate", "--help"])

--- a/tests/test_schema_aggregate.py
+++ b/tests/test_schema_aggregate.py
@@ -19,6 +19,7 @@ only in-process. That one is deliberately NOT marked `e2e`: this repo's `e2e` ma
 this check is cheap and deterministic and belongs in the default PR gate.
 """
 
+import functools
 import json
 import subprocess
 
@@ -29,10 +30,34 @@ from gda.cli import app
 from tests.support import GDA_CMD
 
 
-def _manifest() -> dict:
+@functools.cache
+def _manifest_json() -> str:
+    """The ``gda schema`` emission, produced ONCE per process (#815).
+
+    The surface is immutable for the process lifetime — the product asserts as
+    much for gda-mcp's cache hint — so every test reads the same emission
+    instead of walking the whole command tree again. ``_manifest`` hands each
+    caller its own parse, so no test can mutate what another reads.
+    """
     result = CliRunner().invoke(app, ["schema"])
     assert result.exit_code == 0, result.stdout
-    return json.loads(result.stdout)
+    return result.stdout
+
+
+def _manifest() -> dict:
+    return json.loads(_manifest_json())
+
+
+@functools.cache
+def _own_schema_json(name: str) -> str:
+    """A command's own ``--schema`` emission, produced ONCE per command (#815).
+
+    The four aggregate-versus-own comparisons below read the same table rather
+    than each re-dispatching every command.
+    """
+    result = CliRunner().invoke(app, [*name.split(" "), "--schema"])
+    assert result.exit_code == 0, result.stdout
+    return result.stdout
 
 
 def _live_dispatchable_command_names() -> set[str]:
@@ -109,9 +134,7 @@ def test_each_entry_matches_the_commands_own_schema():
     # command emits under its own `--schema` (ADR-0004): one source of truth,
     # derived through the same CommandSchema.of, not a parallel projection.
     for entry in _manifest()["commands"]:
-        result = CliRunner().invoke(app, [*entry["name"].split(" "), "--schema"])
-        assert result.exit_code == 0, result.stdout
-        own = json.loads(result.stdout)
+        own = json.loads(_own_schema_json(entry["name"]))
         assert entry["input"] == own["input"]
         assert entry["output"] == own["output"]
         assert entry["error"] == own["error"]
@@ -175,9 +198,7 @@ def test_entry_kind_matches_the_commands_own_schema_kind():
     # under its own `--schema` (ADR-0004 / ADR-0012): one descriptor field, not a
     # parallel projection — so the aggregate and per-command forms must agree.
     for entry in _manifest()["commands"]:
-        result = CliRunner().invoke(app, [*entry["name"].split(" "), "--schema"])
-        assert result.exit_code == 0, result.stdout
-        own = json.loads(result.stdout)
+        own = json.loads(_own_schema_json(entry["name"]))
         assert entry["kind"] == own["kind"], entry["name"]
 
 
@@ -202,9 +223,7 @@ def test_entry_constraints_match_the_commands_own_schema_constraints():
     # projection — so the aggregate and per-command forms must agree exactly,
     # including the null case.
     for entry in _manifest()["commands"]:
-        result = CliRunner().invoke(app, [*entry["name"].split(" "), "--schema"])
-        assert result.exit_code == 0, result.stdout
-        own = json.loads(result.stdout)
+        own = json.loads(_own_schema_json(entry["name"]))
         assert entry["constraints"] == own["constraints"], entry["name"]
 
 
@@ -379,9 +398,8 @@ def test_entry_argv_matches_the_commands_own_schema_argv():
     # (ADR-0012's live-tree walk, ADR-0023 §2's "projections, not parallel
     # registries"), so the aggregate and per-command forms cannot drift.
     for entry in _manifest()["commands"]:
-        result = CliRunner().invoke(app, [*entry["name"].split(" "), "--schema"])
-        assert result.exit_code == 0, result.stdout
-        assert entry["argv"] == json.loads(result.stdout)["argv"], entry["name"]
+        own = json.loads(_own_schema_json(entry["name"]))
+        assert entry["argv"] == own["argv"], entry["name"]
 
 
 def test_every_argv_binding_is_constructible_into_a_command_line():

--- a/tests/test_screen_commands.py
+++ b/tests/test_screen_commands.py
@@ -40,6 +40,7 @@ from tests.support import (
     screen_capture_reply,
     screen_frames_reply,
     usage_error_text,
+    minimal_project,
 )
 
 # A 1x1 transparent PNG (valid, decodes to real bytes) so a written file starts
@@ -47,11 +48,6 @@ from tests.support import (
 # tests.support, which the live-contract guard's capture probe reads too.
 _PNG_B64 = PNG_1X1_B64
 _PNG_1X1 = base64.b64decode(_PNG_B64)
-
-
-def _project(tmp_path):
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
 
 
 # --- input contract: output paths are params, not CLI-only (#222, PR #248) ----
@@ -79,7 +75,7 @@ def test_screen_capture_params_json_supplies_the_output_path(monkeypatch, tmp_pa
             "--params-json",
             payload,
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -100,7 +96,7 @@ def test_screen_capture_params_json_without_output_is_invalid_params(tmp_path):
             "--params-json",
             "{}",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -129,7 +125,7 @@ def test_screen_frames_params_json_supplies_the_output_dir(monkeypatch, tmp_path
             "--params-json",
             payload,
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -180,7 +176,7 @@ def test_screen_capture_writes_a_png_and_returns_its_path(monkeypatch, tmp_path)
             "--output",
             str(out),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -220,7 +216,7 @@ def test_screen_capture_inline_embeds_the_base64(monkeypatch, tmp_path):
             "--output",
             str(out),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -248,7 +244,7 @@ def test_screen_capture_with_no_daemon_reports_daemon_not_running(
             "--output",
             str(tmp_path / "shot.png"),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -285,7 +281,7 @@ def test_screen_capture_on_headless_session_reports_live_display_unavailable(
             "--output",
             str(out),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -343,7 +339,7 @@ def test_screen_frames_writes_each_png_and_returns_paths(monkeypatch, tmp_path):
             "--output-dir",
             str(out_dir),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -378,7 +374,7 @@ def test_screen_frames_with_no_daemon_reports_daemon_not_running(monkeypatch, tm
             "--output-dir",
             str(tmp_path / "frames"),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -407,7 +403,7 @@ def test_screen_frames_argv_frames_over_range_is_a_usage_error(monkeypatch, tmp_
             "--output-dir",
             str(tmp_path / "frames"),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -453,7 +449,7 @@ def test_screen_frames_params_json_over_range_frames_is_invalid_params(
             "screen",
             "frames",
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
             "--params-json",
             payload,
@@ -529,7 +525,7 @@ def test_await_predicate_rides_the_wire_with_the_default_ceiling(monkeypatch, tm
     )
     out = tmp_path / "shot.png"
 
-    result = CliRunner().invoke(app, _await_argv(out, _project(tmp_path)))
+    result = CliRunner().invoke(app, _await_argv(out, minimal_project(tmp_path)))
 
     assert result.exit_code == 0, result.stdout + result.stderr
     # One op, the SAME screen-capture op — the predicate is params, not a new
@@ -571,7 +567,12 @@ def test_await_events_ride_the_same_window_and_report_surfaces(monkeypatch, tmp_
     result = CliRunner().invoke(
         app,
         _await_argv(
-            out, _project(tmp_path), "--await-frames", "30", "--await-events", events
+            out,
+            minimal_project(tmp_path),
+            "--await-frames",
+            "30",
+            "--await-events",
+            events,
         ),
     )
 
@@ -612,7 +613,7 @@ def test_await_bare_word_value_is_a_string_predicate(monkeypatch, tmp_path):
         app,
         _capture_argv(
             out,
-            _project(tmp_path),
+            minimal_project(tmp_path),
             "--await-node",
             "/root/Main/VFX",
             "--await-property",
@@ -642,7 +643,7 @@ def test_await_render_carries_the_predicate_line(monkeypatch, tmp_path):
         RunResult(stdout=sentinel(reply), stderr="", exit_code=0),
     )
     out = tmp_path / "shot.png"
-    argv = _await_argv(out, _project(tmp_path))
+    argv = _await_argv(out, minimal_project(tmp_path))
     argv.remove("--json")
 
     result = CliRunner().invoke(app, argv)
@@ -668,7 +669,7 @@ def test_await_unmet_predicate_is_the_typed_live_error(monkeypatch, tmp_path):
     out = tmp_path / "shot.png"
 
     result = CliRunner().invoke(
-        app, _await_argv(out, _project(tmp_path), "--await-frames", "30")
+        app, _await_argv(out, minimal_project(tmp_path), "--await-frames", "30")
     )
 
     assert result.exit_code == EXIT_LIVE
@@ -699,7 +700,7 @@ def test_await_trio_is_all_or_none(monkeypatch, tmp_path):
 
     result = CliRunner().invoke(
         app,
-        _capture_argv(out, _project(tmp_path), "--await-node", "/root/Main/VFX"),
+        _capture_argv(out, minimal_project(tmp_path), "--await-node", "/root/Main/VFX"),
     )
 
     message = _usage_error_message(result)
@@ -713,7 +714,7 @@ def test_await_value_null_is_refused_with_the_trio_message(monkeypatch, tmp_path
         app,
         _capture_argv(
             out,
-            _project(tmp_path),
+            minimal_project(tmp_path),
             "--await-node",
             "/root/Main/VFX",
             "--await-property",
@@ -734,7 +735,7 @@ def test_await_events_need_the_predicate(monkeypatch, tmp_path):
         app,
         _capture_argv(
             out,
-            _project(tmp_path),
+            minimal_project(tmp_path),
             "--await-events",
             '[{"type": "key", "key": "Right"}]',
         ),
@@ -751,7 +752,7 @@ def test_await_events_refuse_the_physics_clock(monkeypatch, tmp_path):
         app,
         _await_argv(
             out,
-            _project(tmp_path),
+            minimal_project(tmp_path),
             "--await-events",
             '[{"type": "key", "key": "Right", "physics_frame": 1}]',
         ),
@@ -782,7 +783,7 @@ def test_out_of_window_event_offset_is_accepted_and_rides_the_wire(
         app,
         _await_argv(
             out,
-            _project(tmp_path),
+            minimal_project(tmp_path),
             "--await-frames",
             "10",
             "--await-events",
@@ -815,7 +816,7 @@ def test_await_event_offset_must_fit_the_shared_total_window(monkeypatch, tmp_pa
         app,
         _await_argv(
             out,
-            _project(tmp_path),
+            minimal_project(tmp_path),
             "--await-frames",
             "10",
             "--await-events",
@@ -841,7 +842,7 @@ def test_await_frames_needs_the_predicate(monkeypatch, tmp_path):
     out = tmp_path / "shot.png"
 
     result = CliRunner().invoke(
-        app, _capture_argv(out, _project(tmp_path), "--await-frames", "30")
+        app, _capture_argv(out, minimal_project(tmp_path), "--await-frames", "30")
     )
 
     message = _usage_error_message(result)
@@ -870,7 +871,7 @@ def test_await_params_json_path_rejects_identically(monkeypatch, tmp_path):
             "--params-json",
             params,
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -913,7 +914,9 @@ def _await_capture(monkeypatch, tmp_path, reply, *extra):
         RunResult(stdout=sentinel(reply), stderr="", exit_code=0),
     )
     out = tmp_path / "shot.png"
-    result = CliRunner().invoke(app, _await_argv(out, _project(tmp_path), *extra))
+    result = CliRunner().invoke(
+        app, _await_argv(out, minimal_project(tmp_path), *extra)
+    )
     return result, out
 
 
@@ -992,7 +995,7 @@ def test_plain_capture_with_unsolicited_predicate_is_contract_violation(
     )
     out = tmp_path / "shot.png"
 
-    result = CliRunner().invoke(app, _capture_argv(out, _project(tmp_path)))
+    result = CliRunner().invoke(app, _capture_argv(out, minimal_project(tmp_path)))
 
     _assert_contract_violation(result, out, "declared no --await predicate")
 
@@ -1018,7 +1021,7 @@ def test_capture_receipt_surfaces_with_the_written_file_hash(monkeypatch, tmp_pa
     )
     out = tmp_path / "shot.png"
 
-    result = CliRunner().invoke(app, _capture_argv(out, _project(tmp_path)))
+    result = CliRunner().invoke(app, _capture_argv(out, minimal_project(tmp_path)))
 
     assert result.exit_code == 0, result.stdout + result.stderr
     receipt = json.loads(result.stdout)["receipt"]
@@ -1044,7 +1047,7 @@ def test_gated_capture_receipt_echoes_the_predicate_evidence(monkeypatch, tmp_pa
     )
     out = tmp_path / "shot.png"
 
-    result = CliRunner().invoke(app, _await_argv(out, _project(tmp_path)))
+    result = CliRunner().invoke(app, _await_argv(out, minimal_project(tmp_path)))
 
     assert result.exit_code == 0, result.stdout + result.stderr
     data = json.loads(result.stdout)
@@ -1067,7 +1070,7 @@ def test_capture_reply_without_a_receipt_is_contract_violation(monkeypatch, tmp_
     )
     out = tmp_path / "shot.png"
 
-    result = CliRunner().invoke(app, _capture_argv(out, _project(tmp_path)))
+    result = CliRunner().invoke(app, _capture_argv(out, minimal_project(tmp_path)))
 
     data = json.loads(result.stdout)
     assert data["error"]["code"] == "contract_violation"
@@ -1086,7 +1089,7 @@ def test_receipt_missing_a_nullable_key_is_contract_violation(monkeypatch, tmp_p
     )
     out = tmp_path / "shot.png"
 
-    result = CliRunner().invoke(app, _capture_argv(out, _project(tmp_path)))
+    result = CliRunner().invoke(app, _capture_argv(out, minimal_project(tmp_path)))
 
     assert json.loads(result.stdout)["error"]["code"] == "contract_violation"
     assert not out.exists()
@@ -1105,7 +1108,7 @@ def test_plain_capture_receipt_with_unsolicited_echo_is_contract_violation(
     )
     out = tmp_path / "shot.png"
 
-    result = CliRunner().invoke(app, _capture_argv(out, _project(tmp_path)))
+    result = CliRunner().invoke(app, _capture_argv(out, minimal_project(tmp_path)))
 
     data = json.loads(result.stdout)
     assert data["error"]["code"] == "contract_violation"
@@ -1145,7 +1148,7 @@ def test_capture_render_carries_the_receipt_line(monkeypatch, tmp_path):
         RunResult(stdout=sentinel(reply), stderr="", exit_code=0),
     )
     out = tmp_path / "shot.png"
-    argv = _capture_argv(out, _project(tmp_path))
+    argv = _capture_argv(out, minimal_project(tmp_path))
     argv.remove("--json")
 
     result = CliRunner().invoke(app, argv)
@@ -1444,7 +1447,7 @@ def test_frames_summary_returns_the_aggregate_and_still_writes_files(
             "--output-dir",
             str(out_dir),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1487,7 +1490,7 @@ def test_frames_default_form_is_unchanged_and_summary_null(monkeypatch, tmp_path
             "--output-dir",
             str(out_dir),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1519,7 +1522,7 @@ def test_frames_summary_rides_params_json_identically(monkeypatch, tmp_path):
             "--params-json",
             payload,
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1593,7 +1596,7 @@ def test_frames_reply_count_mismatch_is_contract_violation(monkeypatch, tmp_path
             "--output-dir",
             str(out_dir),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1628,7 +1631,7 @@ def test_frames_summary_reports_null_dims_for_a_nonuniform_sequence(
             "--output-dir",
             str(out_dir),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1664,7 +1667,7 @@ def test_frames_budget_mismatch_is_contract_violation(monkeypatch, tmp_path):
             "--output-dir",
             str(out_dir),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
             "--json",
         ],
     )
@@ -1741,7 +1744,7 @@ def test_nonuniform_summary_renders_the_varied_size_state(monkeypatch, tmp_path)
             "--output-dir",
             str(out_dir),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
         ],
     )
 
@@ -1812,7 +1815,7 @@ def test_frames_summary_render_is_one_aggregate_line(monkeypatch, tmp_path):
             "--output-dir",
             str(out_dir),
             "--project",
-            str(_project(tmp_path)),
+            str(minimal_project(tmp_path)),
         ],
     )
 

--- a/tests/test_script_commands.py
+++ b/tests/test_script_commands.py
@@ -22,22 +22,21 @@ from tests.support import (
     SCRIPT_GET_RESULT as GET_RESULT,
     SCRIPT_LIST_RESULT as LIST_RESULT,
     SCRIPT_SET_RESULT as SET_RESULT,
-    FakeRunner,
-    inject_runner,
+    assert_operation_error,
+    invoke_cli,
+    minimal_project,
+    recording_runner,
     sentinel,
 )
 
 
 def test_script_create_json_maps_success_to_json_object_and_exit_zero(monkeypatch):
     # Engine banner noise around the sentinel, diagnostics on stderr (ADR-0002).
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(CREATE_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         ["script", "create", "/tmp/proj/hero.gd", "--extends", "Node2D", "--json"],
+        stdout=sentinel(CREATE_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -66,10 +65,8 @@ def test_script_create_default_template_passes_null_content_and_extends(monkeypa
     # The bare template: no --content, no --extends. Both pass through as null,
     # so the operation writes its default minimal template.
     stdout = sentinel({**CREATE_RESULT, "extends": "Node"})
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["script", "create", "/tmp/proj/hero.gd", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch, ["script", "create", "/tmp/proj/hero.gd", "--json"], stdout=stdout
     )
 
     assert result.exit_code == 0
@@ -91,10 +88,8 @@ def test_script_create_content_passes_verbatim_source(monkeypatch):
             "created_dirs": [],
         }
     )
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "create",
@@ -103,6 +98,7 @@ def test_script_create_content_passes_verbatim_source(monkeypatch):
             "extends RefCounted\n",
             "--json",
         ],
+        stdout=stdout,
     )
 
     assert result.exit_code == 0
@@ -121,12 +117,8 @@ def test_script_create_content_passes_verbatim_source(monkeypatch):
 def test_script_create_content_and_extends_are_mutually_exclusive(monkeypatch):
     # Verbatim content is not templated, so a base class has nowhere to go;
     # supplying both is a usage error (exit 2), never a silent precedence rule.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(CREATE_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "create",
@@ -137,6 +129,7 @@ def test_script_create_content_and_extends_are_mutually_exclusive(monkeypatch):
             "Node2D",
             "--json",
         ],
+        stdout=sentinel(CREATE_RESULT),
     )
 
     assert result.exit_code == 2
@@ -147,10 +140,11 @@ def test_script_create_content_and_extends_are_mutually_exclusive(monkeypatch):
 def test_script_get_json_emits_source_and_metadata_and_exit_zero(monkeypatch):
     # script get is the verifier (issue #110): it reads a script's source back
     # as raw text with its class_name/extends, so a create round-trips.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(GET_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(app, ["script", "get", "/tmp/proj/hero.gd", "--json"])
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["script", "get", "/tmp/proj/hero.gd", "--json"],
+        stdout=sentinel(GET_RESULT),
+    )
 
     assert result.exit_code == 0
     data = json.loads(result.stdout)
@@ -167,12 +161,11 @@ def test_script_list_json_enumerates_project_scripts_and_exit_zero(
     # script list enumerates the resolved project's .gd files (issue #117): each
     # entry carries its res:// path plus the class_name/extends parsed cheaply
     # from the script's raw source.
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(LIST_RESULT)
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["script", "list", "--project", str(tmp_path), "--json"]
+    minimal_project(tmp_path)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["script", "list", "--project", str(tmp_path), "--json"],
+        stdout=sentinel(LIST_RESULT),
     )
 
     assert result.exit_code == 0
@@ -192,23 +185,17 @@ def test_script_list_json_enumerates_project_scripts_and_exit_zero(
 def test_script_list_passes_resolved_project_to_the_runner(monkeypatch, tmp_path):
     # script list enumerates res:// in the resolved project, so --project must
     # reach the runner (which hands it to the engine as --path, issue #32).
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    seen: dict = {}
-
-    def record(binary, project):
-        seen["project"] = project
-        return FakeRunner(
-            RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
-        )
-
-    monkeypatch.setattr("gda.dispatch.make_runner", record)
+    minimal_project(tmp_path)
+    projects = recording_runner(
+        monkeypatch, RunResult(stdout=sentinel(LIST_RESULT), stderr="", exit_code=0)
+    )
 
     result = CliRunner().invoke(
         app, ["script", "list", "--project", str(tmp_path), "--json"]
     )
 
     assert result.exit_code == 0
-    assert seen["project"] == tmp_path
+    assert projects[0] == tmp_path
 
 
 def test_script_set_search_replace_dispatches_search_and_replace(monkeypatch):
@@ -217,13 +204,8 @@ def test_script_set_search_replace_dispatches_search_and_replace(monkeypatch):
     # the edit mode once and stamps the explicit `mode` discriminator the op
     # dispatches on (issue #133). The result re-parses the written source's
     # class_name/extends, so set round-trips through get.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(SET_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "set",
@@ -234,6 +216,8 @@ def test_script_set_search_replace_dispatches_search_and_replace(monkeypatch):
             "Node2D",
             "--json",
         ],
+        stdout=sentinel(SET_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -262,12 +246,8 @@ def test_script_set_line_range_dispatches_start_end_and_content(monkeypatch):
     # line-range mode: --start-line/--end-line + --content ride through; the
     # search-replace params pass as null. The CLI stamps the explicit `mode`
     # discriminator the op dispatches on (issue #133).
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "set",
@@ -280,6 +260,7 @@ def test_script_set_line_range_dispatches_start_end_and_content(monkeypatch):
             "extends Node2D",
             "--json",
         ],
+        stdout=sentinel(SET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -303,12 +284,8 @@ def test_script_set_full_overwrite_dispatches_content_only(monkeypatch):
     # full mode: --content with no --start-line overwrites the whole file; every
     # other mode param passes as null. The CLI stamps the explicit `mode`
     # discriminator the op dispatches on (issue #133).
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "set",
@@ -317,6 +294,7 @@ def test_script_set_full_overwrite_dispatches_content_only(monkeypatch):
             "extends Node\n",
             "--json",
         ],
+        stdout=sentinel(SET_RESULT),
     )
 
     assert result.exit_code == 0
@@ -345,11 +323,11 @@ def _assert_set_usage_error(fake, result):
 
 def test_script_set_no_flags_is_a_usage_error(monkeypatch):
     # No edit mode at all is a usage error: set always needs exactly one mode.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["script", "set", "/tmp/proj/hero.gd", "--json"],
+        stdout=sentinel(SET_RESULT),
     )
-
-    result = CliRunner().invoke(app, ["script", "set", "/tmp/proj/hero.gd", "--json"])
 
     _assert_set_usage_error(fake, result)
 
@@ -357,24 +335,20 @@ def test_script_set_no_flags_is_a_usage_error(monkeypatch):
 def test_script_set_search_without_replace_is_a_usage_error(monkeypatch):
     # --search requires --replace (and vice versa) — a half-specified
     # search-replace is a usage error, never a silent default.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "set", "/tmp/proj/hero.gd", "--search", "Node", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["script", "set", "/tmp/proj/hero.gd", "--search", "Node", "--json"],
+        stdout=sentinel(SET_RESULT),
     )
 
     _assert_set_usage_error(fake, result)
 
 
 def test_script_set_replace_without_search_is_a_usage_error(monkeypatch):
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "set", "/tmp/proj/hero.gd", "--replace", "Node2D", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["script", "set", "/tmp/proj/hero.gd", "--replace", "Node2D", "--json"],
+        stdout=sentinel(SET_RESULT),
     )
 
     _assert_set_usage_error(fake, result)
@@ -383,12 +357,8 @@ def test_script_set_replace_without_search_is_a_usage_error(monkeypatch):
 def test_script_set_search_replace_and_content_are_mutually_exclusive(monkeypatch):
     # Mixing search-replace with a line-range/full param (--content) is a usage
     # error: the modes are mutually exclusive.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "set",
@@ -401,6 +371,7 @@ def test_script_set_search_replace_and_content_are_mutually_exclusive(monkeypatc
             "x",
             "--json",
         ],
+        stdout=sentinel(SET_RESULT),
     )
 
     _assert_set_usage_error(fake, result)
@@ -419,13 +390,8 @@ def test_script_attach_dispatches_scene_node_and_script(monkeypatch):
     # script attach (issue #118) binds a .gd to a node in a scene: the scene
     # path, the node path, and the script path ride through as the typed params;
     # the result echoes the attached script's class_name.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(ATTACH_RESULT)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr="engine diagnostic\n", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "attach",
@@ -436,6 +402,8 @@ def test_script_attach_dispatches_scene_node_and_script(monkeypatch):
             "/tmp/proj/hero.gd",
             "--json",
         ],
+        stdout=sentinel(ATTACH_RESULT),
+        stderr="engine diagnostic\n",
     )
 
     assert result.exit_code == 0
@@ -471,11 +439,8 @@ def test_script_attach_reports_the_displaced_script(monkeypatch):
         "class_name": None,
         "replaced_script": "res://old.gd",
     }
-    stdout = "Godot Engine v4.6.3.stable.official\n" + sentinel(payload)
-    inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    result, _ = invoke_cli(
+        monkeypatch,
         [
             "script",
             "attach",
@@ -486,6 +451,7 @@ def test_script_attach_reports_the_displaced_script(monkeypatch):
             "/tmp/proj/new.gd",
             "--json",
         ],
+        stdout=sentinel(payload),
     )
 
     assert result.exit_code == 0
@@ -517,13 +483,10 @@ def test_script_validate_valid_script_reports_valid_true_no_diagnostics(monkeypa
     # reporting valid=true, no error_string, and no diagnostics. A single path is a
     # batch of one (#663), so the verdict sits in the one `scripts` entry and the
     # top-level `valid` is that entry's own.
-    stdout = "Godot Engine v4.6.3.stable.official\n" + _validate_sentinel(
-        _ok("/tmp/proj/ok.gd")
-    )
-    fake = inject_runner(monkeypatch, RunResult(stdout=stdout, stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", "/tmp/proj/ok.gd", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["script", "validate", "/tmp/proj/ok.gd", "--json"],
+        stdout=_validate_sentinel(_ok("/tmp/proj/ok.gd")),
     )
 
     assert result.exit_code == 0
@@ -548,14 +511,6 @@ def test_script_validate_help_mentions_valid_false_success_result():
 # --- project context: the refusal and the reported root (#658) ----------------
 
 
-def _project(tmp_path, name: str):
-    """A directory Godot counts as a project (it holds the marker)."""
-    proj = tmp_path / name
-    proj.mkdir(parents=True, exist_ok=True)
-    (proj / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return proj
-
-
 def test_script_validate_refuses_a_script_outside_the_resolved_project(
     monkeypatch, tmp_path
 ):
@@ -564,15 +519,12 @@ def test_script_validate_refuses_a_script_outside_the_resolved_project(
     # reports a cascade of false missing-file and derived type errors. gda refuses
     # instead — BEFORE the engine runs, which is what `fake.calls == []` pins —
     # and names both sides so the reader sees which one is wrong.
-    proj = _project(tmp_path, "game")
+    proj = minimal_project(tmp_path / "game")
     outsider = tmp_path / "elsewhere" / "deck.gd"
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         ["script", "validate", str(outsider), "--project", str(proj), "--json"],
+        stdout=sentinel({}),
     )
 
     assert result.exit_code == 4
@@ -602,14 +554,10 @@ def test_script_validate_refusal_is_identical_on_the_params_json_path(
     # ADR-0015 parity: --params-json builds the same model and must reach the same
     # refusal. The check lives on the command's recipe — the one hook both input
     # paths share — not in the argv body, which --params-json bypasses.
-    proj = _project(tmp_path, "game")
+    proj = minimal_project(tmp_path / "game")
     outsider = tmp_path / "elsewhere" / "deck.gd"
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "validate",
@@ -619,10 +567,10 @@ def test_script_validate_refusal_is_identical_on_the_params_json_path(
             str(proj),
             "--json",
         ],
+        stdout=sentinel({}),
     )
 
-    assert result.exit_code == 4
-    assert json.loads(result.stdout)["error"]["code"] == "target_outside_project"
+    assert_operation_error(result, "target_outside_project")
     assert fake.calls == []
 
 
@@ -649,22 +597,17 @@ def test_script_validate_refuses_a_res_dotdot_escape_the_same_as_the_absolute_sp
     # one test — not two separate ones — is deliberate: it is exactly the
     # invariant that broke (same file, same command, opposite verdicts), so a
     # future change that fixes one spelling without the other fails HERE.
-    proj = _project(tmp_path, "game")
+    proj = minimal_project(tmp_path / "game")
     outsider = tmp_path / "outside.gd"  # one directory above the project root
 
-    fake_abs = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
-    )
-    result_abs = CliRunner().invoke(
-        app,
+    result_abs, fake_abs = invoke_cli(
+        monkeypatch,
         ["script", "validate", str(outsider), "--project", str(proj), "--json"],
+        stdout=sentinel({}),
     )
 
-    fake_res = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
-    )
-    result_res = CliRunner().invoke(
-        app,
+    result_res, fake_res = invoke_cli(
+        monkeypatch,
         [
             "script",
             "validate",
@@ -673,6 +616,7 @@ def test_script_validate_refuses_a_res_dotdot_escape_the_same_as_the_absolute_sp
             str(proj),
             "--json",
         ],
+        stdout=sentinel({}),
     )
 
     error_abs = json.loads(result_abs.stdout)["error"]
@@ -692,15 +636,12 @@ def test_script_validate_reports_the_resolved_project_root(monkeypatch, tmp_path
     # The result names the root its res:// dependencies resolved against, so a
     # reader can tell a real compile error from a wrong-project one without
     # re-deriving gda's resolution.
-    proj = _project(tmp_path, "game")
+    proj = minimal_project(tmp_path / "game")
     script = proj / "deck.gd"
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(stdout=_validate_sentinel(_ok(str(script))), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", str(script), "--project", str(proj), "--json"]
+        ["script", "validate", str(script), "--project", str(proj), "--json"],
+        stdout=_validate_sentinel(_ok(str(script))),
     )
 
     assert result.exit_code == 0
@@ -716,15 +657,10 @@ def test_script_validate_reports_a_null_project_root_when_projectless(
     # gda's choosing — so any res:// dependency error is not to be trusted.
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("GDA_PROJECT", raising=False)
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(_ok("/tmp/proj/ok.gd")), stderr="", exit_code=0
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", "/tmp/proj/ok.gd", "--json"]
+        ["script", "validate", "/tmp/proj/ok.gd", "--json"],
+        stdout=_validate_sentinel(_ok("/tmp/proj/ok.gd")),
     )
 
     assert result.exit_code == 0
@@ -741,17 +677,11 @@ def test_script_validate_does_not_refuse_a_res_path(monkeypatch, tmp_path):
     # refused. That is no longer true of every res:// spelling (#762): one that
     # lexically escapes the namespace, e.g. `res://../outside.gd`, is refused —
     # see test_script_validate_refuses_a_res_dotdot_escape_the_same_as_the_absolute_spelling.
-    proj = _project(tmp_path, "game")
-    fake = inject_runner(
+    proj = minimal_project(tmp_path / "game")
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(_ok("res://deck.gd")), stderr="", exit_code=0
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app,
         ["script", "validate", "res://deck.gd", "--project", str(proj), "--json"],
+        stdout=_validate_sentinel(_ok("res://deck.gd")),
     )
 
     assert result.exit_code == 0
@@ -767,18 +697,15 @@ def test_script_validate_does_not_refuse_a_colon_bearing_path_as_virtual(
     # an ordinary filesystem path — and this one is outside the project, so it is
     # refused rather than waved through as engine-virtual (which skipped
     # containment entirely and let the engine open the outside file).
-    proj = _project(tmp_path, "game")
+    proj = minimal_project(tmp_path / "game")
     odd = tmp_path / "outside:" / "deck.gd"
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["script", "validate", str(odd), "--project", str(proj), "--json"],
+        stdout=sentinel({}),
     )
 
-    result = CliRunner().invoke(
-        app, ["script", "validate", str(odd), "--project", str(proj), "--json"]
-    )
-
-    assert result.exit_code == 4
-    assert json.loads(result.stdout)["error"]["code"] == "target_outside_project"
+    assert_operation_error(result, "target_outside_project")
     assert fake.calls == []
 
 
@@ -789,14 +716,10 @@ def test_script_validate_refuses_a_target_a_nested_project_owns(monkeypatch, tmp
     # -file errors for a file that is perfectly valid in its own project, and only
     # `project_root` hinted why. ADR-0006's 2026-08-31 amendment (#697) refuses
     # instead and names the owner to pass.
-    outer = _project(tmp_path, "outer")
-    inner = _project(tmp_path, "outer/inner")
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    outer = minimal_project(tmp_path / "outer")
+    inner = minimal_project(tmp_path / "outer/inner")
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "validate",
@@ -805,6 +728,7 @@ def test_script_validate_refuses_a_target_a_nested_project_owns(monkeypatch, tmp
             str(outer),
             "--json",
         ],
+        stdout=sentinel({}),
     )
 
     assert result.exit_code == 4
@@ -827,12 +751,10 @@ def test_script_validate_names_a_res_target_s_real_location(monkeypatch, tmp_pat
     # anchoring made `Path("res://inner/main.gd")` the RELATIVE `res:/inner/main.gd`
     # and reported `<project>/res:/inner/main.gd`, a directory that does not exist —
     # in the human message and in the typed evidence alike.
-    outer = _project(tmp_path, "outer")
-    inner = _project(tmp_path, "outer/inner")
-    inject_runner(monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0))
-
-    result = CliRunner().invoke(
-        app,
+    outer = minimal_project(tmp_path / "outer")
+    inner = minimal_project(tmp_path / "outer/inner")
+    result, _ = invoke_cli(
+        monkeypatch,
         [
             "script",
             "validate",
@@ -841,6 +763,7 @@ def test_script_validate_names_a_res_target_s_real_location(monkeypatch, tmp_pat
             str(outer),
             "--json",
         ],
+        stdout=sentinel({}),
     )
 
     error = json.loads(result.stdout)["error"]
@@ -858,13 +781,13 @@ def test_script_validate_refuses_a_projectless_target_that_has_an_owner(
     # projectless engine, where its res:// references resolved against nothing and
     # produced the same cascade with `project_root: null` as the only clue.
     workspace = tmp_path / "workspace"
-    game = _project(workspace, "game")
+    game = minimal_project(workspace / "game")
     monkeypatch.chdir(workspace)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["script", "validate", "game/main.gd", "--json"],
+        stdout=sentinel({}),
     )
-
-    result = CliRunner().invoke(app, ["script", "validate", "game/main.gd", "--json"])
 
     assert result.exit_code == 4
     error = json.loads(result.stdout)["error"]
@@ -887,12 +810,11 @@ def test_script_validate_still_validates_a_standalone_script_projectless(
     # refusal for the files it exists to serve.
     monkeypatch.chdir(tmp_path)
     (tmp_path / "scratch.gd").write_text("extends Node\n", encoding="utf-8")
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=_validate_sentinel(_ok("scratch.gd")), stderr="", exit_code=0),
+        ["script", "validate", "scratch.gd", "--json"],
+        stdout=_validate_sentinel(_ok("scratch.gd")),
     )
-
-    result = CliRunner().invoke(app, ["script", "validate", "scratch.gd", "--json"])
 
     assert result.exit_code == 0, result.stdout
     assert json.loads(result.stdout)["project_root"] is None
@@ -901,7 +823,7 @@ def test_script_validate_still_validates_a_standalone_script_projectless(
 
 def _ancestor_cwd_project(monkeypatch, tmp_path):
     """A project one level below the cwd, with a script in it (the #658 A shape)."""
-    proj = _project(tmp_path, "game")
+    proj = minimal_project(tmp_path / "game")
     monkeypatch.chdir(tmp_path)
     return proj
 
@@ -914,13 +836,10 @@ def test_script_validate_accepts_a_relative_target_from_an_ancestor_cwd(
     # relatively. The engine anchors `deck.gd` at `--path game`, and the README
     # promises exactly that, so gda must not judge it against its own cwd.
     proj = _ancestor_cwd_project(monkeypatch, tmp_path)
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=_validate_sentinel(_ok("deck.gd")), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", "deck.gd", "--project", "game", "--json"]
+        ["script", "validate", "deck.gd", "--project", "game", "--json"],
+        stdout=_validate_sentinel(_ok("deck.gd")),
     )
 
     assert result.exit_code == 0, result.stdout
@@ -937,13 +856,8 @@ def test_script_validate_relative_target_parity_on_the_params_json_path(
 ):
     # ADR-0015 parity for the same shape: --params-json must anchor identically.
     proj = _ancestor_cwd_project(monkeypatch, tmp_path)
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(stdout=_validate_sentinel(_ok("deck.gd")), stderr="", exit_code=0),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "script",
             "validate",
@@ -953,6 +867,7 @@ def test_script_validate_relative_target_parity_on_the_params_json_path(
             "game",
             "--json",
         ],
+        stdout=_validate_sentinel(_ok("deck.gd")),
     )
 
     assert result.exit_code == 0, result.stdout
@@ -968,12 +883,8 @@ def test_script_validate_still_refuses_a_relative_target_that_climbs_out(
     # Anchoring at the project is not a blanket accept: a relative path that
     # climbs out of the project with `..` is still outside, from either spelling.
     _ancestor_cwd_project(monkeypatch, tmp_path)
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "validate",
@@ -982,10 +893,10 @@ def test_script_validate_still_refuses_a_relative_target_that_climbs_out(
             "game",
             "--json",
         ],
+        stdout=sentinel({}),
     )
 
-    assert result.exit_code == 4
-    assert json.loads(result.stdout)["error"]["code"] == "target_outside_project"
+    assert_operation_error(result, "target_outside_project")
     assert fake.calls == []
 
 
@@ -999,15 +910,11 @@ def test_script_validate_invalid_script_is_success_with_parsed_diagnostics(monke
         'value after "=".\n'
         "          at: GDScript::reload (/tmp/proj/broken.gd:3)\n"
     )
-    stdout = "Godot Engine v4.6.3.stable.official\n" + _validate_sentinel(
-        _broken("/tmp/proj/broken.gd", "Parse error.")
-    )
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=stdout, stderr=stderr, exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", "/tmp/proj/broken.gd", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["script", "validate", "/tmp/proj/broken.gd", "--json"],
+        stdout=_validate_sentinel(_broken("/tmp/proj/broken.gd", "Parse error.")),
+        stderr=stderr,
     )
 
     assert result.exit_code == 0
@@ -1028,12 +935,10 @@ def test_script_validate_invalid_script_is_success_with_parsed_diagnostics(monke
 def test_script_set_start_line_without_content_is_a_usage_error(monkeypatch):
     # --start-line/--end-line require --content: a line range with no replacement
     # text is a usage error.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "set", "/tmp/proj/hero.gd", "--start-line", "2", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["script", "set", "/tmp/proj/hero.gd", "--start-line", "2", "--json"],
+        stdout=sentinel(SET_RESULT),
     )
 
     _assert_set_usage_error(fake, result)
@@ -1042,12 +947,8 @@ def test_script_set_start_line_without_content_is_a_usage_error(monkeypatch):
 def test_script_set_end_line_without_start_line_is_a_usage_error(monkeypatch):
     # --end-line alone (with --content) is a usage error: end without a start has
     # no anchor.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(SET_RESULT), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "set",
@@ -1058,6 +959,7 @@ def test_script_set_end_line_without_start_line_is_a_usage_error(monkeypatch):
             "x",
             "--json",
         ],
+        stdout=sentinel(SET_RESULT),
     )
 
     _assert_set_usage_error(fake, result)
@@ -1068,14 +970,11 @@ def test_script_set_end_line_without_start_line_is_a_usage_error(monkeypatch):
 
 def test_script_validate_human_output_valid(monkeypatch):
     # Without --json, a valid result renders a one-line 'valid <path>'.
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(_ok("/tmp/proj/ok.gd")), stderr="", exit_code=0
-        ),
+        ["script", "validate", "/tmp/proj/ok.gd"],
+        stdout=_validate_sentinel(_ok("/tmp/proj/ok.gd")),
     )
-
-    result = CliRunner().invoke(app, ["script", "validate", "/tmp/proj/ok.gd"])
 
     assert result.exit_code == 0
     assert result.stdout.strip() == "valid /tmp/proj/ok.gd"
@@ -1089,16 +988,12 @@ def test_script_validate_human_output_invalid_lists_diagnostics(monkeypatch):
         "SCRIPT ERROR: Parse Error: the message.\n"
         "          at: GDScript::reload (/tmp/proj/broken.gd:3)\n"
     )
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(_broken("/tmp/proj/broken.gd", "Parse error.")),
-            stderr=stderr,
-            exit_code=0,
-        ),
+        ["script", "validate", "/tmp/proj/broken.gd"],
+        stdout=_validate_sentinel(_broken("/tmp/proj/broken.gd", "Parse error.")),
+        stderr=stderr,
     )
-
-    result = CliRunner().invoke(app, ["script", "validate", "/tmp/proj/broken.gd"])
 
     assert result.exit_code == 0
     assert "invalid /tmp/proj/broken.gd" in result.stdout
@@ -1112,19 +1007,12 @@ def test_script_validate_human_output_invalid_leads_with_the_project_root(
     # An invalid verdict prints the project it was compiled against BEFORE the
     # diagnostics (#658): when the root is wrong every line below it is an
     # artefact of that one mistake, so the cause must not sit under the cascade.
-    proj = _project(tmp_path, "game")
+    proj = minimal_project(tmp_path / "game")
     script = proj / "broken.gd"
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(_broken(str(script), "Parse error.")),
-            stderr="",
-            exit_code=0,
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", str(script), "--project", str(proj)]
+        ["script", "validate", str(script), "--project", str(proj)],
+        stdout=_validate_sentinel(_broken(str(script), "Parse error.")),
     )
 
     assert result.exit_code == 0
@@ -1141,16 +1029,11 @@ def test_script_validate_human_output_names_projectless_explicitly(
     # res:// dependency error.
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("GDA_PROJECT", raising=False)
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(_broken("/tmp/proj/broken.gd", "Parse error.")),
-            stderr="",
-            exit_code=0,
-        ),
+        ["script", "validate", "/tmp/proj/broken.gd"],
+        stdout=_validate_sentinel(_broken("/tmp/proj/broken.gd", "Parse error.")),
     )
-
-    result = CliRunner().invoke(app, ["script", "validate", "/tmp/proj/broken.gd"])
 
     assert result.exit_code == 0
     assert "  project: (none resolved: projectless)" in result.stdout
@@ -1164,12 +1047,8 @@ def test_script_attach_human_output(monkeypatch):
         "script": "/tmp/proj/hero.gd",
         "class_name": "Hero",
     }
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, _ = invoke_cli(
+        monkeypatch,
         [
             "script",
             "attach",
@@ -1179,6 +1058,7 @@ def test_script_attach_human_output(monkeypatch):
             "--script",
             "/tmp/proj/hero.gd",
         ],
+        stdout=sentinel(payload),
     )
 
     assert result.exit_code == 0
@@ -1191,12 +1071,10 @@ def test_script_attach_human_output(monkeypatch):
 def test_script_set_human_output_renders_metadata(monkeypatch):
     # Without --json, set reuses the shared script-metadata renderer.
     payload = {"path": "/tmp/proj/hero.gd", "class_name": "Hero", "extends": "Node2D"}
-    inject_runner(
-        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "set", "/tmp/proj/hero.gd", "--content", "x"]
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["script", "set", "/tmp/proj/hero.gd", "--content", "x"],
+        stdout=sentinel(payload),
     )
 
     assert result.exit_code == 0
@@ -1230,19 +1108,8 @@ def _broken(path: str, error: str = "Parse error") -> dict:
 def test_script_validate_batch_reaches_the_engine_once_with_every_path(monkeypatch):
     # The #663 core: repeated PATH arguments become ONE op call carrying the whole
     # batch, so six related scripts cost one engine launch instead of six.
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(
-                _ok("/tmp/proj/a.gd"), _ok("/tmp/proj/b.gd"), _ok("/tmp/proj/c.gd")
-            ),
-            stderr="",
-            exit_code=0,
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "script",
             "validate",
@@ -1251,6 +1118,9 @@ def test_script_validate_batch_reaches_the_engine_once_with_every_path(monkeypat
             "/tmp/proj/c.gd",
             "--json",
         ],
+        stdout=_validate_sentinel(
+            _ok("/tmp/proj/a.gd"), _ok("/tmp/proj/b.gd"), _ok("/tmp/proj/c.gd")
+        ),
     )
 
     assert result.exit_code == 0
@@ -1277,17 +1147,10 @@ def test_script_validate_batch_aggregate_is_false_when_any_script_is_invalid(
 ):
     # The aggregate verdict: false when ANY file is invalid, and the command still
     # exits 0 — an invalid script is a successful validation, the existing contract.
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(_ok("/tmp/proj/a.gd"), _broken("/tmp/proj/b.gd")),
-            stderr="",
-            exit_code=0,
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", "/tmp/proj/a.gd", "/tmp/proj/b.gd", "--json"]
+        ["script", "validate", "/tmp/proj/a.gd", "/tmp/proj/b.gd", "--json"],
+        stdout=_validate_sentinel(_ok("/tmp/proj/a.gd"), _broken("/tmp/proj/b.gd")),
     )
 
     assert result.exit_code == 0
@@ -1310,21 +1173,8 @@ def test_script_validate_batch_attributes_diagnostics_to_their_own_script(monkey
         "SCRIPT ERROR: Parse Error: bad c\n"
         "   at: GDScript::reload (/tmp/proj/c.gd:7)\n"
     )
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(
-                _ok("/tmp/proj/a.gd"),
-                _broken("/tmp/proj/b.gd"),
-                _broken("/tmp/proj/c.gd"),
-            ),
-            stderr=stderr,
-            exit_code=0,
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app,
         [
             "script",
             "validate",
@@ -1333,6 +1183,12 @@ def test_script_validate_batch_attributes_diagnostics_to_their_own_script(monkey
             "/tmp/proj/c.gd",
             "--json",
         ],
+        stdout=_validate_sentinel(
+            _ok("/tmp/proj/a.gd"),
+            _broken("/tmp/proj/b.gd"),
+            _broken("/tmp/proj/c.gd"),
+        ),
+        stderr=stderr,
     )
 
     assert result.exit_code == 0
@@ -1349,17 +1205,10 @@ def test_script_validate_batch_attributes_diagnostics_to_their_own_script(monkey
 def test_script_validate_keeps_a_duplicate_path_as_its_own_entry(monkeypatch):
     # gda never silently drops an input: a path given twice is validated twice and
     # reported twice, so entry i always corresponds to argument i.
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(_ok("/tmp/proj/a.gd"), _ok("/tmp/proj/a.gd")),
-            stderr="",
-            exit_code=0,
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", "/tmp/proj/a.gd", "/tmp/proj/a.gd", "--json"]
+        ["script", "validate", "/tmp/proj/a.gd", "/tmp/proj/a.gd", "--json"],
+        stdout=_validate_sentinel(_ok("/tmp/proj/a.gd"), _ok("/tmp/proj/a.gd")),
     )
 
     assert result.exit_code == 0
@@ -1373,15 +1222,11 @@ def test_script_validate_refuses_a_batch_whose_second_path_is_outside_the_projec
     # ADR-0006's one resolved project applies to EVERY path in the batch: a batch
     # that spans projects is refused before the engine runs, reusing #658's refusal
     # rather than compiling the outsider against the wrong root.
-    proj = _project(tmp_path, "game")
+    proj = minimal_project(tmp_path / "game")
     inside = proj / "deck.gd"
     outsider = tmp_path / "elsewhere" / "card.gd"
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "validate",
@@ -1391,6 +1236,7 @@ def test_script_validate_refuses_a_batch_whose_second_path_is_outside_the_projec
             str(proj),
             "--json",
         ],
+        stdout=sentinel({}),
     )
 
     assert result.exit_code == 4
@@ -1403,16 +1249,11 @@ def test_script_validate_refuses_a_batch_whose_second_path_is_outside_the_projec
 def test_script_validate_all_asks_the_engine_for_every_project_script(monkeypatch):
     # Project mode: `--all` carries no paths — the engine enumerates the project's
     # res:// tree itself and reports the same result shape.
-    fake = inject_runner(
+    result, fake = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(_ok("res://a.gd"), _ok("res://b.gd")),
-            stderr="",
-            exit_code=0,
-        ),
+        ["script", "validate", "--all", "--json"],
+        stdout=_validate_sentinel(_ok("res://a.gd"), _ok("res://b.gd")),
     )
-
-    result = CliRunner().invoke(app, ["script", "validate", "--all", "--json"])
 
     assert result.exit_code == 0
     assert fake.calls == [("script-validate", {"paths": [], "all_scripts": True})]
@@ -1420,12 +1261,10 @@ def test_script_validate_all_asks_the_engine_for_every_project_script(monkeypatc
 
 
 def test_script_validate_all_with_paths_is_a_usage_error(monkeypatch):
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", "--all", "/tmp/proj/a.gd", "--json"]
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["script", "validate", "--all", "/tmp/proj/a.gd", "--json"],
+        stdout=sentinel({}),
     )
 
     assert result.exit_code == 2
@@ -1433,11 +1272,9 @@ def test_script_validate_all_with_paths_is_a_usage_error(monkeypatch):
 
 
 def test_script_validate_without_paths_or_all_is_a_usage_error(monkeypatch):
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
+    result, fake = invoke_cli(
+        monkeypatch, ["script", "validate", "--json"], stdout=sentinel({})
     )
-
-    result = CliRunner().invoke(app, ["script", "validate", "--json"])
 
     assert result.exit_code == 2
     assert fake.calls == []
@@ -1446,12 +1283,8 @@ def test_script_validate_without_paths_or_all_is_a_usage_error(monkeypatch):
 def test_script_validate_params_json_refuses_an_empty_batch(monkeypatch):
     # ADR-0015 parity: the rule lives on the model, so the JSON route reports it as
     # the structured invalid_params rather than as a usage error.
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "validate",
@@ -1459,20 +1292,16 @@ def test_script_validate_params_json_refuses_an_empty_batch(monkeypatch):
             json.dumps({"paths": []}),
             "--json",
         ],
+        stdout=sentinel({}),
     )
 
-    assert result.exit_code == 4
-    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+    assert_operation_error(result, "invalid_params")
     assert fake.calls == []
 
 
 def test_script_validate_params_json_refuses_paths_together_with_all(monkeypatch):
-    fake = inject_runner(
-        monkeypatch, RunResult(stdout=sentinel({}), stderr="", exit_code=0)
-    )
-
-    result = CliRunner().invoke(
-        app,
+    result, fake = invoke_cli(
+        monkeypatch,
         [
             "script",
             "validate",
@@ -1480,10 +1309,10 @@ def test_script_validate_params_json_refuses_paths_together_with_all(monkeypatch
             json.dumps({"paths": ["/tmp/proj/a.gd"], "all_scripts": True}),
             "--json",
         ],
+        stdout=sentinel({}),
     )
 
-    assert result.exit_code == 4
-    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+    assert_operation_error(result, "invalid_params")
     assert fake.calls == []
 
 
@@ -1494,17 +1323,11 @@ def test_script_validate_batch_human_output_leads_with_the_aggregate(monkeypatch
         "SCRIPT ERROR: Parse Error: bad b\n"
         "   at: GDScript::reload (/tmp/proj/b.gd:3)\n"
     )
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(_ok("/tmp/proj/a.gd"), _broken("/tmp/proj/b.gd")),
-            stderr=stderr,
-            exit_code=0,
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", "/tmp/proj/a.gd", "/tmp/proj/b.gd"]
+        ["script", "validate", "/tmp/proj/a.gd", "/tmp/proj/b.gd"],
+        stdout=_validate_sentinel(_ok("/tmp/proj/a.gd"), _broken("/tmp/proj/b.gd")),
+        stderr=stderr,
     )
 
     assert result.exit_code == 0
@@ -1588,19 +1411,11 @@ def test_script_validate_attribution_is_dropped_when_the_stream_desynchronizes(
         "   at: GDScript::reload (/tmp/proj/b.gd:4)\n"
         "gda: validating: /tmp/proj/unexpected.gd\n"
     )
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(
-                _broken("/tmp/proj/a.gd"), _broken("/tmp/proj/b.gd")
-            ),
-            stderr=stderr,
-            exit_code=0,
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", "/tmp/proj/a.gd", "/tmp/proj/b.gd", "--json"]
+        ["script", "validate", "/tmp/proj/a.gd", "/tmp/proj/b.gd", "--json"],
+        stdout=_validate_sentinel(_broken("/tmp/proj/a.gd"), _broken("/tmp/proj/b.gd")),
+        stderr=stderr,
     )
 
     assert result.exit_code == 0
@@ -1625,17 +1440,11 @@ def test_script_validate_attributes_diagnostics_over_a_crlf_stream(monkeypatch):
         "SCRIPT ERROR: Parse Error: bad token\r\n"
         "   at: GDScript::reload (/tmp/proj/broken.gd:3)\r\n"
     )
-    inject_runner(
+    result, _ = invoke_cli(
         monkeypatch,
-        RunResult(
-            stdout=_validate_sentinel(_broken("/tmp/proj/broken.gd")),
-            stderr=stderr,
-            exit_code=0,
-        ),
-    )
-
-    result = CliRunner().invoke(
-        app, ["script", "validate", "/tmp/proj/broken.gd", "--json"]
+        ["script", "validate", "/tmp/proj/broken.gd", "--json"],
+        stdout=_validate_sentinel(_broken("/tmp/proj/broken.gd")),
+        stderr=stderr,
     )
 
     assert result.exit_code == 0

--- a/tests/test_script_errors.py
+++ b/tests/test_script_errors.py
@@ -8,147 +8,95 @@ mode without parsing prose. The script group reuses the existing file-level
 codes rather than minting parallel ones.
 """
 
-import json
-
-from typer.testing import CliRunner
-
-from gda.cli import app
-from gda.runner import RunResult
-from tests.support import error_sentinel, inject_runner
+from tests.support import assert_operation_error, operation_error_invoker
 
 
-def _invoke_script_create(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: script-create\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, ["script", "create", "/x/hero.gd", "--json"])
+_script_create = operation_error_invoker(
+    ["script", "create", "/x/hero.gd", "--json"],
+    "script-create",
+)
 
 
-def _invoke_script_get(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: script-get\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, ["script", "get", "/x/hero.gd", "--json"])
+_script_get = operation_error_invoker(
+    ["script", "get", "/x/hero.gd", "--json"],
+    "script-get",
+)
 
 
-def _invoke_script_list(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: script-list\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, ["script", "list", "--json"])
+_script_list = operation_error_invoker(
+    ["script", "list", "--json"],
+    "script-list",
+)
 
 
-def _invoke_script_delete(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: script-delete\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, ["script", "delete", "/x/hero.gd", "--json"])
+_script_delete = operation_error_invoker(
+    ["script", "delete", "/x/hero.gd", "--json"],
+    "script-delete",
+)
 
 
 def test_script_create_collision_reuses_stable_already_exists_code(monkeypatch):
     # No-clobber: a create whose target already exists reuses the registered
     # already_exists code (the same one scene create uses), leaving the file
     # untouched — the script group mints no parallel collision code.
-    result = _invoke_script_create(
+    result = _script_create(
         monkeypatch, "already_exists", "script target already exists: /x/hero.gd"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "already_exists"
-    assert "/x/hero.gd" in err["message"]
     # The raw stderr still rides along as diagnostics (ADR-0002).
-    assert err["diagnostics"] == "gda: running operation: script-create\n"
+    assert_operation_error(
+        result,
+        "already_exists",
+        "/x/hero.gd",
+        diagnostics="gda: running operation: script-create\n",
+    )
 
 
 def test_script_create_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
     # A target that is not a .gd script is an invalid path param — reuse the
     # registered invalid_path code rather than a focused per-group code.
-    result = _invoke_script_create(
+    result = _script_create(
         monkeypatch,
         "invalid_path",
         "script path must end in .gd: /x/hero.txt",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "invalid_path"
-    assert ".gd" in err["message"]
+    assert_operation_error(result, "invalid_path", ".gd")
 
 
 def test_script_create_missing_path_reuses_stable_invalid_path_code(monkeypatch):
-    result = _invoke_script_create(
-        monkeypatch, "invalid_path", "missing required param: path"
-    )
+    result = _script_create(monkeypatch, "invalid_path", "missing required param: path")
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "invalid_path"
+    assert_operation_error(result, "invalid_path")
 
 
 def test_script_create_unwritable_target_reuses_stable_save_failed_code(monkeypatch):
-    result = _invoke_script_create(
+    result = _script_create(
         monkeypatch, "save_failed", "failed to save script to /x/hero.gd"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "save_failed"
-    assert "/x/hero.gd" in err["message"]
+    assert_operation_error(result, "save_failed", "/x/hero.gd")
 
 
 def test_script_get_missing_file_reuses_stable_path_not_found_code(monkeypatch):
     # A script that does not exist reuses the registered path_not_found code
     # (now generalized in the registry from scene-specific to any file), so an
     # agent branches on the missing-file mode without a new code.
-    result = _invoke_script_get(
+    result = _script_get(
         monkeypatch, "path_not_found", "script file does not exist: /x/hero.gd"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/hero.gd" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/hero.gd")
 
 
 def test_script_get_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
-    result = _invoke_script_get(
+    result = _script_get(
         monkeypatch,
         "invalid_path",
         "script path must end in .gd: /x/notes.txt",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "invalid_path"
-    assert ".gd" in err["message"]
+    assert_operation_error(result, "invalid_path", ".gd")
 
 
 def test_script_list_without_project_reuses_stable_project_not_found_code(monkeypatch):
@@ -156,46 +104,34 @@ def test_script_list_without_project_reuses_stable_project_not_found_code(monkey
     # (issue #117): with no resolvable project, the operation reuses the
     # registered project_not_found code (the same one scene list uses) so an
     # agent knows to pass --project rather than retry.
-    result = _invoke_script_list(
+    result = _script_list(
         monkeypatch,
         "project_not_found",
         "script list requires a Godot project; none was resolved — pass --project",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "project_not_found"
-    assert "--project" in err["message"]
+    assert_operation_error(result, "project_not_found", "--project")
 
 
 def test_script_delete_missing_file_reuses_stable_path_not_found_code(monkeypatch):
     # A script that does not exist reuses the registered path_not_found code (the
     # same one script get uses), so an agent branches on the missing-file mode
     # without a new code.
-    result = _invoke_script_delete(
+    result = _script_delete(
         monkeypatch, "path_not_found", "script file does not exist: /x/hero.gd"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/hero.gd" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/hero.gd")
 
 
 def test_script_delete_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
     # delete only removes a .gd script, so a non-.gd target is refused with the
     # registered invalid_path code — the same addressing boundary create/get use.
-    result = _invoke_script_delete(
+    result = _script_delete(
         monkeypatch, "invalid_path", "script path must end in .gd: /x/notes.txt"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "invalid_path"
-    assert ".gd" in err["message"]
+    assert_operation_error(result, "invalid_path", ".gd")
 
 
 def test_script_delete_unlink_failure_reuses_stable_delete_failed_code(monkeypatch):
@@ -203,49 +139,35 @@ def test_script_delete_unlink_failure_reuses_stable_delete_failed_code(monkeypat
     # read-only filesystem, a permission boundary): this maps to the stable
     # delete_failed code (the same one scene delete uses) so an agent can tell
     # "deletion was blocked" apart from other failures.
-    result = _invoke_script_delete(
+    result = _script_delete(
         monkeypatch,
         "delete_failed",
         "failed to delete script /x/hero.gd: Permission denied",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "delete_failed"
-    assert "/x/hero.gd" in err["message"]
+    assert_operation_error(result, "delete_failed", "/x/hero.gd")
 
 
-def _invoke_script_set(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: script-set\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app,
-        ["script", "set", "/x/hero.gd", "--search", "a", "--replace", "b", "--json"],
-    )
+_script_set = operation_error_invoker(
+    ["script", "set", "/x/hero.gd", "--search", "a", "--replace", "b", "--json"],
+    "script-set",
+)
 
 
 def test_script_set_no_search_match_maps_to_stable_no_search_match_code(monkeypatch):
     # search-replace mode (issue #118): a search string the source does not
     # contain is a new no_search_match code, so an agent learns the edit landed
     # nowhere (and the file was left untouched) rather than parsing prose.
-    result = _invoke_script_set(
+    result = _script_set(
         monkeypatch, "no_search_match", 'search string not found in script: "xyzzy"'
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "no_search_match"
-    assert "xyzzy" in err["message"]
-    assert err["diagnostics"] == "gda: running operation: script-set\n"
+    assert_operation_error(
+        result,
+        "no_search_match",
+        "xyzzy",
+        diagnostics="gda: running operation: script-set\n",
+    )
 
 
 def test_script_set_invalid_line_range_maps_to_stable_invalid_line_range_code(
@@ -254,84 +176,62 @@ def test_script_set_invalid_line_range_maps_to_stable_invalid_line_range_code(
     # line-range mode: a range outside the script's bounds (or end before start)
     # is a new invalid_line_range code, distinct from no_search_match, so an
     # agent knows the line numbers — not the search string — are the problem.
-    result = _invoke_script_set(
+    result = _script_set(
         monkeypatch,
         "invalid_line_range",
         "line range 5..9 is outside the script's bounds (1..3) or ends before it starts",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "invalid_line_range"
-    assert "1..3" in err["message"]
+    assert_operation_error(result, "invalid_line_range", "1..3")
 
 
 def test_script_set_missing_file_reuses_stable_path_not_found_code(monkeypatch):
     # set edits an existing script; a missing target is path_not_found (the same
     # one get/delete use), never a silent create.
-    result = _invoke_script_set(
+    result = _script_set(
         monkeypatch, "path_not_found", "script file does not exist: /x/hero.gd"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/hero.gd" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/hero.gd")
 
 
 def test_script_set_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
-    result = _invoke_script_set(
+    result = _script_set(
         monkeypatch, "invalid_path", "script path must end in .gd: /x/notes.txt"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "invalid_path"
-    assert ".gd" in err["message"]
+    assert_operation_error(result, "invalid_path", ".gd")
 
 
-def _invoke_script_attach(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: script-attach\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(
-        app,
-        [
-            "script",
-            "attach",
-            "/x/main.tscn",
-            "--node",
-            "Hero",
-            "--script",
-            "/x/hero.gd",
-            "--json",
-        ],
-    )
+_script_attach = operation_error_invoker(
+    [
+        "script",
+        "attach",
+        "/x/main.tscn",
+        "--node",
+        "Hero",
+        "--script",
+        "/x/hero.gd",
+        "--json",
+    ],
+    "script-attach",
+)
 
 
 def test_script_attach_missing_script_reuses_stable_path_not_found_code(monkeypatch):
     # attach binds an existing script; a missing .gd is path_not_found (the same
     # one script get uses) so an agent knows the script file, not the scene, is
     # the thing that's missing.
-    result = _invoke_script_attach(
+    result = _script_attach(
         monkeypatch, "path_not_found", "script file does not exist: /x/hero.gd"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/hero.gd" in err["message"]
-    assert err["diagnostics"] == "gda: running operation: script-attach\n"
+    assert_operation_error(
+        result,
+        "path_not_found",
+        "/x/hero.gd",
+        diagnostics="gda: running operation: script-attach\n",
+    )
 
 
 def test_script_attach_wrong_script_extension_reuses_stable_invalid_path_code(
@@ -339,60 +239,44 @@ def test_script_attach_wrong_script_extension_reuses_stable_invalid_path_code(
 ):
     # A non-.gd script target is refused with invalid_path — the same addressing
     # boundary the rest of the script group uses.
-    result = _invoke_script_attach(
+    result = _script_attach(
         monkeypatch, "invalid_path", "script path must end in .gd: /x/notes.txt"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "invalid_path"
-    assert ".gd" in err["message"]
+    assert_operation_error(result, "invalid_path", ".gd")
 
 
 def test_script_attach_missing_node_reuses_stable_node_not_found_code(monkeypatch):
     # The scene loaded but the node path resolves to nothing — node_not_found
     # (the same one node get/set use), distinct from the file-level path_not_found.
-    result = _invoke_script_attach(
+    result = _script_attach(
         monkeypatch, "node_not_found", "node not found in scene: Hero"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "node_not_found"
-    assert "Hero" in err["message"]
+    assert_operation_error(result, "node_not_found", "Hero")
 
 
 def test_script_attach_missing_scene_reuses_stable_path_not_found_code(monkeypatch):
     # The scene-file-level failure reuses the registered scene code; attach
     # introduces no parallel code for the same mode.
-    result = _invoke_script_attach(
+    result = _script_attach(
         monkeypatch, "path_not_found", "scene file does not exist: /x/main.tscn"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/main.tscn" in err["message"]
+    assert_operation_error(result, "path_not_found", "/x/main.tscn")
 
 
 def test_script_attach_unloadable_resource_reuses_stable_invalid_path_code(monkeypatch):
     # A .gd that cannot even be loaded AS A RESOURCE (a genuine load failure, not
     # a compile error — load returns non-null for a non-compiling script) is the
     # defensive invalid_path branch, naming the path.
-    result = _invoke_script_attach(
+    result = _script_attach(
         monkeypatch,
         "invalid_path",
         "file could not be loaded as a GDScript resource: /x/hero.gd",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "invalid_path"
-    assert "/x/hero.gd" in err["message"]
+    assert_operation_error(result, "invalid_path", "/x/hero.gd")
 
 
 def test_script_attach_non_compiling_script_uses_script_compile_failed_code(
@@ -402,17 +286,13 @@ def test_script_attach_non_compiling_script_uses_script_compile_failed_code(
     # silently rejects it from set_script, so attach refuses with the focused
     # script_compile_failed code rather than report a phantom success over a
     # scene with nothing attached.
-    result = _invoke_script_attach(
+    result = _script_attach(
         monkeypatch,
         "script_compile_failed",
         "script does not compile, so it cannot be attached: /x/hero.gd",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "script_compile_failed"
-    assert "/x/hero.gd" in err["message"]
+    assert_operation_error(result, "script_compile_failed", "/x/hero.gd")
 
 
 def test_script_attach_incompatible_type_uses_incompatible_script_type_code(
@@ -423,56 +303,41 @@ def test_script_attach_incompatible_type_uses_incompatible_script_type_code(
     # a different reason than a compile error — attach reports the distinct
     # incompatible_script_type code so the agent fixes the node/script pairing
     # rather than chasing a non-existent syntax error.
-    result = _invoke_script_attach(
+    result = _script_attach(
         monkeypatch,
         "incompatible_script_type",
         "script extends Node3D, which is incompatible with node Hero of type Node2D",
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "incompatible_script_type"
-    assert "Node3D" in err["message"]
+    err = assert_operation_error(result, "incompatible_script_type", "Node3D")
     assert "Node2D" in err["message"]
 
 
-def _invoke_script_validate(monkeypatch, code: str, message: str):
-    inject_runner(
-        monkeypatch,
-        RunResult(
-            stdout="Godot Engine v4.6.3.stable.official\n"
-            + error_sentinel(code, message),
-            stderr="gda: running operation: script-validate\n",
-            exit_code=1,
-        ),
-    )
-    return CliRunner().invoke(app, ["script", "validate", "/x/hero.gd", "--json"])
+_script_validate = operation_error_invoker(
+    ["script", "validate", "/x/hero.gd", "--json"],
+    "script-validate",
+)
 
 
 def test_script_validate_missing_file_reuses_stable_path_not_found_code(monkeypatch):
     # validate only op-fails (non-zero) for op errors. A missing file is
     # path_not_found (the same one get/set use); an INVALID script is NOT a
     # failure — it is a successful op reporting valid=false (covered in S3 success).
-    result = _invoke_script_validate(
+    result = _script_validate(
         monkeypatch, "path_not_found", "script file does not exist: /x/hero.gd"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "path_not_found"
-    assert "/x/hero.gd" in err["message"]
-    assert err["diagnostics"] == "gda: running operation: script-validate\n"
+    assert_operation_error(
+        result,
+        "path_not_found",
+        "/x/hero.gd",
+        diagnostics="gda: running operation: script-validate\n",
+    )
 
 
 def test_script_validate_wrong_extension_reuses_stable_invalid_path_code(monkeypatch):
-    result = _invoke_script_validate(
+    result = _script_validate(
         monkeypatch, "invalid_path", "script path must end in .gd: /x/notes.txt"
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["category"] == "operation"
-    assert err["code"] == "invalid_path"
-    assert ".gd" in err["message"]
+    assert_operation_error(result, "invalid_path", ".gd")

--- a/tests/test_script_run_commands.py
+++ b/tests/test_script_run_commands.py
@@ -15,13 +15,13 @@ SAME recipe (ADR-0015), not the wrong runner.
 """
 
 import json
-from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import RunResult
+from tests.support import assert_operation_error, minimal_project
 
 
 def _patch_launch(monkeypatch, result: RunResult) -> list:
@@ -41,13 +41,8 @@ def _patch_launch(monkeypatch, result: RunResult) -> list:
     return calls
 
 
-def _project(tmp_path: Path) -> Path:
-    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    return tmp_path
-
-
 def test_clean_run_emits_the_passthrough_result(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="hi\n", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -83,7 +78,7 @@ def test_non_zero_script_exit_is_success_process_exits_zero(monkeypatch, tmp_pat
     # THE CRUX at the CLI boundary: a script quit(1) is a SUCCESS — the JSON carries
     # exit_status=1 but the gda PROCESS exits 0 (not an error envelope). This is the
     # one command where success != zero exit_status.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(monkeypatch, RunResult(stdout="fail\n", stderr="", exit_code=1))
 
     result = CliRunner().invoke(
@@ -105,7 +100,7 @@ def test_strict_makes_the_process_exit_the_registered_operation_code(
     # the JSON — the process exits 4, the registered operation code. Not 1: the
     # child's own status is never propagated verbatim, or a script's quit(3) would
     # alias EXIT_VERSION and a quit(124) the runner's timeout.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(monkeypatch, RunResult(stdout="fail\n", stderr="", exit_code=1))
 
     result = CliRunner().invoke(
@@ -121,16 +116,13 @@ def test_strict_makes_the_process_exit_the_registered_operation_code(
         ],
     )
 
-    assert result.exit_code == 4, result.stdout + result.stderr
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "script_failed"
-    assert err["category"] == "operation"
+    assert_operation_error(result, "script_failed")
 
 
 def test_strict_is_reachable_through_params_json(monkeypatch, tmp_path):
     # --strict is a params field, not an argv-only flag (ADR-0015), so gda-mcp and
     # any JSON caller can opt in exactly as argv does.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=2))
 
     result = CliRunner().invoke(
@@ -146,14 +138,13 @@ def test_strict_is_reachable_through_params_json(monkeypatch, tmp_path):
         ],
     )
 
-    assert result.exit_code == 4, result.stdout + result.stderr
-    assert json.loads(result.stdout)["error"]["code"] == "script_failed"
+    assert_operation_error(result, "script_failed")
 
 
 def test_params_json_drives_the_same_recipe(monkeypatch, tmp_path):
     # --params-json (ADR-0015) must drive the SAME recipe — a regression guard that
     # the generic dispatch hook does not route script run through the wrong runner.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="ok\n", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -179,7 +170,7 @@ def test_both_path_forms_are_accepted_at_the_cli(monkeypatch, tmp_path, form):
     # AC of #675 at the CLI boundary: ONE script-path representation now serves both
     # `script validate` and `script run`. Whichever form the caller types, the launch
     # gets the canonical res:// address and the result reports it back.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="ok\n", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -197,7 +188,7 @@ def test_params_json_accepts_the_project_relative_form_too(monkeypatch, tmp_path
     # ADR-0015: the argv and --params-json paths must agree on the new form as well,
     # since the acceptance rides on the model's shared NormalizedPath plus the one
     # operation-side lift — not on argv-only handling.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="ok\n", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -240,7 +231,7 @@ def test_a_non_project_scoped_path_emits_invalid_path_envelope(
     # reached the engine and came back a phantom exit-0 success before this guard.
     # These are ADDRESS-FORM refusals; the upward escapes moved to the shared
     # containment code below (#763).
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -263,7 +254,7 @@ def test_an_escaping_path_emits_the_shared_containment_code(
     # one containment answer instead of a per-command spelling. It stays a
     # pre-launch refusal, and it names no resolved root, because this whole path
     # edge is decided ahead of the projectless check (ADR-0031).
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -271,9 +262,7 @@ def test_an_escaping_path_emits_the_shared_containment_code(
         ["script", "run", script, "--project", str(project), "--json"],
     )
 
-    assert result.exit_code == 4
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "target_outside_project"
+    err = assert_operation_error(result, "target_outside_project")
     assert "evidence" not in err
     assert not calls, "no engine launch on an escaping path"
 
@@ -282,7 +271,7 @@ def test_a_tilde_path_is_refused_as_the_absolute_path_it_means(monkeypatch, tmp_
     # The shared NormalizedPath is what makes this honest (#675): `~/logic.gd` expands
     # to an absolute path and is refused as one, instead of being lifted into a
     # nonsense `res://~/logic.gd` naming a directory called `~` inside the project.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -365,7 +354,7 @@ def test_an_unexpandable_tilde_keeps_the_structured_refusal(
     # Both channels because they FAIL DIFFERENTLY: --params-json wraps model
     # construction (it would have reported invalid_params), while the argv body builds
     # the model directly and had nothing to catch the raise at all.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
     tilde = "~nosuchuser_gda_test/x.gd"
     argv = ["script", "run"]
@@ -375,10 +364,7 @@ def test_an_unexpandable_tilde_keeps_the_structured_refusal(
 
     result = CliRunner().invoke(app, [*argv, "--project", str(project), "--json"])
 
-    assert result.exit_code == 4, result.stdout + (result.stderr or "")
-    err = json.loads(result.stdout)["error"]
-    assert err["code"] == "invalid_path"
-    assert err["category"] == "operation"
+    err = assert_operation_error(result, "invalid_path")
     # The message names the path the caller gave, tilde intact.
     assert tilde in err["message"]
     assert not calls, "no engine launch on an invalid path"
@@ -391,7 +377,7 @@ def test_an_unexpandable_tilde_keeps_the_structured_refusal(
 
 
 def test_timeout_reaches_the_launch_from_argv(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -418,7 +404,7 @@ def test_timeout_reaches_the_launch_from_argv(monkeypatch, tmp_path):
 def test_timeout_and_marker_reach_the_launch_through_params_json(monkeypatch, tmp_path):
     # ADR-0015: both are params fields, so a JSON/MCP caller opts in exactly as argv
     # does — a fixed ceiling with no JSON route would leave gda-mcp on the old defect.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -460,7 +446,7 @@ def test_a_non_positive_timeout_is_a_usage_error_not_a_launch(
     # A zero or negative ceiling would end every run instantly. It is refused before
     # any spawn — as a usage error on argv, where Click's exit 2 is the ergonomic
     # answer, mirroring how `script set` handles a contradictory edit.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -489,7 +475,7 @@ def test_a_non_positive_timeout_is_structured_through_params_json(
     # The same rule on the JSON path surfaces as the structured `invalid_params`
     # envelope rather than a Click usage error, because the model enforces it
     # (ADR-0015) — one rule, two idiomatic reports.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -515,7 +501,7 @@ def test_an_empty_completion_marker_is_refused(monkeypatch, tmp_path):
     # An empty marker would match every line, disarming the abort while looking
     # declared — the same class of mistake as an empty --godot, so it is refused
     # rather than silently ignored.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -545,7 +531,7 @@ def test_a_non_finite_timeout_is_refused_on_argv(monkeypatch, tmp_path, value):
     # exact opposite of what the option is for, and reached by an ordinary CLI string
     # because Click parses these through float(). `nan` fails the same way, comparing
     # false against everything. `1e400` overflows to inf without ever spelling it.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -576,7 +562,7 @@ def test_a_non_finite_timeout_is_refused_through_params_json(
     # decoder accepts the `Infinity`/`NaN` extensions, and a plain overflowing literal
     # needs no extension at all. Enforced by the shared params model, so it surfaces as
     # the structured `invalid_params` envelope (ADR-0015).
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -603,7 +589,7 @@ def test_a_blank_completion_marker_is_refused_on_argv(monkeypatch, tmp_path, mar
     # The marker is compared as a stripped whole LINE, so a blank one would equal every
     # blank line the run prints and arm the abort on nothing. Refused rather than
     # silently ignored — the same treatment an empty --godot gets.
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(
@@ -629,7 +615,7 @@ def test_a_blank_completion_marker_is_refused_on_argv(monkeypatch, tmp_path, mar
 def test_a_blank_completion_marker_is_refused_through_params_json(
     monkeypatch, tmp_path
 ):
-    project = _project(tmp_path)
+    project = minimal_project(tmp_path)
     calls = _patch_launch(monkeypatch, RunResult(stdout="", stderr="", exit_code=0))
 
     result = CliRunner().invoke(

--- a/tests/test_script_run_operation.py
+++ b/tests/test_script_run_operation.py
@@ -55,6 +55,7 @@ from gda.execution import ExecutionKind
 from gda.models import TerminationPhase
 from gda.exit_codes import EXIT_NOT_FOUND, EXIT_OPERATION, EXIT_TIMEOUT
 from gda.runner import LaunchFailure, LaunchWatch, RunResult
+from tests.support import minimal_project
 
 PROJECT = Path("/tmp/project")
 # The canonical entry the ABORTED_STDERR fixture names, so attribution matches.
@@ -397,8 +398,8 @@ def test_a_script_a_nested_project_owns_is_refused_before_any_launch(tmp_path):
     outer = tmp_path / "outer"
     inner = outer / "inner"
     inner.mkdir(parents=True)
-    (outer / "project.godot").write_text("config_version=5\n", encoding="utf-8")
-    (inner / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(outer)
+    minimal_project(inner)
 
     outcome, launch = _run(
         RunResult(stdout="", stderr="", exit_code=0),
@@ -420,7 +421,7 @@ def test_a_script_the_resolved_project_owns_still_launches(tmp_path):
     # owner and refusing every correct invocation.
     project = tmp_path / "game"
     (project / "tests").mkdir(parents=True)
-    (project / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    minimal_project(project)
 
     outcome, launch = _run(
         RunResult(stdout="ok\n", stderr="", exit_code=0),

--- a/uv.lock
+++ b/uv.lock
@@ -230,6 +230,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "gda"
 version = "0.13.0"
 source = { editable = "." }
@@ -254,6 +263,7 @@ dev = [
     { name = "pillow" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -276,6 +286,7 @@ dev = [
     { name = "pillow", specifier = ">=11.0" },
     { name = "pyright", specifier = ">=1.1.411,<1.2" },
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.15.19,<0.16" },
 ]
 
@@ -739,6 +750,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #815
Closes #816
Closes #817
Closes #818
Closes #824
Closes #827

Promotion of the tests-optimisation round from `feat/tests-optimisation-dev` to `main` — six squashed slices, one per issue, each reviewed independently (an Opus reviewer per slice, with mutation testing) and merged into the integration branch after its findings were adopted or declined on the slice PR. **Merge with a merge commit** (repo `allow_merge_commit` on → merge → off), so release-please sees the five typed commits.

## What landed

| commit | issue | slice PR | what |
| --- | --- | --- | --- |
| `f80f31e5c` test(gda) | #815 | #820 | the immutable `gda schema` manifest is built once per process (schema-aggregate, gda-mcp support, live-contract guards); two socket-lifecycle tests pass a 0.2 s deadline through the existing seam instead of 5.0 s |
| `ad6e7af73` refactor(tests) | #816 | #821 | one deep command invoker for the unit tier in `support.py` (`invoke_cli`, `invoke_operation_error`, `assert_operation_error`, `minimal_project`, `ENGINE_BANNER`, `recording_runner`, `FakeProc`, `server_with_session`); 46 modules migrate; headless ritual sites 147 → 4; −1,060 lines |
| `5868f49ae` refactor(tests) | #817 | #822 | one deep out-of-process `Gda` invoker for the e2e tier (bound project/godot/env/cwd/timeout; raw / `.json()` / `.error()`), `import_project` asserting the engine exit code, live scaffold in `conftest`; fifteen adapters and their copies deleted; every spawn bounded; −1,214 lines |
| `82976a91a` test(gda) | #824 | #825 | two launch-timeout tests stop racing a real 1.0 s deadline against the fake engine's first output (held clock + marker, the #728 technique); the flake pytest-xdist surfaced |
| `7db823192` ci(gda) | #818 | #823 | pytest-xdist in the dev group; CI unit and e2e steps on `-n 4 --dist loadgroup`; `xdist_group("windowed")` on the windowed e2e tests; README line + translations |
| `dbcf1c5eb` test(gda) | #827 | #828 | the two editor-path launch-timeout arms bound their wedged editor at 30 s instead of 4 s (the editor boots to the plugin in 2.1–4.6 s with four concurrent passes); the game-path arm keeps 4 s; assertions unchanged — the real-engine flake the independent review of this PR surfaced |

## Numbers

| | before (main at e44bec3bd) | after (dev tip 7db823192) |
| --- | --- | --- |
| unit tier, CI step | 84 s | 35 s (run 33792443503) |
| e2e tier, CI step | 1,362 s (22:41) | 503 s (8:23) (run 33792443503) |
| `godot-e2e` job total | 28.6 min | 14.2 min |
| unit tier, local serial / 4 workers | 67.4 s / — | 47.5 s / ~17 s |
| e2e tier, local serial / 4 workers | 1,215 s / — | 1,215 s / 373 s |
| lines under `tests/` | — | −2,300 net across the round |

Coverage guard, every slice: the collected test-ID list (`pytest --collect-only -q`, 3,075 IDs; 2,429 unit / 646 e2e) byte-identical before and after; pass counts unchanged (2,429 unit; 645 passed + 1 skipped e2e on macOS, 627 + 19 skipped on the Linux runner). No test added, removed or renamed; no product change; ruff and bare pyright green on every slice.

Wave evidence on the dev tip (7db823192): `workflow_dispatch` with `run-e2e=true` — run 33799028879, all 15 jobs green. Unit step: 2,427 passed / 2 skipped in 28.8 s. e2e step: 627 passed / 19 skipped in 533 s (8:53); the 19 skips are the display-less runner's windowed tests plus the Linux-only user-data case, the same set as before the round.

Integration note: `main` moved by #814 (repository positioning) after this branch forked, so the branch carries one merge commit from `main` (cb0ab6199). The only conflicts were the three translation sync markers, both sides having re-stamped them; resolved by re-stamping against the merged README. On the merged tree the unit tier is 2,430 passed on four workers — the one extra test is #814's own i18n check, not this round's.

## Independent review of this PR (2026-09-04)

Standards: 0 findings. Spec: one P2 — a four-worker run of the full tier failed `test_a_wedged_import_pass_reports_what_the_engine_printed` once (the diagnostics held the engine banner but no plugin line at the 4.0 s ceiling). Adopted: filed as #827 with the boot-latency measurements, fixed on dev by #828 (reviewed independently, MERGEABLE; a controlled A/B reproduced the red at 4.0 s under eight workers plus busy loops and green at 30 s under the same load). Non-blocking: #816's wording said the invoker owns the JSON parse while `invoke_cli` returns the `Result`; the issue text is aligned with a dated note. The review's coverage measurement (Coverage.py, branch coverage, Python subprocesses instrumented): 95.12 % statements / 90.07 % branches on both base and head, with identical executed line and branch sets per file. The three post-merge nightly runs required by #818 remain follow-up acceptance.

## Declined in the round, with evidence (recorded on the issues)

- Scaffold-once-per-module for e2e: an AST probe found only 86 set-up spawns in 94 node tests, 24 sharing a signature — 4–7 % for ~50 test edits. Not done (#817).
- In-process CliRunner adapter for the e2e matrix tests: three tests, a second invocation semantics. Not done; the root cause is #819 (`import gda.cli` ≈ 0.19 s per invocation), parked by decision.
- Module-scoped engine session for the live consumer modules: < 1 s per cycle, State consistency leaks. Not done (#817).

## Follow-ups (not in this round)

- #818's post-merge criterion: three nightly e2e runs observed green; if a flake appears, the next candidates are the daemon socket-lifecycle bounds at the 0.35 s scheduling slack and the 0.5 s trickle bound (reviewer measurements on #823).
- The flake's mechanism (reviewer on #823): macOS Gatekeeper's first-execution scan of a freshly written executable (median 3.3 s under 20 concurrent fresh stand-ins vs ~0.3 s for a reused one). A session-scoped shared `/bin/sh` stand-in would save ~0.3 s per launch test locally — candidate issue.
- 129 live-runner ritual sites (`inject_live_runner` + `CliRunner().invoke`) in the input/screen/game/perf/diag/logger modules were left for a follow-up (#821's review).
- #819 (lazy `import gda.cli`) stays parked.
