### PR TITLE
test(gda): give the editor-path launch-timeout arms a ceiling the boot cannot race (#827)

### DIFF
--- a/tests/test_e2e_launch_timeout.py
+++ b/tests/test_e2e_launch_timeout.py
@@ -45,10 +45,17 @@ from gda.runner import SubprocessGodotRunner
 from tests.conftest import project_godot
 from tests.support import GODOT, Gda
 
-# The ceiling every arm gives its wedged engine. Long enough for a real Godot to
-# boot and print, short enough that three arms plus gda's terminate grace stay
-# well inside a test run.
-CEILING_SECONDS = 4.0
+# The ceiling each arm gives its wedged engine, by the engine path it boots (#827).
+# The GAME path (the sentinel channel) boots and prints in well under a second, so
+# 4.0s bounds it with a wide margin. The EDITOR path (`--import`, `--export-*`)
+# measured 2.2–2.4s to reach the plugin on a quiet 8-core host, 4.3–4.6s with four
+# concurrent editor passes, 8.1–8.3s with eight, and up to 16.5s with stray CPU
+# load on top — so under pytest-xdist a 4.0s ceiling raced the boot and once lost:
+# the diagnostics held the banner but no plugin line. 30s clears the quiet
+# eight-way figure 3.6x and the loaded worst case 1.8x; each editor arm spends it
+# in full plus gda's terminate grace, which xdist parallelism absorbs.
+GAME_CEILING_SECONDS = 4.0
+EDITOR_CEILING_SECONDS = 30.0
 
 # A blocking autoload: it announces itself on BOTH streams and then never returns.
 # `printerr` matters — gda's stdout carries the ADR-0002 result object, so the
@@ -113,12 +120,12 @@ def _wedged_project(tmp_path: Path, *, autoload: bool, plugin: bool) -> Path:
     return tmp_path
 
 
-def _assert_bounded(elapsed: float) -> None:
+def _assert_bounded(elapsed: float, ceiling: float) -> None:
     """The run was ended by gda's ceiling, not by the engine and not by luck."""
-    assert elapsed >= CEILING_SECONDS, f"the run ended early, at {elapsed:.1f}s"
+    assert elapsed >= ceiling, f"the run ended early, at {elapsed:.1f}s"
     # The ceiling plus gda's terminate-then-kill grace, generously. A wedged
     # GDScript loop ignores the SIGTERM, so the grace is always spent in full.
-    assert elapsed < CEILING_SECONDS + 20, f"the run overran its bound: {elapsed:.1f}s"
+    assert elapsed < ceiling + 20, f"the run overran its bound: {elapsed:.1f}s"
 
 
 def _assert_caller_first_remediation(message: str) -> None:
@@ -146,14 +153,14 @@ def _assert_caller_first_remediation(message: str) -> None:
 
 
 def _assert_timeout_envelope(
-    failure: Failure, label: str, *, expect: list[str]
+    failure: Failure, label: str, ceiling: float, *, expect: list[str]
 ) -> None:
     error = failure.error
     assert error.code == "launch_timeout", error
     assert error.category.value == "environment"
     assert error.message.startswith(f"{label} launched but did not return")
-    assert f"timeout of {CEILING_SECONDS}s" in error.message
-    assert "elapsed 4." in error.message, error.message
+    assert f"timeout of {ceiling}s" in error.message
+    assert f"elapsed {int(ceiling)}." in error.message, error.message
     assert "16384 UTF-8 bytes (16 KiB)" in error.message
     _assert_caller_first_remediation(error.message)
     for expected in expect:
@@ -163,18 +170,19 @@ def _assert_timeout_envelope(
 @pytest.mark.e2e
 def test_a_wedged_sentinel_op_reports_what_the_engine_printed(tmp_path):
     project = _wedged_project(tmp_path, autoload=True, plugin=False)
-    runner = SubprocessGodotRunner(GODOT, project=project, timeout=CEILING_SECONDS)
+    runner = SubprocessGodotRunner(GODOT, project=project, timeout=GAME_CEILING_SECONDS)
 
     started = time.monotonic()
     raw = runner.run("info", {})
     elapsed = time.monotonic() - started
 
-    _assert_bounded(elapsed)
+    _assert_bounded(elapsed, GAME_CEILING_SECONDS)
     outcome = classify_run(raw, GODOT, EngineVersion)
     assert isinstance(outcome, Failure)
     _assert_timeout_envelope(
         outcome,
         "Godot",
+        GAME_CEILING_SECONDS,
         # Both streams, and both from the engine itself: the banner it printed on
         # its own, and the autoload's two lines from before it stopped returning.
         expect=["Godot Engine v", "AUTOLOAD REACHED", "AUTOLOAD WEDGED"],
@@ -184,13 +192,15 @@ def test_a_wedged_sentinel_op_reports_what_the_engine_printed(tmp_path):
 @pytest.mark.e2e
 def test_a_wedged_export_reports_what_the_engine_printed(tmp_path):
     project = _wedged_project(tmp_path, autoload=False, plugin=True)
-    runner = SubprocessExportRunner(GODOT, project=project, timeout=CEILING_SECONDS)
+    runner = SubprocessExportRunner(
+        GODOT, project=project, timeout=EDITOR_CEILING_SECONDS
+    )
 
     started = time.monotonic()
     raw = runner.run("Linux/X11", "release", "build/game.x86_64")
     elapsed = time.monotonic() - started
 
-    _assert_bounded(elapsed)
+    _assert_bounded(elapsed, EDITOR_CEILING_SECONDS)
     outcome = classify_export_run(
         raw,
         GODOT,
@@ -202,7 +212,10 @@ def test_a_wedged_export_reports_what_the_engine_printed(tmp_path):
     )
     assert isinstance(outcome, Failure)
     _assert_timeout_envelope(
-        outcome, "Godot export", expect=["PLUGIN REACHED", "PLUGIN WEDGED"]
+        outcome,
+        "Godot export",
+        EDITOR_CEILING_SECONDS,
+        expect=["PLUGIN REACHED", "PLUGIN WEDGED"],
     )
 
 
@@ -220,18 +233,18 @@ def test_a_wedged_import_pass_reports_what_the_engine_printed(tmp_path):
         "import",
         "res://icon.png",
         "--timeout",
-        str(CEILING_SECONDS),
+        str(EDITOR_CEILING_SECONDS),
         "--json",
     )
     elapsed = time.monotonic() - started
 
-    _assert_bounded(elapsed)
+    _assert_bounded(elapsed, EDITOR_CEILING_SECONDS)
     assert run.returncode == 124, run.stdout + run.stderr
     error = json.loads(run.stdout)["error"]
     assert error["code"] == "launch_timeout"
     assert error["message"].startswith("Godot import launched but did not return")
-    assert f"timeout of {CEILING_SECONDS}s" in error["message"]
-    assert "elapsed 4." in error["message"]
+    assert f"timeout of {EDITOR_CEILING_SECONDS}s" in error["message"]
+    assert f"elapsed {int(EDITOR_CEILING_SECONDS)}." in error["message"]
     _assert_caller_first_remediation(error["message"])
     assert "PLUGIN WEDGED" in error["diagnostics"]
     # #687 (the ADR-0004 amendment) end to end, on a REAL wedged engine: the three
@@ -242,8 +255,8 @@ def test_a_wedged_import_pass_reports_what_the_engine_printed(tmp_path):
     # because the clock and the phase are readings of a real process: a fake
     # RunResult would assert only the can.
     evidence = error["evidence"]
-    assert evidence["timeout_seconds"] == CEILING_SECONDS
-    assert evidence["elapsed_seconds"] >= CEILING_SECONDS
+    assert evidence["timeout_seconds"] == EDITOR_CEILING_SECONDS
+    assert evidence["elapsed_seconds"] >= EDITOR_CEILING_SECONDS
     # The engine printed before it wedged, so it reached its own startup: this is the
     # phase that says raise the ceiling, not the one that says suspect the binary.
     assert evidence["termination_phase"] == "output_seen"

--- a/tests/test_e2e_launch_timeout.py
+++ b/tests/test_e2e_launch_timeout.py
@@ -48,12 +48,14 @@ from tests.support import GODOT, Gda
 # The ceiling each arm gives its wedged engine, by the engine path it boots (#827).
 # The GAME path (the sentinel channel) boots and prints in well under a second, so
 # 4.0s bounds it with a wide margin. The EDITOR path (`--import`, `--export-*`)
-# measured 2.2–2.4s to reach the plugin on a quiet 8-core host, 4.3–4.6s with four
-# concurrent editor passes, 8.1–8.3s with eight, and up to 16.5s with stray CPU
+# takes seconds to reach the plugin, and more the more editors boot at once. On
+# one 8-core macOS host (2026-09-04): 1.6–2.4s serially, 2.1–4.6s with four
+# concurrent editor passes, 3.4–8.3s with eight (the low ends from a cool host,
+# the high ends right after an hour of full load), and up to 16.5s with stray CPU
 # load on top — so under pytest-xdist a 4.0s ceiling raced the boot and once lost:
-# the diagnostics held the banner but no plugin line. 30s clears the quiet
-# eight-way figure 3.6x and the loaded worst case 1.8x; each editor arm spends it
-# in full plus gda's terminate grace, which xdist parallelism absorbs.
+# the diagnostics held the banner but no plugin line. A slower CI runner scales
+# these up. 30s clears the eight-way figures 3.6x and the loaded worst case 1.8x;
+# each editor arm spends it in full, which xdist parallelism absorbs.
 GAME_CEILING_SECONDS = 4.0
 EDITOR_CEILING_SECONDS = 30.0
 
@@ -123,8 +125,10 @@ def _wedged_project(tmp_path: Path, *, autoload: bool, plugin: bool) -> Path:
 def _assert_bounded(elapsed: float, ceiling: float) -> None:
     """The run was ended by gda's ceiling, not by the engine and not by luck."""
     assert elapsed >= ceiling, f"the run ended early, at {elapsed:.1f}s"
-    # The ceiling plus gda's terminate-then-kill grace, generously. A wedged
-    # GDScript loop ignores the SIGTERM, so the grace is always spent in full.
+    # The ceiling plus gda's terminate-then-kill grace and its reader join,
+    # generously: the bound holds whether the wedged engine dies on the SIGTERM
+    # at once (observed: the arms end within 0.4s of the ceiling) or sits out the
+    # grace and takes the SIGKILL.
     assert elapsed < ceiling + 20, f"the run overran its bound: {elapsed:.1f}s"
 
 


### PR DESCRIPTION
Closes #827

## What

The two editor-path arms of the launch-timeout module — `test_a_wedged_export_reports_what_the_engine_printed` and `test_a_wedged_import_pass_reports_what_the_engine_printed` — bound their wedged editor at 30 s instead of 4 s. The game-path arm keeps 4 s. Two named constants replace the one (`GAME_CEILING_SECONDS`, `EDITOR_CEILING_SECONDS`), and the two shared assertion helpers take the ceiling as an argument. Every assertion the three arms make is kept: plugin / autoload output in the diagnostics, `launch_timeout` with the ceiling and the elapsed clock in the message, the `evidence` numbers and `termination_phase`, and the run bounded by the ceiling plus gda's terminate grace. No test added, removed or renamed; tests only.

Why not the #824 held-clock technique: this module's subject includes the real wall clock (each arm asserts the run ended at its own ceiling and that the envelope reports it), and the import arm is a full out-of-process CLI round trip whose clock a test cannot hold.

## Evidence (local macOS, 8 cores)

Time from spawn to the plugin's line on the `--import` path, measured with a watch that ends the run on the line:

| concurrent editor passes | quiet host | with four busy loops |
| --- | --- | --- |
| 1 | 2.2–2.4 s | — |
| 4 | 4.3–4.6 s | 4.8–5.3 s |
| 8 | 8.1–8.3 s | — |
| 4–8 with stray busy loops left over from an earlier probe (measurement error, disclosed on #827) | 5.2–16.6 s | |

So four concurrent editor passes already exceed the old 4.0 s ceiling on a quiet host; 30 s clears the quiet eight-way figure 3.6× and the loaded worst case 1.8×.

- The module serially: 3 passed (4.1 s + 30.1 s + 30.8 s).
- 10 consecutive runs of the module beside resource-import, classname-resolution, export-run and harness-install under `-n 4 --dist loadgroup`: 10 / 10 green (36 passed, 1 skipped each; 128–236 s per run — the host carried four to eight stray busy loops throughout, so this doubled as a stress run).
- Full e2e tier on four workers: 414 passed + 231 passed / 1 skipped = 645 + 1.
- `pytest --collect-only -q -m e2e` ID list identical (646); ruff check / format, bare pyright: clean.
- Surface diff: none — tests only.
