### PR TITLE
feat(gda): curate the script --path and --strict near misses (#851)

### DIFF
--- a/src/gda/hints.py
+++ b/src/gda/hints.py
@@ -144,6 +144,31 @@ NEAR_MISSES: dict[tuple[str, ...], NearMiss] = {
         "`script run` takes the script as its positional argument, "
         "project-relative or `res://`",
     ),
+    # GDA-DF-069: the same positional form, missed under a SECOND spelling. Keyed
+    # separately and correcting to the same invocation ON PURPOSE — the table keys on
+    # the spelling a caller typed, and the record shows both — so this row is not a
+    # duplicate to fold into the one above.
+    ("script", "run", "--path"): NearMiss(
+        "gda script run <path>",
+        "`script run` takes the script as its positional argument, "
+        "project-relative or `res://`",
+    ),
+    # GDA-DF-069: `--path VALUE` maps exactly onto `validate`'s positional PATH, which
+    # takes several paths for one batched engine launch.
+    ("script", "validate", "--path"): NearMiss(
+        "gda script validate <path>",
+        "`script validate` takes the scripts as its positional arguments, "
+        "project-relative or `res://` — or `--all` for the whole project",
+    ),
+    # PIPE-DF-165: `--strict` carried over from `script run`, where it is the
+    # failing-exit gate (ADR-0031). `validate` has no such gate, and saying so is the
+    # correction — so the contract goes in the message, never in the `hint`, which is
+    # the corrected invocation and nothing else.
+    ("script", "validate", "--strict"): NearMiss(
+        "gda script validate <path>",
+        "validate reports 'valid' per script and an aggregate under --all; the "
+        "failing-exit gate is 'script run --strict'",
+    ),
 }
 
 

--- a/src/gda/hints.py
+++ b/src/gda/hints.py
@@ -8,7 +8,8 @@ It is a difflib guess rendered into the human message, so it stays unparseable, 
 is silent whenever the typo is not string-similar (`inspect` is nothing like `get`),
 and similarity is not intent: the nearest *string* can be a different — even
 opposite — operation. So the mapping here is CURATED: one row per spelling the
-record actually showed, each naming the supported invocation.
+record actually showed — plus, where a row says so, the sibling spelling of one, when
+the same slip reaches a second command — each naming the supported invocation.
 
 This module owns two things, which are the two halves of one job:
 
@@ -96,7 +97,8 @@ class NearMiss:
 
 # The curated table. The key is the command path the token was rejected under —
 # empty for the root — plus the token itself, so the same word can mean different
