### PR TITLE
docs(readme): link playable gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [Product overview](https://aigengame.xyz/) ·
 [CLI, Agent Skill, or MCP?](https://aigengame.xyz/godot-mcp/) ·
+[Playable demos](https://github.com/aigengame/gallery) ·
 [PyPI](https://pypi.org/project/gda/)
 
 > **Build and verify Godot projects with AI coding agents, shell scripts, and CI.**

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=e225ed00bc75daf0ba46f85f056196e35987afe39341d354b4ec0454b64733a2 -->
+<!-- gda-readme-i18n: source=README.md sha256=150ed6831b06c9466fc94b1a74fc01750974b5285c215a4cbb7cd852cc5c1c4a -->
 
 # gda — Automatización de Godot para agentes de IA
 
@@ -8,6 +8,7 @@
 
 [Descripción del producto](https://aigengame.xyz/) ·
 [¿CLI, Agent Skill o MCP?](https://aigengame.xyz/godot-mcp/) ·
+[Demos jugables](https://github.com/aigengame/gallery) ·
 [PyPI](https://pypi.org/project/gda/)
 
 > **Crea y verifica proyectos de Godot desde agentes de programación con IA, scripts de shell y CI.**

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=e225ed00bc75daf0ba46f85f056196e35987afe39341d354b4ec0454b64733a2 -->
+<!-- gda-readme-i18n: source=README.md sha256=150ed6831b06c9466fc94b1a74fc01750974b5285c215a4cbb7cd852cc5c1c4a -->
 
 # gda — AI エージェント向け Godot オートメーション
 
@@ -8,6 +8,7 @@
 
 [製品概要](https://aigengame.xyz/) ·
 [CLI、Agent Skill、MCP のどれを選ぶ？](https://aigengame.xyz/godot-mcp/) ·
+[プレイ可能なデモ](https://github.com/aigengame/gallery) ·
 [PyPI](https://pypi.org/project/gda/)
 
 > **AI コーディングエージェント、シェルスクリプト、CI から Godot プロジェクトを構築・検証できます。**

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=e225ed00bc75daf0ba46f85f056196e35987afe39341d354b4ec0454b64733a2 -->
+<!-- gda-readme-i18n: source=README.md sha256=150ed6831b06c9466fc94b1a74fc01750974b5285c215a4cbb7cd852cc5c1c4a -->
 
 # gda — 面向 AI Agent 的 Godot 自动化
 
@@ -8,6 +8,7 @@
 
 [产品概览](https://aigengame.xyz/zh/) ·
 [CLI、Agent Skill 还是 MCP？](https://aigengame.xyz/zh/godot-mcp/) ·
+[可玩示例](https://github.com/aigengame/gallery) ·
 [PyPI](https://pypi.org/project/gda/)
 
 > **让 Coding Agent、Shell 脚本与 CI 构建并验证 Godot 项目。**

--- a/tests/repo/test_readme_i18n_sync.py
+++ b/tests/repo/test_readme_i18n_sync.py
@@ -116,6 +116,23 @@ def test_english_readme_links_to_all_translations():
     )
 
 
+def test_all_readmes_link_to_playable_gallery():
+    gallery_url = "https://github.com/aigengame/gallery"
+    files = {"README.md": README} | {
+        f"docs/README.{lang}.md": path for lang, path in TRANSLATIONS.items()
+    }
+    missing = sorted(
+        name
+        for name, path in files.items()
+        if path.exists() and gallery_url not in path.read_text(encoding="utf-8")
+    )
+
+    assert not missing, (
+        f"public READMEs are missing the playable Gallery link: {missing}. "
+        "Keep the proof channel discoverable in every supported language."
+    )
+
+
 # --- In-page anchor integrity (Table of Contents and other "](#...)" links) ---
 
 _FENCE_RE = re.compile(r"^\s*```")


### PR DESCRIPTION
Adds a Playable demos entry to the English README and localized Chinese, Spanish, and Japanese variants, connecting the product repository to the Gallery proof channel. Refreshes translation source hashes and adds a regression test that keeps the Gallery link discoverable in every public README. Verified with uv run pytest tests/repo/test_readme_i18n_sync.py -q (7 passed).