### PR TITLE
feat(gda): input results name the injection route they used (#838)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -86,6 +86,19 @@ the state is bound to the session, not surviving its relaunch. A Phase-2 live-la
 property only — Phase-1 headless calls are stateless (ADR-0020).
 _Avoid_: consistency, coherence, sync
 
+**Injection route**:
+The door a live input injection takes into the running game, and there are exactly
+two: `action_state` drives `Input.action_press` / `action_release`, changing the
+polled state `Input.is_action_*` reads and reaching no `_input` / `_gui_input` /
+`_unhandled_input` handler; `viewport_event` pushes an `InputEvent` through the root
+viewport's `push_input`, reaching those handlers and changing no polled state. The
+two are disjoint by construction — a state change is not an event — so a successful
+action injection is not evidence the event path works, which twice read as one in
+dogfooding. Every `input` result names the route it used (`injection_route`,
+top-level on the single-event commands and per phase on the phased ones), derived
+CLI-side from the event kind (#838). The opt-in event mode for actions is #854.
+_Avoid_: input mode, injection method, path
+
 **Headless launch**:
 The one-shot `godot --headless` spawn primitive that the Phase-1 channels share —
 the sentinel op-dispatch runner, the native-export runner, the `gda resource

--- a/README.md
+++ b/README.md
@@ -529,8 +529,8 @@ names the file, and only `preflight` catches a first-frame failure.
 | `input key` | Inject a key event (with modifiers). |
 | `input mouse-click` | Inject a complete click gesture (move, press, release) at `(x, y)`. |
 | `input mouse-move` | Inject mouse motion to `(x, y)`. |
-| `input action` | Press/release a mapped input action. |
-| `input tap` | Tap one key or action: press, hold, release across frames. |
+| `input action` | Press/release a mapped input action — polled state only, never delivered to `_input`/`_gui_input`. |
+| `input tap` | Tap one key or action: press, hold, release across frames (`--key` delivers an event, `--action` only sets polled state). |
 | `input sequence` | Inject a multi-frame event timeline. |
 
 Read injected mouse coordinates from `event.position` — in a daemon session

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=de18d3f4225e4b4b473921f121ef9f086dddb68cc38e5868433893a52b18ae4b -->
+<!-- gda-readme-i18n: source=README.md sha256=e225ed00bc75daf0ba46f85f056196e35987afe39341d354b4ec0454b64733a2 -->
 
 # gda — Automatización de Godot para agentes de IA
 
@@ -452,7 +452,7 @@ identifica el archivo y solo `preflight` detecta un fallo en el primer fotograma
 | `project set` | Define un ajuste del proyecto, forzando el valor a su tipo declarado. |
 | `project add-autoload` | Registra un singleton autoload (nombre → script/escena). |
 | `project remove-autoload` | Cancela el registro de un singleton autoload por nombre. |
-| `project add-input-action` | Registra una acción del InputMap vinculada a teclas y/o a un mando (`--key`, `--joy-button`, `--joy-axis` como `<eje>[:<signo>]`, `--device`, `--deadzone`, `--physical`); se requiere al menos una vinculación. |
+| `project add-input-action` | Registra una acción del InputMap vinculada a teclas (`--key` nombre o keycode, `--deadzone`, `--physical`). |
 | `project remove-input-action` | Cancela el registro de una acción del InputMap por nombre. |
 | `project find-references` | Encuentra todos los archivos del proyecto que referencian un recurso dado. |
 | `project dependencies` | Mapea cada escena/recurso a los recursos de los que depende. |
@@ -544,8 +544,8 @@ identifica el archivo y solo `preflight` detecta un fallo en el primer fotograma
 | `input key` | Inyecta un evento de tecla (con modificadores). |
 | `input mouse-click` | Inyecta el gesto de clic completo (movimiento, pulsación, liberación) en `(x, y)`. |
 | `input mouse-move` | Inyecta un movimiento de ratón hacia `(x, y)`. |
-| `input action` | Presiona/suelta una acción de entrada mapeada. |
-| `input tap` | Toca una tecla o acción: pulsa, mantiene y suelta a lo largo de varios frames. |
+| `input action` | Presiona/suelta una acción de entrada mapeada: solo cambia el estado consultado, nunca llega a `_input`/`_gui_input`. |
+| `input tap` | Toca una tecla o acción: pulsa, mantiene y suelta a lo largo de varios frames (`--key` entrega un evento, `--action` solo cambia el estado consultado). |
 | `input sequence` | Inyecta una línea de tiempo de eventos de varios frames. |
 
 Lee las coordenadas de ratón inyectadas desde `event.position` — en una sesión del daemon

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=de18d3f4225e4b4b473921f121ef9f086dddb68cc38e5868433893a52b18ae4b -->
+<!-- gda-readme-i18n: source=README.md sha256=e225ed00bc75daf0ba46f85f056196e35987afe39341d354b4ec0454b64733a2 -->
 
 # gda — AI エージェント向け Godot オートメーション
 
@@ -448,7 +448,7 @@ Headless 検証はプロジェクトの実行準備を確認し、Live 操作は
 | `project set` | プロジェクト設定を設定します。値は宣言された型に変換されます。 |
 | `project add-autoload` | オートロードのシングルトンを登録します(名前 → スクリプト/シーン)。 |
 | `project remove-autoload` | オートロードのシングルトンを名前で指定して登録解除します。 |
-| `project add-input-action` | キーやコントローラーに割り当てた InputMap アクションを登録します(`--key`、`--joy-button`、`--joy-axis` は `<軸>[:<符号>]` 形式、`--device`、`--deadzone`、`--physical`)。バインドは 1 つ以上必要です。 |
+| `project add-input-action` | キーに割り当てた InputMap アクションを登録します(`--key` はキー名またはキーコード、`--deadzone`、`--physical`)。 |
 | `project remove-input-action` | InputMap アクションを名前で指定して登録解除します。 |
 | `project find-references` | 指定したリソースを参照するすべてのプロジェクトファイルを見つけます。 |
 | `project dependencies` | 各シーン/リソースを、それが依存するリソースに対応付けます。 |
@@ -540,8 +540,8 @@ Headless 検証はプロジェクトの実行準備を確認し、Live 操作は
 | `input key` | キーイベントを(修飾キー付きで)注入します。 |
 | `input mouse-click` | `(x, y)` の位置に完全なクリックジェスチャ(移動、押下、解放)を注入します。 |
 | `input mouse-move` | `(x, y)` へのマウス移動を注入します。 |
-| `input action` | マッピング済みの入力アクションを押下/解放します。 |
-| `input tap` | キーまたはアクションを 1 回タップします(押下、保持、解放を複数フレームで実行)。 |
+| `input action` | マッピング済みの入力アクションを押下/解放します(ポーリング状態のみが変化し、`_input`/`_gui_input` には届きません)。 |
+| `input tap` | キーまたはアクションを 1 回タップします(押下、保持、解放を複数フレームで実行。`--key` はイベントを届け、`--action` はポーリング状態のみを変えます)。 |
 | `input sequence` | 複数フレームにわたるイベントのタイムラインを注入します。 |
 
 注入されたマウス座標は `event.position` から読み取ってください——デーモンセッションでは

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=de18d3f4225e4b4b473921f121ef9f086dddb68cc38e5868433893a52b18ae4b -->
+<!-- gda-readme-i18n: source=README.md sha256=e225ed00bc75daf0ba46f85f056196e35987afe39341d354b4ec0454b64733a2 -->
 
 # gda — 面向 AI Agent 的 Godot 自动化
 
@@ -428,7 +428,7 @@ Headless 验证确认项目就绪状态；Live 操作返回用于验证实际行
 | `project set` | 设置一个项目设置，并把值强制转换为它声明的类型。 |
 | `project add-autoload` | 注册一个 autoload 单例（名称 → 脚本/场景）。 |
 | `project remove-autoload` | 按名称注销一个 autoload 单例。 |
-| `project add-input-action` | 注册一个绑定按键和/或手柄的 InputMap 动作（`--key`、`--joy-button`、`--joy-axis` 形如 `<轴>[:<符号>]`、`--device`、`--deadzone`、`--physical`）；至少需要一个绑定。 |
+| `project add-input-action` | 注册一个绑定按键的 InputMap 动作（`--key` 键名或键码、`--deadzone`、`--physical`）。 |
 | `project remove-input-action` | 按名称注销一个 InputMap 动作。 |
 | `project find-references` | 找出引用了给定资源的每一个项目文件。 |
 | `project dependencies` | 把每个场景/资源映射到它所依赖的资源。 |
@@ -520,8 +520,8 @@ Headless 验证确认项目就绪状态；Live 操作返回用于验证实际行
 | `input key` | 注入一个按键事件（带修饰键）。 |
 | `input mouse-click` | 在 `(x, y)` 处注入完整的点击手势(移动、按下、释放)。 |
 | `input mouse-move` | 将鼠标移动到 `(x, y)`。 |
-| `input action` | 按下/释放一个已映射的输入动作。 |
-| `input tap` | 轻按一个按键或动作：跨帧完成按下、保持、释放。 |
+| `input action` | 按下/释放一个已映射的输入动作 —— 仅改变轮询状态，绝不会送达 `_input`/`_gui_input`。 |
+| `input tap` | 轻按一个按键或动作：跨帧完成按下、保持、释放（`--key` 送达事件，`--action` 仅改变轮询状态）。 |
 | `input sequence` | 注入一条跨多帧的事件时间线。 |
 
 注入的鼠标坐标请从 `event.position` 读取——daemon 会话中 `get_mouse_position()` /

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -1476,7 +1476,18 @@ re-derives every verdict from a running engine.
   `mouse` sub-group, so each maps to a single `<group>_<command>` MCP tool name
   (ADR-0005/0011/0012). Key/mouse events ride the game's real input flow via the
   root viewport's `push_input` (scene-aware); actions go through
-  `Input.action_press`/`action_release` against the running `InputMap`. For mouse
+  `Input.action_press`/`action_release` against the running `InputMap`. Those are
+  two DISJOINT routes and every result names the one it used (`injection_route`,
+  #838): `viewport_event` for an `InputEvent` pushed through the viewport, and
+  `action_state` for an action — a change to the POLLED action state that builds no
+  `InputEvent` and so reaches no `_input` / `_gui_input` / `_unhandled_input`
+  handler. gda derives the route CLI-side from the event kind; the phased ops
+  (`input tap`, `input mouse-click`, `input sequence`) report it per phase, since
+  one sequence can mix the two — a tap targets exactly one of `--key` / `--action`,
+  and that target selects the route both its phases take. Drive event-driven UI
+  with a key or mouse event and use an action where the game polls
+  `Input.is_action_*`: a successful action injection is not evidence that the event
+  path works (GDA-DF-048, GDA-DF-075). For mouse
   ops and sequence mouse events, the reliable injected coordinate is
   `InputEventMouseButton.position` / `InputEventMouseMotion.position`; Godot may
   leave `Viewport.get_mouse_position()` and `Node2D.get_global_mouse_position()`

--- a/src/gda/commands/input.py
+++ b/src/gda/commands/input.py
@@ -12,7 +12,13 @@ root (``gda.cli``).
 
 Live input injection into the RUNNING game's engine session via the gda harness
 (ADR-0017, ADR-0019). Key/mouse events ride the game's real input flow via the
-root viewport's push_input; actions go through Input.action_press/release. Mouse
+root viewport's push_input; actions go through Input.action_press/release. Those
+are two DISJOINT routes and every result names the one it used
+(``injection_route``, #838): an action changes the polled state and reaches no
+``_input`` / ``_gui_input`` / ``_unhandled_input`` handler, so a successful action
+injection is not evidence that the event path works. gda derives the route
+CLI-side from the event kind — the harness reports what it injected, not which
+door it went through — in ONE place (:func:`injection_route`). Mouse
 event.position is the reliable injected coordinate; Godot does not expose a
 reliable daemon-session seam for updating Viewport.get_mouse_position() /
 Node2D.get_global_mouse_position(), so those tracked positions may stay stale. Every
@@ -35,7 +41,9 @@ from typing import Annotated, Any, Literal, Optional, get_args
 import typer
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from gda.dispatch import dispatch_domain, params_or_bad_parameter
+from gda import dispatch
+from gda.dispatch import dispatch_domain, dispatch_recipe, params_or_bad_parameter
+from gda.errors import Failure, make_failure
 from gda.execution import ExecutionKind
 from gda.headless import (
     HeadlessCommand,
@@ -52,6 +60,71 @@ from gda.models import MAX_WINDOW_FRAMES, RelayedLiveParams
 # runtime validation and the emitted enum (ADR-0015), so a schema client rejects a
 # typo such as "control" before it ever becomes a silently dropped harness flag.
 InputModifier = Literal["shift", "ctrl", "alt", "meta"]
+
+# How an injected input reaches the running game (#838). The group has exactly two
+# routes and they are DISJOINT: `action_state` drives Input.action_press /
+# Input.action_release, which changes the polled action state and constructs no
+# InputEvent at all, so no `_input` / `_gui_input` / `_unhandled_input` handler ever
+# sees it; `viewport_event` pushes an InputEvent through the root viewport, the same
+# surface real OS input flows through. A state change is not an event, and reading a
+# successful action injection as evidence that the event path works cost two
+# dogfooding rounds a false product diagnosis (GDA-DF-048, GDA-DF-075). One Literal
+# is the authority for the vocabulary and the emitted enum, as `InputModifier` is
+# for modifiers (ADR-0015).
+InjectionRoute = Literal["action_state", "viewport_event"]
+
+ACTION_STATE: InjectionRoute = "action_state"
+VIEWPORT_EVENT: InjectionRoute = "viewport_event"
+
+# The phase vocabulary an injected gesture or sequence reports, declared once for
+# the result field and for the per-event derivation that fills it.
+InputPhaseName = Literal["move", "press", "release"]
+
+# The route EVERY event kind takes, declared per kind with NO fallback. A default
+# would silently claim `viewport_event` for a kind added later that changes state
+# instead — and no test could see it, since the wrong answer is the common one. The
+# key set is exactly the sequence union's membership (`InputEventType`, declared far
+# down this module and covering the single-frame ops' kinds too); a test holds the
+# two together, so a sixth kind fails on ABSENCE until it declares its route.
+INJECTION_ROUTES: dict[str, InjectionRoute] = {
+    "key": VIEWPORT_EVENT,
+    "mouse_click": VIEWPORT_EVENT,
+    "mouse_button": VIEWPORT_EVENT,
+    "mouse_move": VIEWPORT_EVENT,
+    "action": ACTION_STATE,
+}
+
+# The route field's description, written once: it rides six result models, so a
+# per-model copy would multiply the same two sentences.
+_INJECTION_ROUTE_DESC = (
+    "How the injection reached the game: 'action_state' for an action driven "
+    "through Input.action_press/action_release (a change to the POLLED action "
+    "state, delivered to no _input / _gui_input / _unhandled_input handler), or "
+    "'viewport_event' for an InputEvent pushed through the root viewport."
+)
+
+
+def injection_route(kind: str) -> InjectionRoute:
+    """The route an injected event of ``kind`` takes into the running game (#838).
+
+    The ONE place gda decides a route. It is decided CLI-side, from the event kind
+    alone, because that is where the knowledge is: the harness reply reports what
+    was injected, not which of the engine's two doors it went through. An action is
+    a state change; every other kind (key, mouse click/button/move) is an event
+    pushed through the root viewport.
+
+    An undeclared kind RAISES rather than defaulting. Every caller passes either a
+    literal from this module or the validated ``type`` of a union variant, so an
+    unknown kind is a gda programming error, never caller input — and a wrong route
+    published as a fact is worse than a crash the test suite catches first.
+    """
+    try:
+        return INJECTION_ROUTES[kind]
+    except KeyError:
+        raise ValueError(
+            f"no injection route is declared for the input kind {kind!r}; "
+            "add it to INJECTION_ROUTES"
+        ) from None
 
 
 class MouseButton(str, Enum):
@@ -71,7 +144,9 @@ class InputKeyParams(RelayedLiveParams):
     """The params of ``gda input key``: inject one key event (#221).
 
     Pushes an ``InputEventKey`` for ``key`` (with any ``modifiers``) into the
-    running game's root viewport, so it rides the game's real input flow. ``key``
+    running game's root viewport, so it rides the game's real input flow — the
+    ``viewport_event`` route, which is what ``_input``, ``_gui_input`` and
+    ``_unhandled_input`` handlers observe. ``key``
     is a Godot key name (e.g. ``Right``, ``A``, ``Space``, ``Escape``) the harness
     resolves with ``OS.find_keycode_from_string``; an unresolvable name is the
     typed ``live_invalid_key`` error. By default the event is a press; ``released``
@@ -101,7 +176,8 @@ class InputKeyResult(BaseModel):
     Echoes the resolved ``keycode`` (so an agent can confirm the name mapped as
     intended), the ``key`` name, the ``modifiers`` applied, and whether it was a
     ``pressed`` event — the live counterpart's confirmation that the event was
-    pushed at a frame boundary (ADR-0020).
+    pushed at a frame boundary (ADR-0020) — plus the ``injection_route`` it took,
+    always ``viewport_event`` for a key (#838).
     """
 
     kind: str = Field(default="key", description="The injected event kind ('key').")
@@ -111,6 +187,9 @@ class InputKeyResult(BaseModel):
         default_factory=list, description="The modifier keys held with the key."
     )
     pressed: bool = Field(description="True for a press event, false for a release.")
+    injection_route: InjectionRoute = Field(
+        default=injection_route("key"), description=_INJECTION_ROUTE_DESC
+    )
 
 
 class InputMouseClickParams(RelayedLiveParams):
@@ -186,10 +265,12 @@ class InputMouseMoveResult(BaseModel):
     """The result of ``gda input mouse-move``: the motion event injected (#221).
 
     Echoes the event ``kind`` (``mouse_move``), the viewport ``position`` it was
-    pushed to as ``[x, y]``, and the historically shared ``button`` / ``double``
+    pushed to as ``[x, y]``, the historically shared ``button`` / ``double``
     fields (always null for a move; ``mouse-click`` now reports its own gesture
-    result, :class:`InputMouseClickResult`). This echoed position mirrors the
-    mouse event's position; engine-tracked mouse positions may remain stale.
+    result, :class:`InputMouseClickResult`), and the ``injection_route`` it took,
+    always ``viewport_event`` for a motion event (#838). This echoed position
+    mirrors the mouse event's position; engine-tracked mouse positions may remain
+    stale.
     """
 
     kind: Literal["mouse_move"] = Field(
@@ -211,32 +292,71 @@ class InputMouseMoveResult(BaseModel):
         default=None,
         description="Always null for a move (a historical field).",
     )
+    injection_route: InjectionRoute = Field(
+        default=injection_route("mouse_move"), description=_INJECTION_ROUTE_DESC
+    )
 
 
 class InputEventPhase(BaseModel):
-    """One phase of an injected activation gesture (#652).
+    """One phase of an injected gesture or sequence (#652, #838).
 
     The structured evidence that an activation op injected the COMPLETE gesture
-    rather than a bare press: the 0-based process-frame offset within the op's
-    window, and the phase applied there (``move``, ``press``, or ``release``).
-    Both fields are constrained so a payload outside the gesture vocabulary
-    fails output validation (``contract_violation``) instead of passing through
-    as a successful result.
+    rather than a bare press: the 0-based frame offset within the op's
+    window, the phase applied there (``move``, ``press``, or ``release``), and the
+    route that phase took into the game. The route rides the PHASE rather than the
+    result's head because one sequence can hold both kinds and so mix the two; a
+    tap does not — its one target selects the route both its phases take (the state
+    route with ``--action``, the event route with ``--key``) — but it reports the
+    same per-phase shape. Every field is constrained so a payload outside the
+    vocabulary fails output validation (``contract_violation``) instead of passing
+    through as a successful result.
     """
 
     frame: int = Field(
-        ge=0, description="The 0-based process-frame offset within the op's window."
+        ge=0,
+        description=(
+            "The 0-based frame offset within the op's window, on the op's clock "
+            "(process frames; a sequence uses the clock its result reports)."
+        ),
     )
-    phase: Literal["move", "press", "release"] = Field(
+    phase: InputPhaseName = Field(
         description="The gesture phase applied at this frame: move, press, or release."
     )
+    injection_route: InjectionRoute = Field(description=_INJECTION_ROUTE_DESC)
+
+
+def _phases_routed(data: object, kind: str) -> object:
+    """Fold the route of ``kind`` into each phase of a raw result payload (#838).
+
+    The harness reply names the phases and the frames they landed on; the ROUTE is
+    gda's to derive (:func:`injection_route`), so it is folded in BEFORE the phase
+    models are built. That is what lets ``InputEventPhase.injection_route`` be
+    required rather than a default nobody set. Returns a new payload — the incoming
+    mapping (a shared fixture, a caller's dict) is never mutated — and passes
+    anything that is not the expected shape through untouched, leaving the refusal
+    to the ordinary field validation.
+    """
+    if not isinstance(data, dict):
+        return data
+    phases = data.get("phases")
+    if not isinstance(phases, list):
+        return data
+    route = injection_route(kind)
+    return {
+        **data,
+        "phases": [
+            {**phase, "injection_route": route} if isinstance(phase, dict) else phase
+            for phase in phases
+        ],
+    }
 
 
 class InputMouseClickResult(BaseModel):
     """The result of ``gda input mouse-click``: the complete click gesture injected (#652).
 
-    ``phases`` reports each injected phase and the window frame it landed on
-    (move at 0, press at 1, release at 2); ``focus_before`` / ``focus_after``
+    ``phases`` reports each injected phase, the window frame it landed on
+    (move at 0, press at 1, release at 2) and the ``injection_route`` it took
+    (always ``viewport_event`` for a click, #838); ``focus_before`` / ``focus_after``
     report the root viewport's focused Control around the gesture (null when
     none) — the activation evidence the engine exposes. The gesture contract is
     VALIDATED here, not merely described: a payload whose phases are not
@@ -283,6 +403,14 @@ class InputMouseClickResult(BaseModel):
         ),
     )
 
+    @model_validator(mode="before")
+    @classmethod
+    def _name_the_route(cls, data: object) -> object:
+        # Every phase of a click is an InputEvent pushed through the root viewport,
+        # so the whole gesture takes one route — but it is still reported per phase,
+        # because a phase is where a mixed-route op (a sequence) can differ.
+        return _phases_routed(data, "mouse_click")
+
     @model_validator(mode="after")
     def _check_gesture(self) -> "InputMouseClickResult":
         # The gesture IS the contract (#652): a reply whose phases are not
@@ -301,9 +429,14 @@ class InputMouseClickResult(BaseModel):
 class InputActionParams(RelayedLiveParams):
     """The params of ``gda input action``: press or release an input action (#221).
 
-    Drives ``Input.action_press`` / ``Input.action_release`` for the named action,
-    so the running game observes it through its ``InputMap`` exactly as a real
-    binding would fire. ``action`` MUST be declared in the running ``InputMap`` —
+    Drives ``Input.action_press`` / ``Input.action_release`` for the named action:
+    the ``action_state`` route, a change to the POLLED action state that
+    ``Input.is_action_pressed`` / ``is_action_just_pressed`` observe. It builds no
+    ``InputEvent``, so ``_input``, ``_gui_input`` and ``_unhandled_input`` never see
+    it — drive event-driven UI with ``gda input key`` or a mouse command (the
+    ``viewport_event`` route) instead, and use an action where the game polls
+    ``Input.is_action_*`` (#838). ``action`` MUST be declared in the running
+    ``InputMap`` —
     an unknown action is the typed ``live_unknown_action`` error (validated
     harness-side via ``InputMap.has_action``). By default the action is pressed;
     ``release`` releases it instead. ``strength`` is the analog strength of a press,
@@ -332,7 +465,10 @@ class InputActionResult(BaseModel):
 
     Echoes the ``action`` driven, whether it was a ``pressed`` event, and the
     ``strength`` applied (the press strength; 0.0 on a release) — confirmation the
-    action fired against the running ``InputMap`` at a frame boundary (ADR-0020).
+    action fired against the running ``InputMap`` at a frame boundary (ADR-0020) —
+    plus the ``injection_route`` it took, always ``action_state`` (#838). That last
+    field is what keeps a success here from reading as event-path evidence: the
+    polled state changed, no handler was called.
     """
 
     kind: str = Field(
@@ -345,6 +481,9 @@ class InputActionResult(BaseModel):
             "The press strength applied (0.0 on a release). " + LIVE_ENGINE_PRECISION
         )
     )
+    injection_route: InjectionRoute = Field(
+        default=injection_route("action"), description=_INJECTION_ROUTE_DESC
+    )
 
 
 class InputTapParams(RelayedLiveParams):
@@ -356,7 +495,13 @@ class InputTapParams(RelayedLiveParams):
     window frame 0, holds for ``hold_frames`` process frames, releases at frame
     ``hold_frames``, then lets ``settle_frames`` more frames run so the game
     observes the release before the op returns. Exactly one of ``key`` /
-    ``action`` selects the target; ``modifiers`` ride a key tap only,
+    ``action`` selects the target — and the target picks the ROUTE (#838): a key
+    tap pushes an ``InputEventKey`` through the root viewport (``viewport_event``,
+    which is what ``_input`` / ``_gui_input`` / ``_unhandled_input`` observe),
+    while an action tap drives ``Input.action_press`` / ``action_release``
+    (``action_state``, a change to the polled state that reaches no handler at
+    all). Tap a key for event-driven UI; tap an action where the game polls
+    ``Input.is_action_*``. ``modifiers`` ride a key tap only,
     ``strength`` an action tap only. The whole window —
     ``hold_frames + settle_frames + 1`` frames — is bounded model-side to the
     shared per-window ceiling (ADR-0015, #223). The two failures that need the
@@ -454,7 +599,8 @@ class InputTapResult(BaseModel):
     Echoes the target — ``key`` + ``keycode`` + ``modifiers`` for a key tap,
     ``action`` + ``strength`` for an action tap; the other family is null — the
     frame counts, the injected ``phases`` (the press at window frame 0, the
-    release at frame ``hold_frames``), and the focus evidence around the gesture.
+    release at frame ``hold_frames``, each naming the ``injection_route`` its
+    target took), and the focus evidence around the gesture.
     The evidence is VALIDATED, not merely described: exactly one target family,
     ``frames == hold_frames + settle_frames + 1``, and exactly the phases
     press@0 / release@hold_frames — a reply outside that contract fails output
@@ -525,6 +671,17 @@ class InputTapResult(BaseModel):
             "when nothing holds focus."
         ),
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _name_the_route(cls, data: object) -> object:
+        # A tap's route follows its TARGET, so it is read off the echoed target
+        # rather than off the request: the payload names the family the harness
+        # actually injected. A payload carrying neither family (or both) is refused
+        # by `_check_tap_evidence` below; stamping it first only decides which
+        # route a phase of a reply that will not survive validation would claim.
+        action = data.get("action") if isinstance(data, dict) else None
+        return _phases_routed(data, "action" if action is not None else "key")
 
     @model_validator(mode="after")
     def _check_tap_evidence(self) -> "InputTapResult":
@@ -758,8 +915,9 @@ class KeySequenceEvent(_SequenceEvent):
     """A key event in a sequence: the ``gda input key`` shape at a clock offset.
 
     Pushes an ``InputEventKey`` for ``key`` (with any ``modifiers``) into the
-    running game's root viewport. It presses by default and releases with
-    ``released`` — the action kind's ``release`` is NOT accepted here.
+    running game's root viewport — the ``viewport_event`` route, delivered to
+    ``_input`` / ``_gui_input`` / ``_unhandled_input``. It presses by default and
+    releases with ``released`` — the action kind's ``release`` is NOT accepted here.
     """
 
     type: Literal[InputEventType.KEY] = Field(description="The event kind.")
@@ -890,7 +1048,11 @@ class ActionSequenceEvent(_SequenceEvent):
     """An input action in a sequence: the ``gda input action`` shape.
 
     Drives ``Input.action_press`` / ``action_release`` for ``action``, which must
-    be declared in the running ``InputMap``. It presses by default and releases
+    be declared in the running ``InputMap``. This is the ``action_state`` route: it
+    changes the POLLED action state and builds no ``InputEvent``, so no ``_input``,
+    ``_gui_input`` or ``_unhandled_input`` handler sees it — use a ``key`` or mouse
+    event in the same sequence to drive event-driven UI (#838). It presses by
+    default and releases
     with ``release`` — the mouse-button kind's ``pressed`` is NOT accepted here,
     so a hold is a press event and a later ``release: true`` event.
     """
@@ -955,6 +1117,15 @@ class InputSequenceParams(RelayedLiveParams):
     offset requires (at least one). ``events`` must be non-empty; each event is
     validated model-side (ADR-0015).
 
+    A sequence may mix the two INJECTION ROUTES (#838), so the result names one per
+    injected phase. An ``action`` event takes the ``action_state`` route —
+    ``Input.action_press`` / ``action_release``, a change to the polled action state
+    that reaches no ``_input`` / ``_gui_input`` / ``_unhandled_input`` handler —
+    while ``key``, ``mouse_click``, ``mouse_button`` and ``mouse_move`` events take
+    the ``viewport_event`` route, an ``InputEvent`` pushed through the root
+    viewport. Drive event-driven UI with the event kinds; use ``action`` events
+    where the game polls ``Input.is_action_*``.
+
     The window the sequence requests — ``max(offset) + 1`` frames on the selected
     clock — is bounded model-side to ``MAX_WINDOW_FRAMES`` (#223). The time-windowed
     harness base has no harness-side timeout (it relies on its driver's model
@@ -1008,6 +1179,60 @@ class InputSequenceParams(RelayedLiveParams):
         return self
 
 
+def _event_phases(event: "InputSequenceEvent") -> list[InputPhaseName]:
+    """The phases one sequence event injects, in the order the harness applies them.
+
+    Mirrors ``_apply_sequence_event`` harness-side: a motion event is a move, a
+    ``mouse_click`` is the press AND the release the harness pushes on the SAME
+    frame (a same-frame pair fully activates a ``Button``), and every other kind is
+    the single edge it spells with its own field — ``released`` for a key,
+    ``release`` for an action and for the normalized mouse-button phase.
+    """
+    if isinstance(event, MouseMoveSequenceEvent):
+        return ["move"]
+    if isinstance(event, MouseClickSequenceEvent):
+        return ["press", "release"]
+    if isinstance(event, KeySequenceEvent):
+        return ["release" if event.released else "press"]
+    return ["release" if event.release else "press"]
+
+
+def sequence_phases(params: "InputSequenceParams") -> list[InputEventPhase]:
+    """The phases a requested sequence injects, in APPLICATION order (#838).
+
+    Derived from the REQUEST, because the harness reply COUNTS the events without
+    enumerating them: only the CLI holds them. Each phase carries the offset its
+    event named on the sequence's clock and the route its kind takes, so a sequence
+    that mixes an action with a key event reports both routes rather than one
+    verdict for the whole window.
+
+    Ordered the way the harness APPLIES them, not the way the request listed them,
+    so a phase list reads like the gesture ops' — those report their phases in frame
+    order, and a sequence whose events were written out of order would otherwise
+    disagree with its siblings about what a phase list means. The harness's sampler
+    advances the selected clock one index at a time and, at each index, walks the
+    events in request order applying those due there; a STABLE sort by ``frame``
+    reproduces exactly that: by frame ascending, request order within a frame.
+    """
+    phases: list[tuple[int, InputPhaseName, InjectionRoute]] = [
+        (
+            (
+                event.physics_frame
+                if event.physics_frame is not None
+                else (event.frame or 0)
+            ),
+            phase,
+            injection_route(event.type),
+        )
+        for event in params.events
+        for phase in _event_phases(event)
+    ]
+    return [
+        InputEventPhase(frame=frame, phase=phase, injection_route=route)
+        for frame, phase, route in sorted(phases, key=lambda entry: entry[0])
+    ]
+
+
 class InputSequenceResult(BaseModel):
     """The result of ``gda input sequence``: what the harness injected (#221).
 
@@ -1015,7 +1240,8 @@ class InputSequenceResult(BaseModel):
     clock, ``physics`` for the explicit Godot physics clock), the number of
     ``events`` applied, and the number of ``frames`` the window spanned on that
     clock (one past the largest selected offset), confirming the whole sequence was
-    injected over the window at frame boundaries (ADR-0020).
+    injected over the window at frame boundaries (ADR-0020) — plus the ``phases``
+    the request injected and the route each took (#838).
     """
 
     kind: str = Field(default="sequence", description="The op kind ('sequence').")
@@ -1029,6 +1255,19 @@ class InputSequenceResult(BaseModel):
     events: int = Field(description="The number of events injected.")
     frames: int = Field(
         description="The number of selected-clock frames the window spanned."
+    )
+    phases: list[InputEventPhase] = Field(
+        default_factory=list,
+        description=(
+            "The phases the requested events injected and the offsets they landed "
+            "on, each naming the route it took: one press or release per key, "
+            "action or mouse_button event, a move per mouse_move event, and a "
+            "press plus a release for a mouse_click event (the harness pushes that "
+            "pair on one frame). In APPLICATION order — by frame, request order "
+            "within a frame — which is how the harness applies them. gda derives "
+            "this from the request: the harness reply counts the events, it does "
+            "not enumerate them."
+        ),
     )
 
 
@@ -1133,12 +1372,42 @@ INPUT_TAP_COMMAND: HeadlessCommand[InputTapResult] = HeadlessCommand(
 )
 
 
+def _input_sequence_recipe(params, *, project, godot):
+    """Run the sequence op, correlate the reply, then name each event's route (#838).
+
+    The one ``input`` command whose result the CLI completes (ADR-0023): the reply
+    counts the events it applied without enumerating them, and only the request
+    holds the per-event routes. That is also why the reply must be CORRELATED with
+    the request before the phases are folded in, the way ``perf monitors`` does it:
+    the phases are derived from what was ASKED, so publishing them beside a count
+    that says something else was applied would make the result state two different
+    sequences at once. A self-consistent reply for a DIFFERENT request is still a
+    ``contract_violation``. The op itself still runs
+    through the descriptor's own ``execute``, so the runner seam, the classifier and
+    the stderr handling are the shared ones, not a second copy.
+    """
+    outcome = INPUT_SEQUENCE_COMMAND.execute(
+        params, godot=godot, project=project, make_runner=dispatch.make_live_runner
+    )
+    if isinstance(outcome, Failure):
+        return outcome
+    if outcome.events != len(params.events):
+        return make_failure(
+            "contract_violation",
+            f"the harness applied {outcome.events} events for a "
+            f"{len(params.events)}-event request.",
+            "",
+        )
+    return outcome.model_copy(update={"phases": sequence_phases(params)})
+
+
 INPUT_SEQUENCE_COMMAND: HeadlessCommand[InputSequenceResult] = HeadlessCommand(
     operation="input-sequence",
     input_model=InputSequenceParams,
     output_model=InputSequenceResult,
     render=render_input_sequence,
     kind=ExecutionKind.LIVE,
+    recipe=_input_sequence_recipe,
 )
 
 
@@ -1307,8 +1576,13 @@ def input_action(
     """Press or release a named input action in the running game (live).
 
     Routes through gda-daemon to the engine session (kind = LIVE, ADR-0017) and
-    drives Input.action_press / action_release against the running InputMap, so the
-    game observes the action exactly as a real binding would fire. An action absent
+    drives Input.action_press / action_release against the running InputMap. That is
+    the `action_state` route: it changes the polled action state, which
+    Input.is_action_pressed / is_action_just_pressed observe, and it builds no
+    InputEvent — so _input, _gui_input and _unhandled_input never see it, however
+    the action is bound. Drive event-driven UI with `gda input key` or a mouse
+    command (the `viewport_event` route) and use an action where the game polls
+    Input.is_action_*; the result names the route it took. An action absent
     from the InputMap is `live_unknown_action`. With no daemon it reports
     `daemon_not_running`.
 
@@ -1395,9 +1669,14 @@ def input_tap(
     without advancing it — so the tap presses at window frame 0, holds for
     --hold-frames process frames, releases, then runs --settle-frames more
     frames before returning. The result reports the injected phases plus the
-    focused Control before and after the tap. Exactly one of --key/--action; an
-    unresolvable key is `live_invalid_key`, an action absent from the running
-    InputMap is `live_unknown_action`. With no daemon it reports
+    focused Control before and after the tap. Exactly one of --key/--action, and
+    the target picks the ROUTE each phase reports: --key pushes an InputEventKey
+    through the root viewport (`viewport_event`, seen by _input / _gui_input /
+    _unhandled_input), while --action drives Input.action_press / action_release
+    (`action_state`, a change to the polled state that reaches no handler at all).
+    Tap a key to exercise event-driven UI; tap an action where the game polls
+    Input.is_action_*. An unresolvable key is `live_invalid_key`, an action absent
+    from the running InputMap is `live_unknown_action`. With no daemon it reports
     `daemon_not_running`.
 
     A value the engine reports crosses the wire at full binary64 precision — the
@@ -1471,13 +1750,18 @@ def input_sequence(
     `physics_frame: 0` and release it at `physics_frame: 30` for a 30-physics-frame
     hold. A `mouse_button` press followed by `mouse_move` events and a matching
     `mouse_button` release carries the held-button mask on the motion events for
-    drag handlers. For sequence mouse events, read the injected coordinate from the
-    mouse event's position; Godot may leave Viewport.get_mouse_position() /
-    Node2D.get_global_mouse_position() stale in daemon sessions. A malformed
-    `--events` (not a JSON array, an empty list, an
-    ill-formed event, or mixed `frame`/`physics_frame` clocks) is a usage error; with
-    no daemon it reports `daemon_not_running`. An event's action absent from the
-    InputMap is `live_unknown_action`, an unresolvable key `live_invalid_key`.
+    drag handlers. A sequence may MIX the two injection routes and the result names
+    one per injected phase, in the order the harness applies them: an `action` event
+    takes the `action_state` route (Input.action_press / action_release — the polled
+    state, seen by no _input, _gui_input or _unhandled_input handler), while `key`,
+    `mouse_click`, `mouse_button` and `mouse_move` events take the `viewport_event`
+    route, an InputEvent pushed through the root viewport. For sequence mouse
+    events, read the injected coordinate from the mouse event's position; Godot may
+    leave Viewport.get_mouse_position() / Node2D.get_global_mouse_position() stale
+    in daemon sessions. A malformed `--events` (not a JSON array, an empty list, an
+    ill-formed event, or mixed `frame`/`physics_frame` clocks) is a usage error;
+    with no daemon it reports `daemon_not_running`. An event's action absent from
+    the InputMap is `live_unknown_action`, an unresolvable key `live_invalid_key`.
     """
     # --events is a JSON array on the argv path; the model is the source of truth for
     # the per-event shape (ADR-0015), so a parse or validation failure is a usage
@@ -1488,7 +1772,7 @@ def input_sequence(
     except json.JSONDecodeError as exc:
         raise typer.BadParameter(f"--events is not valid JSON: {exc}") from exc
     params = params_or_bad_parameter(InputSequenceParams, events=decoded)
-    dispatch_domain(
+    dispatch_recipe(
         INPUT_SEQUENCE_COMMAND,
         params,
         json_output=json_output,

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -250,6 +250,17 @@ Every live reply carries its floats at full binary64 precision, so a value read 
 
 In the other direction the wire is narrower, and EVERY live command RELAYED to the game applies the same rule — not just `game call`; the three the daemon answers itself (`diag errors`, `logger tail`, `daemon wait-ready`) send no number to the engine and are outside it. A number gda cannot send unchanged is refused before the request leaves: a float whose wire literal Godot's parser reads as `0.0` (`DBL_MIN`, any subnormal, many-digit values such as `1.2345678901234567e-300`) and a JSON integer beyond ±(2^53−1). It is a usage error on the argv path and `invalid_params` on `--params-json`, decided without a running daemon, and it reaches nested values — a sequence event's `x`, a `game call` argument inside a dictionary. A float the parser DOES read still arrives changed in its low-order bits: 1 ULP at ordinary magnitudes, tens of doubles for a full-precision literal between `1e-4` and `1e-2`. That residual is disclosed, not refused (#752). `game set --value` is OUTSIDE that rule — the value travels as a STRING, so the wire never sees a number — and has a refusal of its own, decided in the session by the harness: the string is coerced with the engine's own parser and a literal it reads as `0.0` when you did not write zero, or as `NaN` at all, fails with `live_uncoercible_value` (exit 6, the running game untouched), the same rule headless `--value` follows (#772) — containers included, so a destroyed number inside a Dictionary or Array value is refused here too (#805).
 
+`gda input` injects through two routes, and every result names the one it used
+(`injection_route`). `input action`, `input tap --action` and a sequence `action`
+event drive `Input.action_press`/`action_release`: the `action_state` route, a
+change to the POLLED action state that reaches no `_input`, `_gui_input` or
+`_unhandled_input` handler. `input key`, the mouse commands and the `key` /
+`mouse_*` sequence kinds push an InputEvent through the root viewport: the
+`viewport_event` route. Rule of thumb — drive event-driven UI (a Control, a
+modal, a scrollable) with a key or mouse event, and use an action where the game
+polls `Input.is_action_*`. A successful action injection is not evidence that the
+event path works.
+
 For a UI activation, use the gesture commands, not a lone event. Godot activates a
 `Button` on the RELEASE, so a bare press never emits `pressed`; and a focused UI
 does not advance when the press and the release land on the same process frame.

--- a/tests/cli/test_command_descriptor_registry.py
+++ b/tests/cli/test_command_descriptor_registry.py
@@ -209,6 +209,11 @@ _RECIPE_OPERATIONS = {
     # calls the shared launch primitive with the engine's project-wide
     # `--import` argv — not a sentinel op, like `export run`'s native channel.
     "resource-import",
+    # `input sequence` (#838) names the injection route of each phase it applied,
+    # and the harness reply counts the events without enumerating them: only the
+    # request holds the per-event kinds, so the recipe completes the sentinel op's
+    # result the way `perf monitors` correlates its reply.
+    "input-sequence",
 }
 
 

--- a/tests/live/test_e2e_input.py
+++ b/tests/live/test_e2e_input.py
@@ -676,11 +676,12 @@ def test_mouse_click_performs_the_complete_activation_gesture(
         first = gda("input", "mouse-click", "50", "20")
         assert first.returncode == 0, first.stdout + first.stderr
         doc = json.loads(first.stdout)
-        # The structured gesture evidence: the three phases at their frames.
+        # The structured gesture evidence: the three phases at their frames, each
+        # naming the route it took into the game (#838).
         assert doc["phases"] == [
-            {"frame": 0, "phase": "move"},
-            {"frame": 1, "phase": "press"},
-            {"frame": 2, "phase": "release"},
+            {"frame": 0, "phase": "move", "injection_route": "viewport_event"},
+            {"frame": 1, "phase": "press", "injection_route": "viewport_event"},
+            {"frame": 2, "phase": "release", "injection_route": "viewport_event"},
         ]
 
         # The Button observed the COMPLETE activation: down, up, and `pressed`.
@@ -789,8 +790,8 @@ def test_tap_advances_a_focus_driven_ui_exactly_once_repeatably(
         assert first.returncode == 0, first.stdout + first.stderr
         doc = json.loads(first.stdout)
         assert doc["phases"] == [
-            {"frame": 0, "phase": "press"},
-            {"frame": 2, "phase": "release"},
+            {"frame": 0, "phase": "press", "injection_route": "viewport_event"},
+            {"frame": 2, "phase": "release", "injection_route": "viewport_event"},
         ]
         # Exactly one step: A -> B, evidenced by the op's own focus read-back.
         assert doc["focus_before"] == "/root/Main/A", doc
@@ -835,6 +836,68 @@ def test_tap_action_produces_exactly_one_press_and_release_edge(
         assert second.returncode == 0, second.stdout + second.stderr
         assert _property_value(gda, node, "pressed_edges") == 2
         assert _property_value(gda, node, "released_edges") == 2
+    finally:
+        gda("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_input_results_name_the_injection_route_against_a_live_session(
+    tmp_path, daemon_runtime_dir
+):
+    # The #838 live regression: against a REAL engine session, each injected form
+    # reports the route it actually took — a key event pushed through the root
+    # viewport, an action driven as polled state, and a tap holding an action
+    # reporting that route on every phase. The routes are what the two dogfooding
+    # rounds could not see (GDA-DF-048, GDA-DF-075), so they are asserted where the
+    # daemon, the harness and the engine are all real.
+    (tmp_path / "project.godot").write_text(ACTION_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(ACTION_MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "player.gd").write_text(TAP_ACTION_PLAYER_GD, encoding="utf-8")
+    gda = Gda(tmp_path, json_output=True)
+
+    try:
+        assert gda("daemon", "start").returncode == 0
+
+        key = gda("input", "key", "Right")
+        assert key.returncode == 0, key.stdout + key.stderr
+        assert json.loads(key.stdout)["injection_route"] == "viewport_event"
+
+        action = gda("input", "action", "move_right")
+        assert action.returncode == 0, action.stdout + action.stderr
+        assert json.loads(action.stdout)["injection_route"] == "action_state"
+        released = gda("input", "action", "move_right", "--release")
+        assert released.returncode == 0, released.stdout + released.stderr
+
+        tap = gda("input", "tap", "--action", "move_right")
+        assert tap.returncode == 0, tap.stdout + tap.stderr
+        tap_doc = json.loads(tap.stdout)
+        assert [phase["injection_route"] for phase in tap_doc["phases"]] == [
+            "action_state",
+            "action_state",
+        ]
+        # The tap really did drive the action it named the route for: the game's
+        # own polling saw its edges. Two of each by now — the standalone press and
+        # release above are the first pair, the tap is the second.
+        node = "/root/Main/Player"
+        assert _property_value(gda, node, "pressed_edges") == 2
+        assert _property_value(gda, node, "released_edges") == 2
+
+        sequence = gda(
+            "input",
+            "sequence",
+            "--events",
+            json.dumps(
+                [
+                    {"type": "action", "action": "move_right", "frame": 0},
+                    {"type": "key", "key": "Right", "frame": 1},
+                ]
+            ),
+        )
+        assert sequence.returncode == 0, sequence.stdout + sequence.stderr
+        assert json.loads(sequence.stdout)["phases"] == [
+            {"frame": 0, "phase": "press", "injection_route": "action_state"},
+            {"frame": 1, "phase": "press", "injection_route": "viewport_event"},
+        ]
     finally:
         gda("daemon", "stop")
 

--- a/tests/live/test_input_commands.py
+++ b/tests/live/test_input_commands.py
@@ -13,6 +13,8 @@ observed via ``game get``) is the e2e in ``test_e2e_input``.
 import json
 import re
 
+import pytest
+
 from typer.testing import CliRunner
 
 from gda.cli import app
@@ -183,9 +185,9 @@ def test_input_mouse_click_injects_the_whole_gesture_through_the_live_channel(
     # The result carries the COMPLETE gesture's evidence (#652): the three
     # phases at their window frames, and the focus state around the gesture.
     assert data["phases"] == [
-        {"frame": 0, "phase": "move"},
-        {"frame": 1, "phase": "press"},
-        {"frame": 2, "phase": "release"},
+        {"frame": 0, "phase": "move", "injection_route": "viewport_event"},
+        {"frame": 1, "phase": "press", "injection_route": "viewport_event"},
+        {"frame": 2, "phase": "release", "injection_route": "viewport_event"},
     ]
     assert data["focus_before"] is None
     assert data["focus_after"] == "/root/Main/Btn"
@@ -460,8 +462,8 @@ def test_input_tap_key_dispatches_the_press_hold_release_window(monkeypatch, tmp
     # The gesture evidence (#652): press at frame 0, release at frame
     # hold_frames, and the focus state around the tap.
     assert data["phases"] == [
-        {"frame": 0, "phase": "press"},
-        {"frame": 2, "phase": "release"},
+        {"frame": 0, "phase": "press", "injection_route": "viewport_event"},
+        {"frame": 2, "phase": "release", "injection_route": "viewport_event"},
     ]
     assert data["focus_before"] == "/root/Main/A"
     assert data["focus_after"] == "/root/Main/B"
@@ -1238,7 +1240,17 @@ def test_input_sequence_at_the_window_boundary_argv_is_accepted(monkeypatch, tmp
     # MAX_WINDOW_FRAMES). It passes the model and reaches the live seam unchanged.
     fake = inject_live_runner(
         monkeypatch,
-        RunResult(stdout=sentinel(INPUT_SEQUENCE_RESULT), stderr="", exit_code=0),
+        RunResult(
+            stdout=sentinel(
+                {
+                    **INPUT_SEQUENCE_RESULT,
+                    "events": 1,
+                    "frames": MAX_WINDOW_FRAMES,
+                }
+            ),
+            stderr="",
+            exit_code=0,
+        ),
     )
 
     result = CliRunner().invoke(
@@ -1296,14 +1308,17 @@ def test_input_sequence_help_documents_mouse_tracked_position_limitation():
     result = CliRunner().invoke(app, ["input", "sequence", "--help"])
 
     assert result.exit_code == 0, result.stdout + result.stderr
-    assert "mouse_click" in result.stdout
-    assert "mouse_move" in result.stdout
-    assert "mouse event" in result.stdout
-    assert "position" in result.stdout
-    assert "get_mouse_position()" in result.stdout
-    assert "get_global_mouse_position()" in result.stdout
-    assert "stale in" in result.stdout
-    assert "daemon sessions" in result.stdout
+    # Flattened, so a phrase the renderer wraps is still one phrase (the same
+    # reason the mouse-op help tests read `_flat_help`).
+    flat = _flat_help(result)
+    assert "mouse_click" in flat
+    assert "mouse_move" in flat
+    assert "mouse event" in flat
+    assert "position" in flat
+    assert "get_mouse_position()" in flat
+    assert "get_global_mouse_position()" in flat
+    assert "stale in" in flat
+    assert "daemon sessions" in flat
 
 
 # --- model validation via --params-json (ADR-0015) ----------------------------
@@ -1587,7 +1602,17 @@ def test_input_sequence_params_json_at_the_window_boundary_dispatches(
     # dispatches through the same live seam the argv path uses.
     fake = inject_live_runner(
         monkeypatch,
-        RunResult(stdout=sentinel(INPUT_SEQUENCE_RESULT), stderr="", exit_code=0),
+        RunResult(
+            stdout=sentinel(
+                {
+                    **INPUT_SEQUENCE_RESULT,
+                    "events": 1,
+                    "frames": MAX_WINDOW_FRAMES,
+                }
+            ),
+            stderr="",
+            exit_code=0,
+        ),
     )
 
     result = CliRunner().invoke(
@@ -1954,7 +1979,11 @@ def test_an_explicit_null_button_still_means_the_left_button(monkeypatch, tmp_pa
     # sent an explicit null. It stays accepted, and normalizes to a named button.
     fake = inject_live_runner(
         monkeypatch,
-        RunResult(stdout=sentinel(INPUT_SEQUENCE_RESULT), stderr="", exit_code=0),
+        RunResult(
+            stdout=sentinel({**INPUT_SEQUENCE_RESULT, "events": 2, "frames": 1}),
+            stderr="",
+            exit_code=0,
+        ),
     )
     events = [
         {"type": "mouse_click", "x": 1.0, "y": 2.0, "button": None},
@@ -2118,3 +2147,348 @@ def test_a_sequence_variant_keeps_its_single_frame_ops_constraints():
     assert _MIRRORED_NULLABLE_EXEMPTIONS <= pinned, (
         _MIRRORED_NULLABLE_EXEMPTIONS - pinned
     )
+
+
+# --- the injection route every input result names (#838) ----------------------
+# gda injects an action as a STATE change (Input.action_press/action_release) and
+# a key or mouse event as an EVENT pushed through the root viewport. The two are
+# not interchangeable — a state change reaches no `_input` / `_gui_input` /
+# `_unhandled_input` handler — and a success result that named neither read as
+# GUI-path validation twice in dogfooding (GDA-DF-048, GDA-DF-075). Every result
+# now names the route it used; the CLI derives it from the event kind, so the
+# harness reply below is the UNCHANGED one it already sends.
+
+
+def _input_json(monkeypatch, tmp_path, payload, *argv):
+    """Run one `gda input` command over a faked live seam; return its result JSON."""
+    inject_live_runner(
+        monkeypatch, RunResult(stdout=sentinel(payload), stderr="", exit_code=0)
+    )
+    result = CliRunner().invoke(
+        app,
+        ["input", *argv, "--project", str(minimal_project(tmp_path)), "--json"],
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+    return json.loads(result.stdout)
+
+
+def test_input_key_result_names_the_viewport_event_route(monkeypatch, tmp_path):
+    data = _input_json(monkeypatch, tmp_path, INPUT_KEY_RESULT, "key", "Right")
+
+    assert data["injection_route"] == "viewport_event"
+
+
+def test_input_mouse_move_result_names_the_viewport_event_route(monkeypatch, tmp_path):
+    data = _input_json(
+        monkeypatch, tmp_path, INPUT_MOUSE_MOVE_RESULT, "mouse-move", "50", "60"
+    )
+
+    assert data["injection_route"] == "viewport_event"
+
+
+def test_input_action_result_names_the_action_state_route(monkeypatch, tmp_path):
+    data = _input_json(monkeypatch, tmp_path, INPUT_ACTION_RESULT, "action", "jump")
+
+    assert data["injection_route"] == "action_state"
+
+
+def test_input_mouse_click_phases_each_name_the_viewport_event_route(
+    monkeypatch, tmp_path
+):
+    data = _input_json(
+        monkeypatch, tmp_path, INPUT_MOUSE_CLICK_RESULT, "mouse-click", "100", "200"
+    )
+
+    assert [phase["injection_route"] for phase in data["phases"]] == [
+        "viewport_event",
+        "viewport_event",
+        "viewport_event",
+    ]
+
+
+def test_input_tap_key_phases_name_the_viewport_event_route(monkeypatch, tmp_path):
+    data = _input_json(
+        monkeypatch, tmp_path, INPUT_TAP_KEY_RESULT, "tap", "--key", "Right"
+    )
+
+    assert [phase["injection_route"] for phase in data["phases"]] == [
+        "viewport_event",
+        "viewport_event",
+    ]
+
+
+def test_input_tap_action_phases_name_the_action_state_route(monkeypatch, tmp_path):
+    # The tap is the one command whose route depends on the target it was given,
+    # which is why the field rides the PHASE and not the result's head.
+    data = _input_json(
+        monkeypatch, tmp_path, INPUT_TAP_ACTION_RESULT, "tap", "--action", "jump"
+    )
+
+    assert [phase["injection_route"] for phase in data["phases"]] == [
+        "action_state",
+        "action_state",
+    ]
+
+
+def test_input_sequence_reports_one_phase_per_event_naming_its_route(
+    monkeypatch, tmp_path
+):
+    # A sequence can MIX the routes, so each injected phase names its own. The
+    # phases are derived from the request: the harness reply counts the events,
+    # it does not enumerate them.
+    events = [
+        {"type": "action", "action": "jump", "frame": 0},
+        {"type": "key", "key": "Right", "frame": 1},
+        {"type": "mouse_click", "x": 10, "y": 20, "frame": 2},
+    ]
+    data = _input_json(
+        monkeypatch,
+        tmp_path,
+        {**INPUT_SEQUENCE_RESULT, "events": 3, "frames": 3},
+        "sequence",
+        "--events",
+        json.dumps(events),
+    )
+
+    assert data["phases"] == [
+        {"frame": 0, "phase": "press", "injection_route": "action_state"},
+        {"frame": 1, "phase": "press", "injection_route": "viewport_event"},
+        {"frame": 2, "phase": "press", "injection_route": "viewport_event"},
+        {"frame": 2, "phase": "release", "injection_route": "viewport_event"},
+    ]
+
+
+def test_input_sequence_phases_report_releases_and_the_physics_clock(
+    monkeypatch, tmp_path
+):
+    # A release event reports a release phase, and the phase offsets are the
+    # offsets on the clock the result reports — physics here, not process.
+    events = [
+        {"type": "action", "action": "jump", "physics_frame": 0},
+        {"type": "action", "action": "jump", "release": True, "physics_frame": 30},
+        {"type": "mouse_move", "x": 1, "y": 2, "physics_frame": 30},
+    ]
+    data = _input_json(
+        monkeypatch,
+        tmp_path,
+        {**INPUT_SEQUENCE_RESULT, "clock": "physics", "events": 3, "frames": 31},
+        "sequence",
+        "--events",
+        json.dumps(events),
+    )
+
+    assert data["clock"] == "physics"
+    assert data["phases"] == [
+        {"frame": 0, "phase": "press", "injection_route": "action_state"},
+        {"frame": 30, "phase": "release", "injection_route": "action_state"},
+        {"frame": 30, "phase": "move", "injection_route": "viewport_event"},
+    ]
+
+
+def test_every_event_kind_declares_its_route_and_only_action_takes_the_state_one():
+    # The route table must be COMPLETE over the union's own membership, and the
+    # derivation must have no fallback: with one, a sixth kind that changes state
+    # would silently inherit `viewport_event` — the common answer — and this test
+    # would still pass. So the key set is pinned against `InputEventType`, and the
+    # absence of a declared route is an error rather than a default.
+    import gda.commands.input as input_module
+
+    kinds = {kind.value for kind in input_module.InputEventType}
+    assert set(input_module.INJECTION_ROUTES) == kinds, (
+        input_module.INJECTION_ROUTES,
+        kinds,
+    )
+    assert input_module.INJECTION_ROUTES["action"] == "action_state"
+    assert {
+        route
+        for kind, route in input_module.INJECTION_ROUTES.items()
+        if kind != "action"
+    } == {"viewport_event"}
+    assert all(
+        input_module.injection_route(kind) == input_module.INJECTION_ROUTES[kind]
+        for kind in kinds
+    )
+    with pytest.raises(ValueError, match="no injection route is declared"):
+        input_module.injection_route("joypad_button")
+
+
+def test_input_sequence_phases_are_reported_in_application_order(monkeypatch, tmp_path):
+    # The harness applies a sequence by advancing the clock one index at a time and,
+    # at each index, walking the events in REQUEST order — so the reported phases
+    # are sorted by frame with request order kept inside a frame, and a request
+    # written out of frame order still reads like the gesture ops' phase lists.
+    events = [
+        {"type": "key", "key": "Right", "frame": 5},
+        {"type": "action", "action": "jump", "frame": 0},
+        {"type": "mouse_move", "x": 1, "y": 2, "frame": 0},
+    ]
+    data = _input_json(
+        monkeypatch,
+        tmp_path,
+        {**INPUT_SEQUENCE_RESULT, "events": 3, "frames": 6},
+        "sequence",
+        "--events",
+        json.dumps(events),
+    )
+
+    assert data["phases"] == [
+        {"frame": 0, "phase": "press", "injection_route": "action_state"},
+        {"frame": 0, "phase": "move", "injection_route": "viewport_event"},
+        {"frame": 5, "phase": "press", "injection_route": "viewport_event"},
+    ]
+
+
+def test_input_sequence_refuses_a_reply_that_applied_a_different_event_count(
+    monkeypatch, tmp_path
+):
+    # The phases are derived from the REQUEST, so a reply that says it applied a
+    # different sequence must not be published beside them: the result would state
+    # two sequences at once. A self-consistent reply for a DIFFERENT request is a
+    # contract_violation, the rule `perf monitors` already applies to its window.
+    inject_live_runner(
+        monkeypatch,
+        RunResult(
+            stdout=sentinel({**INPUT_SEQUENCE_RESULT, "events": 1, "frames": 1}),
+            stderr="",
+            exit_code=0,
+        ),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "input",
+            "sequence",
+            "--events",
+            json.dumps(
+                [
+                    {"type": "action", "action": "jump", "frame": 0},
+                    {"type": "key", "key": "Right", "frame": 1},
+                    {"type": "key", "key": "Left", "frame": 2},
+                ]
+            ),
+            "--project",
+            str(minimal_project(tmp_path)),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == EXIT_PARSE, result.stdout + result.stderr
+    error = json.loads(result.stdout)["error"]
+    assert error["code"] == "contract_violation"
+    assert error["message"] == "the harness applied 1 events for a 3-event request."
+
+
+def test_input_sequence_publishes_phases_when_the_reply_agrees(monkeypatch, tmp_path):
+    # The other half of the correlation: an agreeing reply still publishes the
+    # derived phases, so the guard refuses drift rather than the feature.
+    data = _input_json(
+        monkeypatch,
+        tmp_path,
+        {**INPUT_SEQUENCE_RESULT, "events": 2, "frames": 2},
+        "sequence",
+        "--events",
+        json.dumps(
+            [
+                {"type": "action", "action": "jump", "frame": 0},
+                {"type": "key", "key": "Right", "frame": 1},
+            ]
+        ),
+    )
+
+    assert data["events"] == 2
+    assert [phase["injection_route"] for phase in data["phases"]] == [
+        "action_state",
+        "viewport_event",
+    ]
+
+
+def test_input_action_help_states_the_route_and_what_it_never_reaches():
+    # The #838 acceptance, and the retraction of the claim that the game
+    # "observes the action exactly as a real binding would fire".
+    result = CliRunner().invoke(app, ["input", "action", "--help"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    flat = _flat_help(result)
+    assert "real binding would fire" not in flat
+    assert "action_state" in flat
+    assert "polled action state" in flat
+    assert "_input" in flat
+    assert "_gui_input" in flat
+    assert "_unhandled_input" in flat
+    assert "Input.is_action_" in flat
+
+
+def test_input_tap_help_states_the_route_of_each_target():
+    result = CliRunner().invoke(app, ["input", "tap", "--help"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    flat = _flat_help(result)
+    assert "action_state" in flat
+    assert "viewport_event" in flat
+    assert "_gui_input" in flat
+    assert "Input.is_action_" in flat
+
+
+def test_input_sequence_help_states_the_route_of_each_event_kind():
+    result = CliRunner().invoke(app, ["input", "sequence", "--help"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    flat = _flat_help(result)
+    assert "action_state" in flat
+    assert "viewport_event" in flat
+    assert "_unhandled_input" in flat
+
+
+def test_input_action_schema_publishes_the_route_it_takes():
+    result = CliRunner().invoke(app, ["input", "action", "--schema"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    schema = json.loads(result.stdout)
+    assert "action_state" in schema["input"]["description"]
+    assert "_gui_input" in schema["input"]["description"]
+    route = schema["output"]["properties"]["injection_route"]
+    assert route["enum"] == ["action_state", "viewport_event"]
+    assert route["default"] == "action_state"
+
+
+def test_input_tap_schema_publishes_the_route_on_every_phase():
+    result = CliRunner().invoke(app, ["input", "tap", "--schema"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    schema = json.loads(result.stdout)
+    assert "action_state" in schema["input"]["description"]
+    assert "_gui_input" in schema["input"]["description"]
+    phase = schema["output"]["$defs"]["InputEventPhase"]
+    assert phase["properties"]["injection_route"]["enum"] == [
+        "action_state",
+        "viewport_event",
+    ]
+    assert "injection_route" in phase["required"]
+
+
+def test_input_sequence_schema_publishes_the_route_per_event_kind():
+    result = CliRunner().invoke(app, ["input", "sequence", "--schema"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    schema = json.loads(result.stdout)
+    assert "action_state" in schema["input"]["description"]
+    assert "_unhandled_input" in schema["input"]["description"]
+    assert "action_state" in _variants()["action"]["description"]
+    assert "viewport_event" in _variants()["key"]["description"]
+    phases = schema["output"]["properties"]["phases"]
+    assert "route" in phases["description"]
+
+
+def test_the_bundled_skill_states_which_route_each_input_command_takes():
+    # ADR-0024 ships the skill in-package, so the guidance an agent reads is
+    # version-locked to this CLI: the route distinction must be in it, not only
+    # in --help.
+    from gda.commands.meta import read_skill_text
+
+    skill = read_skill_text()
+
+    assert "action_state" in skill
+    assert "viewport_event" in skill
+    assert "_gui_input" in skill
+    assert "Input.is_action_" in skill

--- a/tests/meta/test_schema_command.py
+++ b/tests/meta/test_schema_command.py
@@ -13,6 +13,7 @@ from typer.testing import CliRunner
 from gda.cli import app
 from gda.commands.meta import InfoParams
 from gda.models import EngineVersion, GdaErrorEnvelope
+from gda.runner import RunResult
 from tests.support import VERSION_INFO
 
 
@@ -1519,36 +1520,55 @@ def test_input_commands_schema_report_kind_live_and_are_model_derived():
     )
 
 
-def test_sample_input_results_validate_against_emitted_output_schemas():
-    # A sample --json payload of each input command satisfies the contract its
+def test_sample_input_results_validate_against_emitted_output_schemas(
+    monkeypatch, tmp_path
+):
+    # The --json payload each input command EMITS satisfies the contract its
     # --schema emits (the ADR-0004 hard gate for the LIVE input group, #221).
+    # The EMITTED payload, not the harness reply it is built from: since #838 the
+    # two differ — gda derives the injection route CLI-side and folds it into the
+    # result — so validating the reply would no longer check what agents read.
     from tests.support import (
         INPUT_ACTION_RESULT,
         INPUT_KEY_RESULT,
         INPUT_MOUSE_CLICK_RESULT,
         INPUT_MOUSE_MOVE_RESULT,
         INPUT_SEQUENCE_RESULT,
+        INPUT_TAP_ACTION_RESULT,
+        inject_live_runner,
+        minimal_project,
+        sentinel,
     )
 
-    key_doc = json.loads(CliRunner().invoke(app, ["input", "key", "--schema"]).stdout)
-    click_doc = json.loads(
-        CliRunner().invoke(app, ["input", "mouse-click", "--schema"]).stdout
-    )
-    move_doc = json.loads(
-        CliRunner().invoke(app, ["input", "mouse-move", "--schema"]).stdout
-    )
-    action_doc = json.loads(
-        CliRunner().invoke(app, ["input", "action", "--schema"]).stdout
-    )
-    seq_doc = json.loads(
-        CliRunner().invoke(app, ["input", "sequence", "--schema"]).stdout
-    )
+    project = str(minimal_project(tmp_path))
+    cases = [
+        (["input", "key", "Right"], INPUT_KEY_RESULT),
+        (["input", "mouse-click", "100", "200"], INPUT_MOUSE_CLICK_RESULT),
+        (["input", "mouse-move", "50", "60"], INPUT_MOUSE_MOVE_RESULT),
+        (["input", "action", "jump"], INPUT_ACTION_RESULT),
+        (["input", "tap", "--action", "jump"], INPUT_TAP_ACTION_RESULT),
+        (
+            [
+                "input",
+                "sequence",
+                "--events",
+                json.dumps([{"type": "action", "action": "jump"}]),
+            ],
+            # The reply must agree with the request it answers: gda correlates the
+            # applied-event count before it publishes the request-derived phases
+            # (#838), so the shared 3-event sample would be a contract_violation.
+            {**INPUT_SEQUENCE_RESULT, "events": 1, "frames": 1},
+        ),
+    ]
 
-    jsonschema.validate(instance=INPUT_KEY_RESULT, schema=key_doc["output"])
-    jsonschema.validate(instance=INPUT_MOUSE_CLICK_RESULT, schema=click_doc["output"])
-    jsonschema.validate(instance=INPUT_MOUSE_MOVE_RESULT, schema=move_doc["output"])
-    jsonschema.validate(instance=INPUT_ACTION_RESULT, schema=action_doc["output"])
-    jsonschema.validate(instance=INPUT_SEQUENCE_RESULT, schema=seq_doc["output"])
+    for argv, reply in cases:
+        inject_live_runner(
+            monkeypatch, RunResult(stdout=sentinel(reply), stderr="", exit_code=0)
+        )
+        emitted = CliRunner().invoke(app, [*argv, "--project", project, "--json"])
+        assert emitted.exit_code == 0, emitted.stdout + emitted.stderr
+        doc = json.loads(CliRunner().invoke(app, [*argv[:2], "--schema"]).stdout)
+        jsonschema.validate(instance=json.loads(emitted.stdout), schema=doc["output"])
 
 
 def test_schema_kind_is_identical_via_argv_and_params_json_forms():


### PR DESCRIPTION
## Summary

`gda input` reaches the running game two disjoint ways, and until now nothing said which one a call took. An action goes through `Input.action_press` / `action_release` — a change to the POLLED action state that builds no `InputEvent`, so no `_input`, `_gui_input` or `_unhandled_input` handler sees it — while a key or mouse injection pushes an `InputEvent` through the root viewport. Reading a successful action injection as event-path evidence produced a false product diagnosis twice in dogfooding (GDA-DF-048, GDA-DF-075), and `input action --help` claimed the game "observes the action exactly as a real binding would fire".

Every input result now names its route as `injection_route` (`action_state` | `viewport_event`): top-level on `input key`, `input mouse-move` and `input action`, per phase on `input mouse-click`, `input tap` and `input sequence`, because one sequence can mix the two (a tap targets exactly one of `--key` / `--action`, and that target selects the route both its phases take — reported in the same per-phase shape). The route is derived CLI-side from the event kind in ONE place (`injection_route()` in `src/gda/commands/input.py`); **the harness is not touched** and no injection behaviour changes. Help, `--schema`, the bundled skill, the command catalog and the README carry the distinction plus the rule of thumb: drive event-driven UI with a key or mouse event, use an action where the game polls `Input.is_action_*`.

One structural addition: `input sequence` gains the `phases` its result never had. The harness reply counts the events without enumerating them, so only the request holds the per-event kinds — the command now carries a `recipe` that CORRELATES the reply with the request (`events` applied vs `events` asked; a mismatch is a `contract_violation`, the rule `perf monitors` applies to its window) and only then folds in the derived phases. The recipe runs the op through the descriptor's own `execute`, so the runner seam, the classifier and the stderr handling stay the shared ones. The phases are reported in APPLICATION order — by frame, request order within a frame — which is how the harness's sampler applies them.

Closes #838

## Surface diff

Enumerated by diffing `gda schema` and `gda input <cmd> --help` captured at the base commit (`3f68bf3fb`) against this branch.

**`gda schema`** — 7 command entries changed, all additive (no field removed, renamed or retyped):

| command | changed |
| --- | --- |
| `input action` | `.description`; `.input.description`; `.output.description`; **ADDED** `.output.properties.injection_route` |
| `input key` | `.input.description`; `.output.description`; **ADDED** `.output.properties.injection_route` |
| `input mouse-move` | `.output.description`; **ADDED** `.output.properties.injection_route` |
| `input mouse-click` | `.output.description`; `.output.$defs.InputEventPhase.description`; `.output.$defs.InputEventPhase.properties.frame.description`; **ADDED** `.output.$defs.InputEventPhase.properties.injection_route`; `.output.$defs.InputEventPhase.required` +`injection_route` |
| `input tap` | `.description`; `.input.description`; `.output.description`; `.output.$defs.InputEventPhase.description`; `.output.$defs.InputEventPhase.properties.frame.description`; **ADDED** `.output.$defs.InputEventPhase.properties.injection_route`; `.output.$defs.InputEventPhase.required` +`injection_route` |
| `input sequence` | `.description`; `.input.description`; `.input.$defs.ActionSequenceEvent.description`; `.input.$defs.KeySequenceEvent.description`; `.output.description`; **ADDED** `.output.$defs` (`InputEventPhase`); **ADDED** `.output.properties.phases` (its description states the application-order rule) |
| `screen capture` | `.input.$defs.ActionSequenceEvent.description`; `.input.$defs.KeySequenceEvent.description` — see *Disclosed extras* |

`InputEventPhase.injection_route` is REQUIRED (gda folds it in before the phase models are built); the top-level fields and `InputSequenceResult.phases` carry defaults, like the `kind` / `clock` fields beside them. Every other command's schema entry is byte-identical.

**`gda input <cmd> --help`** — 3 of 6 changed, exactly the three the issue names:
- `input action`: the "exactly as a real binding would fire" sentence replaced by the `action_state` statement (what polls it, what it never reaches, which command to use instead, and that the result names the route).
- `input tap`: the "Exactly one of --key/--action" sentence extended — the target picks the route each phase reports, `--key` → `viewport_event`, `--action` → `action_state`, plus the rule of thumb.
- `input sequence`: a new clause after the drag paragraph — a sequence may mix routes, the result names one per phase, `action` → `action_state`, `key`/`mouse_*` → `viewport_event`.
- `input key`, `input mouse-click`, `input mouse-move`: **none** (byte-identical).

**Catalog** (`docs/command-catalog.md`): the `input` bullet's existing "Key/mouse events ride ... actions go through `Input.action_press`" sentence is extended with the route contract (disjoint routes, `injection_route`, per-phase on the phased ops, the rule of thumb, and that a successful action injection is not event-path evidence).

**SKILL** (`src/gda/skill/SKILL.md`): one new paragraph in the input guidance, before the UI-activation paragraph — the two routes, which command takes which, the rule of thumb, and the non-evidence warning. Tables untouched.

**CONTEXT.md**: one new entry under *Operations*, **`Injection route`** — the two doors, what each reaches and does not reach, that they are disjoint by construction, that every `input` result names the one it used, and the pointer to #854. The vocabulary is now on six results, three helps, the schema, the skill and the catalog, so it gets one authority instead of four prose copies.

**README**: two table rows (`input action`, `input tap`) gain the behavioural boundary in plain English, no route names (contract detail stays in `--help` / `--schema` / SKILL / catalog). The same two cells updated in `docs/README.zh-CN.md`, `docs/README.es.md`, `docs/README.ja.md`, then `uv run python scripts/update_readme_i18n.py` re-stamped the sync markers.

## Red-proof evidence

The tests were written first and run against the committed base (`3f68bf3fb`, before any source edit):

```
$ uv run --frozen pytest tests/live/test_input_commands.py -m "not e2e" -q -p no:cacheprovider
16 failed, 71 passed in 1.97s
```

The 16 covered every claim of the change: the six results' routes, the sequence's per-phase derivation over both clocks, the single-authority mapping over `InputEventType`, the three helps, the three `--schema` entries, and the bundled skill. After the implementation the same command reports `87 passed`.

The e2e regression was equally red at the base — the three route assertions in `test_input_results_name_the_injection_route_against_a_live_session` read `injection_route` off results that did not carry it.

## Validation

Host: macOS 15 (Darwin 25.6.0), Apple silicon, load average 2.3–2.7 during the e2e runs; Godot 4.6.3 at the machine-local `~/Applications/Godot.app/Contents/MacOS/Godot` (never hardcoded — passed as `$GDA_GODOT` for the run). All gates run at the pushed head.

| gate | command | result |
| --- | --- | --- |
| fast tier | `uv run --frozen pytest tests -m "not e2e" -q -p no:cacheprovider` | `2473 passed, 651 deselected in 45.11s` |
| lint | `uv run --frozen ruff check .` | `All checks passed!` |
| format | `uv run --frozen ruff format --check .` | `508 files already formatted` |
| types | `uv run --frozen pyright` (bare, src+tests, as CI runs it) | `0 errors, 0 warnings, 0 informations` |
| live e2e | `uv run --frozen pytest tests/live/test_e2e_input.py -m e2e -rs -p no:cacheprovider` | `17 passed in 33.31s` |
| repo gates | `uv run --frozen pytest tests/repo -m "not e2e" -q -p no:cacheprovider` | `102 passed in 0.27s` (README i18n sync markers) |
| live e2e (blast radius) | `uv run --frozen pytest tests/daemon/test_e2e_daemon.py -m e2e -rs -q -k scenetree_paused` | `2 passed, 30 deselected in 15.29s` — the two e2e tests outside the input module that drive `input sequence`, re-run because it now dispatches through a recipe |

e2e ran one pytest process at a time, no `-n`, no launch timeout and so no re-run needed. `GDA_USER_DATA_ROOT` was never exported for a run (PITFALLS.md). Windowed coverage is not needed here — the routes are reported by headless daemon sessions.

CI-only gates (the full nightly `godot-e2e` matrix, Linux) are not reproducible locally; the substitute evidence is the input e2e module plus the two daemon e2e tests above, run against a real daemon, a real engine session and the real harness. Residual risk: low — no injection behaviour changed, and the only dispatch change (`input sequence` → recipe) is exercised by the module's four sequence e2e tests and the two daemon ones.

## Requirement conformance

| AC | how it is satisfied |
| --- | --- |
| `input action --help`, `input tap --help` and the `input sequence` event documentation state the route per event kind and that action-state injection does not reach `_input` / `_gui_input` / `_unhandled_input` | The three command docstrings (`input.py`) now state it; the `input action` overclaim is retracted. Pinned by `test_input_action_help_states_the_route_and_what_it_never_reaches` (which also asserts the old sentence is GONE), `test_input_tap_help_states_the_route_of_each_target`, `test_input_sequence_help_states_the_route_of_each_event_kind`. |
| `--schema` for the three commands carries the same statement; the bundled skill's input guidance is updated in the same change | The params-model docstrings (`InputActionParams`, `InputTapParams`, `InputSequenceParams`) and the `ActionSequenceEvent` / `KeySequenceEvent` variant docstrings carry it, so it reaches `--schema` and `gda schema`. Pinned by the three `..._schema_publishes_...` tests. SKILL.md updated in this PR and pinned by `test_the_bundled_skill_states_which_route_each_input_command_takes`. |
| All six `input` results report `injection_route` as specified (top-level for the single-event commands, per phase for the phased ones); existing fields unchanged | `InputKeyResult` / `InputMouseMoveResult` / `InputActionResult` carry it top-level; `InputEventPhase` carries it for `input mouse-click`, `input tap` and `input sequence`. Six unit tests assert the emitted `--json`; the schema diff above shows every change is an ADD. `test_sample_input_results_validate_against_emitted_output_schemas` now validates the EMITTED payload (not the harness reply) against the emitted output schema, for all six commands. |
| A live regression asserts the reported route for one action, one key, and one tap that holds an action | `tests/live/test_e2e_input.py::test_input_results_name_the_injection_route_against_a_live_session` — one daemon, one session: `input key Right` → `viewport_event`, `input action move_right` → `action_state`, `input tap --action move_right` → `action_state` on both phases (with the game's own `is_action_just_pressed` / `just_released` polling confirming the action was really driven), plus a mixed sequence reporting one route per phase. |

## Review round

Independent review at `96a43ffb` returned CHANGES REQUIRED (1 P2, 3 P3) plus an adopted note. All five are adopted in `7d87a785`.

**P2 — the recipe published request-derived `phases` without correlating the reply.** A reply that says it applied a different sequence was published beside phases describing the requested one. Fixed in `_input_sequence_recipe`, before the fold:

```python
if outcome.events != len(params.events):
    return make_failure(
        "contract_violation",
        f"the harness applied {outcome.events} events for a "
        f"{len(params.events)}-event request.",
        "",
    )
```

Red-proof, both directions. Before the guard, a three-event request against a one-event reply succeeded and published four phases, one past the claimed window; after it:

```
E  AssertionError: {"error":{"category":"parse","code":"contract_violation",
E   "message":"the harness applied 3 events for a 1-event request.","diagnostics":""}}
E  assert 5 == 0
```

(that is the pre-existing `test_input_sequence_at_the_window_boundary_argv_is_accepted` reaching the new guard with the shared 3-event sample reply; it and two siblings now state a reply that agrees with their request, and so does the sequence case of `test_sample_input_results_validate_against_emitted_output_schemas`.) Two new tests pin both directions: `test_input_sequence_refuses_a_reply_that_applied_a_different_event_count` (exit 5, the message above) and `test_input_sequence_publishes_phases_when_the_reply_agrees`.

The aborted-window path is unchanged: the harness's `{"error": …}` sample still becomes a `classify_live` Failure that the recipe returns before the correlation and the fold. Verified byte-identical against the sentinel channel with the same reply and a non-empty child stderr — both emit `{"error":{"category":"live","code":"live_invalid_event_spec","message":"unsupported event type","diagnostics":"engine noise\n"}}` at exit 6.

**P3-1 — phase order.** `sequence_phases` emitted request order while the gesture ops emit frame order. Read against the harness (`gda_harness.gd:1353-1365`, read-only): the sampler advances the selected clock one index at a time and, at each index, walks `events` in request order applying those whose offset equals it — so application order is *by frame ascending, request order within a frame*, and a STABLE sort by `frame` reproduces it. Applied, stated in the `phases` field description, and pinned by `test_input_sequence_phases_are_reported_in_application_order` with the reviewer's own probe (`[{key, frame 5}, {action, frame 0}]`).

**P3-2 — the route test did not guard what it claimed.** The derivation had a `viewport_event` fallback, so a new kind that should be `action_state` would pass silently. Fixed at the source: `INJECTION_ROUTES` is now an explicit, complete table and `injection_route` raises `ValueError` for an undeclared kind (every caller passes a module literal or a validated union `type`, so an unknown kind is a gda bug, never caller input). The test now pins the table's key set against the `InputEventType` membership, so a sixth kind fails on absence, and asserts the raise.

**P3-3 — ragged help lines.** Both inserted paragraphs rewrapped; the `input sequence` rewrap also evens out the pre-existing ragged lines in the sentence that follows.

**Adopted note — `CONTEXT.md`.** Added the `Injection route` entry (see the surface diff).

## Disclosed extras / boundary crossings

- **`screen capture --schema`** changed: its `--await-events` input embeds the same `KeySequenceEvent` / `ActionSequenceEvent` models, so the route sentences added to those two docstrings appear there too. Description-only, no field change, and correct for that command — the atomic await-events take the same routes.
- **`input sequence` now carries a `recipe`** (`ADR-0023`) and is pinned in `tests/cli/test_command_descriptor_registry.py::_RECIPE_OPERATIONS` with the reason. It was the only way to report a per-phase route for a sequence without touching the harness: the reply has no per-event evidence, and only the request holds the kinds. The recipe delegates to `INPUT_SEQUENCE_COMMAND.execute`, so it is not a second copy of the runner/classifier/stderr tail, and it correlates the reply before completing it.
- **`test_input_sequence_help_documents_mouse_tracked_position_limitation`** now reads the help through `_flat_help` like its mouse-op siblings: the rewrap moved a line break inside "stale in daemon sessions", and that assertion was reading raw wrapped stdout.
- **`InputEventPhase` prose generalized**: its docstring and its `frame` description now cover a sequence phase (whose offset can be on the physics clock) as well as a gesture phase. Description-only; the field's shape and bounds are unchanged.
- **`InputSequenceResult.phases` defaults to `[]`** rather than being required, because the same model must still validate the harness reply that has no phases; the recipe always fills it, and the field description says gda derives it from the request.
- **Human renderers are unchanged.** The ACs name help, `--schema`, the skill and the result; the text renderer is not a machine contract and every input command's line would grow a constant. The human channel gets the disclosure through `--help`.
- **Translations**: the `es` and `ja` cells are authored here, not natively reviewed. `zh-CN` is native. Same disclosure as the earlier README rounds.
- Two existing unit assertions and two existing e2e assertions that compared `phases` by exact equality were updated to carry the additive field. No sibling-owned file was touched: `gda_harness.gd`, `harness/install.py`, `commands/game.py`, `commands/project.py`, `commands/script.py`, `hints.py` and `ops/operations.gd` are untouched, and `HARNESS_VERSION` is unchanged.


## Review round 2 (`33b3eb412`)

The second independent review returned one P3 and no code finding: the catalog, this
Summary and #838's result-field rationale said a tap can mix the two routes. It cannot —
`InputTapParams` requires exactly one of `key` / `action` and refuses both, so both
phases take the route its one target selects; a SEQUENCE is what can mix them. Adopted
in the catalog, the `InputEventPhase` docstring, the `mouse-click` route comment, the
Summary above and #838 (dated correction + comment, 2026-09-06). The per-phase field and
the exactly-one-target rule are unchanged; input unit tests 90 passed on this head.
