### PR TITLE
feat(gda): project add-input-action binds joypad buttons and axis directions (#842)

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ names the file, and only `preflight` catches a first-frame failure.
 | `project set` | Set a project setting, coercing the value to its declared type. |
 | `project add-autoload` | Register an autoload singleton (name → script/scene). |
 | `project remove-autoload` | Unregister an autoload singleton by name. |
-| `project add-input-action` | Register an InputMap action bound to keys (`--key` name or keycode, `--deadzone`, `--physical`). |
+| `project add-input-action` | Register an InputMap action bound to keys and/or a controller (`--key`, `--joy-button`, `--joy-axis` as `<axis>[:<sign>]`, `--device`, `--deadzone`, `--physical`); at least one binding is required. |
 | `project remove-input-action` | Unregister an InputMap action by name. |
 | `project find-references` | Find every project file that references a given resource. |
 | `project dependencies` | Map each scene/resource to the resources it depends on. |

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=77bb050928bb00a8ba3ce8936b82593b68eeae2731f81332c327a0010235067d -->
+<!-- gda-readme-i18n: source=README.md sha256=de18d3f4225e4b4b473921f121ef9f086dddb68cc38e5868433893a52b18ae4b -->
 
 # gda — Automatización de Godot para agentes de IA
 
@@ -452,7 +452,7 @@ identifica el archivo y solo `preflight` detecta un fallo en el primer fotograma
 | `project set` | Define un ajuste del proyecto, forzando el valor a su tipo declarado. |
 | `project add-autoload` | Registra un singleton autoload (nombre → script/escena). |
 | `project remove-autoload` | Cancela el registro de un singleton autoload por nombre. |
-| `project add-input-action` | Registra una acción del InputMap vinculada a teclas (`--key` nombre o keycode, `--deadzone`, `--physical`). |
+| `project add-input-action` | Registra una acción del InputMap vinculada a teclas y/o a un mando (`--key`, `--joy-button`, `--joy-axis` como `<eje>[:<signo>]`, `--device`, `--deadzone`, `--physical`); se requiere al menos una vinculación. |
 | `project remove-input-action` | Cancela el registro de una acción del InputMap por nombre. |
 | `project find-references` | Encuentra todos los archivos del proyecto que referencian un recurso dado. |
 | `project dependencies` | Mapea cada escena/recurso a los recursos de los que depende. |

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=77bb050928bb00a8ba3ce8936b82593b68eeae2731f81332c327a0010235067d -->
+<!-- gda-readme-i18n: source=README.md sha256=de18d3f4225e4b4b473921f121ef9f086dddb68cc38e5868433893a52b18ae4b -->
 
 # gda — AI エージェント向け Godot オートメーション
 
@@ -448,7 +448,7 @@ Headless 検証はプロジェクトの実行準備を確認し、Live 操作は
 | `project set` | プロジェクト設定を設定します。値は宣言された型に変換されます。 |
 | `project add-autoload` | オートロードのシングルトンを登録します(名前 → スクリプト/シーン)。 |
 | `project remove-autoload` | オートロードのシングルトンを名前で指定して登録解除します。 |
-| `project add-input-action` | キーに割り当てた InputMap アクションを登録します(`--key` はキー名またはキーコード、`--deadzone`、`--physical`)。 |
+| `project add-input-action` | キーやコントローラーに割り当てた InputMap アクションを登録します(`--key`、`--joy-button`、`--joy-axis` は `<軸>[:<符号>]` 形式、`--device`、`--deadzone`、`--physical`)。バインドは 1 つ以上必要です。 |
 | `project remove-input-action` | InputMap アクションを名前で指定して登録解除します。 |
 | `project find-references` | 指定したリソースを参照するすべてのプロジェクトファイルを見つけます。 |
 | `project dependencies` | 各シーン/リソースを、それが依存するリソースに対応付けます。 |

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=77bb050928bb00a8ba3ce8936b82593b68eeae2731f81332c327a0010235067d -->
+<!-- gda-readme-i18n: source=README.md sha256=de18d3f4225e4b4b473921f121ef9f086dddb68cc38e5868433893a52b18ae4b -->
 
 # gda — 面向 AI Agent 的 Godot 自动化
 
@@ -428,7 +428,7 @@ Headless 验证确认项目就绪状态；Live 操作返回用于验证实际行
 | `project set` | 设置一个项目设置，并把值强制转换为它声明的类型。 |
 | `project add-autoload` | 注册一个 autoload 单例（名称 → 脚本/场景）。 |
 | `project remove-autoload` | 按名称注销一个 autoload 单例。 |
-| `project add-input-action` | 注册一个绑定按键的 InputMap 动作（`--key` 键名或键码、`--deadzone`、`--physical`）。 |
+| `project add-input-action` | 注册一个绑定按键和/或手柄的 InputMap 动作（`--key`、`--joy-button`、`--joy-axis` 形如 `<轴>[:<符号>]`、`--device`、`--deadzone`、`--physical`）；至少需要一个绑定。 |
 | `project remove-input-action` | 按名称注销一个 InputMap 动作。 |
 | `project find-references` | 找出引用了给定资源的每一个项目文件。 |
 | `project dependencies` | 把每个场景/资源映射到它所依赖的资源。 |

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -345,7 +345,7 @@ operation, and parse codes the CLI assigns).
 | `no_uid_assigned` | `operation` | `operation` | `4` | A resource path exists but has no UID assigned in the engine's UID cache. |
 | `unknown_setting` | `operation` | `operation` | `4` | A requested project setting does not exist in the project's ProjectSettings. |
 | `invalid_target` | `operation` | `operation` | `4` | A project find-references target is empty or not a valid `res://` path or `class_name`. |
-| `invalid_key` | `operation` | `operation` | `4` | An input-action key could not be resolved to a Godot keycode (unknown key name or non-positive keycode). |
+| `invalid_key` | `operation` | `operation` | `4` | An input-action binding token could not be resolved: a key name or keycode that maps to no Godot keycode, or a joypad button or axis direction that names no JoyButton / JoyAxis. |
 | `contract_violation` | `parse` | `parser` | `5` | The process claimed success but violated the structured-output contract. |
 | `tree_too_deep` | `parse` | `classifier` | `5` | The engine emitted a valid result tree that nests past gda's recursion limit; the payload is contract-conformant, the limit is wrapper-side (shares the `parse` exit code; the `code` distinguishes it from `contract_violation`). |
 | `daemon_not_running` | `live` | `classifier` | `6` | A live command found no running gda-daemon for the project; start one with `gda daemon start` (Phase 2, ADR-0017 / ADR-0021). |

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -1054,10 +1054,12 @@ required (a call naming none is a usage error, exit 2). `--key` accepts a Godot 
 `TriggerRight`), since an axis names a whole stick dimension and the sign is what makes it one
 binding — an omitted sign is `+`. Joypad names are case- and separator-insensitive (`DPadLeft`,
 `dpad_left`, `DPAD_LEFT` are one button), and `gda project add-input-action --help` / `--schema`
-list the accepted set; an unresolvable token of any kind is a clean `invalid_key` error naming that
-set (exit 4, nothing saved). `--device` pins this call's joypad events to one joypad; it defaults to
-`-1` (`InputMap.ALL_DEVICES`, every joypad) and is set explicitly, because a script-constructed event
-starts at device `0` — key events are always `-1` and `--device` never touches them. `--deadzone`
+list the accepted set; an unresolvable joypad token is a clean `invalid_key` error naming that set
+(exit 4, nothing saved), and an unresolvable key name is `invalid_key` naming the token alone.
+`--device` pins this call's joypad events to one joypad, `-1`..`2147483647` (the engine's 32-bit
+device field — a larger number is refused, since it would wrap to a different joypad); it defaults
+to `-1` (`InputMap.ALL_DEVICES`, every joypad) and is set explicitly, because a script-constructed
+event starts at device `0` — key events are always `-1` and `--device` never touches them. `--deadzone`
 overrides Godot's `0.5` default; `--physical` binds physical keycodes (keyboard position,
 layout-independent) instead of layout keycodes. The action is built from real `InputEventKey`,
 `InputEventJoypadButton` and `InputEventJoypadMotion` objects — appended in that kind order — and

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -1044,16 +1044,26 @@ engine-bookkeeping settings and the non-setting properties the engine's property
 are filtered out, so only real `ProjectSettings` keys appear. Like the rest of the group it requires
 a resolved project (`project_not_found`, exit 4, otherwise) and never instantiates a scene.
 
