### PR TITLE
feat(gda): align package metadata with product positioning

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -397,10 +397,11 @@ _Avoid_: command spec, command config, command registry entry
 The single authoritative core phrase naming what `gda` *is* — "Godot automation for AI
 agents" — front-loading the product category, engine, and audience. The README **H1** uses
 that phrase in Title Case. The `pyproject` and GitHub repository descriptions lead with the
-same phrase and extend it with the three access paths and the main verification capabilities:
-"Godot automation for AI agents through a CLI, Agent Skill, and MCP server, with structured
-results, headless validation, and live runtime control." These three surfaces change together
-and must not drift. The phrase names an automation toolchain, not an agent.
+same phrase and extend it with the primary user outcome, three access paths, structured results,
+and the two operation modes: "Godot automation for AI agents to build and verify projects through
+a CLI, Agent Skill, or MCP server, with structured results, headless operations, and live runtime
+control." These three surfaces change together and must not drift. The phrase names an automation
+toolchain, not an agent.
 _Avoid_: tagline, slogan, hero, the value sentence
 
 **Brand slogan**:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "gda"
 version = "0.13.0"
-description = "Godot automation for AI agents through a CLI, Agent Skill, and MCP server, with structured results, headless validation, and live runtime control."
+description = "Godot automation for AI agents to build and verify projects through a CLI, Agent Skill, or MCP server, with structured results, headless operations, and live runtime control."
 readme = "README.md"
 authors = [
     { name = "haihong.qin", email = "haihongqin@gmail.com" }
 ]
 license = "MIT"
 license-files = ["LICENSE"]
-keywords = ["godot", "godot-engine", "godot-ai", "godot-mcp", "cli", "mcp", "model-context-protocol", "ai-agent", "coding-agent", "agent", "agent-skill", "skill", "gdscript", "structured-output", "game-development", "automation", "llm"]
+keywords = ["godot", "godot-engine", "godot-ai", "godot-mcp", "cli", "mcp", "mcp-server", "model-context-protocol", "ai-agent", "coding-agent", "agent", "agent-skill", "skill", "gdscript", "structured-output", "headless", "runtime-verification", "game-development", "automation", "llm"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",


### PR DESCRIPTION
Align the package description with the GitHub About text and positioning authority. Add focused PyPI discovery keywords for MCP server, headless operation, and runtime verification. Validation: uv build succeeded, and the wheel metadata contains the expected summary, keywords, and project URLs.