-# things in different groups. One row per spelling the dogfooding record showed.
+# things in different groups. One row per spelling the dogfooding record showed, or
+# per the sibling spelling of one where the row states that.
 NEAR_MISSES: dict[tuple[str, ...], NearMiss] = {
     # GDA-DF-025: `inspect` is not a gda verb; the read verb is `get` in every group.
     ("scene", "inspect"): NearMiss(
@@ -144,10 +146,11 @@ NEAR_MISSES: dict[tuple[str, ...], NearMiss] = {
         "`script run` takes the script as its positional argument, "
         "project-relative or `res://`",
     ),
-    # GDA-DF-069: the same positional form, missed under a SECOND spelling. Keyed
-    # separately and correcting to the same invocation ON PURPOSE — the table keys on
-    # the spelling a caller typed, and the record shows both — so this row is not a
-    # duplicate to fold into the one above.
+    # Not in the record itself: GDA-DF-069 showed the second spelling on `validate`;
+    # it is curated onto `run` too because the same caller mistake reaches both
+    # commands. Keyed separately and correcting to the same invocation ON PURPOSE —
+    # the table keys on the spelling typed — so this row is not a duplicate to fold
+    # into the one above.
     ("script", "run", "--path"): NearMiss(
         "gda script run <path>",
         "`script run` takes the script as its positional argument, "
@@ -160,14 +163,17 @@ NEAR_MISSES: dict[tuple[str, ...], NearMiss] = {
         "`script validate` takes the scripts as its positional arguments, "
         "project-relative or `res://` — or `--all` for the whole project",
     ),
-    # PIPE-DF-165: `--strict` carried over from `script run`, where it is the
-    # failing-exit gate (ADR-0031). `validate` has no such gate, and saying so is the
-    # correction — so the contract goes in the message, never in the `hint`, which is
-    # the corrected invocation and nothing else.
+    # PIPE-DF-165: `--strict` carried over from `script run`, where it gates that
+    # run's own non-zero exit status (ADR-0031). `validate` answers a different
+    # question — it reports the verdict and exits 0 either way — so the correction has
+    # to say what to read instead. That contract goes in the message, never in the
+    # `hint`, which is the corrected invocation and nothing else.
     ("script", "validate", "--strict"): NearMiss(
         "gda script validate <path>",
-        "validate reports 'valid' per script and an aggregate under --all; the "
-        "failing-exit gate is 'script run --strict'",
+        "`validate` reports a per-script and an aggregate `valid` — for one path, "
+        "several, or `--all` — and exits 0 either way, so gate on `valid`; "
+        "`--strict` belongs to `script run`, where it fails the run on the script's "
+        "own non-zero exit status",
     ),
 }
 

--- a/tests/cli/test_unknown_invocation.py
+++ b/tests/cli/test_unknown_invocation.py
@@ -174,16 +174,20 @@ def test_each_dogfooded_option_spelling_names_the_positional_form(args, hint):
 
 # The clause the `--strict` refusal must carry: `hint` is the corrected invocation
 # and nothing else, so the difference between the two `--strict`s is stated in the
-# MESSAGE, which both renderings carry.
-STRICT_CLAUSE = "the failing-exit gate is 'script run --strict'"
+# MESSAGE, which both renderings carry. Pinned in two halves, since the message the
+# caller reads must both name what to gate on and place the flag they typed.
+STRICT_VERDICT = "exits 0 either way, so gate on `valid`"
+STRICT_FLAG = "`--strict` belongs to `script run`"
 
 
 def test_the_strict_near_miss_states_the_contract_in_both_renderings():
     # PIPE-DF-165: the caller carried `--strict` over from `script run`, so naming the
     # positional form is not enough — the message says what `validate` reports instead
-    # and where the failing-exit gate lives. Under `--json` that rides the envelope's
-    # message beside the machine-readable `hint`; without it, the same failure renders
-    # as lines with its own `hint:` line.
+    # (a `valid` verdict, at exit 0 whichever way it goes) and what the flag they typed
+    # really gates: `script run`'s own non-zero exit status (ADR-0031), a different
+    # question. Under `--json` that rides the envelope's message beside the
+    # machine-readable `hint`; without it, the same failure renders as lines with its
+    # own `hint:` line.
     structured = CliRunner().invoke(
         app, ["script", "validate", "--strict", "logic.gd", "--json"]
     )
@@ -191,14 +195,16 @@ def test_the_strict_near_miss_states_the_contract_in_both_renderings():
 
     error = _envelope(structured)
     assert error["hint"] == "gda script validate <path>"
-    assert STRICT_CLAUSE in error["message"]
+    assert STRICT_VERDICT in error["message"]
+    assert STRICT_FLAG in error["message"]
 
     assert human.exit_code == EXIT_USAGE
     assert not human.stdout.startswith("{")
     text = plain_text(human.output)
     assert text.startswith(f"error: {UNKNOWN_OPTION} (usage)\n")
     assert "hint: gda script validate <path>" in text
-    assert STRICT_CLAUSE in text
+    assert STRICT_VERDICT in text
+    assert STRICT_FLAG in text
 
 
 # --- the table is the single authority, and it stays honest -------------------

--- a/tests/cli/test_unknown_invocation.py
+++ b/tests/cli/test_unknown_invocation.py
@@ -164,7 +164,9 @@ def test_each_dogfooded_option_spelling_names_the_positional_form(args, hint):
     # positional argument, and `--strict` is `script run`'s gate alone. The refusal is
     # raised by the LEAF command's parser, which is the third interception site (after
     # the root's own parser and a group's). The two `script run` rows are a deliberate
-    # duplicate: the table keys on the SPELLING typed, and both were typed.
+    # duplicate: the table keys on the SPELLING typed. `--script` is the recorded one
+    # (GDA-DF-032); `--path` is curated beside it, because GDA-DF-069 recorded that
+    # spelling on `validate` and the same caller slip reaches both commands.
     result = CliRunner().invoke(app, [*args, "--json"])
 
     error = _envelope(result)

--- a/tests/cli/test_unknown_invocation.py
+++ b/tests/cli/test_unknown_invocation.py
@@ -134,17 +134,71 @@ def test_the_root_schema_option_points_at_the_schema_command():
     assert result.exit_code == EXIT_USAGE
 
 
-def test_script_run_script_option_points_at_the_positional_form():
-    # GDA-DF-032: `script run` takes the script as its positional argument. The
-    # refusal is raised by the LEAF command's parser, which is the third interception
-    # site (after the root's own parser and a group's).
-    result = CliRunner().invoke(
-        app, ["script", "run", "--script", "logic.gd", "--json"]
-    )
+@pytest.mark.parametrize(
+    "args, hint",
+    [
+        pytest.param(
+            ["script", "run", "--script", "logic.gd"],
+            "gda script run <path>",
+            id="script-run--script",
+        ),
+        pytest.param(
+            ["script", "run", "--path", "logic.gd"],
+            "gda script run <path>",
+            id="script-run--path",
+        ),
+        pytest.param(
+            ["script", "validate", "--path", "logic.gd"],
+            "gda script validate <path>",
+            id="script-validate--path",
+        ),
+        pytest.param(
+            ["script", "validate", "--strict", "logic.gd"],
+            "gda script validate <path>",
+            id="script-validate--strict",
+        ),
+    ],
+)
+def test_each_dogfooded_option_spelling_names_the_positional_form(args, hint):
+    # GDA-DF-032/069 and PIPE-DF-165: both `script` commands take their script as a
+    # positional argument, and `--strict` is `script run`'s gate alone. The refusal is
+    # raised by the LEAF command's parser, which is the third interception site (after
+    # the root's own parser and a group's). The two `script run` rows are a deliberate
+    # duplicate: the table keys on the SPELLING typed, and both were typed.
+    result = CliRunner().invoke(app, [*args, "--json"])
 
     error = _envelope(result)
     assert error["code"] == UNKNOWN_OPTION
-    assert error["hint"] == "gda script run <path>"
+    assert error["hint"] == hint
+
+
+# The clause the `--strict` refusal must carry: `hint` is the corrected invocation
+# and nothing else, so the difference between the two `--strict`s is stated in the
+# MESSAGE, which both renderings carry.
+STRICT_CLAUSE = "the failing-exit gate is 'script run --strict'"
+
+
+def test_the_strict_near_miss_states_the_contract_in_both_renderings():
+    # PIPE-DF-165: the caller carried `--strict` over from `script run`, so naming the
+    # positional form is not enough — the message says what `validate` reports instead
+    # and where the failing-exit gate lives. Under `--json` that rides the envelope's
+    # message beside the machine-readable `hint`; without it, the same failure renders
+    # as lines with its own `hint:` line.
+    structured = CliRunner().invoke(
+        app, ["script", "validate", "--strict", "logic.gd", "--json"]
+    )
+    human = CliRunner().invoke(app, ["script", "validate", "--strict", "logic.gd"])
+
+    error = _envelope(structured)
+    assert error["hint"] == "gda script validate <path>"
+    assert STRICT_CLAUSE in error["message"]
+
+    assert human.exit_code == EXIT_USAGE
+    assert not human.stdout.startswith("{")
+    text = plain_text(human.output)
+    assert text.startswith(f"error: {UNKNOWN_OPTION} (usage)\n")
+    assert "hint: gda script validate <path>" in text
+    assert STRICT_CLAUSE in text
 
 
 # --- the table is the single authority, and it stays honest -------------------


### PR DESCRIPTION
## Summary

Three curated rows in `gda.hints.NEAR_MISSES`, the one near-miss table (#670) — two
option spellings the dogfooding record shows, and one curated beside them — so that
each returns the corrected invocation in `hint` instead of a hintless `unknown_option`:

- `script validate --path` -> `gda script validate <path>` (GDA-DF-069)
- `script run --path` -> `gda script run <path>` (curated: GDA-DF-069 recorded that
  spelling on `validate` only, and the same caller slip reaches both commands)
- `script validate --strict` -> `gda script validate <path>`, with the contract
  clause in `because` (PIPE-DF-165)

The new `script run --path` row shares its correction with the existing `script run
--script` row (the two `validate` rows correct to `gda script validate <path>`).
Keeping both `script run` keys is deliberate — the table keys on the spelling a caller
typed — so a comment on the row says so, to stop a later reader "de-duplicating" it.

The `--strict` row is the one that needs prose: naming the positional form is not
enough when the caller carried a flag over from a sibling command, so `because` says
what `validate` answers instead and what the flag they typed really gates —
"`validate` reports a per-script and an aggregate `valid` — for one path, several, or
`--all` — and exits 0 either way, so gate on `valid`; `--strict` belongs to `script
run`, where it fails the run on the script's own non-zero exit status". That is the
clause #851 now carries, corrected 2026-09-05 from this PR's review (see the issue's
dated comment): the first wording called the aggregate `--all`-only and named `script
run --strict` the failing-exit gate for a validation verdict, and both were measured
false. It lives in the message and never in `hint`, which is contractually one
resolvable command line (ADR-0004, #670).

No mechanism change. `near_miss()` already keys an option on its command path — the
existing `("script", "run", "--script")` row is the precedent — so nothing outside
the table moved.

Closes #851

## Surface diff

| Surface | Change |
| --- | --- |
| `gda schema` | byte-identical, sha256 `80d21187cbef587be57faffffc68cc571e4f6148fb45874a7db76001e08b70e9` before and after |
| `gda script validate --help` | byte-identical, sha256 `80f4dafb076e193491228bc3fd303cff50106115c7a35c5d30ebbb66ce11fb4e` |
| `gda script run --help` | byte-identical, sha256 `204d91b936ae7e30ef306e3df97d3bd571086196ebc623c8ba7fed20a5796dbb` |
| command catalog / SKILL / README | none |

A hint is not part of any command's input contract, so the schema cannot move; the
byte comparison is the proof rather than an assertion. README and ADR-0002 already
describe the `hint` key generically ("a recognized near miss also carries the
supported invocation"), and neither enumerates the table, so no doc lists these rows.

## Red-proof evidence

Against the committed base (`3f68bf3fb`), all three exit `2` with `unknown_option`
and no `hint` key:

```
$ uv run --frozen gda script validate --path res://x.gd --json
{"error":{"category":"usage","code":"unknown_option","message":"`gda script validate` has no option `--path`; run `gda script validate --help` for the options it takes, or `gda script validate --schema` for its input contract","diagnostics":""}}
(exit=2)

$ uv run --frozen gda script run --path res://x.gd --json
{"error":{"category":"usage","code":"unknown_option","message":"`gda script run` has no option `--path`; run `gda script run --help` for the options it takes, or `gda script run --schema` for its input contract","diagnostics":""}}
(exit=2)

$ uv run --frozen gda script validate --strict a.gd --json
{"error":{"category":"usage","code":"unknown_option","message":"`gda script validate` has no option `--strict`; run `gda script validate --help` for the options it takes, or `gda script validate --schema` for its input contract","diagnostics":""}}
(exit=2)
```

Without `--json` the base printed click's own message, because gda declines to
answer where it has no advice and no JSON was asked for:

```
$ uv run --frozen gda script validate --strict a.gd
Usage: gda script validate [OPTIONS] [PATHS]...
Try 'gda script validate --help' for help.
| Error |
| No such option: --strict |
(exit=2)
```

The tests were written against that base and failed there:

```
$ uv run --frozen pytest tests/cli/test_unknown_invocation.py -q -p no:cacheprovider
FAILED tests/cli/test_unknown_invocation.py::test_each_dogfooded_option_spelling_names_the_positional_form[script-run--path]
FAILED tests/cli/test_unknown_invocation.py::test_each_dogfooded_option_spelling_names_the_positional_form[script-validate--path]
FAILED tests/cli/test_unknown_invocation.py::test_each_dogfooded_option_spelling_names_the_positional_form[script-validate--strict]
FAILED tests/cli/test_unknown_invocation.py::test_the_strict_near_miss_states_the_contract_in_both_renderings
4 failed, 22 passed in 1.03s
```

(The fourth failure is the `KeyError: 'hint'` the envelope raises for `--strict`.)

## Validation

Host: macOS 26.6.1, arm64, Godot not involved. All commands run from the worktree
with the repository runtime (`uv run --frozen`, `gda 0.14.0` from this checkout).

| Gate | Result |
| --- | --- |
| `uv run --frozen pytest tests -m "not e2e" -q -p no:cacheprovider` | `2458 passed, 650 deselected in 50.79s` (2454 was the pre-slice baseline; +4 are the cases added here) |
| `uv run --frozen pytest tests/cli -q -p no:cacheprovider` | `408 passed in 8.30s` |
| `uv run --frozen ruff check .` | `All checks passed!` |
| `uv run --frozen ruff format --check .` | `508 files already formatted` |
| `uv run --frozen pyright` | `0 errors, 0 warnings, 0 informations` |

Re-run in full on the review-fix head; `gda schema` re-checked there and still
`80d21187cbef587be57faffffc68cc571e4f6148fb45874a7db76001e08b70e9`.

**No Godot e2e was run, deliberately.** This slice touches the near-miss table only.
Every one of these refusals is decided by the click parser before any operation
dispatches, so the path spawns no engine — the four `unknown_option` invocations
above return in milliseconds with no Godot binary involved. There is nothing an e2e
tier could observe here that the CLI-level tests do not.

## Requirement conformance

**AC1 — the three invocations return `unknown_option` with the corrected invocation
as `hint`; for `--strict` the message carries the contract clause, in both
renderings.** On this head:

```
$ uv run --frozen gda script validate --path res://x.gd --json
{"error":{"category":"usage","code":"unknown_option","message":"`gda script validate` has no option `--path`. Use `gda script validate <path>` instead: `script validate` takes the scripts as its positional arguments, project-relative or `res://` — or `--all` for the whole project","diagnostics":"","hint":"gda script validate <path>"}}

$ uv run --frozen gda script run --path res://x.gd --json
{"error":{"category":"usage","code":"unknown_option","message":"`gda script run` has no option `--path`. Use `gda script run <path>` instead: `script run` takes the script as its positional argument, project-relative or `res://`","diagnostics":"","hint":"gda script run <path>"}}

$ uv run --frozen gda script validate --strict a.gd --json
{"error":{"category":"usage","code":"unknown_option","message":"`gda script validate` has no option `--strict`. Use `gda script validate <path>` instead: `validate` reports a per-script and an aggregate `valid` — for one path, several, or `--all` — and exits 0 either way, so gate on `valid`; `--strict` belongs to `script run`, where it fails the run on the script's own non-zero exit status","diagnostics":"","hint":"gda script validate <path>"}}
```

The human rendering of the same three, at the same exit `2` — the `hint:` line is
the shared failure renderer's, unchanged (#685), and the contract clause is in the
message on both sides:

```
$ uv run --frozen gda script validate --strict a.gd
error: unknown_option (usage)
`gda script validate` has no option `--strict`. Use `gda script validate <path>` instead: `validate` reports a per-script and an aggregate `valid` — for one path, several, or `--all` — and exits 0 either way, so gate on `valid`; `--strict` belongs to `script run`, where it fails the run on the script's own non-zero exit status
hint: gda script validate <path>

$ uv run --frozen gda script validate --path res://x.gd
error: unknown_option (usage)
`gda script validate` has no option `--path`. Use `gda script validate <path>` instead: `script validate` takes the scripts as its positional arguments, project-relative or `res://` — or `--all` for the whole project
hint: gda script validate <path>

$ uv run --frozen gda script run --path res://x.gd
error: unknown_option (usage)
`gda script run` has no option `--path`. Use `gda script run <path>` instead: `script run` takes the script as its positional argument, project-relative or `res://`
hint: gda script run <path>
```

Pinned by `test_each_dogfooded_option_spelling_names_the_positional_form` (the four
option spellings, including the pre-existing `--script` one) and
`test_the_strict_near_miss_states_the_contract_in_both_renderings` (both renderings
of the `--strict` refusal in one test, so the two cannot drift apart). That test pins
the clause by its two halves — what to gate on (`exits 0 either way, so gate on
`valid``) and where the typed flag belongs (``--strict` belongs to `script run``) —
rather than by one long string, so a rewording that dropped either half fails.

**AC2 — the hint-table test re-resolves the new entries against the live command
tree and passes.** `test_every_curated_hint_names_a_real_invocation` walks the live
Typer tree for every row; it needed no change, since it already strips `<...>`
placeholders for the existing `gda script run <path>` row. It passes with the three
new rows in the table, which is what proves `gda script validate <path>` names a
real command.

## Disclosed extras / boundary crossings

- The existing `test_script_run_script_option_points_at_the_positional_form` was
  folded into the new parametrized test as its first case rather than left beside a
  near-identical sibling. Same assertion, same coverage, one comment; the `--script`
  row's behaviour is unchanged.
- The `--strict` `because` was rewritten after the independent review, in the table's
  backtick style, and #851's body was amended to match (dated comment, 2026-09-05).
  The two facts it now states were measured, not reasoned: `script validate ok.gd
  broken.gd --json` returns the aggregate `valid` with no `--all`, and `script
  validate` on a broken script is a SUCCESS result with `valid: false` at exit 0.
- The `script run --path` row's comment says truthfully why the row exists: GDA-DF-069
  recorded that spelling on `validate` only, so `run` is a curated sibling, not a
  recorded miss. The module docstring and the table header claimed "one row per
  spelling the record showed", which that row would have contradicted, so both admit
  the curated sibling in one clause.
- Not changed, per the review's own adjudication: the `validate --path` `because` does
  not mention absolute paths.
- Files touched: `src/gda/hints.py` and `tests/cli/test_unknown_invocation.py`, and
  nothing else.


## Review round 2 (`52ca13795`)

The second independent review returned one P3 and no code finding: the Summary, the
#851 sentence and the test comment attributed all three spellings to the record, while
`hints.py` correctly calls `script run --path` a curated sibling. Adopted — the Summary
above, the test comment and #851 (dated correction + comment, 2026-09-06) now make the
recorded-versus-curated distinction the row itself makes. No source change; `gda schema`
still `80d21187cbef587be57faffffc68cc571e4f6148fb45874a7db76001e08b70e9`.

## Review round 3 (no new head)

The re-review of `52ca13795` confirmed the provenance fix and found one adjacent P3: the
Summary said TWO of the three new rows share the existing `script run --script` row's
correction; only `script run --path` does, the two `validate` rows correcting to
`gda script validate <path>`. Corrected in the Summary above. PR body only — no source,
test or issue text makes the claim.
