### PR TITLE
feat(gda): bound `game tree` with --root and --max-depth (#849)

### DIFF
--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -1322,16 +1322,18 @@ re-derives every verdict from a running engine.
   [`node`](#node).
 
 - **`game` (the running game's scene graph):** `game tree` reads the runtime scene
-  tree (shipped — the Phase-2 bootstrap tracer, #7), bounded on request by `--root
-  <runtime path>` (the subtree to serialize; an unknown path is `live_node_not_found`)
-  and `--max-depth N` (0 = the addressed node alone) — shipped, #849, from GDA-DF-052,
-  where an unfiltered read of a production UI exceeded the client's budget and was
-  truncated by IT, which a caller cannot tell from a complete read. What a bound leaves
-  out is counted rather than dropped: `omitted_nodes` totals the unserialized nodes at
-  every depth, `truncated` is that total above zero, and a node whose children were not
-  walked carries `children_omitted` — its DIRECT children only, and the key is absent
-  when nothing was omitted, so the unbounded read pays nothing per node. Unbounded stays
-  the default and the caller's choice; the follow-up read is a narrower `--root`, not a
+  tree (shipped — the Phase-2 bootstrap tracer, #7) from the running current scene
+  (`/root` only when none is current — an autoload is that scene's sibling, so seeing
+  one takes `--root /root`), bounded on request by `--root <runtime path>` (the subtree
+  to serialize; an unknown path is `live_node_not_found`) and `--max-depth N` (0 = the
+  addressed node alone) — shipped, #849, from GDA-DF-052, where an unfiltered read of a
+  production UI exceeded the client's budget and was truncated by IT, which a caller
+  cannot tell from a complete read. What a bound leaves out of the selected subtree is
+  counted rather than dropped: `omitted_nodes` totals the unserialized nodes at every
+  depth, `truncated` is that total above zero, and a node whose children were not walked
+  carries `children_omitted` — its DIRECT children only, and the key is absent when
+  nothing was omitted, so the unbounded read pays nothing per node. Unbounded stays the
+  default and the caller's choice; the follow-up read is a narrower `--root`, not a
   continuation token, which would page a snapshot the live tree has already left behind.
   Runtime node property `game get` /
   `game set` (shipped, #220, extended by #422/#473) read and mutate a running node's live

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -1322,7 +1322,18 @@ re-derives every verdict from a running engine.
   [`node`](#node).
 
 - **`game` (the running game's scene graph):** `game tree` reads the runtime scene
-  tree (shipped — the Phase-2 bootstrap tracer, #7); runtime node property `game get` /
+  tree (shipped — the Phase-2 bootstrap tracer, #7), bounded on request by `--root
+  <runtime path>` (the subtree to serialize; an unknown path is `live_node_not_found`)
+  and `--max-depth N` (0 = the addressed node alone) — shipped, #849, from GDA-DF-052,
+  where an unfiltered read of a production UI exceeded the client's budget and was
+  truncated by IT, which a caller cannot tell from a complete read. What a bound leaves
+  out is counted rather than dropped: `omitted_nodes` totals the unserialized nodes at
+  every depth, `truncated` is that total above zero, and a node whose children were not
+  walked carries `children_omitted` — its DIRECT children only, and the key is absent
+  when nothing was omitted, so the unbounded read pays nothing per node. Unbounded stays
+  the default and the caller's choice; the follow-up read is a narrower `--root`, not a
+  continuation token, which would page a snapshot the live tree has already left behind.
+  Runtime node property `game get` /
   `game set` (shipped, #220, extended by #422/#473) read and mutate a running node's live
   properties — the live counterparts of headless `node get` / `node set`, applying the
   **same** value-coercion table and returning the observed read-back value plus

--- a/src/gda/commands/game.py
+++ b/src/gda/commands/game.py
@@ -20,8 +20,13 @@ import json
 from typing import Any, Optional
 
 import typer
-from pydantic import BaseModel, ConfigDict, Field, model_serializer
-from pydantic_core.core_schema import SerializerFunctionWrapHandler
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SerializerFunctionWrapHandler,
+    model_serializer,
+)
 
 from gda.dispatch import dispatch_domain, params_or_bad_parameter
 from gda.execution import ExecutionKind
@@ -593,10 +598,11 @@ def game_tree(
     max_depth: Optional[int] = typer.Option(
         None,
         "--max-depth",
+        min=0,
         help=(
-            "Read at most this many levels below the root (0 = the root alone). "
-            "Unset is an unbounded read of the whole subtree, which on a large "
-            "tree is the caller's choice."
+            "Read at most this many levels below the root (0 = the root alone); "
+            "must be >= 0. Unset is an unbounded read of the whole subtree, "
+            "which on a large tree is the caller's choice."
         ),
     ),
     json_output: bool = json_option(),

--- a/src/gda/commands/game.py
+++ b/src/gda/commands/game.py
@@ -103,10 +103,13 @@ class GameNode(BaseModel):
 class GameTreeParams(RelayedLiveParams):
     """The params of ``gda game tree``: read the running game's runtime scene tree (#849).
 
-    Unbounded by default — the whole runtime tree of the engine session held by
-    ``gda-daemon``, which on a production UI is a very large result. ``root``
-    narrows the read to one subtree and ``max_depth`` bounds how deep it goes;
-    what a bound leaves out is COUNTED rather than silently dropped, so a partial
+    Unbounded by default, and rooted at the running CURRENT SCENE (``/root``
+    only when no scene is current) — the whole subtree below it, which on a
+    production UI is a very large result. An autoload is that scene's SIBLING
+    under ``/root``, so a read that must see one names ``root="/root"``;
+    ``root`` otherwise narrows the read to one subtree and ``max_depth`` bounds
+    how deep it goes. Both counters cover the SELECTED subtree only, and what a
+    bound leaves out of it is COUNTED rather than silently dropped, so a partial
     read is never mistaken for a complete one (see :class:`GameTreeResult`).
     """
 
@@ -115,8 +118,10 @@ class GameTreeParams(RelayedLiveParams):
         description=(
             "Serialize the subtree at this runtime (absolute) node path, as "
             "`game tree` itself reports it (e.g. /root/Main/HUD). Unset reads "
-            "the running current scene. A path that resolves to nothing is "
-            "`live_node_not_found`, the same refusal every other live op gives."
+            "the running current scene — an autoload is its SIBLING under "
+            "/root, so name /root to see one. A path that resolves to nothing "
+            "is `live_node_not_found`, the same refusal every other live op "
+            "gives."
         ),
     )
     max_depth: int | None = Field(
@@ -591,8 +596,9 @@ def game_tree(
         "--root",
         help=(
             "Read the subtree at this runtime node path, as `game tree` reports "
-            "it (absolute, e.g. /root/Main/HUD). Unset reads the current scene; "
-            "a path that resolves to nothing is `live_node_not_found`."
+            "it (absolute, e.g. /root/Main/HUD). Unset reads the current scene "
+            "(autoloads are its siblings: name /root to see them); a path that "
+            "resolves to nothing is `live_node_not_found`."
         ),
     ),
     max_depth: Optional[int] = typer.Option(
@@ -621,12 +627,14 @@ def game_tree(
     `live_unsupported_platform`. The platform/Godot-version precondition is the
     structured `constraints` field of `--schema` (ADR-0021), not restated here.
 
-    `--root` and `--max-depth` bound the read; without them it is unbounded, and
-    a production UI's whole tree is a very large result. What a bound leaves out
-    is counted, never silently dropped: the result carries `truncated` and
-    `omitted_nodes`, and each node whose children were not walked carries
-    `children_omitted`. Read bounded first, then address the nodes you want by
-    their exact path (`game get`, `game rect`, `game set`).
+    `--root` and `--max-depth` bound the read; without them it is unbounded and
+    rooted at the running current scene, and a production UI's whole tree is a
+    very large result. An autoload is that scene's sibling under `/root`, so a
+    read that must see one names `--root /root`. What a bound leaves out of the
+    selected subtree is counted, never silently dropped: the result carries
+    `truncated` and `omitted_nodes`, and each node whose children were not walked
+    carries `children_omitted`. Read bounded first, then address the nodes you
+    want by their exact path (`game get`, `game rect`, `game set`).
     """
     dispatch_domain(
         GAME_TREE_COMMAND,

--- a/src/gda/commands/game.py
+++ b/src/gda/commands/game.py
@@ -20,7 +20,8 @@ import json
 from typing import Any, Optional
 
 import typer
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_serializer
+from pydantic_core.core_schema import SerializerFunctionWrapHandler
 
 from gda.dispatch import dispatch_domain, params_or_bad_parameter
 from gda.execution import ExecutionKind
@@ -66,20 +67,88 @@ class GameNode(BaseModel):
     type: str
     path: str
     children: list["GameNode"] = []
+    children_omitted: int = Field(
+        default=0,
+        description=(
+            "How many of this node's DIRECT children the read did not serialize "
+            "because `max_depth` stopped it here (#849). ABSENT from the JSON "
+            "when it is 0: an unbounded read serializes every node, so it must "
+            "not pay one extra key per node for a bound it never had. Read it as "
+            "`node.get('children_omitted', 0)`; re-read that subtree with "
+            "`--root <this node's path>` to see what it left out."
+        ),
+    )
+
+    # The presence rule above is a SERIALIZATION rule, so it lives on the writer
+    # rather than on every caller: the field stays a plain int with a 0 default
+    # (a consumer reads a number, never None), and the key is dropped from the
+    # emitted JSON when nothing was omitted. `mode="wrap"` runs pydantic's own
+    # serializer first, so nested children are serialized — and pruned — by this
+    # same rule at every depth.
+    @model_serializer(mode="wrap")
+    def _omit_absent_omission_count(
+        self, handler: SerializerFunctionWrapHandler
+    ) -> dict[str, Any]:
+        rendered = handler(self)
+        if not rendered.get("children_omitted"):
+            rendered.pop("children_omitted", None)
+        return rendered
 
 
 class GameTreeParams(RelayedLiveParams):
-    """The params of ``gda game tree``: read the running game's runtime scene tree.
+    """The params of ``gda game tree``: read the running game's runtime scene tree (#849).
 
-    Empty — it reads the whole runtime tree of the engine session held by
-    ``gda-daemon`` (a subtree root may be added by a later slice).
+    Unbounded by default — the whole runtime tree of the engine session held by
+    ``gda-daemon``, which on a production UI is a very large result. ``root``
+    narrows the read to one subtree and ``max_depth`` bounds how deep it goes;
+    what a bound leaves out is COUNTED rather than silently dropped, so a partial
+    read is never mistaken for a complete one (see :class:`GameTreeResult`).
     """
+
+    root: str | None = Field(
+        default=None,
+        description=(
+            "Serialize the subtree at this runtime (absolute) node path, as "
+            "`game tree` itself reports it (e.g. /root/Main/HUD). Unset reads "
+            "the running current scene. A path that resolves to nothing is "
+            "`live_node_not_found`, the same refusal every other live op gives."
+        ),
+    )
+    max_depth: int | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Serialize at most this many levels BELOW the read's root: 0 is the "
+            "root node alone, 1 adds its children. Unset reads the whole "
+            "subtree — an unbounded read of a large tree is the caller's choice."
+        ),
+    )
 
 
 class GameTreeResult(BaseModel):
-    """The result of ``gda game tree``: the running game's runtime scene tree."""
+    """The result of ``gda game tree``: the running game's runtime scene tree (#849).
+
+    ``truncated`` and ``omitted_nodes`` are always present, so a bounded read
+    reports what it left out instead of looking like a complete one. They are the
+    ONLY difference an unbounded read shows: no node in it carries
+    ``children_omitted``.
+    """
 
     root: GameNode
+    truncated: bool = Field(
+        description=(
+            "Whether a bound stopped the read short — true exactly when "
+            "`omitted_nodes` is above 0. Always false for an unbounded read."
+        )
+    )
+    omitted_nodes: int = Field(
+        description=(
+            "How many nodes, at every depth, the read did not serialize. It "
+            "counts whole omitted subtrees, not just the direct children a node "
+            "reports in `children_omitted`, so it is the size of what is "
+            "missing from this result."
+        )
+    )
 
 
 class GameGetParams(RelayedLiveParams):
@@ -407,13 +476,22 @@ class GameCallResult(BaseModel):
 
 
 def render_game_tree(game: "GameTreeResult") -> str:
-    """Render the running game's runtime scene tree (ADR-0019).
+    """Render the running game's runtime scene tree (ADR-0019, #849).
 
     The runtime counterpart of ``render_scene_tree``: ``render_node_tree`` reads
     only ``name``/``type``/``children``, which a ``GameNode`` carries, so the
     runtime tree flows through the same indented outline as the on-disk scene.
+
+    A bounded read appends ONE trailing line with the omitted total, so the
+    outline cannot be read as a complete tree on the human channel either. The
+    shared outline itself is left alone: the per-node count is a ``game`` shape,
+    and teaching the tree renderer about it would change what the on-disk
+    ``scene``/``node`` trees print (ADR-0040 §5).
     """
-    return render_node_tree(game.root)
+    outline = render_node_tree(game.root)
+    if not game.truncated:
+        return outline
+    return f"{outline}\ntruncated: {game.omitted_nodes} nodes omitted"
 
 
 def render_game_get(got: "GameGetResult") -> str:
@@ -503,6 +581,24 @@ _app = typer.Typer(
 
 @_app.command(name="tree", cls=GAME_TREE_COMMAND.command_class())
 def game_tree(
+    root: Optional[str] = typer.Option(
+        None,
+        "--root",
+        help=(
+            "Read the subtree at this runtime node path, as `game tree` reports "
+            "it (absolute, e.g. /root/Main/HUD). Unset reads the current scene; "
+            "a path that resolves to nothing is `live_node_not_found`."
+        ),
+    ),
+    max_depth: Optional[int] = typer.Option(
+        None,
+        "--max-depth",
+        help=(
+            "Read at most this many levels below the root (0 = the root alone). "
+            "Unset is an unbounded read of the whole subtree, which on a large "
+            "tree is the caller's choice."
+        ),
+    ),
     json_output: bool = json_option(),
     schema: bool = GAME_TREE_COMMAND.schema_option(),
     params_json: Optional[str] = params_json_option(),
@@ -518,10 +614,17 @@ def game_tree(
     naming the remediation (`gda daemon start`); on an unsupported platform,
     `live_unsupported_platform`. The platform/Godot-version precondition is the
     structured `constraints` field of `--schema` (ADR-0021), not restated here.
+
+    `--root` and `--max-depth` bound the read; without them it is unbounded, and
+    a production UI's whole tree is a very large result. What a bound leaves out
+    is counted, never silently dropped: the result carries `truncated` and
+    `omitted_nodes`, and each node whose children were not walked carries
+    `children_omitted`. Read bounded first, then address the nodes you want by
+    their exact path (`game get`, `game rect`, `game set`).
     """
     dispatch_domain(
         GAME_TREE_COMMAND,
-        GameTreeParams(),
+        params_or_bad_parameter(GameTreeParams, root=root, max_depth=max_depth),
         json_output=json_output,
         godot=godot,
         project=project,

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -1829,10 +1829,12 @@ func _resolve_runtime_node(path: String) -> Node:
 	return get_tree().root.get_node_or_null(NodePath(path))
 
 
-# The ONE depth-bounded, counting tree serializer (#849) — the shape `game tree`
-# reports and the walk any later node-search op bounds itself with. `max_depth` is
-# the number of levels BELOW `node` to serialize: 0 stops at `node` itself, and a
-# NEGATIVE value is unbounded. `counts` is the caller's mutable accumulator
+# The ONE depth-bounded, counting tree serializer (#849): it renders `game tree`'s
+# NESTED subtree, so an op that reports a flat match list is a different walk and
+# does not call it — what such an op shares is the per-node shape (name/type/path)
+# and this depth-bounding + omitted-count contract, not this function. `max_depth`
+# is the number of levels BELOW `node` to serialize: 0 stops at `node` itself, and
+# a NEGATIVE value is unbounded. `counts` is the caller's mutable accumulator
 # (Dictionary, so it is shared by reference): its "omitted_nodes" entry grows by
 # every node this walk did not serialize, at every depth — the total the result
 # reports. A node whose children were left out carries `children_omitted`, the

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -383,7 +383,7 @@ func _run(request) -> Variant:
 		params = {}
 	match op:
 		OP_GAME_TREE:
-			return _handle_game_tree()
+			return _handle_game_tree(params)
 		OP_GAME_GET:
 			return _handle_game_get(params)
 		OP_GAME_RECT:
@@ -418,11 +418,38 @@ func _run(request) -> Variant:
 			return _error("operation_failed", "unsupported live operation")
 
 
-func _handle_game_tree() -> String:
-	var scene: Node = get_tree().current_scene
-	if scene == null:
-		scene = get_tree().root
-	return _ok({"root": _serialize(scene)})
+# game tree: serialize the running SceneTree, optionally BOUNDED (#849). Without
+# params it reports the whole current scene, as it always has. `root` names the
+# subtree to read by its absolute runtime path — an unknown one is the same
+# live_node_not_found every other live op reports for a path that resolves to
+# nothing, so an empty --root is a refusal here too rather than a silent whole-tree
+# read. `max_depth` bounds the walk (0 = the addressed node alone); absent, it is
+# unbounded, which stays the caller's choice on a large tree. Both counters ride
+# back so a partial read is never mistaken for a complete one.
+func _handle_game_tree(params: Dictionary) -> String:
+	var scene: Node
+	var root_param: Variant = params.get("root")
+	if root_param is String:
+		scene = _resolve_runtime_node(root_param)
+		if scene == null:
+			return _error(LIVE_ERROR_NODE_NOT_FOUND,
+					"no node at runtime path: " + String(root_param))
+	else:
+		scene = get_tree().current_scene
+		if scene == null:
+			scene = get_tree().root
+
+	# A missing bound is -1, the "unbounded" sentinel _serialize reads; the CLI
+	# refuses a negative --max-depth, so a caller cannot spell it.
+	var max_depth := _int_param(params, "max_depth", -1)
+	var counts := {"omitted_nodes": 0}
+	var tree := _serialize(scene, max_depth, counts)
+	var omitted := int(counts["omitted_nodes"])
+	return _ok({
+		"root": tree,
+		"truncated": omitted > 0,
+		"omitted_nodes": omitted,
+	})
 
 
 # game get: resolve a node by its ABSOLUTE runtime path (as game tree reports it,
@@ -1802,16 +1829,48 @@ func _resolve_runtime_node(path: String) -> Node:
 	return get_tree().root.get_node_or_null(NodePath(path))
 
 
-func _serialize(node: Node) -> Dictionary:
-	var children: Array = []
-	for child in node.get_children():
-		children.append(_serialize(child))
-	return {
+# The ONE depth-bounded, counting tree serializer (#849) — the shape `game tree`
+# reports and the walk any later node-search op bounds itself with. `max_depth` is
+# the number of levels BELOW `node` to serialize: 0 stops at `node` itself, and a
+# NEGATIVE value is unbounded. `counts` is the caller's mutable accumulator
+# (Dictionary, so it is shared by reference): its "omitted_nodes" entry grows by
+# every node this walk did not serialize, at every depth — the total the result
+# reports. A node whose children were left out carries `children_omitted`, the
+# count of its DIRECT children only; the key is ABSENT when nothing was omitted, so
+# an unbounded read carries no per-node weight for a bound it never had.
+func _serialize(node: Node, max_depth: int, counts: Dictionary) -> Dictionary:
+	var children: Array = node.get_children()
+	var serialized: Dictionary = {
 		"name": String(node.name),
 		"type": node.get_class(),
 		"path": String(node.get_path()),
-		"children": children,
+		"children": [],
 	}
+	if max_depth == 0:
+		if not children.is_empty():
+			serialized["children_omitted"] = children.size()
+			var omitted := 0
+			for child in children:
+				omitted += _subtree_size(child)
+			counts["omitted_nodes"] = int(counts["omitted_nodes"]) + omitted
+		return serialized
+	# Unbounded stays unbounded; a bound spends one level per descent.
+	var next_depth := max_depth if max_depth < 0 else max_depth - 1
+	var rendered: Array = []
+	for child in children:
+		rendered.append(_serialize(child, next_depth, counts))
+	serialized["children"] = rendered
+	return serialized
+
+
+# The number of nodes in `node`'s subtree, `node` included — what one omitted
+# child costs the result's omitted_nodes total. Counts only; it builds nothing,
+# so bounding a huge tree still pays a walk but not a serialization.
+func _subtree_size(node: Node) -> int:
+	var total := 1
+	for child in node.get_children():
+		total += _subtree_size(child)
+	return total
 
 
 # The ONE JSON writer for everything this harness sends back (#752). Godot's

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -1867,11 +1867,18 @@ func _serialize(node: Node, max_depth: int, counts: Dictionary) -> Dictionary:
 
 # The number of nodes in `node`'s subtree, `node` included — what one omitted
 # child costs the result's omitted_nodes total. Counts only; it builds nothing,
-# so bounding a huge tree still pays a walk but not a serialization.
+# so bounding a huge tree still pays a walk but not a serialization. The walk
+# keeps its OWN stack rather than recursing: a chain deeper than GDScript's call
+# stack (1024 frames by default) overflowed the recursive form, which then
+# returned a partial total that the op published as a successful read. Order
+# does not matter to a count, so the pending list is a plain LIFO.
 func _subtree_size(node: Node) -> int:
-	var total := 1
-	for child in node.get_children():
-		total += _subtree_size(child)
+	var total := 0
+	var pending: Array[Node] = [node]
+	while not pending.is_empty():
+		var current: Node = pending.pop_back()
+		total += 1
+		pending.append_array(current.get_children())
 	return total
 
 

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -87,7 +87,7 @@ HARNESS_ADDONS_RES_PATH = f"res://{HARNESS_ADDONS_DIR}"
 # copy to it (#225). The installed copy declares its version in a leading header
 # (`# gda-harness-version: <N>`); a mismatch re-materializes via the content
 # compare. NOT the package version — the harness changes far less often.
-HARNESS_VERSION = "19"
+HARNESS_VERSION = "20"
 
 _VERSION_HEADER_PREFIX = "# gda-harness-version:"
 _AUTOLOAD_HEADER = "[autoload]"

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -305,19 +305,23 @@ freeze-frame in an agent session, use `paused`, which live operations survive; a
 Every live op that ADDRESSES a node takes an exact runtime path, and `game tree` is how
 you learn one. Read it in TWO steps rather than dumping the whole tree:
 
-1. **Bound the read.** `gda game tree --max-depth 2 --json` shows the top levels; then
-   `gda game tree --root /root/Main/HUD --max-depth 2 --json` walks into the branch you
-   want. An unbounded `game tree` on a production UI is a very large result — it can
-   exceed your own context budget and be truncated by your client, and a truncated dump
-   cannot prove a node is absent.
+1. **Bound the read.** `gda game tree --max-depth 2 --json` shows the top levels of the
+   running CURRENT SCENE; then `gda game tree --root /root/Main/HUD --max-depth 2 --json`
+   walks into the branch you want. An autoload is not under the current scene but beside
+   it, so to discover one read `gda game tree --root /root --max-depth 1 --json`. An
+   unbounded `game tree` on a production UI is a very large result — it can exceed your
+   own context budget and be truncated by your client, and a truncated dump cannot prove
+   a node is absent.
 2. **Address exactly.** With the path in hand, use `game get` / `game rect` / `game set`
    / `game call` on that path. Do not re-read the tree per node.
 
 A bounded read says what it left out, so you never mistake it for a complete one:
-`omitted_nodes` counts every unserialized node at any depth, `truncated` is that count
-above zero, and a node whose children were not walked carries `children_omitted` (its
-direct children only; the key is absent when nothing was omitted). To see what a node
-hid, re-read with `--root <that node's path>`. There is no continuation token — a live
+`omitted_nodes` counts every unserialized node at any depth below the selected root,
+`truncated` is that count above zero, and a node whose children were not walked carries
+`children_omitted` (its direct children only; the key is absent when nothing was
+omitted). The counters cover the selected subtree alone — a complete current-scene read
+says nothing about its siblings. To see what a node hid, re-read with `--root <that
+node's path>`. There is no continuation token — a live
 tree changes between calls, so the follow-up is a narrower `--root`, not a resumed page.
 
 ### Structured logging from game code

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -302,8 +302,8 @@ freeze-frame in an agent session, use `paused`, which live operations survive; a
 
 ### Find a node before you address it
 
-Every live op takes an exact runtime path, and `game tree` is how you learn one. Read it
-in TWO steps rather than dumping the whole tree:
+Every live op that ADDRESSES a node takes an exact runtime path, and `game tree` is how
+you learn one. Read it in TWO steps rather than dumping the whole tree:
 
 1. **Bound the read.** `gda game tree --max-depth 2 --json` shows the top levels; then
    `gda game tree --root /root/Main/HUD --max-depth 2 --json` walks into the branch you

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -231,7 +231,7 @@ already-running daemon's lazy Engine-session launch; only the outer
 | Group | Commands |
 | ----- | -------- |
 | `daemon` | `start`, `wait-ready`, `stop`, `status`, `install`, `uninstall` (lifecycle; `start` installs the in-game harness itself, so `install` is only for doing that step deliberately — e.g. to review or commit the `project.godot` change — and `uninstall` reverses it; `wait-ready` establishes the lazily-launched engine session, with `--timeout` shared by its waits and new-work decisions, so a first `diag errors` serves instead of reporting `engine_session_not_running`; `status` reports the last successfully established engine session's `session_id` — the identity a `screen capture` receipt correlates with, minted anew per established session and retained across a failed replacement launch) |
-| `game` | `tree`, `get`, `rect`, `set`, `call` (the running game's runtime scene graph; `get --texture-digest` opts a read into content digests for path-less `Texture2D` values. `call --method NAME [--args JSON]` invokes a method named by the `GDA_CALLABLE` declaration resolved from the node's attached script along its base chain — use it for a debug/state contract exposed as a method rather than a property. gda calls nothing undeclared, so an undeclared-but-present method is `live_method_not_allowlisted` and its message names the declared set; a missing one is `live_unknown_method`, and arguments the declared parameters cannot take (wrong count, a type the engine would not convert, a typed `Array[int]` parameter) are `live_invalid_call_args`, refused before the call. The live parser materializes every JSON number as float. `NaN`/`Infinity` are refused; RFC JSON excludes them, although some in-memory schema validators accept them as numbers. Finite floats do not inherit the integer bound, but a float whose wire literal Godot's parser reads as `0.0` is refused too — `DBL_MIN`, any subnormal, and many-digit values such as `1.2345678901234567e-300`, none of which any decimal spelling can deliver; a float it does read arrives changed in its low-order bits — 1 ULP at ordinary magnitudes, and tens of doubles for a full-precision literal between `1e-4` and `1e-2`, where the parser truncates past 18 mantissa digits (#752). JSON integer values beyond ±(2^53−1) are refused CLI-side because the wire can change them. Standard JSON Schema cannot distinguish an exponent-form float from the equal integer, so the params model enforces the integer-token limit at execution. LIMIT: gda CANNOT verify a declared method has no side effects — the constant records the project's own read-only assertion, and what gda guarantees is only that no undeclared method is called. GDScript forbids redeclaring a base class's constant, so an opted-in inheritance chain has at most one declaration owner; a base owner covers its subclasses and need not define every method it names) |
+| `game` | `tree`, `get`, `rect`, `set`, `call` (the running game's runtime scene graph; `tree --root <runtime path> --max-depth N` bounds the read — see "Find a node before you address it" below; `get --texture-digest` opts a read into content digests for path-less `Texture2D` values. `call --method NAME [--args JSON]` invokes a method named by the `GDA_CALLABLE` declaration resolved from the node's attached script along its base chain — use it for a debug/state contract exposed as a method rather than a property. gda calls nothing undeclared, so an undeclared-but-present method is `live_method_not_allowlisted` and its message names the declared set; a missing one is `live_unknown_method`, and arguments the declared parameters cannot take (wrong count, a type the engine would not convert, a typed `Array[int]` parameter) are `live_invalid_call_args`, refused before the call. The live parser materializes every JSON number as float. `NaN`/`Infinity` are refused; RFC JSON excludes them, although some in-memory schema validators accept them as numbers. Finite floats do not inherit the integer bound, but a float whose wire literal Godot's parser reads as `0.0` is refused too — `DBL_MIN`, any subnormal, and many-digit values such as `1.2345678901234567e-300`, none of which any decimal spelling can deliver; a float it does read arrives changed in its low-order bits — 1 ULP at ordinary magnitudes, and tens of doubles for a full-precision literal between `1e-4` and `1e-2`, where the parser truncates past 18 mantissa digits (#752). JSON integer values beyond ±(2^53−1) are refused CLI-side because the wire can change them. Standard JSON Schema cannot distinguish an exponent-form float from the equal integer, so the params model enforces the integer-token limit at execution. LIMIT: gda CANNOT verify a declared method has no side effects — the constant records the project's own read-only assertion, and what gda guarantees is only that no undeclared method is called. GDScript forbids redeclaring a base class's constant, so an opted-in inheritance chain has at most one declaration owner; a base owner covers its subclasses and need not define every method it names) |
 | `diag` | `errors` (structured runtime errors with callstacks; survive a crash) |
 | `logger` | `tail` (the running game's structured log stream; `--raw` for verbatim lines, `--level <min>` to filter by severity, `--limit N`) |
 | `perf` | `monitors`, `monitor` (counters: a one-frame snapshot, or with `--frames` a bounded window with statistics and optional `--budget` verdicts / a per-node timeline) |
@@ -299,6 +299,26 @@ and the engine's only callers are the remote debugger's suspend/next-frame messa
 the editor Game view's buttons, which do not reach a daemon-launched session. So for a
 freeze-frame in an agent session, use `paused`, which live operations survive; a
 `live_timeout` never means the game is paused — see the causes it does name, above.
+
+### Find a node before you address it
+
+Every live op takes an exact runtime path, and `game tree` is how you learn one. Read it
+in TWO steps rather than dumping the whole tree:
+
+1. **Bound the read.** `gda game tree --max-depth 2 --json` shows the top levels; then
+   `gda game tree --root /root/Main/HUD --max-depth 2 --json` walks into the branch you
+   want. An unbounded `game tree` on a production UI is a very large result — it can
+   exceed your own context budget and be truncated by your client, and a truncated dump
+   cannot prove a node is absent.
+2. **Address exactly.** With the path in hand, use `game get` / `game rect` / `game set`
+   / `game call` on that path. Do not re-read the tree per node.
+
+A bounded read says what it left out, so you never mistake it for a complete one:
+`omitted_nodes` counts every unserialized node at any depth, `truncated` is that count
+above zero, and a node whose children were not walked carries `children_omitted` (its
+direct children only; the key is absent when nothing was omitted). To see what a node
+hid, re-read with `--root <that node's path>`. There is no continuation token — a live
+tree changes between calls, so the follow-up is a narrower `--root`, not a resumed page.
 
 ### Structured logging from game code
 

--- a/tests/harness/test_harness_install.py
+++ b/tests/harness/test_harness_install.py
@@ -807,7 +807,7 @@ def test_ready_gates_on_template_feature_as_its_first_statement():
 #   3. update the current pins below (the failure carries the new hash).
 PINNED_HARNESS_VERSION = "20"
 PINNED_HARNESS_SHA256 = (
-    "5f486aefa4280e35834cf714fb6cb52840cd60265a175bb76e8273aa278e4b45"
+    "cb5dd790d2d4c4fd040775d77cf40c23403692f544090b343d39c1d77d7dbf8e"
 )
 
 

--- a/tests/harness/test_harness_install.py
+++ b/tests/harness/test_harness_install.py
@@ -807,7 +807,7 @@ def test_ready_gates_on_template_feature_as_its_first_statement():
 #   3. update the current pins below (the failure carries the new hash).
 PINNED_HARNESS_VERSION = "20"
 PINNED_HARNESS_SHA256 = (
-    "cb5dd790d2d4c4fd040775d77cf40c23403692f544090b343d39c1d77d7dbf8e"
+    "1074e1ecb10913b0e020e4ac99991631840cbd8966dce4c8f928c4e994b0ea18"
 )
 
 

--- a/tests/harness/test_harness_install.py
+++ b/tests/harness/test_harness_install.py
@@ -805,9 +805,9 @@ def test_ready_gates_on_template_feature_as_its_first_statement():
 #   1. edit gda_harness.gd;
 #   2. bump HARNESS_VERSION in src/gda/harness/install.py;
 #   3. update the current pins below (the failure carries the new hash).
-PINNED_HARNESS_VERSION = "19"
+PINNED_HARNESS_VERSION = "20"
 PINNED_HARNESS_SHA256 = (
-    "ef4327202bd71f03223410e1451af8a37f3e7661a02192e9c5a4ab6f903f30d2"
+    "5f486aefa4280e35834cf714fb6cb52840cd60265a175bb76e8273aa278e4b45"
 )
 
 

--- a/tests/live/test_e2e_game.py
+++ b/tests/live/test_e2e_game.py
@@ -795,3 +795,73 @@ def test_game_tree_bounds_the_read_and_counts_what_it_left_out(
         assert json.loads(missing.stdout)["error"]["code"] == "live_node_not_found"
     finally:
         run("daemon", "stop")
+
+
+# A chain deeper than GDScript's call stack (1024 frames by default), built by the
+# main scene's script so the fixture stays small. The count-only pass over an
+# omitted subtree recursed at first: at this depth it overflowed, returned a partial
+# total, and the op published that as a successful read — the exact-count promise
+# of #849 broken on a finite, valid tree.
+DEEP_CHAIN_DEPTH = 2200
+DEEP_CHAIN_MAIN_GD = (
+    "extends Node2D\n"
+    "func _ready() -> void:\n"
+    "\tvar current: Node = self\n"
+    f"\tfor index in range({DEEP_CHAIN_DEPTH}):\n"
+    "\t\tvar child := Node.new()\n"
+    "\t\tchild.name = str(index)\n"
+    "\t\tcurrent.add_child(child)\n"
+    "\t\tcurrent = child\n"
+)
+DEEP_CHAIN_MAIN_TSCN = (
+    "[gd_scene load_steps=2 format=3]\n\n"
+    '[ext_resource type="Script" path="res://main.gd" id="1"]\n\n'
+    '[node name="Main" type="Node2D"]\n'
+    'script = ExtResource("1")\n'
+)
+
+
+@pytest.mark.e2e
+def test_game_tree_counts_an_omitted_subtree_deeper_than_the_call_stack(
+    tmp_path, daemon_runtime_dir
+):
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(DEEP_CHAIN_MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "main.gd").write_text(DEEP_CHAIN_MAIN_GD, encoding="utf-8")
+
+    run = Gda(tmp_path, json_output=True)
+
+    try:
+        assert run("daemon", "start").returncode == 0
+
+        # Depth 0 on the current scene omits the whole chain: ONE direct child,
+        # and every chain node in the total — exact, at a depth the recursive
+        # count could not reach.
+        root_only = run("game", "tree", "--max-depth", "0")
+        assert root_only.returncode == 0, root_only.stdout + root_only.stderr
+        alone = json.loads(root_only.stdout)
+        assert alone["root"]["path"] == "/root/Main"
+        assert alone["root"]["children"] == []
+        assert alone["root"]["children_omitted"] == 1
+        assert alone["omitted_nodes"] == DEEP_CHAIN_DEPTH
+        assert alone["truncated"] is True
+
+        # The same chain counted from one level higher: /root's children are
+        # serialized, everything below them is omitted, and the total is still
+        # exactly the chain — the engine session's own nodes have no children.
+        from_root = run("game", "tree", "--root", "/root", "--max-depth", "1")
+        assert from_root.returncode == 0, from_root.stdout + from_root.stderr
+        top = json.loads(from_root.stdout)
+        main = next(
+            child for child in top["root"]["children"] if child["name"] == "Main"
+        )
+        assert main["children_omitted"] == 1
+        assert top["omitted_nodes"] == DEEP_CHAIN_DEPTH
+
+        # And the count left no engine error behind: the overflow surfaced here
+        # as "Stack overflow" while the op still reported success.
+        errors = run("diag", "errors")
+        assert errors.returncode == 0, errors.stdout + errors.stderr
+        assert json.loads(errors.stdout)["errors"] == []
+    finally:
+        run("daemon", "stop")

--- a/tests/live/test_e2e_game.py
+++ b/tests/live/test_e2e_game.py
@@ -711,3 +711,87 @@ def test_game_call_preserves_large_finite_float_arguments(tmp_path, daemon_runti
             assert json.loads(result.stdout)["value"] is True, literal
     finally:
         run("daemon", "stop")
+
+
+# --- game tree: the bounded read (#849, GDA-DF-052) ---------------------------
+# The dogfooding shape: an unfiltered tree of a production UI exceeded the
+# client's budget and was truncated by it, which a caller cannot distinguish from
+# a complete read. The fixture is the acceptance shape — a HUD with three direct
+# children, one of which has two of its own.
+
+TREE_MAIN_TSCN = (
+    "[gd_scene format=3]\n\n"
+    '[node name="Main" type="Node2D"]\n\n'
+    '[node name="HUD" type="Control" parent="."]\n\n'
+    '[node name="Panel" type="Control" parent="HUD"]\n\n'
+    '[node name="Title" type="Label" parent="HUD/Panel"]\n\n'
+    '[node name="Value" type="Label" parent="HUD/Panel"]\n\n'
+    '[node name="Score" type="Label" parent="HUD"]\n\n'
+    '[node name="Timer" type="Label" parent="HUD"]\n'
+)
+
+
+@pytest.mark.e2e
+def test_game_tree_bounds_the_read_and_counts_what_it_left_out(
+    tmp_path, daemon_runtime_dir
+):
+    # The three acceptance cases of #849 against a real engine session: a
+    # subtree root, a depth bound with both counters, and the unbounded read
+    # that must stay what it was apart from the two totals.
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(TREE_MAIN_TSCN, encoding="utf-8")
+
+    run = Gda(tmp_path, json_output=True)
+
+    def names(node):
+        return [child["name"] for child in node["children"]]
+
+    try:
+        assert run("daemon", "start").returncode == 0
+
+        # AC1: the subtree root plus one level. The node whose children were not
+        # walked reports how many; the result totals every unserialized node.
+        bounded = run("game", "tree", "--root", "/root/Main/HUD", "--max-depth", "1")
+        assert bounded.returncode == 0, bounded.stdout + bounded.stderr
+        doc = json.loads(bounded.stdout)
+        assert doc["root"]["path"] == "/root/Main/HUD"
+        assert names(doc["root"]) == ["Panel", "Score", "Timer"]
+        panel, score, timer = doc["root"]["children"]
+        assert panel["children_omitted"] == 2
+        assert panel["children"] == []
+        assert "children_omitted" not in score
+        assert "children_omitted" not in timer
+        assert "children_omitted" not in doc["root"]
+        assert doc["omitted_nodes"] == 2
+        assert doc["truncated"] is True
+
+        # AC2: depth 0 is the root alone — three direct children omitted, and
+        # five nodes in total, since the count reaches every depth.
+        root_only = run("game", "tree", "--root", "/root/Main/HUD", "--max-depth", "0")
+        assert root_only.returncode == 0, root_only.stdout + root_only.stderr
+        alone = json.loads(root_only.stdout)
+        assert alone["root"]["path"] == "/root/Main/HUD"
+        assert alone["root"]["children"] == []
+        assert alone["root"]["children_omitted"] == 3
+        assert alone["omitted_nodes"] == 5
+        assert alone["truncated"] is True
+
+        # AC3: with no options the whole current scene is serialized as before,
+        # and the addition is exactly the two totals — no node grows a key.
+        whole = run("game", "tree")
+        assert whole.returncode == 0, whole.stdout + whole.stderr
+        full = json.loads(whole.stdout)
+        assert full["root"]["path"] == "/root/Main"
+        assert full["omitted_nodes"] == 0
+        assert full["truncated"] is False
+        assert "children_omitted" not in json.dumps(full)
+        hud = full["root"]["children"][0]
+        assert names(hud) == ["Panel", "Score", "Timer"]
+        assert names(hud["children"][0]) == ["Title", "Value"]
+
+        # An unknown --root is the existing typed refusal, not an empty tree.
+        missing = run("game", "tree", "--root", "/root/Main/Nope")
+        assert missing.returncode == EXIT_LIVE, missing.stdout + missing.stderr
+        assert json.loads(missing.stdout)["error"]["code"] == "live_node_not_found"
+    finally:
+        run("daemon", "stop")

--- a/tests/live/test_game_commands.py
+++ b/tests/live/test_game_commands.py
@@ -21,10 +21,12 @@ from tests.support import (
     GAME_RECT_RESULT,
     GAME_SET_RESULT,
     GAME_TREE_RESULT,
+    GAME_TREE_TRUNCATED_RESULT,
     error_sentinel,
     inject_live_runner,
     panel_text,
     sentinel,
+    usage_error_text,
     minimal_project,
 )
 
@@ -45,8 +47,136 @@ def test_game_tree_emits_runtime_tree_json_through_the_live_channel(
     data = json.loads(result.stdout)
     assert data["root"]["name"] == "Main"
     assert data["root"]["children"][0]["type"] == "CharacterBody2D"
-    # Routed through the LIVE seam, dispatching the game-tree operation (no args).
-    assert fake.calls == [("game-tree", {})]
+    # AC3 (#849): an unbounded read gains only the two totals. No node carries
+    # `children_omitted` — the key is ABSENT rather than zero, so the read a
+    # caller did not bound does not grow by one key per node.
+    assert data["truncated"] is False
+    assert data["omitted_nodes"] == 0
+    assert "children_omitted" not in data["root"]
+    assert "children_omitted" not in data["root"]["children"][0]
+    # Routed through the LIVE seam, dispatching the game-tree operation; both
+    # bounding params ride unset, as `game get`'s optional filter does.
+    assert fake.calls == [("game-tree", {"root": None, "max_depth": None})]
+
+
+def test_game_tree_relays_the_bounding_options(monkeypatch, tmp_path):
+    # #849: --root and --max-depth are threaded to the operation params; the
+    # harness applies them (it owns the walk).
+    fake = inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(GAME_TREE_TRUNCATED_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "game",
+            "tree",
+            "--root",
+            "/root/Main/HUD",
+            "--max-depth",
+            "1",
+            "--project",
+            str(minimal_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert fake.calls == [
+        ("game-tree", {"root": "/root/Main/HUD", "max_depth": 1}),
+    ]
+
+
+def test_game_tree_reports_the_omitted_counts_of_a_bounded_read(monkeypatch, tmp_path):
+    # AC1 (#849): the partial read is never mistaken for a complete one — the
+    # result totals the unserialized nodes and the node whose children were left
+    # out says how many.
+    inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(GAME_TREE_TRUNCATED_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "game",
+            "tree",
+            "--root",
+            "/root/Main/HUD",
+            "--max-depth",
+            "1",
+            "--project",
+            str(minimal_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    data = json.loads(result.stdout)
+    assert data["truncated"] is True
+    assert data["omitted_nodes"] == 2
+    children = data["root"]["children"]
+    assert [child["name"] for child in children] == ["Panel", "Score", "Timer"]
+    assert children[0]["children_omitted"] == 2
+    # A node whose children were ALL serialized keeps the key absent.
+    assert "children_omitted" not in children[1]
+    assert "children_omitted" not in children[2]
+
+
+def test_game_tree_renders_the_omission_for_a_human(monkeypatch, tmp_path):
+    # Without --json the outline must not read as a complete tree: the total
+    # rides one trailing line, so a truncated read is visible on both channels.
+    inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(GAME_TREE_TRUNCATED_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "game",
+            "tree",
+            "--max-depth",
+            "1",
+            "--project",
+            str(minimal_project(tmp_path)),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert "HUD (Control)" in result.stdout
+    assert "truncated: 2 nodes omitted" in result.stdout
+
+
+def test_game_tree_refuses_a_negative_max_depth(monkeypatch, tmp_path):
+    # The bound is a depth, so a negative one is a usage error decided by the
+    # params model (ADR-0015) — before any daemon is involved.
+    result = CliRunner().invoke(
+        app,
+        [
+            "game",
+            "tree",
+            "--max-depth",
+            "-1",
+            "--project",
+            str(minimal_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 2, result.stdout + result.stderr
+    assert "max_depth" in usage_error_text(result)
+
+
+def test_game_tree_help_states_the_bounding_options(monkeypatch, tmp_path):
+    result = CliRunner().invoke(app, ["game", "tree", "--help"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    text = panel_text(result.stdout)
+    assert "--root" in text and "--max-depth" in text
+    # The unbounded default is the caller's choice, and help says so.
+    assert "unbounded" in text
 
 
 def test_game_tree_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_path):
@@ -63,6 +193,22 @@ def test_game_tree_with_no_daemon_reports_daemon_not_running(monkeypatch, tmp_pa
     assert error["code"] == "daemon_not_running"
     assert error["category"] == "live"
     assert "gda daemon start" in error["message"]
+
+
+def test_game_tree_schema_publishes_the_bounding_params_and_counts():
+    # AC4 (#849): the two params and the two result totals are published, and
+    # `children_omitted` rides the node shape as an OPTIONAL key — the presence
+    # decision is part of the contract, not an implementation detail.
+    result = CliRunner().invoke(app, ["game", "tree", "--schema"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    doc = json.loads(result.stdout)
+    assert {"root", "max_depth"} <= set(doc["input"]["properties"])
+    assert {"truncated", "omitted_nodes"} <= set(doc["output"]["properties"])
+    assert {"truncated", "omitted_nodes"} <= set(doc["output"]["required"])
+    node = doc["output"]["$defs"]["GameNode"]
+    assert "children_omitted" in node["properties"]
+    assert "children_omitted" not in node.get("required", [])
 
 
 def test_game_tree_schema_is_self_describing():

--- a/tests/live/test_game_commands.py
+++ b/tests/live/test_game_commands.py
@@ -150,8 +150,10 @@ def test_game_tree_renders_the_omission_for_a_human(monkeypatch, tmp_path):
 
 
 def test_game_tree_refuses_a_negative_max_depth(monkeypatch, tmp_path):
-    # The bound is a depth, so a negative one is a usage error decided by the
-    # params model (ADR-0015) — before any daemon is involved.
+    # The bound is a depth, so a negative one is a usage error — before any
+    # daemon is involved. Click's own `min=0` mirrors the model's `ge=0` and
+    # decides first, so the message names the FLAG the caller typed; the model
+    # still refuses the same value on the --params-json path (ADR-0015).
     result = CliRunner().invoke(
         app,
         [
@@ -166,10 +168,10 @@ def test_game_tree_refuses_a_negative_max_depth(monkeypatch, tmp_path):
     )
 
     assert result.exit_code == 2, result.stdout + result.stderr
-    assert "max_depth" in usage_error_text(result)
+    assert "--max-depth" in usage_error_text(result)
 
 
-def test_game_tree_help_states_the_bounding_options(monkeypatch, tmp_path):
+def test_game_tree_help_states_the_bounding_options():
     result = CliRunner().invoke(app, ["game", "tree", "--help"])
 
     assert result.exit_code == 0, result.stdout + result.stderr

--- a/tests/meta/test_schema_command.py
+++ b/tests/meta/test_schema_command.py
@@ -1363,6 +1363,7 @@ def test_sample_game_results_validate_against_emitted_output_schemas():
         GAME_RECT_RESULT,
         GAME_SET_RESULT,
         GAME_TREE_RESULT,
+        GAME_TREE_TRUNCATED_RESULT,
     )
 
     tree_doc = json.loads(CliRunner().invoke(app, ["game", "tree", "--schema"]).stdout)
@@ -1371,6 +1372,9 @@ def test_sample_game_results_validate_against_emitted_output_schemas():
     set_doc = json.loads(CliRunner().invoke(app, ["game", "set", "--schema"]).stdout)
 
     jsonschema.validate(instance=GAME_TREE_RESULT, schema=tree_doc["output"])
+    # The bounded read's shape is published too (#849): the optional per-node
+    # `children_omitted` and the two result totals.
+    jsonschema.validate(instance=GAME_TREE_TRUNCATED_RESULT, schema=tree_doc["output"])
     jsonschema.validate(instance=GAME_GET_RESULT, schema=get_doc["output"])
     jsonschema.validate(instance=GAME_RECT_RESULT, schema=rect_doc["output"])
     jsonschema.validate(instance=GAME_SET_RESULT, schema=set_doc["output"])

--- a/tests/support.py
+++ b/tests/support.py
@@ -989,7 +989,10 @@ THEME_CREATE_RESULT = {
 }
 
 # A sample ``gda game tree`` result — the running game's runtime scene tree
-# (ADR-0019). Shared by the game-command success/schema tests.
+# (ADR-0019). Shared by the game-command success/schema tests. The UNBOUNDED read
+# (#849): every node was serialized, so the two totals report no omission and no
+# node carries ``children_omitted`` — the key is absent, not zero, so the read a
+# caller did not bound does not grow by one key per node.
 GAME_TREE_RESULT = {
     "root": {
         "name": "Main",
@@ -1003,7 +1006,45 @@ GAME_TREE_RESULT = {
                 "children": [],
             }
         ],
-    }
+    },
+    "truncated": False,
+    "omitted_nodes": 0,
+}
+
+# The BOUNDED counterpart (#849): what the harness sends for
+# ``game tree --root /root/Main/HUD --max-depth 1`` on a HUD with three direct
+# children, one of which has two of its own. ``children_omitted`` sits on the one
+# node whose children the read did not serialize; ``omitted_nodes`` totals the
+# unserialized nodes at every depth.
+GAME_TREE_TRUNCATED_RESULT = {
+    "root": {
+        "name": "HUD",
+        "type": "Control",
+        "path": "/root/Main/HUD",
+        "children": [
+            {
+                "name": "Panel",
+                "type": "Control",
+                "path": "/root/Main/HUD/Panel",
+                "children": [],
+                "children_omitted": 2,
+            },
+            {
+                "name": "Score",
+                "type": "Label",
+                "path": "/root/Main/HUD/Score",
+                "children": [],
+            },
+            {
+                "name": "Timer",
+                "type": "Label",
+                "path": "/root/Main/HUD/Timer",
+                "children": [],
+            },
+        ],
+    },
+    "truncated": True,
+    "omitted_nodes": 2,
 }
 
 # Sample ``gda game get`` / ``gda game set`` results — a running node's runtime


### PR DESCRIPTION
## Summary

`gda game tree` serialized the whole runtime subtree of the running current scene
(`/root` only when no scene is current) and took no options. On a
production UI that result exceeded the caller's own budget and was truncated by the
CLIENT (GDA-DF-052) — a truncated dump reads exactly like a complete one, so a missing
node could not be inferred from it.

This slice bounds the read and reports what a bound left out:

- `--root <runtime path>` reads one subtree, addressed by the absolute runtime path
  `game tree` itself reports. A path that resolves to nothing is the existing
  `live_node_not_found` (an empty `--root` included — the same refusal `game get` gives
  for an empty node path).
- `--max-depth N` bounds the walk; `0` is the addressed node alone. A negative value is
  a usage error decided by the params model, before any daemon is involved.
- The result always carries `truncated` and `omitted_nodes` (every unserialized node, at
  every depth — whole omitted subtrees, not just direct children). A node whose children
  were not walked carries `children_omitted`, its DIRECT children only.
- No continuation token (declined in the issue): a live tree changes between calls, so a
  token would page a snapshot that no longer exists. The follow-up read is a narrower
  `--root`.

The harness's tree serializer becomes the one depth-bounded, counting walk,
`_serialize(node: Node, max_depth: int, counts: Dictionary) -> Dictionary`
(`max_depth < 0` = unbounded; `counts["omitted_nodes"]` accumulates by reference), with
`_subtree_size(node) -> int` for the count-only pass over an omitted subtree. It renders
a NESTED subtree, so an op that reports a FLAT match list (#855's `game find`) is a
different walk and does not call it — what such an op inherits from here is the per-node
shape (`name`/`type`/`path`) and this depth-bounding + omitted-count contract, not the
function.

Closes #849

## Surface diff

**`gda schema`** — 104 diff lines, all under `game tree` (base captured before the first
edit, head after the last):

- `argv`: two new option entries — `--root` (`input_property: root`) and `--max-depth`
  (`input_property: max_depth`), both `required: false`.
- `description`: one new paragraph on the command doc (the same six lines the help adds).
- `input.description`: rewritten (the params model is no longer empty).
- `input.properties`: new `root` (`anyOf` string/null, default null) and `max_depth`
  (`anyOf` integer `minimum: 0`/null, default null).
- `output.$defs.GameNode.properties`: new `children_omitted` (integer, `default: 0`) —
  NOT added to `GameNode.required`.
- `output.description`: rewritten.
- `output.properties`: new `truncated` (boolean) and `omitted_nodes` (integer).
- `output.required`: `["root"]` -> `["root", "truncated", "omitted_nodes"]`.

**`gda game tree --help`** — the docstring paragraph above, plus the two option rows:
`--root TEXT` and `--max-depth INTEGER RANGE [x>=0]`, whose help ends "must be >= 0". The
pre-existing rows are unchanged in text; Rich re-columns them because the metavar column
widened. The published schema is byte-identical before and after adding Click's `min=0`
(the input model already carried `minimum: 0`), so the enumerated schema diff above is
the whole schema change.

**`docs/command-catalog.md`** — the `game` bullet's `game tree` sentence now states the
two options, the three counters with their exact definitions, the absent-when-zero rule,
and the declined continuation token with its reason.

**`src/gda/skill/SKILL.md`** — the `game` row points at a new `### Find a node before you
address it` subsection (a peer of the existing `### Structured logging from game code`,
placed so it re-parents no existing prose). It gives the two-step pattern: bounded read
first, then exact addressing, plus how to read the three counters and why there is no
resumed page.

**`README.md`** — none. The `game tree` row describes the command, and per the README
scope rule option detail lives in `--help` / SKILL / the catalog; the shipped
`game get --texture-digest` is likewise absent from its row. No behavioural boundary is
dropped: the unbounded default is unchanged. Consequently no `README.*.md` regeneration
was needed and `scripts/update_readme_i18n.py` was not run.

## Harness version

- `HARNESS_VERSION` 19 -> 20 (`src/gda/harness/install.py`). Merge base re-read at commit
  time: `git merge-base origin/feat/gda-dogfooding-dev HEAD` = `3f68bf3fb` declaring
  `"19"`, so head is base + 1.
- `PINNED_HARNESS_VERSION` / `PINNED_HARNESS_SHA256` re-pinned in
  `tests/harness/test_harness_install.py` to
  `cb5dd790d2d4c4fd040775d77cf40c23403692f544090b343d39c1d77d7dbf8e`. (The review-fix
  commit reworded a harness comment, so the pin was re-taken a second time;
  `HARNESS_VERSION` stays 20 — the guard requires an increase across the MERGE BASE,
  which still declares 19, not one per commit.)
- Guard, run against the committed head (a pre-commit run passes vacuously, since it
  compares committed blobs):

```
$ uv run --frozen python scripts/harness_version_guard.py origin/feat/gda-dogfooding-dev HEAD
harness version transition is valid
```

## Red-proof evidence

Tests written first and run with the source at the committed base (`3f68bf3fb`, only test
files modified):

```
FAILED tests/live/test_game_commands.py::test_game_tree_emits_runtime_tree_json_through_the_live_channel
FAILED tests/live/test_game_commands.py::test_game_tree_relays_the_bounding_options
FAILED tests/live/test_game_commands.py::test_game_tree_reports_the_omitted_counts_of_a_bounded_read
FAILED tests/live/test_game_commands.py::test_game_tree_renders_the_omission_for_a_human
FAILED tests/live/test_game_commands.py::test_game_tree_refuses_a_negative_max_depth
FAILED tests/live/test_game_commands.py::test_game_tree_help_states_the_bounding_options
FAILED tests/live/test_game_commands.py::test_game_tree_schema_publishes_the_bounding_params_and_counts
7 failed, 128 passed, 10 deselected in 3.70s
```

Sample failures: `assert 'max_depth' in ''` (no such option, so the usage error names
nothing), `assert ('--root' in "Usage: gda game tree [OPTIONS] ...")`, and
`KeyError-shaped` `'max_depth'` on the published input properties.

One caveat, disclosed: `tests/meta/test_schema_command.py`'s sample-validates-schema test
did NOT go red for the added `GAME_TREE_TRUNCATED_RESULT`, because the published output
schema does not set `additionalProperties: false`, so extra keys validate under the old
schema too. That fixture is a forward drift guard, not the AC4 gate; the real gate is
`test_game_tree_schema_publishes_the_bounding_params_and_counts`, which did go red.

The e2e regression could not be run red in a useful way: the harness at base has no
`children_omitted` at all, so it fails on the first assertion. It is reported green below.

Review-fix round (`40d675a0b`): adding Click's `min=0` moves the refusal from the params
model to Click, which names the FLAG rather than the field, so the old pin went red first:

```
>       assert "max_depth" in usage_error_text(result)
E       assert 'max_depth' in "Usage: gda game tree [OPTIONS] Try 'gda game tree --help' for help. Error Invalid value for '--max-depth': -1 is not in the range x>=0."
1 failed in 0.31s
```

The assertion was then flipped to the flag spelling, which is the message an argv caller
actually reads. The `--params-json` path still refuses through the model's `ge=0`
(`invalid_params: max_depth: Input should be greater than or equal to 0`).

## Validation

Host: macOS 15 (Darwin 25.6.0), arm64, Godot `4.6.3.stable.official.7d41c59c4` at the
machine-local `~/Applications/Godot.app/Contents/MacOS/Godot` (passed as `$GDA_GODOT` per
invocation, never hardcoded). No launch timeout occurred in either round, so no re-run was
needed; load average was 9.20 at the first round (sibling wave slices) and 3.17 at the
review-fix round. Every row below is from the review-fix head `40d675a0b`, except the two
"extra" e2e rows, which were run at `539ffff27` and are unaffected by that commit (it
changes one harness COMMENT, the pin, an import, a Click bound and one SKILL sentence).

| Gate | Command | Result |
| --- | --- | --- |
| Unit | `uv run --frozen pytest tests -m "not e2e" -q -p no:cacheprovider` | `2460 passed, 651 deselected in 45.23s` |
| Lint | `uv run --frozen ruff check .` | `All checks passed!` |
| Format | `uv run --frozen ruff format --check .` | `508 files already formatted` |
| Types | `uv run --frozen pyright` | `0 errors, 0 warnings, 0 informations` |
| Harness guard | `uv run --frozen python scripts/harness_version_guard.py origin/feat/gda-dogfooding-dev HEAD` | `harness version transition is valid` |
| e2e (game) | `pytest tests/live/test_e2e_game.py -m e2e -rs -p no:cacheprovider -q` | `10 passed in 31.29s` |
| e2e (harness) | `pytest tests/harness -m e2e -rs -p no:cacheprovider -q` | `4 passed, 51 deselected in 11.53s` |
| e2e (other live) | `pytest tests/live/test_e2e_diag.py tests/live/test_e2e_perf.py tests/live/test_e2e_logger.py -m e2e -rs -q` | `10 passed in 21.01s` |
| e2e (input) | `pytest tests/live/test_e2e_input.py -m e2e -rs -q` | `16 passed in 53.50s` |

The last two rows are extra: a GDScript edit that failed to parse would make EVERY live op
fail, and the auto-merge hazard for duplicate GDScript functions is only caught live, so
the other harness-served groups were exercised too. PR CI at `539ffff27` was green on all
seven required jobs (`Godot e2e tests` is `skipping` by repository policy — that tier runs
nightly on `main`, which is why the live evidence above is local). `tests/live/test_e2e_screen.py` was
not run — it needs a windowed session and this run had no attached desktop session; the
slice touches nothing on that path (the screen ops do not call the tree serializer).

Baseline unit count is unchanged at 2460 relative to the pre-edit `main` snapshot plus
this slice's 6 new unit tests and 1 new e2e test.

## Requirement conformance

**AC1** — `game tree --root /root/Main/HUD --max-depth 1 --json` returns the HUD node and
its 3 children, `children_omitted: 2` on the one child that has 2 of its own,
`omitted_nodes: 2`, `truncated: true`. Covered live in
`tests/live/test_e2e_game.py::test_game_tree_bounds_the_read_and_counts_what_it_left_out`
against a real engine session, on a fixture whose HUD has `Panel` (2 children), `Score`,
`Timer`; and at unit speed in
`test_game_tree_reports_the_omitted_counts_of_a_bounded_read`.

**AC2** — `--max-depth 0` on the same root returns the root alone with
`children_omitted: 3` and `omitted_nodes: 5`. Same live test. The 5 is the whole omitted
subtree at every depth (3 children + 2 grandchildren), which is why the harness keeps a
count-only `_subtree_size` pass over what it did not serialize.

**AC3** — without the options the result is unchanged except for `truncated: false` and
`omitted_nodes: 0`. Same live test asserts the full current-scene read still nests
`Main -> HUD -> Panel -> {Title, Value}` and that the literal string `children_omitted`
appears nowhere in the payload; the unit test
`test_game_tree_emits_runtime_tree_json_through_the_live_channel` asserts the same two
totals and the key's absence on both the root and a child.

**AC4** — the schema publishes the new params and fields (enumerated under Surface diff),
and a live regression covers the three cases. Gated by
`test_game_tree_schema_publishes_the_bounding_params_and_counts`, which also asserts
`children_omitted` is NOT in `GameNode.required`.

**`children_omitted` presence decision: present only when non-zero; the key is ABSENT
when a node's children were all serialized.** Reasons:

1. AC3 says the unbounded result is unchanged "except for `truncated: false` and
   `omitted_nodes: 0`". A per-node `children_omitted: 0` would change every node, so an
   always-present field contradicts the stated acceptance.
2. The issue exists because the unbounded read is too big. Adding ~22 bytes per node to
   it would push the exact result GDA-DF-052 could not fit further over the budget.
3. It is what the harness naturally produces: the key is written only where the walk
   stopped.

The cost is one branch for a raw-JSON consumer, so the description tells them the idiom
(`node.get('children_omitted', 0)`). Model-side there is no branch at all: `GameNode`
keeps `children_omitted: int = 0` and a `@model_serializer(mode="wrap")` drops the key
when it is zero, so the presence rule is a serialization rule owned by the writer rather
than a `None` every consumer must handle. The schema, the two `tests/support.py` fixtures
(`GAME_TREE_RESULT` unbounded, `GAME_TREE_TRUNCATED_RESULT` bounded) and the renderer all
follow that one decision.

## Disclosed extras / boundary crossings

- **Dispatch arm touched.** The brief confined harness edits to `_handle_game_tree` and
  `_serialize`. One further line was unavoidable: `_run`'s `OP_GAME_TREE` arm now reads
  `_handle_game_tree(params)` — the handler previously took none. No new `OP_*` const, no
  other harness section, and `_serialize` stayed physically where it was.
- **`_subtree_size` added** next to `_serialize` — the count-only pass AC2's
  `omitted_nodes: 5` needs. It is part of the replaced serializer, not a new section.
- **Human renderer.** `render_game_tree` appends one line, `truncated: <N> nodes
  omitted`, when the read was bounded, so the outline cannot be read as a complete tree on
  the human channel either. `gda/render.py` is deliberately NOT touched: `render_node_tree`
  is shared with the on-disk `scene`/`node` trees and `NodeOutline` has no per-node count,
  so the marker lives in the group that owns the shape (ADR-0040 §5). Consequence: the
  human channel reports the TOTAL, not which node hid what — the JSON channel has that.
- **`tests/support.py`** was edited additively, inside the game-tree fixture region only:
  the two totals were added to `GAME_TREE_RESULT` and `GAME_TREE_TRUNCATED_RESULT` was
  added beside it.
- **`tests/meta/test_schema_command.py`** gained one `jsonschema.validate` call for the
  new fixture (additive; see the caveat under Red-proof).
- **Live contract guards** needed no change: both new result fields are `int`/`bool`, and
  `_carries_float` admits neither, so no float-writer sentence is owed. No new op name, so
  the op-table mirror is untouched.
- **Wire numbers.** `max_depth` rides the relayed request as a JSON number, so it is
  covered by `RelayedLiveParams`: `ge=0` rejects negatives only, and the wire ceiling is
  the inherited `RelayedLiveParams` guard (`9007199254740991` accepted, `9007199254740992`
  refused as `max_depth integer values must be within +/-9007199254740991`). No extra
  depth cap is imposed; the harness reads the value through the existing defensive
  `_int_param` (a null or non-numeric value falls back to the unbounded sentinel).
- **Nothing outside the slice was edited**: `commands/input.py`, `commands/project.py`,
  `commands/script.py`, `commands/scene.py`, `hints.py`, `ops/operations.gd` and
  `gda.project` are untouched, and nothing in them was found to need changing.

## Review round (`40d675a0b`)

The independent review returned READY with five P3 findings; all five are adopted in the
second commit:

1. `SerializerFunctionWrapHandler` now comes from `pydantic`, the public API the two
   existing wrap-serializer sites (`provenance.py`, `commands/scene.py`) use, instead of
   `pydantic_core.core_schema`.
2. Click's `min=0` now mirrors the model's `ge=0` on `--max-depth`, per the convention
   `diag_limit_option` states and `input`/`perf`/`screen`/`resource` follow. The argv
   refusal now names the flag; the help states the bound; the schema is unchanged.
3. The harness serializer's forward reference to a later node-search op was inaccurate —
   `_serialize` returns a NESTED subtree, while a `game find` reports a FLAT match list.
   Reworded to what is actually shared: the per-node shape and the depth-bounding +
   omitted-count contract, not the function.
4. SKILL: "Every live op takes an exact runtime path" was false for the live ops that
   address no node (`diag errors`, `logger tail`, `perf monitors`, `screen capture`, the
   `daemon` group). It now says every live op that ADDRESSES a node.
5. Two unused pytest fixtures dropped from the help test.


## Review round 2 (`092fdec0b`)

The second independent review returned one P2 and two P3:

1. **P2 — `_subtree_size` overflowed the GDScript call stack.** The count-only pass
   recursed; on a 2200-node chain the walk overflowed (1024 frames by default),
   returned a partial total, and the op published it as a SUCCESSFUL read
   (`omitted_nodes: 2044` under `--max-depth 0`, with `Stack overflow in _subtree_size`
   in `diag errors`). Fixed: the walk keeps its own LIFO (`Array[Node]`), so a count
   costs no call depth. Regression
   `tests/live/test_e2e_game.py::test_game_tree_counts_an_omitted_subtree_deeper_than_the_call_stack`
   builds the chain from the main scene's script and asserts `children_omitted: 1`,
   `omitted_nodes: 2200` from the current scene AND from `--root /root --max-depth 1`,
   and an empty `diag errors`. Red on the previous harness (`assert 2044 == 2200`,
   the reviewer's number), green on this one. The nested serializer `_serialize` is
   unchanged, as the review asked: its depth is the caller's `--max-depth`, and an
   UNBOUNDED read of a tree deeper than the call stack is the pre-existing behaviour of
   the base serializer, outside #849.
2. **P3 — the default root.** The issue baseline and the params docstring said the
   default read covers the whole tree from `/root`; the harness selects
   `current_scene` and falls back to `/root` only when none is current, so an autoload
   (the scene's sibling) was never in it. Fixed in the params docstring, the `--root`
   help/schema description, the command docstring, the catalog and the skill's
   two-step pattern — all now say where the default is rooted, that the counters cover
   the SELECTED subtree only, and that discovering an autoload takes `--root /root`.
   #849's body carries a dated correction and comment (2026-09-06). The default itself
   is unchanged (AC3).
3. **P3 — "Wire numbers".** Corrected above: `ge=0` rejects negatives only; the wire
   ceiling is `RelayedLiveParams`'s.

`HARNESS_VERSION` stays 20 (the merge base still declares 19); the pin is re-taken
(`1074e1ecb10913b0e020e4ac99991631840cbd8966dce4c8f928c4e994b0ea18`), and the guard
against `origin/feat/gda-dogfooding-dev` passes. Re-run on this head: unit 369 passed over
game/harness/meta/live-guard modules, ruff/format/pyright clean, e2e game + harness 15
passed (Godot 4.6.3, macOS).