-**Input actions** (established by #380): `gda project add-input-action NAME --key K...` registers an
-InputMap action under `input/<name>` — the compound `{deadzone, events}` entry `project set` cannot
-express — with **key events only** for this slice (mouse/joypad kinds may extend it later). `--key`
-is repeatable and accepts a Godot key **name** (`J`, `Space`, `Escape`) or a raw base-10 **keycode**;
-an unresolvable token is a clean `invalid_key` error (exit 4, nothing saved). `--deadzone` overrides
-Godot's `0.5` default; `--physical` binds physical keycodes (keyboard position, layout-independent)
-instead of layout keycodes. The action is built from real `InputEventKey` objects and persisted via
-`ProjectSettings.save()`, so the serialization is exactly the engine's own `var_to_str` form — the
-editor and a running game load it identically to a hand-authored entry, and the action is immediately
-driveable by `gda input action NAME` in a live session started afterwards. Adding an existing action
+**Input actions** (established by #380, joypad kinds added by #842): `gda project add-input-action
+NAME --key K... --joy-button B... --joy-axis A...` registers an InputMap action under `input/<name>`
+— the compound `{deadzone, events}` entry `project set` cannot express — from keyboard and controller
+bindings declared in ONE call. Each option is repeatable and **at least one binding of any kind** is
+required (a call naming none is a usage error, exit 2). `--key` accepts a Godot key **name** (`J`,
+`Space`, `Escape`) or a raw base-10 **keycode**; `--joy-button` a `JoyButton` name (`A`, `Start`,
+`DPadLeft`, …) or index; `--joy-axis` an axis DIRECTION spelled `<axis>[:<sign>]` (`LeftX:-`,
+`TriggerRight`), since an axis names a whole stick dimension and the sign is what makes it one
+binding — an omitted sign is `+`. Joypad names are case- and separator-insensitive (`DPadLeft`,
+`dpad_left`, `DPAD_LEFT` are one button), and `gda project add-input-action --help` / `--schema`
+list the accepted set; an unresolvable token of any kind is a clean `invalid_key` error naming that
+set (exit 4, nothing saved). `--device` pins this call's joypad events to one joypad; it defaults to
+`-1` (`InputMap.ALL_DEVICES`, every joypad) and is set explicitly, because a script-constructed event
+starts at device `0` — key events are always `-1` and `--device` never touches them. `--deadzone`
+overrides Godot's `0.5` default; `--physical` binds physical keycodes (keyboard position,
+layout-independent) instead of layout keycodes. The action is built from real `InputEventKey`,
+`InputEventJoypadButton` and `InputEventJoypadMotion` objects — appended in that kind order — and
+persisted via `ProjectSettings.save()`, so the serialization is exactly the engine's own `var_to_str`
+form — the editor and a running game load it identically to a hand-authored entry, and the action is
+immediately driveable by `gda input action NAME` in a live session started afterwards. Adding an existing action
 name is `already_exists` (never a silent clobber — remove first to replace; note the engine registers
 the built-in `ui_*` actions as defaults, so adding e.g. `ui_accept` reports `already_exists` by
 design). `gda project remove-input-action NAME` unregisters the action and persists `project.godot`;
@@ -1066,7 +1076,7 @@ a missing action is `unknown_setting`, mirroring `remove-autoload`. A failed sav
 | `gda project list` | List the project's settings keys (customized by default; `--all` adds defaults, `--section` filters) |
 | `gda project set` | Modify a project setting (value coerced to its declared type) |
 | `gda project add-autoload` / `remove-autoload` | Register / unregister an autoload singleton |
-| `gda project add-input-action` / `remove-input-action` | Register / unregister an InputMap action (key events) |
+| `gda project add-input-action` / `remove-input-action` | Register / unregister an InputMap action (key, joypad button and joypad axis events) |
 
 ### `resource`
 

--- a/src/gda/commands/project.py
+++ b/src/gda/commands/project.py
@@ -14,10 +14,10 @@ DIRECTORY (ADR-0006): that one stays in the shared core below this layer, and
 the absolute imports keep the two names apart.
 """
 
-from typing import Any, Optional
+from typing import Annotated, Any, Literal, Optional, Union
 
 import typer
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from gda.dispatch import dispatch_domain, params_or_bad_parameter
 from gda.headless import (
@@ -498,13 +498,78 @@ class ProjectRemoveAutoloadResult(BaseModel):
     name: str = Field(description="The unregistered autoload's global name.")
 
 
+# The joypad binding NAMES `--joy-button` / `--joy-axis` accept, for the help and
+# schema prose. The RESOLVER's table lives in `operations.gd`, mapping each name
+# to the engine's own JoyButton/JoyAxis constant (issue #842); these tuples are a
+# doc-facing copy, pinned to that table by
+# tests/project/test_input_action_joy_names.py, which in turn diffs it against
+# the enum the engine itself dumps. The copy exists because the CLI has to
+# document the accepted set without reading GDScript at import time.
+JOY_BUTTON_NAMES: tuple[str, ...] = (
+    "A",
+    "B",
+    "X",
+    "Y",
+    "Back",
+    "Guide",
+    "Start",
+    "LeftStick",
+    "RightStick",
+    "LeftShoulder",
+    "RightShoulder",
+    "DPadUp",
+    "DPadDown",
+    "DPadLeft",
+    "DPadRight",
+    "Misc1",
+    "Paddle1",
+    "Paddle2",
+    "Paddle3",
+    "Paddle4",
+    "Touchpad",
+)
+
+JOY_AXIS_NAMES: tuple[str, ...] = (
+    "LeftX",
+    "LeftY",
+    "RightX",
+    "RightY",
+    "TriggerLeft",
+    "TriggerRight",
+)
+
+JOY_BUTTON_DESC = (
+    "A joypad button to bind (repeatable): a JoyButton NAME — "
+    + ", ".join(JOY_BUTTON_NAMES)
+    + " (case- and separator-insensitive, so DPadLeft, dpad_left and DPAD_LEFT "
+    "are one button) — or a base-10 button index."
+)
+
+JOY_AXIS_DESC = (
+    "A joypad axis DIRECTION to bind (repeatable), spelled <axis>[:<sign>]: a "
+    "JoyAxis name — "
+    + ", ".join(JOY_AXIS_NAMES)
+    + " (case- and separator-insensitive) — or a base-10 axis index, with the "
+    "sign + (the default) or - selecting the direction, e.g. LeftX:- for stick "
+    "left. One direction is one binding."
+)
+
+DEVICE_DESC = (
+    "The joypad device this call's joypad bindings match: -1 (the default) is "
+    "InputMap.ALL_DEVICES and matches every joypad, 0 and up name one specific "
+    "joypad. Key bindings are always -1 and are unaffected."
+)
+
+
 class ProjectAddInputActionParams(BaseModel):
-    """The operation params of ``gda project add-input-action`` (issue #380).
+    """The operation params of ``gda project add-input-action`` (issues #380, #842).
 
     Registers an InputMap action: ``name`` is the action name (the key under the
-    ``input/`` section of ``project.godot``), bound to one or more keyboard keys.
-    The operation builds real ``InputEventKey`` events and persists the action
-    via ``ProjectSettings`` — never a hand-built string — so the serialization is
+    ``input/`` section of ``project.godot``), bound to keyboard keys, joypad
+    buttons and joypad axis directions — at least one binding of any kind. The
+    operation builds real ``InputEventKey`` / ``InputEventJoypadButton`` /
+    ``InputEventJoypadMotion`` events and persists the action via
+    ``ProjectSettings`` — never a hand-built string — so the serialization is
     exactly the engine's own ``var_to_str`` form. The project is process context
     (``--project``), not an operation param (ADR-0006).
     """
@@ -516,11 +581,24 @@ class ProjectAddInputActionParams(BaseModel):
         )
     )
     keys: list[str] = Field(
-        min_length=1,
+        default_factory=list,
         description=(
-            "The keys to bind (at least one): each item is a Godot key NAME "
+            "The keys to bind: each item is a Godot key NAME "
             "(e.g. J, Space, Escape) or a base-10 keycode integer string."
         ),
+    )
+    joy_buttons: list[str] = Field(
+        default_factory=list,
+        description=JOY_BUTTON_DESC,
+    )
+    joy_axes: list[str] = Field(
+        default_factory=list,
+        description=JOY_AXIS_DESC,
+    )
+    device: int = Field(
+        default=-1,
+        ge=-1,
+        description=DEVICE_DESC,
     )
     deadzone: float = Field(
         default=0.5,
@@ -539,19 +617,33 @@ class ProjectAddInputActionParams(BaseModel):
         ),
     )
 
+    @model_validator(mode="after")
+    def _check_at_least_one_binding(self) -> "ProjectAddInputActionParams":
+        """Refuse an action that would match nothing.
+
+        The rule spans the three binding lists, so it cannot be a ``minItems``
+        on one of them: ``--key`` stopped being individually required when the
+        joypad kinds landed (#842), and an action registered with an empty event
+        list is a dead entry no input can ever trigger.
+        """
+        if not self.keys and not self.joy_buttons and not self.joy_axes:
+            raise ValueError(
+                "at least one binding is required: pass --key, --joy-button "
+                "or --joy-axis."
+            )
+        return self
+
 
 class InputActionKeyEvent(BaseModel):
-    """One key binding of a registered InputMap action (issue #380).
+    """One KEY binding of a registered InputMap action (issue #380).
 
-    ``kind`` discriminates the event type so mouse/joypad kinds can extend the
-    shape later without breaking; this slice emits only ``key`` events. ``key``
-    echoes the raw ``--key`` token, ``keycode`` the Godot keycode it resolved to,
-    and ``physical`` whether it was bound as ``physical_keycode``.
+    ``key`` echoes the raw ``--key`` token, ``keycode`` the Godot keycode it
+    resolved to, and ``physical`` whether it was bound as ``physical_keycode``.
+    A key event is always bound at device -1 (``InputMap.ALL_DEVICES``), so it
+    carries no ``device`` of its own.
     """
 
-    kind: str = Field(
-        default="key", description="The event kind ('key' for this slice)."
-    )
+    kind: Literal["key"] = Field(default="key", description="The event kind.")
     key: str = Field(description="The raw --key token as given (name or keycode).")
     keycode: int = Field(description="The Godot keycode the token resolved to.")
     physical: bool = Field(
@@ -559,18 +651,78 @@ class InputActionKeyEvent(BaseModel):
     )
 
 
+class InputActionJoyButtonEvent(BaseModel):
+    """One joypad BUTTON binding of a registered InputMap action (issue #842).
+
+    ``button`` echoes the raw ``--joy-button`` token, ``button_index`` the
+    ``JoyButton`` value it resolved to, and ``device`` the joypad the binding
+    matches (-1 = every joypad).
+    """
+
+    kind: Literal["joy_button"] = Field(
+        default="joy_button", description="The event kind."
+    )
+    button: str = Field(
+        description="The raw --joy-button token as given (name or index)."
+    )
+    button_index: int = Field(
+        description="The Godot JoyButton value the token resolved to."
+    )
+    device: int = Field(
+        description="The joypad device the binding matches (-1 = every joypad)."
+    )
+
+
+class InputActionJoyAxisEvent(BaseModel):
+    """One joypad AXIS DIRECTION binding of a registered action (issue #842).
+
+    ``axis`` echoes the raw ``--joy-axis`` token (sign included),
+    ``axis_index`` the ``JoyAxis`` value it resolved to, ``axis_value`` the
+    direction the sign selected (+1.0 or -1.0), and ``device`` the joypad the
+    binding matches (-1 = every joypad).
+    """
+
+    kind: Literal["joy_axis"] = Field(default="joy_axis", description="The event kind.")
+    axis: str = Field(description="The raw --joy-axis token as given, sign included.")
+    axis_index: int = Field(
+        description="The Godot JoyAxis value the token resolved to."
+    )
+    axis_value: float = Field(
+        description="The direction the token's sign selected: +1.0 or -1.0."
+    )
+    device: int = Field(
+        description="The joypad device the binding matches (-1 = every joypad)."
+    )
+
+
+# One bound event, as a DISCRIMINATED union on `kind` (#842). #380 shipped `kind`
+# on the key event precisely so the joypad kinds could extend the shape without
+# breaking it; making the extension a discriminated union publishes each kind's
+# own field set in the schema, so a client reads what a joypad event carries from
+# the contract rather than from a sample payload.
+InputActionEvent = Annotated[
+    Union[InputActionKeyEvent, InputActionJoyButtonEvent, InputActionJoyAxisEvent],
+    Field(discriminator="kind"),
+]
+
+
 class ProjectAddInputActionResult(BaseModel):
     """The result of ``gda project add-input-action``: the action it registered.
 
     Echoes the action's ``name``, the ``deadzone`` persisted, and the resolved
-    key ``events`` exactly as they were bound — so an agent can confirm each key
-    token mapped to the intended keycode without re-reading ``project.godot``.
+    ``events`` exactly as they were bound — so an agent can confirm each token
+    mapped to the intended keycode, button or axis direction without re-reading
+    ``project.godot``. The events are reported (and persisted) in kind order:
+    keys, then joypad buttons, then joypad axis directions.
     """
 
     name: str = Field(description="The registered input action's name.")
     deadzone: float = Field(description="The deadzone persisted with the action.")
-    events: list[InputActionKeyEvent] = Field(
-        description="The key events bound to the action, in --key order."
+    events: list[InputActionEvent] = Field(
+        description=(
+            "The events bound to the action: the --key ones first, then the "
+            "--joy-button ones, then the --joy-axis ones, each in argv order."
+        )
     )
 
 
@@ -649,17 +801,36 @@ def render_project_remove_autoload(removed: "ProjectRemoveAutoloadResult") -> st
     return f"removed autoload {removed.name}"
 
 
-def render_project_add_input_action(added: "ProjectAddInputActionResult") -> str:
-    """Render a registered input action with its resolved key bindings.
+def _render_input_action_binding(event: "InputActionEvent") -> str:
+    """Render one bound event as ``<token> -> <resolved>``, per kind."""
+    if isinstance(event, InputActionKeyEvent):
+        physical = " (physical)" if event.physical else ""
+        return f"{event.key} -> {event.keycode}{physical}"
+    if isinstance(event, InputActionJoyButtonEvent):
+        return f"joy button {event.button} -> {event.button_index}"
+    return f"joy axis {event.axis} -> {event.axis_index} ({event.axis_value})"
 
-    e.g. ``added input action jump (deadzone 0.5): J -> 74, Space -> 32``; a
-    physical binding is marked ``(physical)`` after its keycode.
+
+def render_project_add_input_action(added: "ProjectAddInputActionResult") -> str:
+    """Render a registered input action with its resolved bindings.
+
+    e.g. ``added input action jump (deadzone 0.5): J -> 74, joy button A -> 0
+    [device -1]``; a physical key binding is marked ``(physical)`` after its
+    keycode, and an axis direction shows the ``axis_value`` its sign selected.
+    The device is stated ONCE at the end, and only when the action has a joypad
+    binding: ``--device`` is a property of the call, not of a single binding, and
+    it never applies to a key event.
     """
-    bindings = ", ".join(
-        f"{event.key} -> {event.keycode}" + (" (physical)" if event.physical else "")
+    bindings = ", ".join(_render_input_action_binding(event) for event in added.events)
+    line = f"added input action {added.name} (deadzone {added.deadzone}): {bindings}"
+    joypad = [
+        event
         for event in added.events
-    )
-    return f"added input action {added.name} (deadzone {added.deadzone}): {bindings}"
+        if isinstance(event, (InputActionJoyButtonEvent, InputActionJoyAxisEvent))
+    ]
+    if joypad:
+        line += f" [device {joypad[0].device}]"
+    return line
 
 
 def render_project_remove_input_action(
@@ -1055,12 +1226,28 @@ def project_add_input_action(
         ..., help="The input action's name (the input/<name> key)."
     ),
     keys: list[str] = typer.Option(
-        ...,
+        [],
         "--key",
         help=(
-            "A key to bind (repeatable, at least one): a Godot key name "
-            "(e.g. J, Space, Escape) or a base-10 keycode integer."
+            "A key to bind (repeatable): a Godot key name "
+            "(e.g. J, Space, Escape) or a base-10 keycode integer. At least one "
+            "binding of any kind is required."
         ),
+    ),
+    joy_buttons: list[str] = typer.Option(
+        [],
+        "--joy-button",
+        help=JOY_BUTTON_DESC,
+    ),
+    joy_axes: list[str] = typer.Option(
+        [],
+        "--joy-axis",
+        help=JOY_AXIS_DESC,
+    ),
+    device: int = typer.Option(
+        -1,
+        "--device",
+        help=DEVICE_DESC,
     ),
     deadzone: float = typer.Option(
         0.5,
@@ -1081,11 +1268,14 @@ def project_add_input_action(
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
-    """Register an InputMap action bound to one or more keys, then save project.godot."""
+    """Register an InputMap action bound to keys and/or joypad inputs, then save project.godot."""
     params = params_or_bad_parameter(
         ProjectAddInputActionParams,
         name=name,
         keys=keys,
+        joy_buttons=joy_buttons,
+        joy_axes=joy_axes,
+        device=device,
         deadzone=deadzone,
         physical=physical,
     )

--- a/src/gda/commands/project.py
+++ b/src/gda/commands/project.py
@@ -554,10 +554,18 @@ JOY_AXIS_DESC = (
     "left. One direction is one binding."
 )
 
+# InputEvent.device is a 32-bit field in the engine. A larger integer is not
+# refused by GDScript's 64-bit int but WRAPS on assignment (4294967295 becomes
+# -1, every joypad; 2147483648 becomes -2147483648), so the bound is the model's,
+# refused before any engine is spawned.
+INPUT_EVENT_DEVICE_MAX = 2**31 - 1
+
 DEVICE_DESC = (
     "The joypad device this call's joypad bindings match: -1 (the default) is "
     "InputMap.ALL_DEVICES and matches every joypad, 0 and up name one specific "
-    "joypad. Key bindings are always -1 and are unaffected."
+    f"joypad, at most {INPUT_EVENT_DEVICE_MAX} (the engine stores an event's "
+    "device as a 32-bit integer; a larger number would wrap and match a "
+    "different joypad). Key bindings are always -1 and are unaffected."
 )
 
 
@@ -619,6 +627,7 @@ class ProjectAddInputActionParams(BaseModel):
     device: int = Field(
         default=-1,
         ge=-1,
+        le=INPUT_EVENT_DEVICE_MAX,
         description=DEVICE_DESC,
     )
     deadzone: float = Field(

--- a/src/gda/commands/project.py
+++ b/src/gda/commands/project.py
@@ -17,7 +17,7 @@ the absolute imports keep the two names apart.
 from typing import Annotated, Any, Literal, Optional, Union
 
 import typer
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from gda.dispatch import dispatch_domain, params_or_bad_parameter
 from gda.headless import (
@@ -561,6 +561,25 @@ DEVICE_DESC = (
 )
 
 
+# The "at least one binding" rule, published as JSON Schema so a standard Draft
+# 2020-12 validator reaches the SAME verdict as the model. ADR-0015 makes the
+# params model the one authority for both, which means the published input
+# contract must not be wider than the ABI `--params-json` actually accepts, and a
+# model-validator cross-field rule has to be visible to a plain validator (#743).
+# While `keys` was the only binding kind the rule rode on it as `minItems: 1`;
+# spread across three lists it becomes an `anyOf` — at least one list present and
+# non-empty. `_check_at_least_one_binding` below stays the ENFORCING authority; a
+# parity corpus (tests/project/test_project_commands.py) runs the same payloads
+# through the schema and the model and requires one verdict, so the two cannot
+# drift.
+_AT_LEAST_ONE_BINDING_SCHEMA: dict[str, Any] = {
+    "anyOf": [
+        {"required": [field], "properties": {field: {"minItems": 1}}}
+        for field in ("keys", "joy_buttons", "joy_axes")
+    ]
+}
+
+
 class ProjectAddInputActionParams(BaseModel):
     """The operation params of ``gda project add-input-action`` (issues #380, #842).
 
@@ -573,6 +592,8 @@ class ProjectAddInputActionParams(BaseModel):
     exactly the engine's own ``var_to_str`` form. The project is process context
     (``--project``), not an operation param (ADR-0006).
     """
+
+    model_config = ConfigDict(json_schema_extra=_AT_LEAST_ONE_BINDING_SCHEMA)
 
     name: str = Field(
         description=(
@@ -624,7 +645,10 @@ class ProjectAddInputActionParams(BaseModel):
         The rule spans the three binding lists, so it cannot be a ``minItems``
         on one of them: ``--key`` stopped being individually required when the
         joypad kinds landed (#842), and an action registered with an empty event
-        list is a dead entry no input can ever trigger.
+        list is a dead entry no input can ever trigger. This check is the
+        enforcing authority; ``_AT_LEAST_ONE_BINDING_SCHEMA`` publishes the same
+        rule so a schema-only client is refused here too, not surprised at
+        dispatch.
         """
         if not self.keys and not self.joy_buttons and not self.joy_axes:
             raise ValueError(

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -639,7 +639,9 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.OPERATION,
         EXIT_OPERATION,
         ErrorCodeSource.OPERATION,
-        "An input-action key could not be resolved to a Godot keycode (unknown key name or non-positive keycode).",
+        "An input-action binding token could not be resolved: a key name or "
+        "keycode that maps to no Godot keycode, or a joypad button or axis "
+        "direction that names no JoyButton / JoyAxis.",
     ),
     ErrorCodeSpec(
         "contract_violation",

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -226,6 +226,10 @@ const AUTOLOAD_ENABLED_PREFIX := "*"
 # are real InputEventKey Objects, persisted via ProjectSettings.save() so the
 # serialization is exactly the engine's own var_to_str form.
 const INPUT_SETTING_PREFIX := "input/"
+# InputEvent.device is a 32-bit field: a larger int wraps on assignment (issue
+# #842 review), so the op refuses it as the CLI does rather than storing a
+# different device than the caller named.
+const INPUT_EVENT_DEVICE_MAX := 2147483647
 
 # The exit code the process will use. Defaults to failure, so an operation that
 # aborts before recording an outcome (e.g. an uncaught runtime error) still
@@ -3981,8 +3985,10 @@ func _op_project_add_input_action(params: Dictionary) -> void:
 	var deadzone := float(raw_deadzone)
 	var physical := bool(params.get("physical", false))
 	var raw_device: Variant = params.get("device", -1)
-	if not (raw_device is int or raw_device is float) or int(raw_device) < -1:
-		_fail(OP_ERROR_INVALID_PARAMS, "device must be an integer >= -1 (-1 matches every joypad)")
+	if (not (raw_device is int or raw_device is float) or int(raw_device) < -1
+			or int(raw_device) > INPUT_EVENT_DEVICE_MAX):
+		_fail(OP_ERROR_INVALID_PARAMS, "device must be an integer in -1.." + str(INPUT_EVENT_DEVICE_MAX)
+				+ " (-1 matches every joypad; the engine stores the device as a 32-bit integer)")
 		return
 	var device := int(raw_device)
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -3846,6 +3846,11 @@ const JOY_AXIS_BY_NAME := {
 # Fold a joypad binding name to its comparison form: case- and separator-
 # insensitive, so DPadLeft, dpad_left and DPAD_LEFT all name the same button —
 # a caller may spell it gda's way or the engine documentation's way.
+# Separator-insensitivity is total on purpose: separators are DELETED, not
+# normalized, so a leading or trailing one folds away too ("A-" is A). That
+# widens the spellings accepted and never makes two buttons collide — the
+# oracle test asserts the folded names stay unique — and the alternative would
+# be a separator grammar for a token no caller writes deliberately.
 func _fold_joy_name(token: String) -> String:
 	return token.strip_edges().replace("_", "").replace("-", "").replace(" ", "").to_upper()
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -3799,23 +3799,146 @@ func _resolve_input_keycode(token: String) -> int:
 	return OS.find_keycode_from_string(trimmed)
 
 
+# The JoyButton / JoyAxis names --joy-button and --joy-axis accept (issue #842),
+# each mapped to the ENGINE's own global constant. Godot ships no name resolver
+# for the joypad enums — there is no counterpart of OS.find_keycode_from_string —
+# so gda has to carry the table; mapping every name to the engine constant keeps
+# each VALUE the engine's (the GDScript compiler resolves it) and leaves gda
+# owning only the SPELLING. The enums' INVALID / SDL_MAX / MAX entries are
+# deliberately absent: they are enum bookkeeping, not bindable inputs.
+# tests/project/test_input_action_joy_names.py diffs both tables against the enum
+# the engine itself dumps, so an engine that gains a button fails a test here
+# instead of silently going unbindable.
+const JOY_BUTTON_BY_NAME := {
+	"A": JOY_BUTTON_A,
+	"B": JOY_BUTTON_B,
+	"X": JOY_BUTTON_X,
+	"Y": JOY_BUTTON_Y,
+	"Back": JOY_BUTTON_BACK,
+	"Guide": JOY_BUTTON_GUIDE,
+	"Start": JOY_BUTTON_START,
+	"LeftStick": JOY_BUTTON_LEFT_STICK,
+	"RightStick": JOY_BUTTON_RIGHT_STICK,
+	"LeftShoulder": JOY_BUTTON_LEFT_SHOULDER,
+	"RightShoulder": JOY_BUTTON_RIGHT_SHOULDER,
+	"DPadUp": JOY_BUTTON_DPAD_UP,
+	"DPadDown": JOY_BUTTON_DPAD_DOWN,
+	"DPadLeft": JOY_BUTTON_DPAD_LEFT,
+	"DPadRight": JOY_BUTTON_DPAD_RIGHT,
+	"Misc1": JOY_BUTTON_MISC1,
+	"Paddle1": JOY_BUTTON_PADDLE1,
+	"Paddle2": JOY_BUTTON_PADDLE2,
+	"Paddle3": JOY_BUTTON_PADDLE3,
+	"Paddle4": JOY_BUTTON_PADDLE4,
+	"Touchpad": JOY_BUTTON_TOUCHPAD,
+}
+
+const JOY_AXIS_BY_NAME := {
+	"LeftX": JOY_AXIS_LEFT_X,
+	"LeftY": JOY_AXIS_LEFT_Y,
+	"RightX": JOY_AXIS_RIGHT_X,
+	"RightY": JOY_AXIS_RIGHT_Y,
+	"TriggerLeft": JOY_AXIS_TRIGGER_LEFT,
+	"TriggerRight": JOY_AXIS_TRIGGER_RIGHT,
+}
+
+
+# Fold a joypad binding name to its comparison form: case- and separator-
+# insensitive, so DPadLeft, dpad_left and DPAD_LEFT all name the same button —
+# a caller may spell it gda's way or the engine documentation's way.
+func _fold_joy_name(token: String) -> String:
+	return token.strip_edges().replace("_", "").replace("-", "").replace(" ", "").to_upper()
+
+
+# Look one folded token up in a joypad name table, or return -1 (the INVALID
+# member both enums share) when nothing matches.
+func _lookup_joy_name(table: Dictionary, token: String) -> int:
+	var folded := _fold_joy_name(token)
+	for name in table:
+		if _fold_joy_name(name) == folded:
+			return table[name]
+	return -1
+
+
+# The accepted-name list a refusal message names, read off the table itself so
+# the message cannot drift from what the resolver accepts.
+func _joy_name_list(table: Dictionary) -> String:
+	return ", ".join(PackedStringArray(table.keys()))
+
+
+# Resolve one --joy-button token to a JoyButton index (issue #842). A base-10
+# integer is taken as a raw index and must sit inside the engine's own JoyButton
+# range (0..JOY_BUTTON_MAX - 1 — a device may report more buttons than the SDL
+# names cover); anything else is a name looked up case- and separator-
+# insensitively. Returns JOY_BUTTON_INVALID when the token names nothing.
+func _resolve_joy_button(token: String) -> int:
+	var trimmed := token.strip_edges()
+	if trimmed.is_valid_int():
+		var index := trimmed.to_int()
+		return index if index >= 0 and index < JOY_BUTTON_MAX else JOY_BUTTON_INVALID
+	return _lookup_joy_name(JOY_BUTTON_BY_NAME, trimmed)
+
+
+# Resolve one --joy-axis token to a JoyAxis index (issue #842), same rules as
+# _resolve_joy_button over the JoyAxis range. Returns JOY_AXIS_INVALID when the
+# token names nothing.
+func _resolve_joy_axis(token: String) -> int:
+	var trimmed := token.strip_edges()
+	if trimmed.is_valid_int():
+		var index := trimmed.to_int()
+		return index if index >= 0 and index < JOY_AXIS_MAX else JOY_AXIS_INVALID
+	return _lookup_joy_name(JOY_AXIS_BY_NAME, trimmed)
+
+
+# Split one --joy-axis token into its axis part and its axis_value (issue #842).
+# The token is `<axis>[:<sign>]`: an axis names a whole stick DIMENSION, so the
+# sign is what turns it into one bindable direction (`LeftX:-` is "stick left").
+# An omitted sign is the positive direction — the only sensible reading for a
+# trigger, which never goes negative. Returns an empty Dictionary when the token
+# is not a resolvable direction; the caller reports it with the accepted set.
+func _parse_joy_axis_token(token: String) -> Dictionary:
+	var parts := token.strip_edges().split(":")
+	if parts.size() > 2:
+		return {}
+	var axis := _resolve_joy_axis(parts[0])
+	if axis == JOY_AXIS_INVALID:
+		return {}
+	var axis_value := 1.0
+	if parts.size() == 2:
+		match parts[1]:
+			"+":
+				axis_value = 1.0
+			"-":
+				axis_value = -1.0
+			_:
+				return {}
+	return {"axis": axis, "axis_value": axis_value}
+
+
 # project-add-input-action: register an InputMap action under input/<name> with
-# one or more keyboard key bindings, then persist project.godot (issue #380).
+# keyboard and/or joypad bindings, then persist project.godot (issues #380, #842).
 #
 # The stored value is the InputMap Dictionary shape — {deadzone, events} with
-# real InputEventKey Objects, deadzone first (Godot's own key order) — set via
+# real InputEvent Objects, deadzone first (Godot's own key order) — set via
 # ProjectSettings.set_setting and serialized by ProjectSettings.save() (the
 # engine's own var_to_str form). gda never hand-builds the Object(InputEventKey,
 # …) string, so the persisted entry is byte-equivalent to a hand-authored one.
+# That holds for every event kind: the joypad kinds are real
+# InputEventJoypadButton / InputEventJoypadMotion objects, serialized the same way.
+#
+# The events are appended in kind order — keys, then joypad buttons, then joypad
+# axis directions — so one call's persisted order is deterministic.
 #
 # Failure modes use registered codes: an empty name is invalid_path (the
-# missing-required-param convention the autoload ops set); malformed keys /
-# deadzone / physical params are invalid_params; an action name already present
-# is already_exists (add never silently clobbers — remove first to replace).
-# NOTE: the engine registers the built-in ui_* actions (input/ui_accept, …) as
-# ProjectSettings defaults, so has_setting answers true for them and adding e.g.
-# ui_accept reports already_exists by design. An unresolvable key token is
-# invalid_key (nothing saved); a failed save is save_failed.
+# missing-required-param convention the autoload ops set); malformed params,
+# and a call naming no binding at all, are invalid_params; an action name already
+# present is already_exists (add never silently clobbers — remove first to
+# replace). NOTE: the engine registers the built-in ui_* actions
+# (input/ui_accept, …) as ProjectSettings defaults, so has_setting answers true
+# for them and adding e.g. ui_accept reports already_exists by design. An
+# unresolvable BINDING token — a key, a joypad button or a joypad axis direction —
+# is invalid_key naming the accepted set (nothing saved); a failed save is
+# save_failed.
 func _op_project_add_input_action(params: Dictionary) -> void:
 	_diag("running operation: project-add-input-action")
 	if not _has_project():
@@ -3827,9 +3950,24 @@ func _op_project_add_input_action(params: Dictionary) -> void:
 		return
 	# Defensive params reads: the params arrive as arbitrary JSON, so a wrong
 	# shape surfaces as a structured failure rather than a runtime error.
-	var raw_keys: Variant = params.get("keys")
-	if not (raw_keys is Array) or (raw_keys as Array).is_empty():
-		_fail(OP_ERROR_INVALID_PARAMS, "keys must be a non-empty array of key names or keycodes")
+	var raw_keys: Variant = params.get("keys", [])
+	if not (raw_keys is Array):
+		_fail(OP_ERROR_INVALID_PARAMS, "keys must be an array of key names or keycodes")
+		return
+	var raw_joy_buttons: Variant = params.get("joy_buttons", [])
+	if not (raw_joy_buttons is Array):
+		_fail(OP_ERROR_INVALID_PARAMS, "joy_buttons must be an array of JoyButton names or indices")
+		return
+	var raw_joy_axes: Variant = params.get("joy_axes", [])
+	if not (raw_joy_axes is Array):
+		_fail(OP_ERROR_INVALID_PARAMS, "joy_axes must be an array of <axis>[:<sign>] tokens")
+		return
+	# An action with no event matches nothing, so the op refuses it rather than
+	# registering a dead entry. On the argv path the same rule is a model-side
+	# usage error before dispatch (ADR-0015); this is the params-json edge.
+	if (raw_keys as Array).is_empty() and (raw_joy_buttons as Array).is_empty() \
+			and (raw_joy_axes as Array).is_empty():
+		_fail(OP_ERROR_INVALID_PARAMS, "at least one binding is required: keys, joy_buttons or joy_axes")
 		return
 	var raw_deadzone: Variant = params.get("deadzone", 0.5)
 	if not (raw_deadzone is float or raw_deadzone is int):
@@ -3837,6 +3975,11 @@ func _op_project_add_input_action(params: Dictionary) -> void:
 		return
 	var deadzone := float(raw_deadzone)
 	var physical := bool(params.get("physical", false))
+	var raw_device: Variant = params.get("device", -1)
+	if not (raw_device is int or raw_device is float) or int(raw_device) < -1:
+		_fail(OP_ERROR_INVALID_PARAMS, "device must be an integer >= -1 (-1 matches every joypad)")
+		return
+	var device := int(raw_device)
 
 	var setting := INPUT_SETTING_PREFIX + action_name
 	if ProjectSettings.has_setting(setting):
@@ -3844,16 +3987,17 @@ func _op_project_add_input_action(params: Dictionary) -> void:
 				+ " — add-input-action never overwrites; remove it first to replace it")
 		return
 
-	# Resolve every key token before touching ProjectSettings, so a bad token
+	# Resolve every binding token before touching ProjectSettings, so a bad token
 	# fails the whole add cleanly with nothing saved. `events` stays an UNTYPED
 	# Array: a typed Array[InputEventKey] would serialize with an
 	# `Array[InputEventKey](...)` annotation, not the plain `[Object(...)]` form
-	# the editor writes — untyped keeps the persisted entry byte-equivalent.
+	# the editor writes — untyped keeps the persisted entry byte-equivalent, and
+	# it is also what lets the three event kinds share one array.
 	var events := []
 	var reported_events := []
 	for raw_token in (raw_keys as Array):
 		if not (raw_token is String):
-			_fail(OP_ERROR_INVALID_PARAMS, "keys must be a non-empty array of key names or keycodes")
+			_fail(OP_ERROR_INVALID_PARAMS, "keys must be an array of key names or keycodes")
 			return
 		var token: String = raw_token
 		var keycode := _resolve_input_keycode(token)
@@ -3864,7 +4008,8 @@ func _op_project_add_input_action(params: Dictionary) -> void:
 		# Match from ANY device, the editor's convention (InputMap::ALL_DEVICES,
 		# -1): InputMap matching filters on device, and a real keyboard event
 		# carries DEVICE_ID_KEYBOARD (16), so the InputEventKey.new() default of
-		# device 0 would never match a physical key press.
+		# device 0 would never match a physical key press. --device names a
+		# JOYPAD and so is never applied to a key event.
 		event.device = -1
 		# --physical binds the keyboard POSITION (physical_keycode) instead of
 		# the layout symbol (keycode) — set only the requested one, exactly as
@@ -3879,6 +4024,58 @@ func _op_project_add_input_action(params: Dictionary) -> void:
 			"key": token,
 			"keycode": keycode,
 			"physical": physical,
+		})
+	for raw_token in (raw_joy_buttons as Array):
+		if not (raw_token is String):
+			_fail(OP_ERROR_INVALID_PARAMS, "joy_buttons must be an array of JoyButton names or indices")
+			return
+		var token: String = raw_token
+		var button_index := _resolve_joy_button(token)
+		if button_index == JOY_BUTTON_INVALID:
+			_fail(OP_ERROR_INVALID_KEY, "cannot resolve joypad button: " + token
+					+ " — accepted names (case- and separator-insensitive): "
+					+ _joy_name_list(JOY_BUTTON_BY_NAME)
+					+ "; or an index 0.." + str(JOY_BUTTON_MAX - 1))
+			return
+		var event := InputEventJoypadButton.new()
+		# InputEvent::device defaults to 0 in the engine, which matches only the
+		# FIRST joypad; --device defaults to -1 (InputMap::ALL_DEVICES) and is set
+		# explicitly here for the same reason the key path sets it.
+		event.device = device
+		event.button_index = button_index as JoyButton
+		events.append(event)
+		reported_events.append({
+			"kind": "joy_button",
+			"button": token,
+			"button_index": button_index,
+			"device": device,
+		})
+	for raw_token in (raw_joy_axes as Array):
+		if not (raw_token is String):
+			_fail(OP_ERROR_INVALID_PARAMS, "joy_axes must be an array of <axis>[:<sign>] tokens")
+			return
+		var token: String = raw_token
+		var parsed := _parse_joy_axis_token(token)
+		if parsed.is_empty():
+			_fail(OP_ERROR_INVALID_KEY, "cannot resolve joypad axis direction: " + token
+					+ " — expected <axis>[:<sign>] with sign + or - (default +) and an axis"
+					+ " named (case- and separator-insensitive): "
+					+ _joy_name_list(JOY_AXIS_BY_NAME)
+					+ "; or an index 0.." + str(JOY_AXIS_MAX - 1))
+			return
+		var axis: int = parsed["axis"]
+		var axis_value: float = parsed["axis_value"]
+		var event := InputEventJoypadMotion.new()
+		event.device = device
+		event.axis = axis as JoyAxis
+		event.axis_value = axis_value
+		events.append(event)
+		reported_events.append({
+			"kind": "joy_axis",
+			"axis": token,
+			"axis_index": axis,
+			"axis_value": axis_value,
+			"device": device,
 		})
 
 	# deadzone first — the key order Godot itself writes for an input action.

--- a/tests/cli/test_models.py
+++ b/tests/cli/test_models.py
@@ -3,6 +3,8 @@
 import json
 
 import jsonschema
+import pytest
+from pydantic import ValidationError
 
 from gda.commands.node import (
     NodeAddResult,
@@ -44,6 +46,9 @@ from gda.commands.export import (
     ExportRunResult,
 )
 from gda.commands.project import (
+    InputActionJoyAxisEvent,
+    InputActionJoyButtonEvent,
+    InputActionKeyEvent,
     ListedProjectSetting,
     ProjectAddAutoloadResult,
     ProjectAddInputActionResult,
@@ -1259,8 +1264,7 @@ def test_project_remove_autoload_result_round_trips_the_unregistered_name():
 def test_project_add_input_action_result_round_trips_the_registered_action():
     # project add-input-action echoes the action it registered (issue #380): the
     # name, the persisted deadzone, and each key event with the raw token, the
-    # resolved keycode, and whether it was bound as physical_keycode. `kind`
-    # discriminates the event type so mouse/joypad kinds can extend it later.
+    # resolved keycode, and whether it was bound as physical_keycode.
     payload = {
         "name": "jump",
         "deadzone": 0.2,
@@ -1274,10 +1278,59 @@ def test_project_add_input_action_result_round_trips_the_registered_action():
 
     assert added.name == "jump"
     assert added.deadzone == 0.2
-    assert [event.keycode for event in added.events] == [74, 4194320]
-    assert added.events[0].kind == "key"
-    assert added.events[1].physical is True
+    keys = [event for event in added.events if isinstance(event, InputActionKeyEvent)]
+    assert [event.keycode for event in keys] == [74, 4194320]
+    assert keys[0].kind == "key"
+    assert keys[1].physical is True
     assert json.loads(added.model_dump_json()) == payload
+
+
+def test_project_add_input_action_result_round_trips_joypad_events():
+    # `kind` was put on the key event so joypad kinds could extend it (#380);
+    # #842 is that extension, as a DISCRIMINATED union: each kind validates into
+    # its own model with its own fields, and a wrong-kind field is a refusal
+    # rather than a silently ignored extra.
+    payload = {
+        "name": "jump",
+        "deadzone": 0.5,
+        "events": [
+            {"kind": "joy_button", "button": "A", "button_index": 0, "device": -1},
+            {
+                "kind": "joy_axis",
+                "axis": "LeftX:-",
+                "axis_index": 0,
+                "axis_value": -1.0,
+                "device": 1,
+            },
+        ],
+    }
+
+    added = ProjectAddInputActionResult.model_validate(payload)
+
+    button, axis = added.events
+    assert isinstance(button, InputActionJoyButtonEvent)
+    assert (button.button, button.button_index, button.device) == ("A", 0, -1)
+    assert isinstance(axis, InputActionJoyAxisEvent)
+    assert (axis.axis, axis.axis_index, axis.axis_value, axis.device) == (
+        "LeftX:-",
+        0,
+        -1.0,
+        1,
+    )
+    assert json.loads(added.model_dump_json()) == payload
+
+
+def test_project_add_input_action_result_rejects_an_unknown_event_kind():
+    # The discriminator is closed: an event kind the contract does not publish is
+    # a validation refusal, not an untyped passthrough.
+    with pytest.raises(ValidationError):
+        ProjectAddInputActionResult.model_validate(
+            {
+                "name": "jump",
+                "deadzone": 0.5,
+                "events": [{"kind": "mouse_button", "button_index": 1}],
+            }
+        )
 
 
 def test_project_remove_input_action_result_round_trips_the_unregistered_name():

--- a/tests/project/test_e2e_project.py
+++ b/tests/project/test_e2e_project.py
@@ -15,6 +15,7 @@ import json
 
 import pytest
 
+from gda.commands.project import INPUT_EVENT_DEVICE_MAX
 from tests.support import Gda, panel_text
 
 from tests.conftest import project_godot
@@ -782,6 +783,45 @@ def test_project_add_input_action_device_pins_the_joypad_events(godot_project):
     events = {event["type"]: event for event in value["events"]}
     assert events["InputEventKey"]["device"] == -1
     assert events["InputEventJoypadButton"]["device"] == 1
+
+
+@pytest.mark.e2e
+def test_project_add_input_action_refuses_a_device_the_engine_field_cannot_hold(
+    godot_project,
+):
+    # InputEvent.device is a 32-bit field: the engine ACCEPTED 4294967295 and
+    # stored -1 (every joypad), so a binding meant for one joypad silently
+    # matched all of them. The ceiling is refused before any engine is spawned,
+    # and the project is untouched; the largest representable device round-trips.
+    before = (godot_project / "project.godot").read_text(encoding="utf-8")
+
+    refused = Gda(godot_project)(
+        "project",
+        "add-input-action",
+        "overflow",
+        "--joy-button",
+        "A",
+        "--device",
+        "4294967295",
+        "--json",
+    )
+
+    assert refused.returncode == 2, refused.stdout + refused.stderr
+    assert (godot_project / "project.godot").read_text(encoding="utf-8") == before
+
+    added = Gda(godot_project).json(
+        "project",
+        "add-input-action",
+        "last_pad",
+        "--joy-button",
+        "A",
+        "--device",
+        str(INPUT_EVENT_DEVICE_MAX),
+    )
+    assert added["events"][0]["device"] == INPUT_EVENT_DEVICE_MAX
+
+    value = Gda(godot_project).json("project", "get", "input/last_pad")["value"]
+    assert value["events"][0]["device"] == INPUT_EVENT_DEVICE_MAX
 
 
 @pytest.mark.e2e

--- a/tests/project/test_e2e_project.py
+++ b/tests/project/test_e2e_project.py
@@ -15,7 +15,7 @@ import json
 
 import pytest
 
-from tests.support import Gda
+from tests.support import Gda, panel_text
 
 from tests.conftest import project_godot
 
@@ -607,3 +607,223 @@ def test_project_info_without_project_is_a_clean_error():
     assert proc.returncode == 4
     err = json.loads(proc.stdout)["error"]
     assert err["code"] == "project_not_found"
+
+
+# --- joypad bindings (#842) --------------------------------------------------
+
+# A headless probe of the InputMap the ENGINE built from project.godot: it prints
+# one JSON line per bound event of an action, so the assertion is on what the
+# engine loaded, not on what gda wrote. `project get` reads the stored SETTING;
+# this reads the InputMap the running game actually consults, which is the thing
+# a controller binding has to reach.
+INPUT_MAP_PROBE_GD = """\
+extends SceneTree
+
+func _initialize() -> void:
+\tvar rows := []
+\tfor event in InputMap.action_get_events("jump"):
+\t\tvar row := {"class": event.get_class(), "device": event.device}
+\t\tif event is InputEventKey:
+\t\t\trow["keycode"] = event.keycode
+\t\telif event is InputEventJoypadButton:
+\t\t\trow["button_index"] = event.button_index
+\t\telif event is InputEventJoypadMotion:
+\t\t\trow["axis"] = event.axis
+\t\t\trow["axis_value"] = event.axis_value
+\t\trows.append(row)
+\tprint("INPUT_MAP=", JSON.stringify(rows))
+\tquit(0)
+"""
+
+
+@pytest.mark.e2e
+def test_project_add_input_action_persists_key_and_joypad_events_in_var_to_str_form(
+    godot_project,
+):
+    # The #380 byte-equivalence regression, EXTENDED to the joypad event types
+    # (#842): one call declares a key, a joypad button and a joypad axis
+    # direction, and project.godot carries all three as the engine's own
+    # var_to_str Object literals — gda hand-builds none of them (ADR-0033).
+    # Issue #843 extends this same fixture with its restored-line assertions.
+    added = Gda(godot_project).json(
+        "project",
+        "add-input-action",
+        "jump",
+        "--key",
+        "Space",
+        "--joy-button",
+        "A",
+        "--joy-axis",
+        "LeftX:-",
+    )
+
+    assert added["name"] == "jump"
+    assert added["events"] == [
+        {"kind": "key", "key": "Space", "keycode": 32, "physical": False},
+        {"kind": "joy_button", "button": "A", "button_index": 0, "device": -1},
+        {
+            "kind": "joy_axis",
+            "axis": "LeftX:-",
+            "axis_index": 0,
+            "axis_value": -1.0,
+            "device": -1,
+        },
+    ]
+
+    normalized = _normalized_project_godot(godot_project)
+    assert "[input]" in normalized
+    assert "Object(InputEventKey" in normalized
+    assert "Object(InputEventJoypadButton" in normalized
+    assert "Object(InputEventJoypadMotion" in normalized
+    # JOY_BUTTON_A is 0 and JOY_AXIS_LEFT_X is 0 (godot 4.6.3-stable,
+    # core/input/input_enums.h); the `-` sign is axis_value -1.0.
+    assert '"button_index":0' in normalized
+    assert '"axis":0' in normalized
+    assert '"axis_value":-1.0' in normalized
+    # Every event matches ANY device by default (InputMap ALL_DEVICES).
+    assert '"device":0' not in normalized
+    assert '"device":-1' in normalized
+
+
+@pytest.mark.e2e
+def test_project_add_input_action_joypad_events_read_back_through_project_get(
+    godot_project,
+):
+    # The structured verification the AC asks for: `project get input/<name>`
+    # projects the stored compound value, so the joypad events read back with
+    # their device, button_index and axis/axis_value (ADR-0035 inline kind).
+    Gda(godot_project).json(
+        "project",
+        "add-input-action",
+        "jump",
+        "--joy-button",
+        "DPadLeft",
+        "--joy-axis",
+        "TriggerRight",
+    )
+
+    value = Gda(godot_project).json("project", "get", "input/jump")["value"]
+    assert value["deadzone"] == 0.5
+    events = {event["type"]: event for event in value["events"]}
+    # JOY_BUTTON_DPAD_LEFT is 13, JOY_AXIS_TRIGGER_RIGHT is 5 (4.6.3-stable).
+    assert events["InputEventJoypadButton"]["button_index"] == 13
+    assert events["InputEventJoypadButton"]["device"] == -1
+    assert events["InputEventJoypadMotion"]["axis"] == 5
+    # An omitted sign is the POSITIVE direction.
+    assert events["InputEventJoypadMotion"]["axis_value"] == 1.0
+    assert events["InputEventJoypadMotion"]["device"] == -1
+
+
+@pytest.mark.e2e
+def test_project_add_input_action_bindings_reach_the_loaded_input_map(godot_project):
+    # The engine-side half of the verification: after the project loads, the
+    # bindings are in the InputMap the running game consults.
+    Gda(godot_project).json(
+        "project",
+        "add-input-action",
+        "jump",
+        "--key",
+        "Space",
+        "--joy-button",
+        "A",
+        "--joy-axis",
+        "LeftX:-",
+    )
+    (godot_project / "input_map_probe.gd").write_text(
+        INPUT_MAP_PROBE_GD, encoding="utf-8"
+    )
+
+    run = Gda(godot_project).json(
+        "script", "run", "res://input_map_probe.gd", retry=True
+    )
+
+    line = next(
+        row for row in run["stdout"].splitlines() if row.startswith("INPUT_MAP=")
+    )
+    rows = json.loads(line.removeprefix("INPUT_MAP="))
+    assert rows == [
+        {"class": "InputEventKey", "device": -1, "keycode": 32},
+        {"class": "InputEventJoypadButton", "device": -1, "button_index": 0},
+        {
+            "class": "InputEventJoypadMotion",
+            "device": -1,
+            "axis": 0,
+            "axis_value": -1.0,
+        },
+    ]
+
+
+@pytest.mark.e2e
+def test_project_add_input_action_device_pins_the_joypad_events(godot_project):
+    # --device applies to the joypad events of THIS call. The key event stays at
+    # ALL_DEVICES: a real keyboard event carries its own device id, so pinning it
+    # to a joypad number would stop it matching (the #380 reason).
+    added = Gda(godot_project).json(
+        "project",
+        "add-input-action",
+        "jump",
+        "--key",
+        "Space",
+        "--joy-button",
+        "A",
+        "--device",
+        "1",
+    )
+
+    assert added["events"][0] == {
+        "kind": "key",
+        "key": "Space",
+        "keycode": 32,
+        "physical": False,
+    }
+    assert added["events"][1]["device"] == 1
+
+    value = Gda(godot_project).json("project", "get", "input/jump")["value"]
+    events = {event["type"]: event for event in value["events"]}
+    assert events["InputEventKey"]["device"] == -1
+    assert events["InputEventJoypadButton"]["device"] == 1
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    ("option", "token", "accepted"),
+    [
+        ("--joy-button", "NotAButton", "DPadLeft"),
+        ("--joy-axis", "NotAnAxis:-", "TriggerRight"),
+        # A recognized axis with an unusable sign is the same refusal: the whole
+        # token could not be resolved to a binding.
+        ("--joy-axis", "LeftX:sideways", "TriggerRight"),
+    ],
+)
+def test_project_add_input_action_unresolvable_joypad_token_names_the_accepted_set(
+    godot_project, option, token, accepted
+):
+    err = Gda(godot_project).error(
+        "project",
+        "add-input-action",
+        "jump",
+        option,
+        token,
+        code="invalid_key",
+    )
+
+    assert err["category"] == "operation"
+    assert token.split(":")[0] in err["message"]
+    # The message names the accepted set, so a caller can correct without
+    # reading the docs (#842 AC).
+    assert accepted in err["message"]
+    # Nothing was saved.
+    assert "[input]" not in _normalized_project_godot(godot_project)
+
+
+@pytest.mark.e2e
+def test_project_add_input_action_with_no_binding_is_a_usage_error(godot_project):
+    bad = Gda(godot_project)("project", "add-input-action", "jump", "--json")
+
+    assert bad.returncode == 2, bad.stdout + bad.stderr
+    assert "at least one binding" in panel_text(bad.stderr)
+    assert (
+        not (godot_project / "project.godot")
+        .read_text(encoding="utf-8")
+        .count("[input]")
+    )

--- a/tests/project/test_input_action_joy_names.py
+++ b/tests/project/test_input_action_joy_names.py
@@ -1,0 +1,154 @@
+"""The joypad name tables of ``project add-input-action``, against the engine (#842).
+
+``--joy-button`` and ``--joy-axis`` accept NAMES that mirror two engine enums,
+``JoyButton`` and ``JoyAxis``. The engine has no name resolver for them (unlike
+``OS.find_keycode_from_string`` for keys), so gda carries its own table — and a
+hand-typed table is exactly the kind of mirror that rots silently when the engine
+adds a button. **The engine is the oracle**, and the chain is pinned end to end
+by the two tests here:
+
+1. ``operations.gd`` maps each gda name to the engine's own global constant
+   (``"DPadLeft": JOY_BUTTON_DPAD_LEFT``), so gda hand-types no enum VALUE: the
+   GDScript compiler resolves it. What gda does own is the NAME and the
+   normalization between the two spellings — and that is what the e2e test below
+   diffs against the enum the engine itself enumerates, via
+   ``godot --headless --dump-extension-api`` (the engine's own JSON dump of its
+   API, ``global_enums``).
+2. The Python tuples that build the ``--help`` / ``--schema`` prose are a second
+   copy of the names, so a unit test pins them to the same GDScript table. That
+   copy exists because the CLI must document the accepted set without reading
+   GDScript at import time; it is a copy under a guard, not a second authority.
+
+The sentinels are excluded EXPLICITLY (asserted present, then dropped) rather
+than filtered by a value bound: ``INVALID``/``SDL_MAX``/``MAX`` are enum
+bookkeeping, not bindable buttons, and naming them here means a rename shows up
+as a failure instead of silently widening the accepted set.
+"""
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from gda.commands.project import JOY_AXIS_NAMES, JOY_BUTTON_NAMES
+
+from tests.support import GODOT
+
+ROOT = Path(__file__).resolve().parents[2]
+OPERATIONS_GD = ROOT / "src" / "gda" / "ops" / "operations.gd"
+
+# The enum bookkeeping entries that are not bindable inputs. Excluded by NAME so
+# the exclusion is visible and a rename fails loudly.
+SENTINELS = ("INVALID", "SDL_MAX", "MAX")
+
+_ENTRY = re.compile(r'^\t"([A-Za-z0-9]+)":\s*([A-Z0-9_]+),$', re.M)
+
+
+def _gd_table(const_name: str) -> dict[str, str]:
+    """Read one ``const <NAME> := { "Gda": ENGINE_CONST, ... }`` table from operations.gd."""
+    source = OPERATIONS_GD.read_text(encoding="utf-8")
+    block = re.search(
+        r"^const " + const_name + r" := \{\n(.*?)^\}$", source, re.M | re.S
+    )
+    assert block is not None, f"{const_name} table not found in {OPERATIONS_GD}"
+    entries = _ENTRY.findall(block.group(1))
+    assert entries, f"{const_name} table is empty"
+    return dict(entries)
+
+
+def _fold(name: str) -> str:
+    """The declared normalization: case- and separator-insensitive."""
+    return name.replace("_", "").replace("-", "").replace(" ", "").upper()
+
+
+@pytest.fixture(scope="module")
+def engine_enums(tmp_path_factory) -> dict[str, dict[str, int]]:
+    """``{enum: {CONSTANT: value}}`` as the ENGINE enumerates its own global enums.
+
+    ``--dump-extension-api`` writes ``extension_api.json`` into the working
+    directory — the engine's own machine-readable API description, which is where
+    a global enum (not a class enum) is enumerable at all: ``@GlobalScope`` is not
+    a ClassDB class, so ``ClassDB.class_get_enum_constants`` answers nothing for
+    ``JoyButton`` (verified against 4.6.3).
+    """
+    work = tmp_path_factory.mktemp("extension-api")
+    proc = subprocess.run(
+        [
+            str(GODOT),
+            "--headless",
+            "--dump-extension-api",
+            "--log-file",
+            str(work / "godot.log"),
+        ],
+        cwd=work,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    dump = work / "extension_api.json"
+    assert dump.exists(), proc.stdout + proc.stderr
+    api = json.loads(dump.read_text(encoding="utf-8"))
+    return {
+        enum["name"]: {value["name"]: value["value"] for value in enum["values"]}
+        for enum in api["global_enums"]
+    }
+
+
+@pytest.mark.parametrize(
+    ("const_name", "python_names", "enum_name", "prefix"),
+    [
+        ("JOY_BUTTON_BY_NAME", JOY_BUTTON_NAMES, "JoyButton", "JOY_BUTTON_"),
+        ("JOY_AXIS_BY_NAME", JOY_AXIS_NAMES, "JoyAxis", "JOY_AXIS_"),
+    ],
+)
+def test_python_help_names_mirror_the_operations_gd_table(
+    const_name, python_names, enum_name, prefix
+):
+    # The doc-facing tuple and the resolver's table are the same names, in the
+    # same order: the help/schema prose cannot drift from what gda accepts.
+    assert tuple(_gd_table(const_name)) == tuple(python_names)
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    ("const_name", "python_names", "enum_name", "prefix"),
+    [
+        ("JOY_BUTTON_BY_NAME", JOY_BUTTON_NAMES, "JoyButton", "JOY_BUTTON_"),
+        ("JOY_AXIS_BY_NAME", JOY_AXIS_NAMES, "JoyAxis", "JOY_AXIS_"),
+    ],
+)
+def test_joy_name_table_matches_the_engine_enum(
+    engine_enums, const_name, python_names, enum_name, prefix
+):
+    engine = engine_enums[enum_name]
+    for sentinel in SENTINELS:
+        # Asserted present before it is dropped: a renamed sentinel must fail
+        # here, not quietly become a bindable name.
+        assert prefix + sentinel in engine, (
+            f"{prefix}{sentinel} vanished from {enum_name}"
+        )
+    bindable = {
+        constant
+        for constant in engine
+        if constant.removeprefix(prefix) not in SENTINELS
+    }
+
+    table = _gd_table(const_name)
+
+    # 1. Coverage both ways: every bindable engine constant has a gda name, and
+    #    gda names nothing the engine does not declare.
+    assert set(table.values()) == bindable
+
+    # 2. The normalization IS the thing under test: gda's CamelCase name and the
+    #    engine's SCREAMING_SNAKE key are the same token, case- and
+    #    separator-folded (DPadLeft <-> JOY_BUTTON_DPAD_LEFT, LeftX <-> LEFT_X).
+    for gda_name, constant in table.items():
+        assert _fold(gda_name) == _fold(constant.removeprefix(prefix)), (
+            f"{gda_name} is not the folded form of {constant}"
+        )
+
+    # 3. Folded names stay unique, so the case-insensitive resolver cannot be
+    #    ambiguous.
+    assert len({_fold(name) for name in table}) == len(table)

--- a/tests/project/test_input_action_joy_names.py
+++ b/tests/project/test_input_action_joy_names.py
@@ -19,6 +19,13 @@ by the two tests here:
    copy exists because the CLI must document the accepted set without reading
    GDScript at import time; it is a copy under a guard, not a second authority.
 
+**Which tier runs what.** Only the enum COVERAGE diff (and the sentinel check it
+rests on) needs a real engine, so only that is ``e2e``-marked. The fold identity
+between a gda name and the engine constant it maps to reads both sides out of
+gda's own sources, so it runs on the unit tier — on PR CI — where a mis-mapped
+constant (``"DPadLeft": JOY_BUTTON_DPAD_RIGHT``) belongs, rather than waiting for
+a nightly run.
+
 The sentinels are excluded EXPLICITLY (asserted present, then dropped) rather
 than filtered by a value bound: ``INVALID``/``SDL_MAX``/``MAX`` are enum
 bookkeeping, not bindable buttons, and naming them here means a rename shows up
@@ -103,12 +110,30 @@ def engine_enums(tmp_path_factory) -> dict[str, dict[str, int]]:
         ("JOY_AXIS_BY_NAME", JOY_AXIS_NAMES, "JoyAxis", "JOY_AXIS_"),
     ],
 )
-def test_python_help_names_mirror_the_operations_gd_table(
+def test_joy_names_fold_to_their_engine_constants_and_match_the_help_tuples(
     const_name, python_names, enum_name, prefix
 ):
+    # ENGINE-FREE, so it runs on PR CI rather than only in the nightly e2e tier:
+    # both sides of every assertion here are read from gda's own sources. A
+    # mis-mapped constant ("DPadLeft": JOY_BUTTON_DPAD_RIGHT) is a fold mismatch,
+    # and catching that needs no engine — only the coverage diff below does.
+    table = _gd_table(const_name)
+
     # The doc-facing tuple and the resolver's table are the same names, in the
     # same order: the help/schema prose cannot drift from what gda accepts.
-    assert tuple(_gd_table(const_name)) == tuple(python_names)
+    assert tuple(table) == tuple(python_names)
+
+    # The normalization IS the thing under test: gda's CamelCase name and the
+    # engine's SCREAMING_SNAKE key are the same token, case- and
+    # separator-folded (DPadLeft <-> JOY_BUTTON_DPAD_LEFT, LeftX <-> LEFT_X).
+    for gda_name, constant in table.items():
+        assert _fold(gda_name) == _fold(constant.removeprefix(prefix)), (
+            f"{gda_name} is not the folded form of {constant}"
+        )
+
+    # Folded names stay unique, so the case-insensitive resolver cannot be
+    # ambiguous.
+    assert len({_fold(name) for name in table}) == len(table)
 
 
 @pytest.mark.e2e
@@ -135,20 +160,8 @@ def test_joy_name_table_matches_the_engine_enum(
         if constant.removeprefix(prefix) not in SENTINELS
     }
 
-    table = _gd_table(const_name)
-
-    # 1. Coverage both ways: every bindable engine constant has a gda name, and
-    #    gda names nothing the engine does not declare.
-    assert set(table.values()) == bindable
-
-    # 2. The normalization IS the thing under test: gda's CamelCase name and the
-    #    engine's SCREAMING_SNAKE key are the same token, case- and
-    #    separator-folded (DPadLeft <-> JOY_BUTTON_DPAD_LEFT, LeftX <-> LEFT_X).
-    for gda_name, constant in table.items():
-        assert _fold(gda_name) == _fold(constant.removeprefix(prefix)), (
-            f"{gda_name} is not the folded form of {constant}"
-        )
-
-    # 3. Folded names stay unique, so the case-insensitive resolver cannot be
-    #    ambiguous.
-    assert len({_fold(name) for name in table}) == len(table)
+    # Coverage both ways: every bindable engine constant has a gda name, and gda
+    # names nothing the engine does not declare. This is the half that genuinely
+    # needs the engine — the fold identity between a gda name and the constant it
+    # maps to is checked engine-free, on the unit tier, above.
+    assert set(_gd_table(const_name).values()) == bindable

--- a/tests/project/test_project_commands.py
+++ b/tests/project/test_project_commands.py
@@ -10,6 +10,7 @@ real Godot.
 import json
 
 import jsonschema
+from pydantic import ValidationError
 from typer.testing import CliRunner
 
 from gda.cli import app
@@ -673,6 +674,40 @@ def test_project_add_input_action_human_output_lists_joypad_bindings(monkeypatch
         "added input action jump (deadzone 0.5): Space -> 32, "
         "joy button A -> 0, joy axis LeftX:- -> 0 (-1.0) [device -1]"
     )
+
+
+def test_add_input_action_schema_and_model_agree_on_the_binding_rule():
+    # A standard Draft 2020-12 validator and the pydantic model must give the
+    # SAME verdict on the published input contract (ADR-0015): the "at least one
+    # binding" rule spans three lists, so it is published as an anyOf beside the
+    # model validator that enforces it. Without it a schema-only client would
+    # build {"name": "jump"} — valid by the contract, refused at dispatch.
+    schema = ProjectAddInputActionParams.model_json_schema()
+    validator = jsonschema.Draft202012Validator(schema)
+    corpus = [
+        ({"name": "j", "keys": ["Space"]}, True),
+        ({"name": "j", "joy_buttons": ["A"]}, True),
+        ({"name": "j", "joy_axes": ["LeftX:-"]}, True),
+        ({"name": "j", "keys": ["Space"], "joy_buttons": [], "joy_axes": []}, True),
+        ({"name": "j", "joy_buttons": ["A"], "device": 0}, True),
+        # No binding of any kind, spelled both ways.
+        ({"name": "jump"}, False),
+        ({"name": "jump", "keys": [], "joy_buttons": [], "joy_axes": []}, False),
+        ({"name": "jump", "keys": []}, False),
+        # The scalar bounds ride the same contract.
+        ({"name": "j", "keys": ["Space"], "device": -2}, False),
+        ({"name": "j", "keys": ["Space"], "deadzone": 1.5}, False),
+    ]
+
+    for payload, expected in corpus:
+        schema_ok = validator.is_valid(payload)
+        try:
+            ProjectAddInputActionParams(**payload)
+            model_ok = True
+        except ValidationError:
+            model_ok = False
+        assert schema_ok == expected, f"schema verdict for {payload}"
+        assert model_ok == expected, f"model verdict for {payload}"
 
 
 def test_project_add_input_action_help_documents_the_accepted_joypad_names():

--- a/tests/project/test_project_commands.py
+++ b/tests/project/test_project_commands.py
@@ -32,7 +32,13 @@ from gda.commands.project import (
     ProjectSetResult,
 )
 from gda.models import GdaErrorEnvelope
-from tests.support import VERSION_INFO, invoke_cli, sentinel
+from tests.support import (
+    VERSION_INFO,
+    invoke_cli,
+    panel_text,
+    sentinel,
+    usage_error_text,
+)
 
 INFO_RESULT = {
     "name": "My Game",
@@ -434,6 +440,9 @@ def test_project_add_input_action_dispatches_full_params_and_reports_result(
             {
                 "name": "jump",
                 "keys": ["J", "Space"],
+                "joy_buttons": [],
+                "joy_axes": [],
+                "device": -1,
                 "deadzone": 0.5,
                 "physical": False,
             },
@@ -464,21 +473,30 @@ def test_project_add_input_action_dispatches_deadzone_and_physical_overrides(
     assert fake.calls == [
         (
             "project-add-input-action",
-            {"name": "jump", "keys": ["74"], "deadzone": 0.2, "physical": True},
+            {
+                "name": "jump",
+                "keys": ["74"],
+                "joy_buttons": [],
+                "joy_axes": [],
+                "device": -1,
+                "deadzone": 0.2,
+                "physical": True,
+            },
         )
     ]
 
 
-def test_project_add_input_action_requires_at_least_one_key(monkeypatch):
-    # --key is required: an add with no keys is a usage error (exit 2), not a
-    # dispatch of an empty key list.
+def test_project_add_input_action_requires_at_least_one_binding(monkeypatch):
+    # --key stopped being required when the joypad kinds landed (#842), so the
+    # rule moved to the model: an add naming NO binding of any kind is a usage
+    # error (exit 2), not a dispatch of three empty lists.
     result, fake = invoke_cli(
         monkeypatch,
         ["project", "add-input-action", "jump"],
         stdout=sentinel(ADD_INPUT_ACTION_RESULT),
     )
 
-    assert result.exit_code == 2
+    assert "at least one binding" in usage_error_text(result)
     assert fake.calls == []
 
 
@@ -526,6 +544,146 @@ def test_project_add_input_action_human_output_marks_physical_bindings(monkeypat
         result.stdout.strip()
         == "added input action jump (deadzone 0.5): J -> 74 (physical)"
     )
+
+
+ADD_INPUT_ACTION_JOYPAD_RESULT = {
+    "name": "jump",
+    "deadzone": 0.5,
+    "events": [
+        {"kind": "key", "key": "Space", "keycode": 32, "physical": False},
+        {"kind": "joy_button", "button": "A", "button_index": 0, "device": -1},
+        {
+            "kind": "joy_axis",
+            "axis": "LeftX:-",
+            "axis_index": 0,
+            "axis_value": -1.0,
+            "device": -1,
+        },
+    ],
+}
+
+
+def test_project_add_input_action_dispatches_joypad_bindings_and_device(monkeypatch):
+    result, fake = invoke_cli(
+        monkeypatch,
+        [
+            "project",
+            "add-input-action",
+            "jump",
+            "--key",
+            "Space",
+            "--joy-button",
+            "A",
+            "--joy-axis",
+            "LeftX:-",
+            "--device",
+            "0",
+            "--json",
+        ],
+        stdout=sentinel(ADD_INPUT_ACTION_JOYPAD_RESULT),
+    )
+
+    assert result.exit_code == 0
+    # Each repeatable joypad option rides through in its own list, in argv order,
+    # with the per-call device beside them (#842).
+    assert fake.calls == [
+        (
+            "project-add-input-action",
+            {
+                "name": "jump",
+                "keys": ["Space"],
+                "joy_buttons": ["A"],
+                "joy_axes": ["LeftX:-"],
+                "device": 0,
+                "deadzone": 0.5,
+                "physical": False,
+            },
+        )
+    ]
+    data = json.loads(result.stdout)
+    # The three event kinds are a discriminated union on `kind`: each carries its
+    # own fields, so an agent branches on the kind rather than sniffing keys.
+    assert [event["kind"] for event in data["events"]] == [
+        "key",
+        "joy_button",
+        "joy_axis",
+    ]
+    assert data["events"][1] == {
+        "kind": "joy_button",
+        "button": "A",
+        "button_index": 0,
+        "device": -1,
+    }
+    assert data["events"][2] == {
+        "kind": "joy_axis",
+        "axis": "LeftX:-",
+        "axis_index": 0,
+        "axis_value": -1.0,
+        "device": -1,
+    }
+
+
+def test_project_add_input_action_accepts_a_joypad_only_action(monkeypatch):
+    # --key is optional since #842: a controller-only action is a valid add.
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["project", "add-input-action", "pause", "--joy-button", "Start", "--json"],
+        stdout=sentinel(ADD_INPUT_ACTION_JOYPAD_RESULT),
+    )
+
+    assert result.exit_code == 0
+    assert fake.calls[0][1]["keys"] == []
+    assert fake.calls[0][1]["joy_buttons"] == ["Start"]
+
+
+def test_project_add_input_action_rejects_a_device_below_all_devices(monkeypatch):
+    # -1 is InputMap's ALL_DEVICES floor; anything below it names no joypad.
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["project", "add-input-action", "jump", "--joy-button", "A", "--device", "-2"],
+        stdout=sentinel(ADD_INPUT_ACTION_JOYPAD_RESULT),
+    )
+
+    assert result.exit_code == 2
+    assert fake.calls == []
+
+
+def test_project_add_input_action_human_output_lists_joypad_bindings(monkeypatch):
+    result, _ = invoke_cli(
+        monkeypatch,
+        [
+            "project",
+            "add-input-action",
+            "jump",
+            "--key",
+            "Space",
+            "--joy-button",
+            "A",
+            "--joy-axis",
+            "LeftX:-",
+        ],
+        stdout=sentinel(ADD_INPUT_ACTION_JOYPAD_RESULT),
+    )
+
+    assert result.exit_code == 0
+    # The key form is unchanged; each joypad binding names its kind and resolved
+    # index, and the per-call device is stated ONCE at the end (it is a property
+    # of the call, not of an individual binding).
+    assert result.stdout.strip() == (
+        "added input action jump (deadzone 0.5): Space -> 32, "
+        "joy button A -> 0, joy axis LeftX:- -> 0 (-1.0) [device -1]"
+    )
+
+
+def test_project_add_input_action_help_documents_the_accepted_joypad_names():
+    help_text = panel_text(
+        CliRunner().invoke(app, ["project", "add-input-action", "--help"]).stdout
+    )
+
+    for name in ("A", "Start", "DPadLeft", "Touchpad"):
+        assert name in help_text
+    for name in ("LeftX", "TriggerRight"):
+        assert name in help_text
 
 
 # --- project remove-input-action --------------------------------------------
@@ -667,8 +825,20 @@ def test_project_add_input_action_schema_emits_model_derived_contract_without_ot
     assert "keys" in doc["input"]["properties"]
     assert "deadzone" in doc["input"]["properties"]
     assert "physical" in doc["input"]["properties"]
-    # The key list is bounded model-side: at least one key (ADR-0015).
-    assert doc["input"]["properties"]["keys"]["minItems"] == 1
+    assert "joy_buttons" in doc["input"]["properties"]
+    assert "joy_axes" in doc["input"]["properties"]
+    assert "device" in doc["input"]["properties"]
+    # No per-list floor since #842: the "at least one binding" rule spans the
+    # three lists, so it is a model rule, not a minItems on one of them.
+    assert "minItems" not in doc["input"]["properties"]["keys"]
+    # --schema documents the accepted joypad names (issue #842 AC).
+    assert "DPadLeft" in doc["input"]["properties"]["joy_buttons"]["description"]
+    assert "TriggerRight" in doc["input"]["properties"]["joy_axes"]["description"]
+    # The result's events are a discriminated union on `kind`.
+    assert (
+        doc["output"]["properties"]["events"]["items"]["discriminator"]["propertyName"]
+        == "kind"
+    )
     jsonschema.Draft202012Validator.check_schema(doc["input"])
     jsonschema.Draft202012Validator.check_schema(doc["output"])
 
@@ -718,6 +888,9 @@ def test_sample_project_results_validate_against_emitted_output_schemas():
     jsonschema.validate(instance=REMOVE_AUTOLOAD_RESULT, schema=remove_doc["output"])
     jsonschema.validate(
         instance=ADD_INPUT_ACTION_RESULT, schema=add_input_doc["output"]
+    )
+    jsonschema.validate(
+        instance=ADD_INPUT_ACTION_JOYPAD_RESULT, schema=add_input_doc["output"]
     )
     jsonschema.validate(
         instance=REMOVE_INPUT_ACTION_RESULT, schema=remove_input_doc["output"]

--- a/tests/project/test_project_commands.py
+++ b/tests/project/test_project_commands.py
@@ -15,6 +15,7 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.commands.project import (
+    INPUT_EVENT_DEVICE_MAX,
     ProjectAddAutoloadParams,
     ProjectAddAutoloadResult,
     ProjectAddInputActionParams,
@@ -649,6 +650,28 @@ def test_project_add_input_action_rejects_a_device_below_all_devices(monkeypatch
     assert fake.calls == []
 
 
+def test_project_add_input_action_rejects_a_device_above_the_engine_field(monkeypatch):
+    # InputEvent.device is 32-bit: 2147483648 would be stored as -2147483648 and
+    # 4294967295 as -1 (every joypad), so the ceiling is refused before dispatch.
+    result, fake = invoke_cli(
+        monkeypatch,
+        [
+            "project",
+            "add-input-action",
+            "jump",
+            "--joy-button",
+            "A",
+            "--device",
+            str(INPUT_EVENT_DEVICE_MAX + 1),
+        ],
+        stdout=sentinel(ADD_INPUT_ACTION_JOYPAD_RESULT),
+    )
+
+    assert result.exit_code == 2
+    assert "device" in usage_error_text(result)
+    assert fake.calls == []
+
+
 def test_project_add_input_action_human_output_lists_joypad_bindings(monkeypatch):
     result, _ = invoke_cli(
         monkeypatch,
@@ -690,12 +713,14 @@ def test_add_input_action_schema_and_model_agree_on_the_binding_rule():
         ({"name": "j", "joy_axes": ["LeftX:-"]}, True),
         ({"name": "j", "keys": ["Space"], "joy_buttons": [], "joy_axes": []}, True),
         ({"name": "j", "joy_buttons": ["A"], "device": 0}, True),
+        ({"name": "j", "joy_buttons": ["A"], "device": INPUT_EVENT_DEVICE_MAX}, True),
         # No binding of any kind, spelled both ways.
         ({"name": "jump"}, False),
         ({"name": "jump", "keys": [], "joy_buttons": [], "joy_axes": []}, False),
         ({"name": "jump", "keys": []}, False),
         # The scalar bounds ride the same contract.
         ({"name": "j", "keys": ["Space"], "device": -2}, False),
+        ({"name": "j", "keys": ["Space"], "device": INPUT_EVENT_DEVICE_MAX + 1}, False),
         ({"name": "j", "keys": ["Space"], "deadzone": 1.5}, False),
     ]
 


### PR DESCRIPTION
## Summary

`gda project add-input-action` bound keyboard keys only, so a controller-accessible game had to
hand-write `InputEventJoypadButton` records into `project.godot` — the reverse-engineered
serialization #380 existed to remove (GDA-DF-068). One call now declares keyboard and controller
bindings together:

- `--joy-button <name|index>` (repeatable) → a real `InputEventJoypadButton`.
- `--joy-axis <axis>[:<sign>]` (repeatable) → a real `InputEventJoypadMotion` whose `axis_value` is
  the direction the sign selects (`+1.0` by default, `-1.0` for `-`). An axis names a whole stick
  dimension, so only a direction is a binding.
- `--device <n>` pins this call's joypad events to one joypad; it defaults to `-1`
  (`InputMap.ALL_DEVICES`) and is set **explicitly**, because a script-constructed event starts at
  device `0`. Key events stay at `-1` and `--device` never touches them.
- `--key` is no longer individually required; the model requires **at least one binding of any
  kind**.

The engine still serializes every event (ADR-0033): the op constructs real objects and persists them
through `ProjectSettings.save()`. Events are appended in kind order — keys, joypad buttons, joypad
axis directions — so one call's persisted order is deterministic.

The result's `events` became a **discriminated union on `kind`** — the extension point #380 put
there — so each kind publishes its own field set in `--schema` instead of a caller learning it from
a sample payload.

Closes #842

## Surface diff

**`gda schema`** — 208 unified-diff lines, all inside `project add-input-action`:

1. *bindings*: `--key` `"required": true` → `false`; three rows added — `--joy-button` →
   `joy_buttons` (`multiple: true`), `--joy-axis` → `joy_axes` (`multiple: true`), `--device` →
   `device`.
2. *command description*: "…bound to one or more keys…" → "…bound to keys and/or joypad inputs…".
3. *input schema*: params docstring reworded (`issue #380` → `issues #380, #842`); new properties
   `joy_buttons`, `joy_axes` (string arrays, accepted names in their `description`) and `device`
   (`integer`, `minimum: -1`, `default: -1`); `keys` lost `"minItems": 1` and its description
   dropped "(at least one)"; `"required"` went `["name", "keys"]` → `["name"]`; and a top-level
   **`anyOf` of three branches** (`{"required": ["<list>"], "properties": {"<list>": {"minItems": 1}}}`
   for `keys`, `joy_buttons`, `joy_axes`) publishes the "at least one binding" rule that `keys`'
   `minItems` used to carry. That `anyOf` is the review fix's whole schema delta — 32 added lines,
   nothing else changed, and `--help` is byte-identical across it.
4. *output schema*: two new `$defs` — `InputActionJoyButtonEvent`, `InputActionJoyAxisEvent`;
   `InputActionKeyEvent.kind` gained `"const": "key"` and its docstring/description were reworded;
   `events.items` went from `{"$ref": "#/$defs/InputActionKeyEvent"}` to a `oneOf` of the three
   models with a `discriminator` (`propertyName: "kind"`) mapping; `events.description` and the
   result docstring reworded.

**`gda project add-input-action --help`**: the one-line description reworded; `--key` lost
`[required]` and gained "At least one binding of any kind is required."; `--joy-button`,
`--joy-axis` and `--device` added, each documenting the accepted set; the options panel lost its
`*` column because no option is required any more (Rich rendering, not a contract change).

**`docs/command-catalog.md`**: the "Input actions" paragraph in the `project` section rewritten
(joypad options, the sign rule, the case/separator-insensitive names, `--device`, the ≥1-binding
usage error, the three event classes); the group table row now reads "key, joypad button and joypad
axis events".

**`src/gda/skill/SKILL.md`**: none — its `project` row lists command names only, and no command was
added or renamed.

**`README.md`** (`project add-input-action` row) + **`docs/README.zh-CN.md` / `.es.md` / `.ja.md`**
(same row translated), re-stamped with `uv run python scripts/update_readme_i18n.py`
(`de18d3f4225e…`); `tests/repo/test_readme_i18n_sync.py` green.

**`docs/adr/0002` + `src/gda/error_codes.py`**: the `invalid_key` description widened from
"An input-action key could not be resolved to a Godot keycode…" to cover a joypad button or axis
direction too. Both authorities changed together; the #701 description pin compares them.

## Oracle

`--joy-button` / `--joy-axis` names mirror two engine enums, and Godot ships **no** name resolver for
them (there is no counterpart of `OS.find_keycode_from_string`), so gda has to carry the table. The
table is `operations.gd`'s `JOY_BUTTON_BY_NAME` / `JOY_AXIS_BY_NAME`, and every entry maps a gda name
to the engine's **own global constant** (`"DPadLeft": JOY_BUTTON_DPAD_LEFT`), so gda hand-types no
enum VALUE — the GDScript compiler resolves it. What gda owns is the spelling, and that is what
`tests/project/test_input_action_joy_names.py` puts under test:

- **How the enum is read**: `godot --headless --dump-extension-api` writes the engine's own
  `extension_api.json`, whose `global_enums` enumerates `JoyButton` and `JoyAxis` with names and
  values (≈0.6 s, module-scoped fixture). This is the engine enumerating itself. `@GlobalScope` is
  **not** a ClassDB class, so `ClassDB.class_get_enum_constants("@GlobalScope", "JoyButton")` answers
  `[]` — verified against 4.6.3 before choosing the dump.
- **The normalization under test**: gda's CamelCase name and the engine's `SCREAMING_SNAKE` key must
  be the same token once case- and separator-folded — `DPadLeft` ↔ `JOY_BUTTON_DPAD_LEFT`, `LeftX` ↔
  `JOY_AXIS_LEFT_X`. The same fold is what the resolver applies to a caller's token, so `DPadLeft`,
  `dpad_left` and `DPAD_LEFT` are one button. The test also asserts the folded names stay unique, so
  the case-insensitive resolver cannot be ambiguous.
- **Sentinel exclusions**: `INVALID`, `SDL_MAX`, `MAX` are excluded **by name** — asserted present in
  the engine's enum first, then dropped — so a renamed sentinel fails loudly instead of quietly
  becoming a bindable name.
- **Coverage both ways**: every non-sentinel engine constant has a gda name, and gda names nothing
  the engine does not declare.
- **The doc copy is pinned, not a second authority**: the Python `JOY_BUTTON_NAMES` /
  `JOY_AXIS_NAMES` tuples that build the `--help` / `--schema` prose are compared (same names, same
  order) to the GDScript table by a unit test, so the published prose cannot drift from what gda
  accepts.
- **Which tier runs what** (review fix): only the enum COVERAGE diff, and the sentinel assertions it
  rests on, need a real engine, so only those are `e2e`-marked. The fold identity, the folded-name
  uniqueness check and the Python-tuple mirror read both sides out of gda's own sources, so they run
  on the **unit tier — on PR CI**. Previously the fold loop sat inside the e2e test, which left a
  mis-mapped constant (`"DPadLeft": JOY_BUTTON_DPAD_RIGHT`) detectable only in a nightly run.

Mutation-checked: deleting `"Touchpad": JOY_BUTTON_TOUCHPAD` from `operations.gd` fails both halves
— `2 failed, 2 passed in 1.00s`, `Extra items in the right set: 'JOY_BUTTON_TOUCHPAD'` — then the
table was restored.

## Red-proof

Tests written first against the committed base:

1. Oracle module, before the Python tuples existed:
   `ImportError: cannot import name 'JOY_AXIS_NAMES' from 'gda.commands.project'` → `1 error in 0.14s`.
2. `tests/project/test_project_commands.py` after the joypad expectations were written and before any
   implementation: **`9 failed, 33 passed in 1.49s`** — the two full-params dispatch assertions, the
   at-least-one-binding usage error, the joypad dispatch/joypad-only/device-floor/human-render/help
   tests, the `--schema` contract test and the sample-payload schema validation.

Both are green after the implementation (`44 passed, 2 deselected` for the two modules).

**Review-fix round**, each mutated locally, quoted, then reverted:

3. Schema/model parity, with `model_config` removed from `ProjectAddInputActionParams`:
   `AssertionError: schema verdict for {'name': 'jump'}` / `assert True == False` → `1 failed in
   0.21s`; restored → `1 passed in 0.15s`.
4. The fold identity at the UNIT tier (`-m "not e2e"`, i.e. what PR CI runs), with
   `"DPadLeft": JOY_BUTTON_DPAD_RIGHT` in `operations.gd`:
   `AssertionError: DPadLeft is not the folded form of JOY_BUTTON_DPAD_RIGHT` / `assert 'DPADLEFT' ==
   'DPADRIGHT'` → `1 failed, 1 passed, 2 deselected in 0.13s`; reverted → `2 passed, 2 deselected in
   0.12s`. Before the move this mutation left the unit tier green.

## Validation

Host: macOS (Darwin 25.6.0, arm64), Godot `4.6.3.stable.official.7d41c59c4` at
`~/Applications/Godot.app/Contents/MacOS/Godot`; load average 4–7 (sibling worktree agents on the
same machine). One pytest process at a time, no `-n`; no `GDA_USER_DATA_ROOT` exported for a run.

| Gate | Command | Result |
| --- | --- | --- |
| fast tier | `uv run --frozen pytest tests -m "not e2e" -q -p no:cacheprovider` | `2464 passed, 660 deselected in 45.40s` |
| lint | `uv run --frozen ruff check .` | `All checks passed!` |
| format | `uv run --frozen ruff format --check .` | `509 files already formatted` |
| types | `uv run --frozen pyright` | `0 errors, 0 warnings, 0 informations` |
| e2e (project group) | `uv run --frozen pytest tests/project/test_e2e_project.py -m e2e -rs -p no:cacheprovider` | `34 passed in 27.33s` |
| oracle module (both tiers) | `uv run --frozen pytest tests/project/test_input_action_joy_names.py -rs -p no:cacheprovider` | `4 passed in 0.47s` |
| e2e (whole `tests/project`) | `uv run --frozen pytest tests/project -m e2e -rs -p no:cacheprovider` | `108 passed, 221 deselected in 122.48s` |
| e2e (#380 live regression) | `…pytest "tests/live/test_e2e_input.py::test_add_input_action_makes_the_action_immediately_driveable" -m e2e` | `1 passed in 2.36s` |
| i18n sync | `uv run --frozen pytest tests/repo/test_readme_i18n_sync.py -q` | `6 passed in 0.01s` |

Numbers above are the review-fix head (`b3c923783`), macOS load average 2.0–2.6. The
`tests/project` whole-package and live-driveability rows were measured at `99e73d0d2` and are
unaffected by the fix commit (it touches only the params schema and the test tier a name check runs
in).

**Not run**: the repository's Godot e2e CI workflow is schedule/dispatch-only, so PR CI does not
execute it. Substitute evidence: the whole `tests/project` e2e package plus the live driveability
regression above, on a real 4.6.3 engine.

**Residual risk**: the accepted-name tables are pinned to *this* engine's enums. A Godot release that
adds a joypad button fails the oracle test (by design) rather than silently leaving the button
unbindable — the failure is the signal, and it needs a real engine to fire, so it only shows up in
the e2e tier.

## Requirement conformance

| AC | How it is satisfied |
| --- | --- |
| `add-input-action jump --key Space --joy-button A` writes one `InputEventKey` + one `InputEventJoypadButton` the engine and editor load as a normal action | `test_project_add_input_action_persists_key_and_joypad_events_in_var_to_str_form` asserts the `Object(InputEventKey…)`, `Object(InputEventJoypadButton…)` and `Object(InputEventJoypadMotion…)` literals `ProjectSettings.save()` wrote; `test_project_add_input_action_bindings_reach_the_loaded_input_map` runs a `script run` fixture that prints `InputMap.action_get_events("jump")` after the project loads and asserts the three events, their classes, devices and values. |
| `--joy-axis LeftX:-` writes the declared axis and sign; `--device` applies to every joypad event of the call; an omitted `--device` writes `-1` | Same persistence test asserts `"axis":0` / `"axis_value":-1.0` / `"device":-1`; `test_project_add_input_action_device_pins_the_joypad_events` asserts `--device 1` reaches the joypad event while the key event stays `-1`; `test_project_add_input_action_joypad_events_read_back_through_project_get` asserts `device == -1` when `--device` is omitted, and that an omitted axis sign is `+1.0`. |
| A call with no binding is a usage error; an unknown button or axis name is a structured error naming the accepted set | `test_project_add_input_action_with_no_binding_is_a_usage_error` (exit 2, "at least one binding" in the Click panel) and `test_project_add_input_action_requires_at_least_one_binding` (unit). `test_project_add_input_action_unresolvable_joypad_token_names_the_accepted_set` covers an unknown button, an unknown axis and a recognized axis with an unusable sign — each `invalid_key` (exit 4), naming the token and the accepted set, nothing saved. |
| The written binding is verified directly by `project get input/<name>` and a `script run` fixture over `InputMap.action_get_events` | The `project get` readback test asserts `button_index`, `device`, `axis` and `axis_value` off the ADR-0035 inline projection; the `script run` probe asserts the loaded `InputMap`. (No live `input action` arm — it drives the polled state without consulting the bound events.) |
| Help and `--schema` document the accepted names; existing key-only behavior unchanged | `test_project_add_input_action_help_documents_the_accepted_joypad_names` and the `--schema` assertions on the `joy_buttons` / `joy_axes` descriptions. Key-only behavior: the persisted `InputEventKey` literal, the `--physical` arm, the `already_exists` / `invalid_key` arms and the human render of a key-only action are the pre-existing tests, unchanged and green. |

**Error code for an unknown button/axis name: `invalid_key`** (operation source, exit 4) — the
existing code for "an `add-input-action` binding token could not be resolved". Reusing it keeps ONE
code for the whole class, so an agent branches on one value whichever binding kind it got wrong, and
avoids minting a code (which would cost a registry row, an ADR-0002 table row and the description
pin). Its description was widened in both authorities to say so; a *malformed* param shape (a
non-array, a non-string item, a bad `device`) stays `invalid_params`, and the argv-side
no-binding refusal stays a Click usage error (exit 2) with `--params-json` reporting the same rule
as `invalid_params`, per ADR-0015.

## Decisions (review P3s, recorded rather than changed)

- **`--device 7 --key Space` is a silent no-op.** Kept as-is. `--device` names a JOYPAD, and a key
  event is always bound at `-1` because a real keyboard event carries its own device id — refusing
  the combination would add a rule #842 did not ask for, and it would be the only cross-option
  refusal on the command. The behaviour is stated in `--help` ("Key bindings are always -1 and are
  unaffected"), in the catalog, and in `InputActionKeyEvent`'s docstring.
- **The fold drops leading and trailing separators (`"A-"` → `A`).** Kept. The fold DELETES
  separators rather than normalizing them, so a stray one at either end folds away; that widens the
  spellings accepted and can never make two buttons collide — the oracle test asserts the folded
  names stay unique. The alternative is a separator grammar for a token no caller writes
  deliberately. `_fold_joy_name`'s comment now says so; no behaviour and no harness changed (this is
  `operations.gd`, not the harness, so no sha pin is involved).

## Disclosed extras / boundary crossings

- **`operations.gd` scope**: edits are confined to `_op_project_add_input_action` and helpers placed
  beside `_resolve_input_keycode` (`JOY_BUTTON_BY_NAME`, `JOY_AXIS_BY_NAME`, `_fold_joy_name`,
  `_lookup_joy_name`, `_joy_name_list`, `_resolve_joy_button`, `_resolve_joy_axis`,
  `_parse_joy_axis_token`). No other operation, and none of the sibling-owned files
  (`gda_harness.gd`, `harness/install.py`, `commands/input.py`, `commands/game.py`,
  `commands/script.py`, `hints.py`, `gda.project`), was touched.
- **Wire payload**: a key-only call now dispatches three extra params (`joy_buttons: []`,
  `joy_axes: []`, `device: -1`). The op reads them defensively with defaults, and the persisted
  `project.godot` bytes for a key-only call are unchanged.
- **Review fix, one line beyond the letter of the finding**: the folded-name uniqueness assertion
  moved to the unit tier alongside the fold-identity loop. It is engine-free by the same argument, so
  leaving it e2e would have left the identical defect behind.
- **`tests/cli/test_models.py`** gained a joypad round-trip and a closed-discriminator refusal test,
  and its existing key round-trip narrows the union before reading `keycode`/`physical` (pyright).
- **For #843**: the regression to extend is
  `tests/project/test_e2e_project.py::test_project_add_input_action_persists_key_and_joypad_events_in_var_to_str_form`
  — one fixture already carrying a key, a joypad button and a joypad axis direction, which is the
  "call with joypad events" #843's restored-line check needs.
- **Range choice (not in the issue text)**: a raw integer `--joy-button` is accepted over
  `0..JOY_BUTTON_MAX-1` (128 — a device may report more buttons than the SDL names cover) and a raw
  `--joy-axis` index over `0..JOY_AXIS_MAX-1`; both bounds are read from the engine constants, not
  hard-coded, and both are stated in the refusal message.
- Not observed as an issue here, but noted: `ProjectSettings.save()` still drops explicit
  default-equal lines and rewrites `config/features` on every write — that is #843, unchanged by
  this slice.
