### PR TITLE
docs(readme): align adoption guide with brand charter

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ gda scene get scenes/main.tscn --json
 > No project? `gda` still runs **projectless** on plain filesystem paths (relative to your current
 > directory) — only `res://` resolution needs a project. See [Configuration](#configuration).
 
-**Inspect and drive the *running* game with Live operations.** These operations run the
+**Inspect the *running* game with Live operations.** These operations run the
 project's **main scene**, so point it at the one you just built via Godot's
 `application/run/main_scene` project setting (the editor's *Application → Run → Main Scene*),
 then start the daemon (macOS/Linux, Godot 4.6+):
@@ -323,11 +323,11 @@ operation modes:
 | Component        | Role                                                                         |
 | ---------------- | ---------------------------------------------------------------------------- |
 | **`gda`**        | Runs Godot operations directly as a CLI and returns structured `--json` results. |
-| **`gda-mcp`**    | Maps the same operations and structured results to MCP tools from `--schema`. |
+| **`gda-mcp`**    | Generates MCP tools from `--schema`, invokes the same operations, and returns their structured results. |
 | **`gda-daemon`** | Supervises a running game per project for Live operations.                  |
 
-- **Headless operations** run one-shot — no daemon, nothing to install (create a scene, edit
-  a script, validate or boot a scene, export, analyze).
+- **Headless operations** run as one-shot processes — no daemon or editor plugin to install
+  (create a scene, edit a script, validate or boot a scene, export, analyze).
 - **Live operations** require a running game — `gda-daemon` launches it, injects an inert
   in-game harness, and brokers requests over a Unix domain socket (runtime tree, input,
   frame capture, performance, diagnostics).

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ gda scene get scenes/main.tscn --json
 > No project? `gda` still runs **projectless** on plain filesystem paths (relative to your current
 > directory) — only `res://` resolution needs a project. See [Configuration](#configuration).
 
-**Inspect the *running* game with Live operations.** These operations run the
+**Inspect and drive the *running* game with Live operations.** These operations run the
 project's **main scene**, so point it at the one you just built via Godot's
 `application/run/main_scene` project setting (the editor's *Application → Run → Main Scene*),
 then start the daemon (macOS/Linux, Godot 4.6+):
@@ -323,7 +323,7 @@ operation modes:
 | Component        | Role                                                                         |
 | ---------------- | ---------------------------------------------------------------------------- |
 | **`gda`**        | Runs Godot operations directly as a CLI and returns structured `--json` results. |
-| **`gda-mcp`**    | Generates MCP tools from `--schema`, invokes the same operations, and returns their structured results. |
+| **`gda-mcp`**    | Maps the same operations and structured results to MCP tools generated from `--schema`. |
 | **`gda-daemon`** | Supervises a running game per project for Live operations.                  |
 
 - **Headless operations** run as one-shot processes — no daemon or editor plugin to install

--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ These capabilities were refined while
 
 ## Installation
 
-**Requirements:** Python 3.13+, and a [Godot](https://godotengine.org) binary — 4.4+ for
-headless commands, 4.6+ on macOS/Linux for live (daemon) commands.
+**Requirements:** Python 3.13+ and a [Godot](https://godotengine.org) binary — 4.4+ for
+Headless operations, 4.6+ on macOS/Linux for Live operations.
 
-Install the CLI from PyPI onto your `PATH`:
+Install `gda`, the Godot CLI for AI agents, from PyPI onto your `PATH`:
 
 ```bash
 uv tool install gda      # or: pipx install gda
@@ -130,7 +130,7 @@ gda info --json
 # {"major":4,"minor":6,"patch":3,"status":"stable","string":"4.6.3-stable (official)",…}
 ```
 
-stdout is always clean JSON you can pipe; all engine and script diagnostics go to stderr:
+With `--json`, stdout is clean JSON you can pipe; all engine and script diagnostics go to stderr:
 
 ```bash
 gda info --json | jq .major   # → 4
@@ -145,6 +145,7 @@ export GDA_PROJECT="/path/to/your/godot-project"   # or pass --project to any co
 gda scene create scenes/main.tscn --root-type Node2D --json
 gda node add  scenes/main.tscn --type Sprite2D --name Hero --json
 gda node set  scenes/main.tscn --node Hero --property position --value 10,20 --json
+gda scene validate scenes/main.tscn --json
 gda scene get scenes/main.tscn --json
 # {"path":"scenes/main.tscn","root":{"name":"main","type":"Node2D","children":[{"name":"Hero",…}]}}
 ```
@@ -152,9 +153,10 @@ gda scene get scenes/main.tscn --json
 > No project? `gda` still runs **projectless** on plain filesystem paths (relative to your current
 > directory) — only `res://` resolution needs a project. See [Configuration](#configuration).
 
-**Drive a *running* game live.** Live ops run the project's **main scene**, so point it at the
-one you just built via Godot's `application/run/main_scene` project setting (the editor's
-*Application → Run → Main Scene*), then start the daemon (macOS/Linux, Godot 4.6+):
+**Inspect and drive the *running* game with Live operations.** These operations run the
+project's **main scene**, so point it at the one you just built via Godot's
+`application/run/main_scene` project setting (the editor's *Application → Run → Main Scene*),
+then start the daemon (macOS/Linux, Godot 4.6+):
 
 ```bash
 gda project set application/run/main_scene --value res://scenes/main.tscn --json  # a Godot project setting key
@@ -171,19 +173,25 @@ with `gda daemon start --windowed`.)
 
 ## Choose your integration
 
-`gda` exposes the **same command surface** three ways — pick whichever your agent (or you) supports:
+`gda` provides one operation surface through three complementary access paths. Use the CLI,
+the Agent Skill, the MCP server, or a combination that fits your workflow. The underlying
+operations and structured results stay the same.
 
-| Entry point | Best for | How |
+Not sure which path fits your workflow? See
+[Godot MCP vs CLI vs Agent Skill](https://aigengame.xyz/godot-mcp/).
+
+| Access path | Best for | How |
 | --- | --- | --- |
 | **CLI** (`gda`) | humans, shell scripts, CI, and agents that can run commands | `gda <group> <command> --json` |
-| **Skill** (`gda skill`) | coding agents that support Agent Skills and prefer a token-light CLI workflow | print/install `SKILL.md` (below) |
-| **MCP** (`gda-mcp`) | agents that call tools over the Model Context Protocol | run the stdio server (below) |
+| **Agent Skill** (`gda skill`) | coding agents that support Agent Skills and prefer a token-light CLI workflow | print or install the bundled guidance (below) |
+| **MCP** (`gda-mcp`) | MCP-compatible clients that discover and call tools | run the stdio server (below) |
 
-### Use it as a Skill
+### Use the Agent Skill
 
-`gda` ships an agent **Skill** — a `SKILL.md` that teaches an AI agent *how and when* to drive
-Godot from the CLI. It's the lightest way in (no server to register), bundled in the package and
-version-locked to your install. Print it, or install it into your agent's skills directory:
+`gda` ships a bundled **Agent Skill** that teaches an AI agent *when and how* to drive Godot
+from the CLI. Use it when your coding agent supports Agent Skills and you want reusable guidance
+without registering a server. The guidance stays aligned with your installed `gda` version.
+Print it, or install it into your agent's skills directory:
 
 ```bash
 gda skill                                              # print SKILL.md (redirect it anywhere)
@@ -191,18 +199,19 @@ gda skill --install --provider claude --scope user     # resolve a known agent's
 gda skill --install --dir ~/.claude/skills/gda         # …or give the directory yourself
 ```
 
-The [skill recipes](docs/gda-skill.md) list each agent's skills directory. Or fetch the same
-file straight from the repo — you still install `gda`, since the Skill drives it:
+The [Agent Skill recipes](docs/gda-skill.md) list each agent's skills directory. Or fetch the
+same file straight from the repo — you still install `gda`, since the Agent Skill drives it:
 
 ```bash
 curl --create-dirs -o ~/.claude/skills/gda/SKILL.md \
   https://raw.githubusercontent.com/aigengame/godot-agent/main/src/gda/skill/SKILL.md
 ```
 
-### Use it as an MCP server
+### Use the MCP server
 
-`gda` ships a stdio [MCP](https://modelcontextprotocol.io) server behind a `[mcp]` extra,
-so any MCP agent (Claude Code, Codex, Cursor, …) can drive Godot. Try it with no install:
+`gda-mcp` is the bundled Godot MCP server for compatible clients. It implements the
+[Model Context Protocol](https://modelcontextprotocol.io) over stdio and is available through
+the `[mcp]` extra. Run it through `uvx` without a permanent install:
 
 ```bash
 uvx --from "gda[mcp]" gda-mcp
@@ -308,19 +317,23 @@ command — register via the JSON above or the Settings → MCP UI.
 
 ## How it works
 
-`gda` is three components serving operations in two modes:
+`gda` is one Godot automation toolchain with three components and two complementary
+operation modes:
 
-| Component        | Role                                                                  |
-| ---------------- | --------------------------------------------------------------------- |
-| **`gda`**        | The agent-facing CLI — exposes Godot with structured `--json` output. |
-| **`gda-mcp`**    | An MCP server exposing the same operations as tools, from `--schema`. |
-| **`gda-daemon`** | A per-project process supervising a running game for live operations. |
+| Component        | Role                                                                         |
+| ---------------- | ---------------------------------------------------------------------------- |
+| **`gda`**        | Runs Godot operations directly as a CLI and returns structured `--json` results. |
+| **`gda-mcp`**    | Maps the same operations and structured results to MCP tools from `--schema`. |
+| **`gda-daemon`** | Supervises a running game per project for Live operations.                  |
 
 - **Headless operations** run one-shot — no daemon, nothing to install (create a scene, edit
-  a script, export, analyze).
+  a script, validate or boot a scene, export, analyze).
 - **Live operations** require a running game — `gda-daemon` launches it, injects an inert
   in-game harness, and brokers requests over a Unix domain socket (runtime tree, input,
-  screenshots, performance, diagnostics).
+  frame capture, performance, diagnostics).
+
+Headless validation confirms project readiness; Live operations return runtime evidence about
+actual behavior.
 
 The in-game harness `gda-daemon` injects is **dev-only**: `gda export run` strips it from the
 artifact entirely, and built any other way (editor GUI, raw `godot --export`) it still

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=a7f521f06441d07917e5e56ee6630e5caf08b50979afc0cc93a0748cf87e9bb4 -->
+<!-- gda-readme-i18n: source=README.md sha256=9ee455d8eacbad676baab58de7bf10903ba66bc48f64fb0c59f41c0a7cf92d54 -->
 
 # gda — Automatización de Godot para agentes de IA
 
@@ -162,7 +162,7 @@ gda scene get scenes/main.tscn --json
 > ¿Sin proyecto? `gda` igualmente se ejecuta **sin proyecto** (projectless) sobre rutas simples del sistema de
 > archivos (relativas a tu directorio actual) — solo la resolución de `res://` necesita un proyecto. Consulta [Configuración](#configuration).
 
-**Inspecciona el juego *en ejecución* con operaciones Live.** Estas operaciones ejecutan
+**Inspecciona y controla el juego *en ejecución* con operaciones Live.** Estas operaciones ejecutan
 la **escena principal** del proyecto, así que apúntala a la que acabas de construir mediante el
 ajuste de proyecto `application/run/main_scene` de Godot (el *Application → Run → Main Scene* del
 editor), y luego arranca el daemon (macOS/Linux, Godot 4.6+):
@@ -336,7 +336,7 @@ modos de operación complementarios:
 | Componente       | Rol |
 | ---------------- | --- |
 | **`gda`**        | Ejecuta operaciones de Godot directamente como CLI y devuelve resultados estructurados con `--json`. |
-| **`gda-mcp`**    | Genera herramientas MCP a partir de `--schema`, invoca las mismas operaciones y devuelve sus resultados estructurados. |
+| **`gda-mcp`**    | Asigna las mismas operaciones y resultados estructurados a herramientas MCP generadas a partir de `--schema`. |
 | **`gda-daemon`** | Supervisa un juego en ejecución por proyecto para las operaciones Live. |
 
 - **Las operaciones Headless** se ejecutan como procesos de una sola pasada — sin daemon ni

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=7645aa9bfcabd98aa3e48cf84b793a38351886bae203d11baba7cffcb9b70bd5 -->
+<!-- gda-readme-i18n: source=README.md sha256=52dae55852b715d695d1cb49789dca82a930f5fab9f3ac2302f95df7305cbab1 -->
 
 # gda — Automatización de Godot para agentes de IA
 
@@ -97,9 +97,9 @@ en un [registro público de dogfooding](https://github.com/aigengame/godot-agent
 ## Instalación
 
 **Requisitos:** Python 3.13+ y un binario de [Godot](https://godotengine.org) — 4.4+ para
-los comandos headless, 4.6+ en macOS/Linux para los comandos live (daemon).
+las operaciones Headless, 4.6+ en macOS/Linux para las operaciones Live.
 
-Instala la CLI desde PyPI en tu `PATH`:
+Instala `gda`, la CLI de Godot para agentes de IA, desde PyPI en tu `PATH`:
 
 ```bash
 uv tool install gda      # or: pipx install gda
@@ -138,7 +138,8 @@ gda info --json
 # {"major":4,"minor":6,"patch":3,"status":"stable","string":"4.6.3-stable (official)",…}
 ```
 
-stdout siempre es JSON limpio que puedes canalizar; todos los diagnósticos del motor y de los scripts van a stderr:
+Con `--json`, stdout contiene JSON limpio que puedes canalizar; todos los diagnósticos del motor
+y de los scripts van a stderr:
 
 ```bash
 gda info --json | jq .major   # → 4
@@ -153,6 +154,7 @@ export GDA_PROJECT="/path/to/your/godot-project"   # or pass --project to any co
 gda scene create scenes/main.tscn --root-type Node2D --json
 gda node add  scenes/main.tscn --type Sprite2D --name Hero --json
 gda node set  scenes/main.tscn --node Hero --property position --value 10,20 --json
+gda scene validate scenes/main.tscn --json
 gda scene get scenes/main.tscn --json
 # {"path":"scenes/main.tscn","root":{"name":"main","type":"Node2D","children":[{"name":"Hero",…}]}}
 ```
@@ -160,9 +162,10 @@ gda scene get scenes/main.tscn --json
 > ¿Sin proyecto? `gda` igualmente se ejecuta **sin proyecto** (projectless) sobre rutas simples del sistema de
 > archivos (relativas a tu directorio actual) — solo la resolución de `res://` necesita un proyecto. Consulta [Configuración](#configuration).
 
-**Controla un juego *en ejecución* en vivo.** Las operaciones live ejecutan la **escena principal** del proyecto, así que
-apúntala a la que acabas de construir mediante el ajuste de proyecto `application/run/main_scene` de Godot (el
-*Application → Run → Main Scene* del editor), y luego arranca el daemon (macOS/Linux, Godot 4.6+):
+**Inspecciona y controla el juego *en ejecución* con operaciones Live.** Estas operaciones ejecutan
+la **escena principal** del proyecto, así que apúntala a la que acabas de construir mediante el
+ajuste de proyecto `application/run/main_scene` de Godot (el *Application → Run → Main Scene* del
+editor), y luego arranca el daemon (macOS/Linux, Godot 4.6+):
 
 ```bash
 gda project set application/run/main_scene --value res://scenes/main.tscn --json  # a Godot project setting key
@@ -180,19 +183,25 @@ con `gda daemon start --windowed`.)
 <a id="choose-your-integration"></a>
 ## Elige tu integración
 
-`gda` expone la **misma superficie de comandos** de tres formas — elige la que tu agente (o tú) admita:
+`gda` ofrece una sola superficie de operaciones mediante tres vías de acceso complementarias.
+Usa la CLI, la Agent Skill, el servidor MCP o una combinación que se adapte a tu flujo de trabajo.
+Las operaciones subyacentes y los resultados estructurados son los mismos.
 
-| Punto de entrada | Ideal para | Cómo |
+¿No sabes qué vía se adapta mejor a tu flujo de trabajo? Consulta
+[Godot MCP vs CLI vs Agent Skill](https://aigengame.xyz/godot-mcp/).
+
+| Vía de acceso | Ideal para | Cómo |
 | --- | --- | --- |
 | **CLI** (`gda`) | humanos, scripts de shell, CI y agentes que pueden ejecutar comandos | `gda <group> <command> --json` |
-| **Skill** (`gda skill`) | agentes de programación que admiten Agent Skills y prefieren un flujo de CLI ligero en tokens | imprimir/instalar `SKILL.md` (abajo) |
-| **MCP** (`gda-mcp`) | agentes que invocan herramientas mediante el Model Context Protocol | ejecutar el servidor stdio (abajo) |
+| **Agent Skill** (`gda skill`) | agentes de programación que admiten Agent Skills y prefieren un flujo de CLI ligero en tokens | imprimir o instalar la guía incluida (abajo) |
+| **MCP** (`gda-mcp`) | clientes compatibles con MCP que descubren e invocan herramientas | ejecutar el servidor stdio (abajo) |
 
-### Úsalo como Skill
+### Usa la Agent Skill
 
-`gda` incluye una **Skill** para agentes — un `SKILL.md` que enseña a un agente de IA *cómo y cuándo* manejar
-Godot desde la CLI. Es la forma más ligera de entrar (no hay servidor que registrar), viene incluida en el paquete y
-queda fijada a la versión de tu instalación. Imprímela, o instálala en el directorio de skills de tu agente:
+`gda` incluye una **Agent Skill** que enseña a un agente de IA *cuándo y cómo* manejar Godot
+desde la CLI. Úsala cuando tu agente de programación admita Agent Skills y quieras una guía
+reutilizable sin registrar un servidor. La guía se mantiene alineada con la versión instalada de
+`gda`. Imprímela o instálala en el directorio de skills de tu agente:
 
 ```bash
 gda skill                                              # print SKILL.md (redirect it anywhere)
@@ -200,18 +209,20 @@ gda skill --install --provider claude --scope user     # resolve a known agent's
 gda skill --install --dir ~/.claude/skills/gda         # …or give the directory yourself
 ```
 
-Las [recetas de skills](gda-skill.md) listan el directorio de skills de cada agente. O bien obtén el
-mismo archivo directamente del repositorio — aun así instalas `gda`, ya que la Skill lo invoca:
+Las [recetas de Agent Skill](gda-skill.md) indican el directorio de skills de cada agente. También
+puedes obtener el mismo archivo directamente del repositorio — aun así necesitas instalar `gda`,
+ya que la Agent Skill invoca su CLI:
 
 ```bash
 curl --create-dirs -o ~/.claude/skills/gda/SKILL.md \
   https://raw.githubusercontent.com/aigengame/godot-agent/main/src/gda/skill/SKILL.md
 ```
 
-### Úsalo como servidor MCP
+### Usa el servidor MCP
 
-`gda` incluye un servidor [MCP](https://modelcontextprotocol.io) por stdio detrás de un extra `[mcp]`,
-de modo que cualquier agente MCP (Claude Code, Codex, Cursor, …) puede manejar Godot. Pruébalo sin instalar nada:
+`gda-mcp` es el servidor MCP de Godot incluido para clientes compatibles. Implementa el
+[Model Context Protocol](https://modelcontextprotocol.io) mediante stdio y está disponible a través
+del extra `[mcp]`. Ejecútalo con `uvx` sin una instalación permanente:
 
 ```bash
 uvx --from "gda[mcp]" gda-mcp
@@ -319,19 +330,23 @@ funciona en el ámbito de proyecto; usa el ámbito de proyecto para varios proye
 <a id="how-it-works"></a>
 ## Cómo funciona
 
-`gda` son tres componentes que sirven operaciones en dos modos:
+`gda` es una sola cadena de herramientas de automatización de Godot con tres componentes y dos
+modos de operación complementarios:
 
-| Componente       | Rol                                                                   |
-| ---------------- | --------------------------------------------------------------------- |
-| **`gda`**        | La CLI orientada a agentes — expone Godot con salida estructurada `--json`. |
-| **`gda-mcp`**    | Un servidor MCP que expone las mismas operaciones como herramientas, a partir de `--schema`. |
-| **`gda-daemon`** | Un proceso por proyecto que supervisa un juego en ejecución para las operaciones live. |
+| Componente       | Rol |
+| ---------------- | --- |
+| **`gda`**        | Ejecuta operaciones de Godot directamente como CLI y devuelve resultados estructurados con `--json`. |
+| **`gda-mcp`**    | Asigna las mismas operaciones y resultados estructurados a herramientas MCP a partir de `--schema`. |
+| **`gda-daemon`** | Supervisa un juego en ejecución por proyecto para las operaciones Live. |
 
-- **Las operaciones headless** se ejecutan de una sola pasada — sin daemon, nada que instalar (crear una escena, editar
-  un script, exportar, analizar).
-- **Las operaciones live** requieren un juego en ejecución — `gda-daemon` lo lanza, inyecta un harness inerte
+- **Las operaciones Headless** se ejecutan de una sola pasada — sin daemon, nada que instalar
+  (crear una escena, editar un script, validar o iniciar una escena, exportar, analizar).
+- **Las operaciones Live** requieren un juego en ejecución — `gda-daemon` lo lanza, inyecta un harness inerte
   dentro del juego e intermedia las peticiones a través de un socket de dominio Unix (árbol de runtime, entrada,
-  capturas de pantalla, rendimiento, diagnósticos).
+  captura de frames, rendimiento, diagnósticos).
+
+La validación Headless confirma que el proyecto está listo; las operaciones Live devuelven
+evidencia en runtime sobre el comportamiento real.
 
 El harness dentro del juego que `gda-daemon` inyecta es **solo para desarrollo**: `gda export run` lo elimina por
 completo del artefacto y, si se compila de cualquier otra forma (GUI del editor, `godot --export` directo), igualmente

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=52dae55852b715d695d1cb49789dca82a930f5fab9f3ac2302f95df7305cbab1 -->
+<!-- gda-readme-i18n: source=README.md sha256=a7f521f06441d07917e5e56ee6630e5caf08b50979afc0cc93a0748cf87e9bb4 -->
 
 # gda — Automatización de Godot para agentes de IA
 
@@ -162,7 +162,7 @@ gda scene get scenes/main.tscn --json
 > ¿Sin proyecto? `gda` igualmente se ejecuta **sin proyecto** (projectless) sobre rutas simples del sistema de
 > archivos (relativas a tu directorio actual) — solo la resolución de `res://` necesita un proyecto. Consulta [Configuración](#configuration).
 
-**Inspecciona y controla el juego *en ejecución* con operaciones Live.** Estas operaciones ejecutan
+**Inspecciona el juego *en ejecución* con operaciones Live.** Estas operaciones ejecutan
 la **escena principal** del proyecto, así que apúntala a la que acabas de construir mediante el
 ajuste de proyecto `application/run/main_scene` de Godot (el *Application → Run → Main Scene* del
 editor), y luego arranca el daemon (macOS/Linux, Godot 4.6+):
@@ -336,11 +336,12 @@ modos de operación complementarios:
 | Componente       | Rol |
 | ---------------- | --- |
 | **`gda`**        | Ejecuta operaciones de Godot directamente como CLI y devuelve resultados estructurados con `--json`. |
-| **`gda-mcp`**    | Asigna las mismas operaciones y resultados estructurados a herramientas MCP a partir de `--schema`. |
+| **`gda-mcp`**    | Genera herramientas MCP a partir de `--schema`, invoca las mismas operaciones y devuelve sus resultados estructurados. |
 | **`gda-daemon`** | Supervisa un juego en ejecución por proyecto para las operaciones Live. |
 
-- **Las operaciones Headless** se ejecutan de una sola pasada — sin daemon, nada que instalar
-  (crear una escena, editar un script, validar o iniciar una escena, exportar, analizar).
+- **Las operaciones Headless** se ejecutan como procesos de una sola pasada — sin daemon ni
+  plugin del editor que instalar (crear una escena, editar un script, validar o iniciar una escena,
+  exportar, analizar).
 - **Las operaciones Live** requieren un juego en ejecución — `gda-daemon` lo lanza, inyecta un harness inerte
   dentro del juego e intermedia las peticiones a través de un socket de dominio Unix (árbol de runtime, entrada,
   captura de frames, rendimiento, diagnósticos).

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=52dae55852b715d695d1cb49789dca82a930f5fab9f3ac2302f95df7305cbab1 -->
+<!-- gda-readme-i18n: source=README.md sha256=a7f521f06441d07917e5e56ee6630e5caf08b50979afc0cc93a0748cf87e9bb4 -->
 
 # gda — AI エージェント向け Godot オートメーション
 
@@ -159,7 +159,7 @@ gda scene get scenes/main.tscn --json
 > 相対)に対して **projectless(プロジェクトなし)** で動作します — プロジェクトが必要なのは `res://`
 > の解決だけです。[設定](#configuration) を参照してください。
 
-**Live 操作で実行中のゲームを検査・操作します。** これらの操作はプロジェクトの
+**Live 操作で実行中のゲームを検査します。** これらの操作はプロジェクトの
 **メインシーン**を実行します。そのため、いま構築したシーンを Godot の
 `application/run/main_scene` プロジェクト設定(エディタの *Application → Run → Main Scene*)で
 指定し、デーモンを起動します(macOS/Linux、Godot 4.6 以上)。
@@ -333,11 +333,12 @@ codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- 
 | コンポーネント | 役割 |
 | ---------------- | ---- |
 | **`gda`**        | CLI として Godot 操作を直接実行し、構造化された `--json` 結果を返します。 |
-| **`gda-mcp`**    | `--schema` から同じ操作と構造化結果を MCP ツールにマッピングします。 |
+| **`gda-mcp`**    | `--schema` から MCP ツールを生成し、同じ操作を呼び出して構造化結果を返します。 |
 | **`gda-daemon`** | Live 操作のために、プロジェクトごとに実行中ゲームを監督します。 |
 
-- **Headless 操作** はワンショットで実行されます — デーモンも、インストールするものも不要です
-  (シーンの作成、スクリプトの編集、シーンの検証または起動、エクスポート、解析)。
+- **Headless 操作** はワンショットプロセスとして実行されます — デーモンやエディタプラグインを
+  インストールする必要はありません(シーンの作成、スクリプトの編集、シーンの検証または起動、
+  エクスポート、解析)。
 - **Live 操作** には実行中のゲームが必要です — `gda-daemon` がそれを起動し、不活性なゲーム内ハーネスを
   注入し、Unix ドメインソケット経由でリクエストを仲介します(ランタイムツリー、入力、フレーム取得、
   パフォーマンス、診断)。

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=a7f521f06441d07917e5e56ee6630e5caf08b50979afc0cc93a0748cf87e9bb4 -->
+<!-- gda-readme-i18n: source=README.md sha256=9ee455d8eacbad676baab58de7bf10903ba66bc48f64fb0c59f41c0a7cf92d54 -->
 
 # gda — AI エージェント向け Godot オートメーション
 
@@ -159,7 +159,7 @@ gda scene get scenes/main.tscn --json
 > 相対)に対して **projectless(プロジェクトなし)** で動作します — プロジェクトが必要なのは `res://`
 > の解決だけです。[設定](#configuration) を参照してください。
 
-**Live 操作で実行中のゲームを検査します。** これらの操作はプロジェクトの
+**Live 操作で実行中のゲームを検査・操作します。** これらの操作はプロジェクトの
 **メインシーン**を実行します。そのため、いま構築したシーンを Godot の
 `application/run/main_scene` プロジェクト設定(エディタの *Application → Run → Main Scene*)で
 指定し、デーモンを起動します(macOS/Linux、Godot 4.6 以上)。
@@ -333,7 +333,7 @@ codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- 
 | コンポーネント | 役割 |
 | ---------------- | ---- |
 | **`gda`**        | CLI として Godot 操作を直接実行し、構造化された `--json` 結果を返します。 |
-| **`gda-mcp`**    | `--schema` から MCP ツールを生成し、同じ操作を呼び出して構造化結果を返します。 |
+| **`gda-mcp`**    | 同じ操作と構造化結果を、`--schema` から生成された MCP ツールにマッピングします。 |
 | **`gda-daemon`** | Live 操作のために、プロジェクトごとに実行中ゲームを監督します。 |
 
 - **Headless 操作** はワンショットプロセスとして実行されます — デーモンやエディタプラグインを

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=7645aa9bfcabd98aa3e48cf84b793a38351886bae203d11baba7cffcb9b70bd5 -->
+<!-- gda-readme-i18n: source=README.md sha256=52dae55852b715d695d1cb49789dca82a930f5fab9f3ac2302f95df7305cbab1 -->
 
 # gda — AI エージェント向け Godot オートメーション
 
@@ -92,10 +92,10 @@
 <a id="installation"></a>
 ## インストール
 
-**要件:** Python 3.13 以上、および [Godot](https://godotengine.org) バイナリ — Headless コマンドには
-4.4 以上、macOS/Linux での Live(デーモン)コマンドには 4.6 以上。
+**要件:** Python 3.13 以上、および [Godot](https://godotengine.org) バイナリ — Headless 操作には
+4.4 以上、macOS/Linux での Live 操作には 4.6 以上。
 
-PyPI から CLI を `PATH` 上にインストールします。
+AI エージェント向け Godot CLI の `gda` を PyPI から `PATH` 上にインストールします。
 
 ```bash
 uv tool install gda      # or: pipx install gda
@@ -134,8 +134,8 @@ gda info --json
 # {"major":4,"minor":6,"patch":3,"status":"stable","string":"4.6.3-stable (official)",…}
 ```
 
-stdout は常にパイプ可能なクリーンな JSON です。エンジンとスクリプトの診断出力はすべて stderr に
-流れます。
+`--json` を使うと、stdout はパイプ可能なクリーンな JSON になります。エンジンとスクリプトの
+診断出力はすべて stderr に流れます。
 
 ```bash
 gda info --json | jq .major   # → 4
@@ -150,6 +150,7 @@ export GDA_PROJECT="/path/to/your/godot-project"   # or pass --project to any co
 gda scene create scenes/main.tscn --root-type Node2D --json
 gda node add  scenes/main.tscn --type Sprite2D --name Hero --json
 gda node set  scenes/main.tscn --node Hero --property position --value 10,20 --json
+gda scene validate scenes/main.tscn --json
 gda scene get scenes/main.tscn --json
 # {"path":"scenes/main.tscn","root":{"name":"main","type":"Node2D","children":[{"name":"Hero",…}]}}
 ```
@@ -158,9 +159,10 @@ gda scene get scenes/main.tscn --json
 > 相対)に対して **projectless(プロジェクトなし)** で動作します — プロジェクトが必要なのは `res://`
 > の解決だけです。[設定](#configuration) を参照してください。
 
-**実行中のゲームを Live で操作します。** Live 操作はプロジェクトの **メインシーン** を実行します。
-そのため、いま構築したシーンを Godot の `application/run/main_scene` プロジェクト設定(エディタの
-*Application → Run → Main Scene*)で指定し、デーモンを起動します(macOS/Linux、Godot 4.6 以上)。
+**Live 操作で実行中のゲームを検査・操作します。** これらの操作はプロジェクトの
+**メインシーン**を実行します。そのため、いま構築したシーンを Godot の
+`application/run/main_scene` プロジェクト設定(エディタの *Application → Run → Main Scene*)で
+指定し、デーモンを起動します(macOS/Linux、Godot 4.6 以上)。
 
 ```bash
 gda project set application/run/main_scene --value res://scenes/main.tscn --json  # a Godot project setting key
@@ -178,21 +180,25 @@ start --windowed` でデーモンを起動してください。)
 <a id="choose-your-integration"></a>
 ## 統合方法を選ぶ
 
-`gda` は **同じコマンド体系** を 3 通りで公開します — エージェント(またはあなた)が対応している
-方法を選んでください。
+`gda` は、1 つの操作体系を 3 つの相補的なアクセス方法で提供します。CLI、Agent Skill、
+MCP サーバー、またはワークフローに合う組み合わせを使用できます。基盤となる操作と構造化結果は
+どの方法でも同じです。
 
-| 入口 | 適した用途 | 方法 |
+どの方法がワークフローに合うかわからない場合は、
+[Godot MCP vs CLI vs Agent Skill](https://aigengame.xyz/godot-mcp/) を参照してください。
+
+| アクセス方法 | 適した用途 | 方法 |
 | --- | --- | --- |
 | **CLI**(`gda`) | 人間、シェルスクリプト、CI、コマンドを実行できるエージェント | `gda <group> <command> --json` |
-| **Skill**(`gda skill`) | Agent Skills に対応し、トークン消費の少ない CLI ワークフローを好むコーディングエージェント | `SKILL.md` を出力/インストール(下記) |
-| **MCP**(`gda-mcp`) | Model Context Protocol 経由でツールを呼び出すエージェント | stdio サーバーを実行(下記) |
+| **Agent Skill**(`gda skill`) | Agent Skills に対応し、トークン消費の少ない CLI ワークフローを好むコーディングエージェント | 同梱ガイダンスを出力またはインストール(下記) |
+| **MCP**(`gda-mcp`) | ツールを検出・呼び出しできる MCP 互換クライアント | stdio サーバーを実行(下記) |
 
-### Skill として使う
+### Agent Skill を使う
 
-`gda` はエージェント **Skill** を同梱しています — `SKILL.md` であり、AI エージェントに CLI から Godot を
-操作する *方法とタイミング* を教えます。これは最も軽量な入口で(登録するサーバーがありません)、
-パッケージに同梱され、インストール済みのバージョンに固定されています。出力するか、エージェントの
-スキルディレクトリにインストールします。
+`gda` は、AI エージェントに CLI から Godot を操作する *タイミングと方法* を教える
+**Agent Skill** を同梱しています。コーディングエージェントが Agent Skills に対応し、サーバーを
+登録せずに再利用可能なガイダンスを使いたい場合に適しています。ガイダンスはインストール済みの
+`gda` バージョンと一致します。出力するか、エージェントのスキルディレクトリにインストールします。
 
 ```bash
 gda skill                                              # print SKILL.md (redirect it anywhere)
@@ -200,19 +206,20 @@ gda skill --install --provider claude --scope user     # resolve a known agent's
 gda skill --install --dir ~/.claude/skills/gda         # …or give the directory yourself
 ```
 
-[Skill レシピ](gda-skill.md) には各エージェントのスキルディレクトリが記載されています。あるいは同じファイルを
-リポジトリから直接取得することもできます — Skill は `gda` を呼び出して動くので、`gda` 自体のインストールは引き続き必要です。
+[Agent Skill レシピ](gda-skill.md)には各エージェントのスキルディレクトリが記載されています。
+同じファイルをリポジトリから直接取得することもできますが、Agent Skill は `gda` の CLI を
+呼び出すため、`gda` 自体のインストールは引き続き必要です。
 
 ```bash
 curl --create-dirs -o ~/.claude/skills/gda/SKILL.md \
   https://raw.githubusercontent.com/aigengame/godot-agent/main/src/gda/skill/SKILL.md
 ```
 
-### MCP サーバーとして使う
+### MCP サーバーを使う
 
-`gda` は `[mcp]` エクストラの背後に stdio の [MCP](https://modelcontextprotocol.io) サーバーを同梱しており、
-あらゆる MCP エージェント(Claude Code、Codex、Cursor など)が Godot を操作できます。インストールせずに
-試すには:
+`gda-mcp` は、互換クライアント向けに同梱された Godot MCP サーバーです。stdio 経由で
+[Model Context Protocol](https://modelcontextprotocol.io) を実装し、`[mcp]` エクストラから利用できます。
+永続的にインストールせず `uvx` で実行するには:
 
 ```bash
 uvx --from "gda[mcp]" gda-mcp
@@ -320,19 +327,22 @@ codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- 
 <a id="how-it-works"></a>
 ## 仕組み
 
-`gda` は、2 つのモードで操作を提供する 3 つのコンポーネントから成ります。
+`gda` は、3 つのコンポーネントと 2 つの相補的な操作モードを備えた 1 つの Godot
+オートメーションツールチェーンです。
 
 | コンポーネント | 役割 |
-| ---------------- | --------------------------------------------------------------------- |
-| **`gda`**        | エージェント向けの CLI — Godot を構造化された `--json` 出力で公開します。 |
-| **`gda-mcp`**    | 同じ操作を `--schema` からツールとして公開する MCP サーバー。 |
-| **`gda-daemon`** | Live 操作のために実行中ゲームを監督する、プロジェクトごとのプロセス。 |
+| ---------------- | ---- |
+| **`gda`**        | CLI として Godot 操作を直接実行し、構造化された `--json` 結果を返します。 |
+| **`gda-mcp`**    | `--schema` から同じ操作と構造化結果を MCP ツールにマッピングします。 |
+| **`gda-daemon`** | Live 操作のために、プロジェクトごとに実行中ゲームを監督します。 |
 
 - **Headless 操作** はワンショットで実行されます — デーモンも、インストールするものも不要です
-  (シーンの作成、スクリプトの編集、エクスポート、解析)。
+  (シーンの作成、スクリプトの編集、シーンの検証または起動、エクスポート、解析)。
 - **Live 操作** には実行中のゲームが必要です — `gda-daemon` がそれを起動し、不活性なゲーム内ハーネスを
-  注入し、Unix ドメインソケット経由でリクエストを仲介します(ランタイムツリー、入力、スクリーン
-  ショット、パフォーマンス、診断)。
+  注入し、Unix ドメインソケット経由でリクエストを仲介します(ランタイムツリー、入力、フレーム取得、
+  パフォーマンス、診断)。
+
+Headless 検証はプロジェクトの実行準備を確認し、Live 操作は実際の挙動に関するランタイム証拠を返します。
 
 `gda-daemon` が注入するゲーム内ハーネスは **開発専用** です。`gda export run` は成果物からそれを完全に
 取り除きます。また、それ以外の方法(エディタの GUI、素の `godot --export`)でビルドしても、エクスポート

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=7645aa9bfcabd98aa3e48cf84b793a38351886bae203d11baba7cffcb9b70bd5 -->
+<!-- gda-readme-i18n: source=README.md sha256=52dae55852b715d695d1cb49789dca82a930f5fab9f3ac2302f95df7305cbab1 -->
 
 # gda — 面向 AI Agent 的 Godot 自动化
 
@@ -87,10 +87,10 @@
 <a id="installation"></a>
 ## 安装
 
-**环境要求：** Python 3.13+，以及一个 [Godot](https://godotengine.org) 二进制文件——
-Headless 命令需要 4.4+，macOS/Linux 上的 Live（daemon）命令需要 4.6+。
+**环境要求：** Python 3.13+ 和一个 [Godot](https://godotengine.org) 二进制文件——
+Headless 操作需要 4.4+，macOS/Linux 上的 Live 操作需要 4.6+。
 
-把 CLI 从 PyPI 安装到你的 `PATH` 上：
+从 PyPI 安装面向 AI Agent 的 Godot CLI `gda`，并将它加入 `PATH`：
 
 ```bash
 uv tool install gda      # or: pipx install gda
@@ -129,7 +129,7 @@ gda info --json
 # {"major":4,"minor":6,"patch":3,"status":"stable","string":"4.6.3-stable (official)",…}
 ```
 
-stdout 永远是干净、可管道传递的 JSON；所有引擎和脚本的诊断信息都走 stderr：
+使用 `--json` 时，stdout 是干净、可管道传递的 JSON；所有引擎和脚本诊断信息都走 stderr：
 
 ```bash
 gda info --json | jq .major   # → 4
@@ -143,6 +143,7 @@ export GDA_PROJECT="/path/to/your/godot-project"   # or pass --project to any co
 gda scene create scenes/main.tscn --root-type Node2D --json
 gda node add  scenes/main.tscn --type Sprite2D --name Hero --json
 gda node set  scenes/main.tscn --node Hero --property position --value 10,20 --json
+gda scene validate scenes/main.tscn --json
 gda scene get scenes/main.tscn --json
 # {"path":"scenes/main.tscn","root":{"name":"main","type":"Node2D","children":[{"name":"Hero",…}]}}
 ```
@@ -150,9 +151,10 @@ gda scene get scenes/main.tscn --json
 > 没有项目？`gda` 仍可在普通文件系统路径上以**无项目（projectless）**方式运行（路径相对于你的当前目录）——
 > 只有 `res://` 解析才需要项目。参见[配置](#configuration)。
 
-**实时操控*正在运行*的游戏。** Live 操作会运行项目的**主场景**，所以先通过 Godot 的
-`application/run/main_scene` 项目设置（也就是编辑器里的 *Application → Run → Main Scene*）
-把它指向你刚构建好的那个场景，然后启动 daemon（macOS/Linux，Godot 4.6+）：
+**使用 Live 操作检查并操控*正在运行*的游戏。** 这些操作会运行项目的**主场景**，所以先通过
+Godot 的 `application/run/main_scene` 项目设置（也就是编辑器里的
+*Application → Run → Main Scene*）把它指向你刚构建好的那个场景，然后启动 daemon
+（macOS/Linux，Godot 4.6+）：
 
 ```bash
 gda project set application/run/main_scene --value res://scenes/main.tscn --json  # a Godot project setting key
@@ -170,19 +172,23 @@ gda daemon stop
 <a id="choose-your-integration"></a>
 ## 选择你的集成方式
 
-`gda` 用三种方式暴露**同一套命令界面**——你的 agent（或你自己）支持哪种就用哪种：
+`gda` 通过三种互补的接入方式提供同一套操作能力。可以使用 CLI、Agent Skill、MCP server，
+也可以组合使用，以适配你的工作流。无论如何接入，底层操作与结构化结果都保持一致。
 
-| 入口 | 适合 | 怎么用 |
+还不确定哪种方式适合你的工作流？参见
+[Godot MCP、CLI 与 Agent Skill 对比](https://aigengame.xyz/zh/godot-mcp/)。
+
+| 接入方式 | 适合 | 怎么用 |
 | --- | --- | --- |
 | **CLI**（`gda`） | 人类、shell 脚本、CI，以及能运行命令的 agent | `gda <group> <command> --json` |
-| **Skill**（`gda skill`） | 支持 Agent Skills、偏好省 token 的 CLI 工作流的编程 agent | 打印/安装 `SKILL.md`（见下文） |
-| **MCP**（`gda-mcp`） | 通过 Model Context Protocol 调用工具的 agent | 运行 stdio 服务器（见下文） |
+| **Agent Skill**（`gda skill`） | 支持 Agent Skills、偏好省 token 的 CLI 工作流的 Coding Agent | 打印或安装内置指导（见下文） |
+| **MCP**（`gda-mcp`） | 能够发现并调用工具的 MCP 兼容客户端 | 运行 stdio server（见下文） |
 
-### 作为 Skill 使用
+### 使用 Agent Skill
 
-`gda` 附带一个 agent **Skill**——一份 `SKILL.md`，教 AI agent *何时*以及*如何*使用 CLI 操控
-Godot。这是最轻量的接入方式（没有服务器要注册），随包附带，并与你的安装版本锁定。把它打印出来，
-或安装到你的 agent 的 skills 目录里：
+`gda` 内置 **Agent Skill**，指导 AI Agent *何时*以及*如何*通过 CLI 操控 Godot。适合支持
+Agent Skills、需要可复用指导且不想注册服务器的 Coding Agent。其指导内容与已安装的 `gda`
+版本保持一致。可以将它打印出来，或安装到 Agent 的 skills 目录：
 
 ```bash
 gda skill                                              # print SKILL.md (redirect it anywhere)
@@ -190,18 +196,19 @@ gda skill --install --provider claude --scope user     # resolve a known agent's
 gda skill --install --dir ~/.claude/skills/gda         # …or give the directory yourself
 ```
 
-[Skill 配方](gda-skill.md) 列出了每个 agent 的 skills 目录。或者直接从仓库获取同一个文件——
-你仍然需要安装 `gda`，因为 Skill 靠它来驱动：
+[Agent Skill 配方](gda-skill.md)列出了不同 Agent 的 skills 目录。也可以直接从仓库获取同一文件——
+你仍然需要安装 `gda`，因为 Agent Skill 会调用它的 CLI：
 
 ```bash
 curl --create-dirs -o ~/.claude/skills/gda/SKILL.md \
   https://raw.githubusercontent.com/aigengame/godot-agent/main/src/gda/skill/SKILL.md
 ```
 
-### 作为 MCP 服务器使用
+### 使用 MCP server
 
-`gda` 在 `[mcp]` 这个 extra 之下附带了一个 stdio [MCP](https://modelcontextprotocol.io) 服务器，
-因此任何 MCP agent（Claude Code、Codex、Cursor 等）都能操控 Godot。无需安装即可一试：
+`gda-mcp` 是面向兼容客户端的内置 Godot MCP server。它通过 stdio 实现
+[Model Context Protocol](https://modelcontextprotocol.io)，并由 `[mcp]` extra 提供。
+无需永久安装即可通过 `uvx` 运行：
 
 ```bash
 uvx --from "gda[mcp]" gda-mcp
@@ -304,17 +311,20 @@ Cursor 没有 `mcp add` 命令——请通过上面的 JSON 或 Settings → MCP
 <a id="how-it-works"></a>
 ## 工作原理
 
-`gda` 由三个组件构成，以两种模式覆盖各类操作：
+`gda` 是一个 Godot 自动化工具链，包含三个组件和两种互补的操作模式：
 
-| 组件             | 职责                                                                  |
-| ---------------- | --------------------------------------------------------------------- |
-| **`gda`**        | 面向 agent 的 CLI——以结构化的 `--json` 输出暴露 Godot。 |
-| **`gda-mcp`**    | 一个 MCP 服务器，从 `--schema` 出发，把同一套操作以工具形式暴露。 |
-| **`gda-daemon`** | 一个按项目运行的进程，为 Live 操作守护一个正在运行的游戏。 |
+| 组件             | 职责 |
+| ---------------- | ---- |
+| **`gda`**        | 以 CLI 直接执行 Godot 操作并返回结构化的 `--json` 结果。 |
+| **`gda-mcp`**    | 根据 `--schema` 将相同的操作和结构化结果映射为 MCP 工具。 |
+| **`gda-daemon`** | 按项目监督运行中的游戏，以支持 Live 操作。 |
 
-- **Headless 操作**一次性运行——没有 daemon、无需安装任何东西（创建场景、编辑脚本、导出、分析）。
+- **Headless 操作**一次性运行——没有 daemon、无需安装任何东西（创建场景、编辑脚本、
+  校验或启动场景、导出、分析）。
 - **Live 操作**需要一个正在运行的游戏——`gda-daemon` 启动它、注入一个默认处于休眠状态的游戏内 harness，
-  并通过 Unix 域套接字中转请求（运行时树、输入、截图、性能、诊断）。
+  并通过 Unix 域套接字中转请求（运行时树、输入、画面捕获、性能、诊断）。
+
+Headless 验证确认项目就绪状态；Live 操作返回用于验证实际行为的运行时证据。
 
 `gda-daemon` 注入的游戏内 harness **仅用于开发**：`gda export run` 会把它从产物中彻底剥离；
 而即便用其他方式构建（编辑器 GUI、直接执行 `godot --export`），它在导出后的游戏里也会自动禁用——

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=52dae55852b715d695d1cb49789dca82a930f5fab9f3ac2302f95df7305cbab1 -->
+<!-- gda-readme-i18n: source=README.md sha256=a7f521f06441d07917e5e56ee6630e5caf08b50979afc0cc93a0748cf87e9bb4 -->
 
 # gda — 面向 AI Agent 的 Godot 自动化
 
@@ -151,7 +151,7 @@ gda scene get scenes/main.tscn --json
 > 没有项目？`gda` 仍可在普通文件系统路径上以**无项目（projectless）**方式运行（路径相对于你的当前目录）——
 > 只有 `res://` 解析才需要项目。参见[配置](#configuration)。
 
-**使用 Live 操作检查并操控*正在运行*的游戏。** 这些操作会运行项目的**主场景**，所以先通过
+**使用 Live 操作检查*正在运行*的游戏。** 这些操作会运行项目的**主场景**，所以先通过
 Godot 的 `application/run/main_scene` 项目设置（也就是编辑器里的
 *Application → Run → Main Scene*）把它指向你刚构建好的那个场景，然后启动 daemon
 （macOS/Linux，Godot 4.6+）：
@@ -316,10 +316,10 @@ Cursor 没有 `mcp add` 命令——请通过上面的 JSON 或 Settings → MCP
 | 组件             | 职责 |
 | ---------------- | ---- |
 | **`gda`**        | 以 CLI 直接执行 Godot 操作并返回结构化的 `--json` 结果。 |
-| **`gda-mcp`**    | 根据 `--schema` 将相同的操作和结构化结果映射为 MCP 工具。 |
+| **`gda-mcp`**    | 根据 `--schema` 生成 MCP 工具，调用相同的操作并返回其结构化结果。 |
 | **`gda-daemon`** | 按项目监督运行中的游戏，以支持 Live 操作。 |
 
-- **Headless 操作**一次性运行——没有 daemon、无需安装任何东西（创建场景、编辑脚本、
+- **Headless 操作**以一次性进程运行——无需安装 daemon 或编辑器插件（创建场景、编辑脚本、
   校验或启动场景、导出、分析）。
 - **Live 操作**需要一个正在运行的游戏——`gda-daemon` 启动它、注入一个默认处于休眠状态的游戏内 harness，
   并通过 Unix 域套接字中转请求（运行时树、输入、画面捕获、性能、诊断）。

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=a7f521f06441d07917e5e56ee6630e5caf08b50979afc0cc93a0748cf87e9bb4 -->
+<!-- gda-readme-i18n: source=README.md sha256=9ee455d8eacbad676baab58de7bf10903ba66bc48f64fb0c59f41c0a7cf92d54 -->
 
 # gda — 面向 AI Agent 的 Godot 自动化
 
@@ -151,7 +151,7 @@ gda scene get scenes/main.tscn --json
 > 没有项目？`gda` 仍可在普通文件系统路径上以**无项目（projectless）**方式运行（路径相对于你的当前目录）——
 > 只有 `res://` 解析才需要项目。参见[配置](#configuration)。
 
-**使用 Live 操作检查*正在运行*的游戏。** 这些操作会运行项目的**主场景**，所以先通过
+**使用 Live 操作检查并操控*正在运行*的游戏。** 这些操作会运行项目的**主场景**，所以先通过
 Godot 的 `application/run/main_scene` 项目设置（也就是编辑器里的
 *Application → Run → Main Scene*）把它指向你刚构建好的那个场景，然后启动 daemon
 （macOS/Linux，Godot 4.6+）：
@@ -316,7 +316,7 @@ Cursor 没有 `mcp add` 命令——请通过上面的 JSON 或 Settings → MCP
 | 组件             | 职责 |
 | ---------------- | ---- |
 | **`gda`**        | 以 CLI 直接执行 Godot 操作并返回结构化的 `--json` 结果。 |
-| **`gda-mcp`**    | 根据 `--schema` 生成 MCP 工具，调用相同的操作并返回其结构化结果。 |
+| **`gda-mcp`**    | 将相同的操作和结构化结果映射到由 `--schema` 生成的 MCP 工具。 |
 | **`gda-daemon`** | 按项目监督运行中的游戏，以支持 Live 操作。 |
 
 - **Headless 操作**以一次性进程运行——无需安装 daemon 或编辑器插件（创建场景、编辑脚本、


### PR DESCRIPTION
Aligns Installation, Quick start, Choose your integration, and How it works with the gda Repository and Website Collaboration Charter. Adds an explicit Headless validation step, clarifies the three complementary access paths, and frames gda as one Godot automation toolchain. Synchronizes English, Simplified Chinese, Spanish, and Japanese README copy. Validation: README translation sync tests (6 passed); gda scene validate --help.