### PR TITLE
refactor(gda): lift the import-evidence adapter into a core import_evidence module (#741)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -71,6 +71,16 @@ drives or observes the scene from outside, there is no `Engine session` and no
 `gda-daemon`, and the process ends with the verdict.
 _Avoid_: smoke test, dry run, live check
 
+**Import evidence**:
+The read-side verdict gda takes on one asset's import cache before deciding to run
+the engine's project-wide pass — `cached` / `missing` / `stale` / `invalid`, read
+from the same artifacts `EditorFileSystem::_test_for_reimport` reads, in the
+engine's own order, with the engine-state checks it cannot read declared as a
+one-way remainder (delay a re-import, never spend a pass the engine would not).
+Owned by the core `import_evidence` module; settlements are the command's
+post-pass verdicts, not evidence.
+_Avoid_: cache check, freshness probe, validity scan
+
 **Engine session**:
 A single transient run of a gda-owned Godot game, launched and held by `gda-daemon`
 with the `gda harness` injected, against which `Live operation`s are served. The

--- a/src/gda/commands/resource.py
+++ b/src/gda/commands/resource.py
@@ -6,9 +6,10 @@ params/result models, its human renderers, its ``HeadlessCommand`` descriptors
 through :func:`register`. It imports the shared machinery downward — the
 dispatch tail (``gda.dispatch``), the descriptor machinery (``gda.headless``),
 the cross-command contract core (``gda.models``, for the shared
-:class:`~gda.models.NodeProperty` shape) and the shared render helpers
-(``gda.render``) — and is imported by nothing but the composition root
-(``gda.cli``).
+:class:`~gda.models.NodeProperty` shape), the shared render helpers
+(``gda.render``) and the import-evidence adapter (``gda.import_evidence``, whose
+engine-parity contract this group used to carry inline, #741) — and is imported
+by nothing but the composition root (``gda.cli``).
 
 :class:`~gda.commands.project.ResourceReference` is NOT this group's model
 despite its name: it is the ``project find-references`` result shape, so it

--- a/src/gda/commands/resource.py
+++ b/src/gda/commands/resource.py
@@ -15,10 +15,7 @@ despite its name: it is the ``project find-references`` result shape, so it
 lives with its single consumer in the ``project`` group (ADR-0040 §5).
 """
 
-import hashlib
-import json
 import os
-import re
 from pathlib import Path
 from typing import Any, Literal, Optional
 
@@ -40,6 +37,13 @@ from gda.headless import (
     json_option,
     params_json_option,
     project_option,
+)
+from gda.import_evidence import (
+    CACHE_ROOT_REL,
+    CreatedFileClass,
+    asset_state,
+    classify_created_file,
+    project_import_gaps,
 )
 from gda.models import (
     CREATED_DIRS_DESC,
@@ -573,7 +577,7 @@ class ImportCreatedFile(BaseModel):
     """
 
     path: str = Field(description="The created file's res:// path.")
-    classification: Literal["cache_owned", "source_adjacent"] = Field(
+    classification: CreatedFileClass = Field(
         description="cache_owned (under .godot/) or source_adjacent."
     )
 
@@ -719,59 +723,6 @@ class ResourceImportResult(BaseModel):
         return self
 
 
-_CACHE_ROOT_REL = ".godot"
-_DEST_FILES_LINE = re.compile(r"^dest_files=(\[.*\])$", re.MULTILINE)
-_INVALID_LINE = re.compile(r"^valid=false$", re.MULTILINE)
-_RECEIPT_ASSIGNMENT_LINE = re.compile(
-    r'^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*("(?:\\.|[^"\\])*")\s*(?:;.*)?$'
-)
-_IMPORTER_LINE = re.compile(r'^importer="([^"]*)"$', re.MULTILINE)
-_UID_LINE = re.compile(r'^uid="[^"]*"$', re.MULTILINE)
-_SOURCE_FILE_LINE = re.compile(r'^source_file="([^"]*)"$', re.MULTILINE)
-_PATH_LINE = re.compile(r'^path[.\w]*="([^"]*)"$', re.MULTILINE)
-_FILES_LINE = re.compile(r"^files=(\[.*\])$", re.MULTILINE)
-# The engine keeps ONE `.md5` receipt per asset at `<import base>.md5`, where
-# the import base is DERIVED FROM THE ASSET PATH — `.godot/imported/
-# <filename>-<md5 of the res:// path>` (ResourceFormatImporter::
-# get_import_base_path) — independent of whether the sidecar declares any
-# destinations. Deriving it the same way (verified against a real import's
-# hash) is what lets the verdict follow the engine on a no-destination
-# sidecar (#738 re-review 4).
-
-
-def _parse_receipt_assignments(text: str) -> "dict[str, str] | None":
-    """Parse gda's documented VariantParser-compatible receipt subset.
-
-    Godot writes quoted-string assignments. Its parser also permits spacing,
-    ``;`` comments, JSON-style escapes, and repeated keys; assignments are
-    applied in order, so the last value wins. A broader Variant value returns
-    ``None`` so the caller takes the contract's conservative no-pass direction
-    — as does a lone UTF-16 surrogate escape, which json accepts but
-    VariantParser rejects (the engine's parse-error skip).
-    """
-    assignments: dict[str, str] = {}
-    for line in text.splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith(";"):
-            continue
-        assignment = _RECEIPT_ASSIGNMENT_LINE.match(line)
-        if assignment is None:
-            return None
-        try:
-            value = json.loads(assignment.group(2))
-        except (TypeError, ValueError):
-            return None
-        if any("\ud800" <= ch <= "\udfff" for ch in value):
-            # json.loads accepts a LONE UTF-16 surrogate escape; VariantParser
-            # rejects it ("unpaired lead/trail surrogate", TK_ERROR) — the
-            # engine's deliberate skip. Paired surrogates decode to a real
-            # code point on both sides, so any surrogate left in the decoded
-            # value is lone by construction. Stay on the no-pass side.
-            return None
-        assignments[assignment.group(1)] = value
-    return assignments
-
-
 def _asset_res_path(project: Path, raw: str) -> "str | Failure":
     """Normalize one requested asset to its res:// path, or the refusal.
 
@@ -873,147 +824,21 @@ def _asset_res_path(project: Path, raw: str) -> "str | Failure":
     return canonical_res_path(RES_PREFIX + rel_fs.as_posix())
 
 
-def _asset_state(project: Path, res_path: str) -> ResourceImportAsset:
-    """One asset's evidence state, read as the engine's own reimport test reads it.
+def _asset_record(project: Path, res_path: str) -> ResourceImportAsset:
+    """Address one asset's evidence: the core adapter's verdict, in the wire shape.
 
-    A faithful adaptation of ``EditorFileSystem::_test_for_reimport`` (#738
-    review), in the engine's own order: an unparseable or ``valid=false``
-    sidecar is ``invalid`` (the engine SKIPS these rather than retrying), and
-    so is an unparseable ``.md5`` receipt — the engine's receipt parse-error
-    branch is the same deliberate skip, never a re-import (#738 re-review 5);
-    gda's receipt grammar covers the quoted-string assignments the engine
-    writes plus VariantParser spacing, ``;`` comments, JSON-style escapes
-    (lone UTF-16 surrogates excluded, as VariantParser rejects them), and
-    repeated assignments (the last value wins). Broader Variant value syntax errs
-    toward ``invalid``, the no-pass direction the contract sanctions; a
-    ``keep``/``skip`` importer is ``cached``; the pre-UID format, a missing
-    remap/destination file, a ``source_file`` naming a different source (a
-    copied sidecar), a missing ``.md5`` receipt (located at the PATH-derived
-    import base, as the engine locates it), or a ``source_md5`` /
-    ``dest_md5`` disagreeing with the actual bytes are all ``stale`` (the
-    engine WOULD re-import). ``cached`` needs POSITIVE evidence: a keep/skip
-    importer, or the path-derived receipt present and matching — with any
-    DECLARED destinations also present and digest-checked; a sidecar
-    declaring none but carrying a matching receipt passes the same checks
-    (#738 re-review 4; the engine's own pass leaves it untouched when the
-    declared remainder below is controlled — verified live). A sidecar with no importer line proves nothing
-    and is conservatively ``stale`` (#738 re-review 2). The checks the engine makes
-    from its own state — whether the DECLARED importer still exists (its
-    registry is open: import plugins add names, so no offline list can be
-    authoritative), its format version, its project-settings validity, and
-    the editor cache's expected sidecar MD5 — cannot be read from the
-    project's artifacts, so a sidecar drifted in those dimensions can look
-    ``cached`` here until any pass runs; the contract names that remainder,
-    and its direction: it can delay a re-import until the next pass, never
-    spend a pass the engine would not.
+    The command's whole share of the reimport test (#741) — ``gda.import_evidence``
+    reads the artifacts and returns the four EVIDENCE states; this maps them onto
+    ``ResourceImportAsset``, whose vocabulary also carries the settlements a real
+    run adds afterwards.
     """
-    rel = res_path[len("res://") :]
-    sidecar_fs = project / (rel + ".import")
-    if not sidecar_fs.is_file():
-        return ResourceImportAsset(path=res_path, status="missing")
-    sidecar_res = res_path + ".import"
-
-    def state(
-        status: AssetStatus, dests: "list[str] | None" = None
-    ) -> ResourceImportAsset:
-        return ResourceImportAsset(
-            path=res_path,
-            status=status,
-            sidecar=sidecar_res,
-            dest_files=dests or [],
-        )
-
-    try:
-        text = sidecar_fs.read_text(encoding="utf-8")
-    except UnicodeDecodeError:
-        # The engine's parse-error branch: skip, never auto-reimport.
-        return state("invalid")
-    if _INVALID_LINE.search(text):
-        return state("invalid")
-    importer = _IMPORTER_LINE.search(text)
-    if importer is None:
-        # No importer DECLARED: nothing proves this sidecar's cache.
-        # Conservatively stale (#738 re-review 2). Whether a declared name
-        # still RESOLVES is engine state (an open registry) — part of the
-        # declared remainder, not decidable here.
-        return state("stale")
-    if importer.group(1) in ("keep", "skip"):
-        return state("cached")
-    dest_match = _DEST_FILES_LINE.search(text)
-    dests: list[str] = []
-    if dest_match is not None:
-        try:
-            dests = [str(d) for d in json.loads(dest_match.group(1))]
-        except ValueError:
-            return state("invalid")
-    if _UID_LINE.search(text) is None:
-        return state("stale", dests)  # pre-UID format: the engine re-imports
-    # Every remap/destination reference must exist (path=, path.<variant>=,
-    # files=[...], dest_files=[...] — the engine's to_check set).
-    to_check = list(dests)
-    to_check.extend(_PATH_LINE.findall(text))
-    files_match = _FILES_LINE.search(text)
-    if files_match is not None:
-        try:
-            to_check.extend(str(f) for f in json.loads(files_match.group(1)))
-        except ValueError:
-            return state("invalid")
-    for ref in to_check:
-        if ref.startswith("res://") and not (project / ref[len("res://") :]).is_file():
-            return state("stale", dests)
-    source_file = _SOURCE_FILE_LINE.search(text)
-    if source_file is not None and source_file.group(1) != res_path:
-        return state("stale", dests)  # a copied sidecar names another source
-    # The engine's one .md5 receipt per asset, at the path-derived import
-    # base — read whether or not destinations are declared, exactly as
-    # _test_for_reimport reads it. A missing receipt is what the engine
-    # re-imports; a present, matching one is the POSITIVE evidence a cached
-    # verdict needs — including for a sidecar that declares no destinations,
-    # which the engine leaves untouched (#738 re-review 4, verified live).
-    receipt = (
-        project
-        / ".godot"
-        / "imported"
-        / (
-            Path(rel).name
-            + "-"
-            + hashlib.md5(res_path.encode("utf-8")).hexdigest()
-            + ".md5"
-        )
+    evidence = asset_state(project, res_path)
+    return ResourceImportAsset(
+        path=res_path,
+        status=evidence.status,
+        sidecar=evidence.sidecar,
+        dest_files=list(evidence.dest_files),
     )
-    if not receipt.is_file():
-        return state("stale", dests)
-    receipt_text = receipt.read_text(encoding="utf-8", errors="replace")
-    # The engine parses the receipt with VariantParser, and ANY parse error
-    # is the same deliberate skip as a valid=false sidecar ("skip and let
-    # user attempt manual reimport to avoid reimport loop") — never a
-    # re-import (#738 re-review 5). Parse assignments in engine order: Godot's
-    # VariantParser applies every assignment, so repeated keys are last-write-
-    # wins (#738 re-review 6). The engine writes quoted-string values; accept
-    # that public subset plus its spacing/comments/escapes, while broader
-    # Variant values conservatively take the sanctioned no-pass direction.
-    assignments = _parse_receipt_assignments(receipt_text)
-    if assignments is None:
-        return state("invalid", dests)
-    recorded_source = assignments.get("source_md5")
-    if recorded_source is None:
-        # Parseable but lacking source_md5: the engine's "Lacks md5, so
-        # just reimport" — a pass state, unlike the parse error above.
-        return state("stale", dests)
-    if hashlib.md5((project / rel).read_bytes()).hexdigest() != recorded_source:
-        return state("stale", dests)
-    recorded_dest = assignments.get("dest_md5")
-    if dests and recorded_dest:
-        # The engine's multi-file digest: one MD5 over every destination's
-        # bytes, in the sidecar's order (FileAccess::get_multiple_md5).
-        ctx = hashlib.md5()
-        for dest in dests:
-            dest_fs = project / dest[len("res://") :]
-            if dest_fs.is_file():
-                ctx.update(dest_fs.read_bytes())
-        if ctx.hexdigest() != recorded_dest:
-            return state("stale", dests)
-    return state("cached", dests)
 
 
 def _project_files(project: Path) -> set[str]:
@@ -1026,99 +851,6 @@ def _project_files(project: Path) -> set[str]:
         if path.is_file():
             files.add(rel.as_posix())
     return files
-
-
-# The two marker files the engine's scan skips a directory on. Named here, not
-# spelled inline, because the same two literals are declared a second time in
-# ``operations.gd`` (``NESTED_PROJECT_MARKER`` / ``GDIGNORE_MARKER``) for the walk
-# — one rule, two languages. ``test_the_two_spellings_of_the_skip_markers_agree``
-# reads both files and fails if they drift apart (#808 review).
-NESTED_PROJECT_MARKER = "project.godot"
-GDIGNORE_MARKER = ".gdignore"
-
-
-def _engine_skips_directory_of(project: Path, rel: str) -> bool:
-    """Whether the engine's own scan never reaches ``rel`` (#804).
-
-    Two clauses of ``EditorFileSystem``'s scan decide this, and the prediction
-    needs BOTH because the scan asks them in order:
-
-    * ``_scan_new_dir`` drops every **dot-prefixed directory** before it
-      consults the skip rule at all (``editor/file_system/
-      editor_file_system.cpp:1157-1168``, line numbers from the 4.6.3-stable
-      tag) — so ``res://.hidden/h.png`` is unreachable however ordinary it
-      looks. This clause subsumes the ``.godot`` cache and a ``.git`` checkout,
-      at any depth rather than at the project root alone;
-    * ``_should_skip_directory`` (same file, ``3460-3480``) then skips a
-      directory holding a ``project.godot`` — another project inside this one —
-      or a ``.gdignore`` marker.
-
-    Every directory ABOVE ``rel`` up to (but never including) the project root
-    is asked, because one marker hides the whole subtree.
-
-    **This is not the walk's rule, and must not be read as it.** The same two
-    markers gate ``_should_descend`` in ``operations.gd``, but that walk answers
-    a different question — what gda ENUMERATES — and deliberately keeps hidden
-    and dot-prefixed directories in (#54, #712). This predicate answers what the
-    ENGINE reaches, so it drops them. Two further divergences are known and
-    stated rather than chased: ``Path.rglob`` does not descend a symlinked
-    directory while the walk does (#760), so a stale asset behind a link is not
-    predicted — an omission, never a false promise, and the real run's
-    ``created`` list stays authoritative; and the OS "hidden" attribute the
-    engine also honours (``DirAccess::current_is_hidden``) has no portable
-    Python reading, so only the dot-prefix half of that clause is modelled.
-
-    Cost: the ancestors are re-probed per sidecar and memoized nowhere — 2000
-    sidecars at depth 4 cost ~16k ``stat`` calls, measured at 0.11 s. A cache
-    was declined for the same reason the walk declines one: the state would buy
-    nothing at this size.
-    """
-    parts = Path(rel).parent.parts
-    for depth in range(1, len(parts) + 1):
-        if parts[depth - 1].startswith("."):
-            return True
-        directory = project.joinpath(*parts[:depth])
-        if (directory / NESTED_PROJECT_MARKER).is_file():
-            return True
-        if (directory / GDIGNORE_MARKER).is_file():
-            return True
-    return False
-
-
-def _project_import_gaps(project: Path, requested: set[str]) -> list[str]:
-    """Other assets the project-wide pass WILL re-import (#738 review).
-
-    The dry-run inventory's project-wide half: every asset OUTSIDE the request
-    whose committed sidecar fails an engine check (``stale``) — the states the
-    engine's own reimport test acts on. ``invalid`` sidecars are EXCLUDED: the
-    engine deliberately skips a previously failed import (verified against a
-    live pass — the invalid sidecar's bytes stay untouched). Assets with NO
-    sidecar (and the ``.uid`` sidecars the pass may generate) cannot be
-    predicted from here — the engine decides those — so the real run's
-    ``created`` list stays the authoritative inventory, and the contract says
-    so.
-
-    An asset the engine's scan never reaches is not a gap either (#804): the
-    pass skips a nested project's, a ``.gdignore``d and a dot-prefixed
-    directory's contents, so predicting a re-import there promised work the
-    engine will not do. That one predicate replaced the ``.godot``/``.git``
-    prefix test this loop used to make, which was the same clause spelled for
-    two directories at the project root only (#808 review).
-    """
-    gaps: list[str] = []
-    for sidecar in sorted(project.rglob("*.import")):
-        rel = sidecar.relative_to(project).as_posix()
-        if _engine_skips_directory_of(project, rel):
-            continue
-        res_path = "res://" + rel[: -len(".import")]
-        if res_path in requested:
-            continue
-        source = project / rel[: -len(".import")]
-        if not source.is_file():
-            continue
-        if _asset_state(project, res_path).status == "stale":
-            gaps.append(res_path)
-    return gaps
 
 
 def _summarize(
@@ -1170,8 +902,8 @@ def run_resource_import_operation(
     # A repeated asset is idempotent; normalize it away, order preserved.
     res_paths = list(dict.fromkeys(res_paths))
 
-    assets = [_asset_state(project, res_path) for res_path in res_paths]
-    cache_root = "res://" + _CACHE_ROOT_REL
+    assets = [_asset_record(project, res_path) for res_path in res_paths]
+    cache_root = "res://" + CACHE_ROOT_REL
     # The pass runs for what the engine would act on: missing and stale.
     # An invalid request never triggers it — the engine skips a previously
     # failed import and an unparseable artifact (delete the sidecar to
@@ -1192,7 +924,7 @@ def run_resource_import_operation(
             assets=assets,
             predicted_source_adjacent=predicted,
             pass_will_also_import=(
-                _project_import_gaps(project, set(res_paths)) if needs_pass else []
+                project_import_gaps(project, set(res_paths)) if needs_pass else []
             ),
             summary=_summarize(assets, []),
         )
@@ -1223,11 +955,7 @@ def run_resource_import_operation(
         created = [
             ImportCreatedFile(
                 path="res://" + rel,
-                classification=(
-                    "cache_owned"
-                    if rel == _CACHE_ROOT_REL or rel.startswith(_CACHE_ROOT_REL + "/")
-                    else "source_adjacent"
-                ),
+                classification=classify_created_file(rel),
             )
             for rel in sorted(after - before)
         ]
@@ -1241,7 +969,7 @@ def run_resource_import_operation(
         if asset.status == "cached":
             settled.append(asset)
             continue
-        now = _asset_state(project, asset.path)
+        now = _asset_record(project, asset.path)
         if now.status == "cached":
             settled.append(now.model_copy(update={"status": "imported"}))
         elif now.sidecar is None or not needs_pass:

--- a/src/gda/import_evidence.py
+++ b/src/gda/import_evidence.py
@@ -1,0 +1,350 @@
+"""The import-evidence adapter: one asset's cache verdict, as the engine reads it.
+
+Lifted out of ``gda.commands.resource`` (#741) so the engine-parity contract
+below has a seam of its own. ADR-0040 keeps a group module's whole command slice
+(params/result models, render, recipe, command body) in the group and hosts
+non-command engine knowledge in the core, as ``binary`` and ``display`` already
+do; the dependency direction stays commands -> core only, so nothing here
+imports Typer, the CLI, or the wire models.
+
+The adapter answers with EVIDENCE only — the four states below. A settlement
+(``imported`` / ``not_importable`` / ``failed``) is the command's post-pass
+verdict over the same artifacts, never something this module can return.
+
+One asset's evidence state, read as the engine's own reimport test reads it.
+
+A faithful adaptation of ``EditorFileSystem::_test_for_reimport`` (#738
+review), in the engine's own order: an unparseable or ``valid=false``
+sidecar is ``invalid`` (the engine SKIPS these rather than retrying), and
+so is an unparseable ``.md5`` receipt — the engine's receipt parse-error
+branch is the same deliberate skip, never a re-import (#738 re-review 5);
+gda's receipt grammar covers the quoted-string assignments the engine
+writes plus VariantParser spacing, ``;`` comments, JSON-style escapes
+(lone UTF-16 surrogates excluded, as VariantParser rejects them), and
+repeated assignments (the last value wins). Broader Variant value syntax errs
+toward ``invalid``, the no-pass direction the contract sanctions; a
+``keep``/``skip`` importer is ``cached``; the pre-UID format, a missing
+remap/destination file, a ``source_file`` naming a different source (a
+copied sidecar), a missing ``.md5`` receipt (located at the PATH-derived
+import base, as the engine locates it), or a ``source_md5`` /
+``dest_md5`` disagreeing with the actual bytes are all ``stale`` (the
+engine WOULD re-import). ``cached`` needs POSITIVE evidence: a keep/skip
+importer, or the path-derived receipt present and matching — with any
+DECLARED destinations also present and digest-checked; a sidecar
+declaring none but carrying a matching receipt passes the same checks
+(#738 re-review 4; the engine's own pass leaves it untouched when the
+declared remainder below is controlled — verified live). A sidecar with no importer line proves nothing
+and is conservatively ``stale`` (#738 re-review 2). The checks the engine makes
+from its own state — whether the DECLARED importer still exists (its
+registry is open: import plugins add names, so no offline list can be
+authoritative), its format version, its project-settings validity, and
+the editor cache's expected sidecar MD5 — cannot be read from the
+project's artifacts, so a sidecar drifted in those dimensions can look
+``cached`` here until any pass runs; the contract names that remainder,
+and its direction: it can delay a re-import until the next pass, never
+spend a pass the engine would not.
+"""
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+EvidenceStatus = Literal["cached", "missing", "stale", "invalid"]
+"""The four states the adapter can read from a project's own artifacts."""
+
+CreatedFileClass = Literal["cache_owned", "source_adjacent"]
+"""Which side of the cache root a file the engine pass created falls on."""
+
+# The engine's cache directory, project-relative: the single authority for that
+# layout, read by every consumer rather than spelled again (#741). `resource
+# import` reports it as the explicit `cache_root` and classifies created files
+# against it; `export run`'s tree-mutation report reuses the same rule (#839).
+CACHE_ROOT_REL = ".godot"
+
+
+@dataclass(frozen=True)
+class AssetEvidence:
+    """One asset's evidence verdict and the sidecar facts behind it.
+
+    ``sidecar`` is the ``res://`` path of the ``.import`` sidecar that was read,
+    or ``None`` when the asset has none; ``dest_files`` are the destinations that
+    sidecar declares, in the engine's own order (empty when there is no sidecar
+    or it declares none).
+    """
+
+    status: EvidenceStatus
+    sidecar: "str | None" = None
+    dest_files: list[str] = field(default_factory=list)
+
+
+def classify_created_file(rel: str) -> CreatedFileClass:
+    """Which side of the cache root a created file falls on (#741).
+
+    ``rel`` is a project-relative posix path. A file under the project's
+    ``.godot/`` is ``cache_owned``; anything else the engine pass wrote beside
+    the sources (an asset's ``.import`` sidecar, a script's ``.uid``) is
+    ``source_adjacent``.
+    """
+    return (
+        "cache_owned"
+        if rel == CACHE_ROOT_REL or rel.startswith(CACHE_ROOT_REL + "/")
+        else "source_adjacent"
+    )
+
+
+_DEST_FILES_LINE = re.compile(r"^dest_files=(\[.*\])$", re.MULTILINE)
+_INVALID_LINE = re.compile(r"^valid=false$", re.MULTILINE)
+_RECEIPT_ASSIGNMENT_LINE = re.compile(
+    r'^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*("(?:\\.|[^"\\])*")\s*(?:;.*)?$'
+)
+_IMPORTER_LINE = re.compile(r'^importer="([^"]*)"$', re.MULTILINE)
+_UID_LINE = re.compile(r'^uid="[^"]*"$', re.MULTILINE)
+_SOURCE_FILE_LINE = re.compile(r'^source_file="([^"]*)"$', re.MULTILINE)
+_PATH_LINE = re.compile(r'^path[.\w]*="([^"]*)"$', re.MULTILINE)
+_FILES_LINE = re.compile(r"^files=(\[.*\])$", re.MULTILINE)
+# The engine keeps ONE `.md5` receipt per asset at `<import base>.md5`, where
+# the import base is DERIVED FROM THE ASSET PATH — `.godot/imported/
+# <filename>-<md5 of the res:// path>` (ResourceFormatImporter::
+# get_import_base_path) — independent of whether the sidecar declares any
+# destinations. Deriving it the same way (verified against a real import's
+# hash) is what lets the verdict follow the engine on a no-destination
+# sidecar (#738 re-review 4).
+
+
+def _parse_receipt_assignments(text: str) -> "dict[str, str] | None":
+    """Parse gda's documented VariantParser-compatible receipt subset.
+
+    Godot writes quoted-string assignments. Its parser also permits spacing,
+    ``;`` comments, JSON-style escapes, and repeated keys; assignments are
+    applied in order, so the last value wins. A broader Variant value returns
+    ``None`` so the caller takes the contract's conservative no-pass direction
+    — as does a lone UTF-16 surrogate escape, which json accepts but
+    VariantParser rejects (the engine's parse-error skip).
+    """
+    assignments: dict[str, str] = {}
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith(";"):
+            continue
+        assignment = _RECEIPT_ASSIGNMENT_LINE.match(line)
+        if assignment is None:
+            return None
+        try:
+            value = json.loads(assignment.group(2))
+        except (TypeError, ValueError):
+            return None
+        if any("\ud800" <= ch <= "\udfff" for ch in value):
+            # json.loads accepts a LONE UTF-16 surrogate escape; VariantParser
+            # rejects it ("unpaired lead/trail surrogate", TK_ERROR) — the
+            # engine's deliberate skip. Paired surrogates decode to a real
+            # code point on both sides, so any surrogate left in the decoded
+            # value is lone by construction. Stay on the no-pass side.
+            return None
+        assignments[assignment.group(1)] = value
+    return assignments
+
+
+# The two marker files the engine's scan skips a directory on. Named here, not
+# spelled inline, because the same two literals are declared a second time in
+# ``operations.gd`` (``NESTED_PROJECT_MARKER`` / ``GDIGNORE_MARKER``) for the walk
+# — one rule, two languages. ``test_the_two_spellings_of_the_skip_markers_agree``
+# reads both files and fails if they drift apart (#808 review).
+NESTED_PROJECT_MARKER = "project.godot"
+GDIGNORE_MARKER = ".gdignore"
+
+
+def _engine_skips_directory_of(project: Path, rel: str) -> bool:
+    """Whether the engine's own scan never reaches ``rel`` (#804).
+
+    Two clauses of ``EditorFileSystem``'s scan decide this, and the prediction
+    needs BOTH because the scan asks them in order:
+
+    * ``_scan_new_dir`` drops every **dot-prefixed directory** before it
+      consults the skip rule at all (``editor/file_system/
+      editor_file_system.cpp:1157-1168``, line numbers from the 4.6.3-stable
+      tag) — so ``res://.hidden/h.png`` is unreachable however ordinary it
+      looks. This clause subsumes the ``.godot`` cache and a ``.git`` checkout,
+      at any depth rather than at the project root alone;
+    * ``_should_skip_directory`` (same file, ``3460-3480``) then skips a
+      directory holding a ``project.godot`` — another project inside this one —
+      or a ``.gdignore`` marker.
+
+    Every directory ABOVE ``rel`` up to (but never including) the project root
+    is asked, because one marker hides the whole subtree.
+
+    **This is not the walk's rule, and must not be read as it.** The same two
+    markers gate ``_should_descend`` in ``operations.gd``, but that walk answers
+    a different question — what gda ENUMERATES — and deliberately keeps hidden
+    and dot-prefixed directories in (#54, #712). This predicate answers what the
+    ENGINE reaches, so it drops them. Two further divergences are known and
+    stated rather than chased: ``Path.rglob`` does not descend a symlinked
+    directory while the walk does (#760), so a stale asset behind a link is not
+    predicted — an omission, never a false promise, and the real run's
+    ``created`` list stays authoritative; and the OS "hidden" attribute the
+    engine also honours (``DirAccess::current_is_hidden``) has no portable
+    Python reading, so only the dot-prefix half of that clause is modelled.
+
+    Cost: the ancestors are re-probed per sidecar and memoized nowhere — 2000
+    sidecars at depth 4 cost ~16k ``stat`` calls, measured at 0.11 s. A cache
+    was declined for the same reason the walk declines one: the state would buy
+    nothing at this size.
+    """
+    parts = Path(rel).parent.parts
+    for depth in range(1, len(parts) + 1):
+        if parts[depth - 1].startswith("."):
+            return True
+        directory = project.joinpath(*parts[:depth])
+        if (directory / NESTED_PROJECT_MARKER).is_file():
+            return True
+        if (directory / GDIGNORE_MARKER).is_file():
+            return True
+    return False
+
+
+def asset_state(project: Path, res_path: str) -> AssetEvidence:
+    """One asset's evidence state; the module docstring states the contract."""
+    rel = res_path[len("res://") :]
+    sidecar_fs = project / (rel + ".import")
+    if not sidecar_fs.is_file():
+        return AssetEvidence(status="missing")
+    sidecar_res = res_path + ".import"
+
+    def state(
+        status: EvidenceStatus, dests: "list[str] | None" = None
+    ) -> AssetEvidence:
+        return AssetEvidence(
+            status=status,
+            sidecar=sidecar_res,
+            dest_files=dests or [],
+        )
+
+    try:
+        text = sidecar_fs.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        # The engine's parse-error branch: skip, never auto-reimport.
+        return state("invalid")
+    if _INVALID_LINE.search(text):
+        return state("invalid")
+    importer = _IMPORTER_LINE.search(text)
+    if importer is None:
+        # No importer DECLARED: nothing proves this sidecar's cache.
+        # Conservatively stale (#738 re-review 2). Whether a declared name
+        # still RESOLVES is engine state (an open registry) — part of the
+        # declared remainder, not decidable here.
+        return state("stale")
+    if importer.group(1) in ("keep", "skip"):
+        return state("cached")
+    dest_match = _DEST_FILES_LINE.search(text)
+    dests: list[str] = []
+    if dest_match is not None:
+        try:
+            dests = [str(d) for d in json.loads(dest_match.group(1))]
+        except ValueError:
+            return state("invalid")
+    if _UID_LINE.search(text) is None:
+        return state("stale", dests)  # pre-UID format: the engine re-imports
+    # Every remap/destination reference must exist (path=, path.<variant>=,
+    # files=[...], dest_files=[...] — the engine's to_check set).
+    to_check = list(dests)
+    to_check.extend(_PATH_LINE.findall(text))
+    files_match = _FILES_LINE.search(text)
+    if files_match is not None:
+        try:
+            to_check.extend(str(f) for f in json.loads(files_match.group(1)))
+        except ValueError:
+            return state("invalid")
+    for ref in to_check:
+        if ref.startswith("res://") and not (project / ref[len("res://") :]).is_file():
+            return state("stale", dests)
+    source_file = _SOURCE_FILE_LINE.search(text)
+    if source_file is not None and source_file.group(1) != res_path:
+        return state("stale", dests)  # a copied sidecar names another source
+    # The engine's one .md5 receipt per asset, at the path-derived import
+    # base — read whether or not destinations are declared, exactly as
+    # _test_for_reimport reads it. A missing receipt is what the engine
+    # re-imports; a present, matching one is the POSITIVE evidence a cached
+    # verdict needs — including for a sidecar that declares no destinations,
+    # which the engine leaves untouched (#738 re-review 4, verified live).
+    receipt = (
+        project
+        / CACHE_ROOT_REL
+        / "imported"
+        / (
+            Path(rel).name
+            + "-"
+            + hashlib.md5(res_path.encode("utf-8")).hexdigest()
+            + ".md5"
+        )
+    )
+    if not receipt.is_file():
+        return state("stale", dests)
+    receipt_text = receipt.read_text(encoding="utf-8", errors="replace")
+    # The engine parses the receipt with VariantParser, and ANY parse error
+    # is the same deliberate skip as a valid=false sidecar ("skip and let
+    # user attempt manual reimport to avoid reimport loop") — never a
+    # re-import (#738 re-review 5). Parse assignments in engine order: Godot's
+    # VariantParser applies every assignment, so repeated keys are last-write-
+    # wins (#738 re-review 6). The engine writes quoted-string values; accept
+    # that public subset plus its spacing/comments/escapes, while broader
+    # Variant values conservatively take the sanctioned no-pass direction.
+    assignments = _parse_receipt_assignments(receipt_text)
+    if assignments is None:
+        return state("invalid", dests)
+    recorded_source = assignments.get("source_md5")
+    if recorded_source is None:
+        # Parseable but lacking source_md5: the engine's "Lacks md5, so
+        # just reimport" — a pass state, unlike the parse error above.
+        return state("stale", dests)
+    if hashlib.md5((project / rel).read_bytes()).hexdigest() != recorded_source:
+        return state("stale", dests)
+    recorded_dest = assignments.get("dest_md5")
+    if dests and recorded_dest:
+        # The engine's multi-file digest: one MD5 over every destination's
+        # bytes, in the sidecar's order (FileAccess::get_multiple_md5).
+        ctx = hashlib.md5()
+        for dest in dests:
+            dest_fs = project / dest[len("res://") :]
+            if dest_fs.is_file():
+                ctx.update(dest_fs.read_bytes())
+        if ctx.hexdigest() != recorded_dest:
+            return state("stale", dests)
+    return state("cached", dests)
+
+
+def project_import_gaps(project: Path, requested: set[str]) -> list[str]:
+    """Other assets the project-wide pass WILL re-import (#738 review).
+
+    The dry-run inventory's project-wide half: every asset OUTSIDE the request
+    whose committed sidecar fails an engine check (``stale``) — the states the
+    engine's own reimport test acts on. ``invalid`` sidecars are EXCLUDED: the
+    engine deliberately skips a previously failed import (verified against a
+    live pass — the invalid sidecar's bytes stay untouched). Assets with NO
+    sidecar (and the ``.uid`` sidecars the pass may generate) cannot be
+    predicted from here — the engine decides those — so the real run's
+    ``created`` list stays the authoritative inventory, and the contract says
+    so.
+
+    An asset the engine's scan never reaches is not a gap either (#804): the
+    pass skips a nested project's, a ``.gdignore``d and a dot-prefixed
+    directory's contents, so predicting a re-import there promised work the
+    engine will not do. That one predicate replaced the ``.godot``/``.git``
+    prefix test this loop used to make, which was the same clause spelled for
+    two directories at the project root only (#808 review).
+    """
+    gaps: list[str] = []
+    for sidecar in sorted(project.rglob("*.import")):
+        rel = sidecar.relative_to(project).as_posix()
+        if _engine_skips_directory_of(project, rel):
+            continue
+        res_path = "res://" + rel[: -len(".import")]
+        if res_path in requested:
+            continue
+        source = project / rel[: -len(".import")]
+        if not source.is_file():
+            continue
+        if asset_state(project, res_path).status == "stale":
+            gaps.append(res_path)
+    return gaps

--- a/src/gda/import_evidence.py
+++ b/src/gda/import_evidence.py
@@ -60,10 +60,13 @@ EvidenceStatus = Literal["cached", "missing", "stale", "invalid"]
 CreatedFileClass = Literal["cache_owned", "source_adjacent"]
 """Which side of the cache root a file the engine pass created falls on."""
 
-# The engine's cache directory, project-relative: the single authority for that
-# layout, read by every consumer rather than spelled again (#741). `resource
-# import` reports it as the explicit `cache_root` and classifies created files
-# against it; `export run`'s tree-mutation report reuses the same rule (#839).
+# The engine's DEFAULT cache directory name, project-relative: the authority for
+# gda's cache-layout READS — `resource import`'s explicit `cache_root` and its
+# created-file classification, and `export run`'s tree-mutation report (#839) —
+# so those spell it once (#741). Godot derives the name from
+# `application/config/use_hidden_project_data_directory` (`godot/` when false),
+# which this module does not read; `gda.project` models both spellings for its
+# UID-cache probe, and `operations.gd` carries the engine-side `ENGINE_CACHE_DIR`.
 CACHE_ROOT_REL = ".godot"
 
 
@@ -85,10 +88,12 @@ class AssetEvidence:
 def classify_created_file(rel: str) -> CreatedFileClass:
     """Which side of the cache root a created file falls on (#741).
 
-    ``rel`` is a project-relative posix path. A file under the project's
-    ``.godot/`` is ``cache_owned``; anything else the engine pass wrote beside
-    the sources (an asset's ``.import`` sidecar, a script's ``.uid``) is
-    ``source_adjacent``.
+    ``rel`` is a project-relative posix path, as ``_project_files`` yields them.
+    The cache root itself and every file under it are ``cache_owned``; anything
+    else a gda-run engine pass created beside the sources (an asset's ``.import``
+    sidecar, a script's ``.uid``) is ``source_adjacent``. The rule is a prefix test
+    on that form only: a ``res://``-prefixed or absolute spelling reads as
+    ``source_adjacent``, so callers pass the project-relative path.
     """
     return (
         "cache_owned"

--- a/src/gda/import_evidence.py
+++ b/src/gda/import_evidence.py
@@ -266,9 +266,6 @@ def asset_state(project: Path, res_path: str) -> AssetEvidence:
     for ref in to_check:
         if ref.startswith("res://") and not (project / ref[len("res://") :]).is_file():
             return state("stale", dests)
-    source_file = _SOURCE_FILE_LINE.search(text)
-    if source_file is not None and source_file.group(1) != res_path:
-        return state("stale", dests)  # a copied sidecar names another source
     # The engine's one .md5 receipt per asset, at the path-derived import
     # base — read whether or not destinations are declared, exactly as
     # _test_for_reimport reads it. A missing receipt is what the engine
@@ -300,6 +297,14 @@ def asset_state(project: Path, res_path: str) -> AssetEvidence:
     assignments = _parse_receipt_assignments(receipt_text)
     if assignments is None:
         return state("invalid", dests)
+    # The engine compares the sidecar's source_file only AFTER the receipt has
+    # parsed — the .md5 read sits above the "file was moved" check in
+    # _test_for_reimport — so a copied sidecar naming another source is stale,
+    # while a malformed receipt beside it is the skip above, never a pass
+    # (PR #882 review round 3).
+    source_file = _SOURCE_FILE_LINE.search(text)
+    if source_file is not None and source_file.group(1) != res_path:
+        return state("stale", dests)
     recorded_source = assignments.get("source_md5")
     if recorded_source is None:
         # Parseable but lacking source_md5: the engine's "Lacks md5, so

--- a/src/gda/import_evidence.py
+++ b/src/gda/import_evidence.py
@@ -11,6 +11,8 @@ The adapter answers with EVIDENCE only — the four states below. A settlement
 (``imported`` / ``not_importable`` / ``failed``) is the command's post-pass
 verdict over the same artifacts, never something this module can return.
 
+The contract, as the command carried it (moved intact, #741):
+
 One asset's evidence state, read as the engine's own reimport test reads it.
 
 A faithful adaptation of ``EditorFileSystem::_test_for_reimport`` (#738
@@ -76,7 +78,7 @@ class AssetEvidence:
     """
 
     status: EvidenceStatus
-    sidecar: "str | None" = None
+    sidecar: str | None = None
     dest_files: list[str] = field(default_factory=list)
 
 

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -181,7 +181,7 @@ const ENGINE_CACHE_DIR := "res://.godot"
 # Values only — the decision that uses them is _should_descend's alone (#804).
 #
 # The same two literals are spelled a second time in Python, in
-# `_engine_skips_directory_of` (src/gda/commands/resource.py), which predicts the
+# `_engine_skips_directory_of` (src/gda/import_evidence.py), which predicts the
 # same rule for an inventory that never spawns the engine. The two spellings are
 # held together by `test_the_two_spellings_of_the_skip_markers_agree` (#808
 # review), not by derivation.

--- a/tests/project/test_project_walk.py
+++ b/tests/project/test_project_walk.py
@@ -16,7 +16,7 @@ a real engine in ``test_e2e_project_walk.py``.
 import re
 from pathlib import Path
 
-from gda.commands import resource
+from gda import import_evidence
 
 ROOT = Path(__file__).resolve().parents[2]
 OPERATIONS_GD = ROOT / "src" / "gda" / "ops" / "operations.gd"
@@ -254,7 +254,7 @@ def _const_value(source: str, name: str) -> str:
 
 def test_the_two_spellings_of_the_skip_markers_agree():
     # #808 review: the rule crossed the language seam. `_should_descend` decides
-    # it for the walk; `_engine_skips_directory_of` (src/gda/commands/resource.py)
+    # it for the walk; `_engine_skips_directory_of` (src/gda/import_evidence.py)
     # predicts the SAME engine behaviour for the import gap listing, which reads
     # the project's files from Python and so genuinely cannot ask the walk. Two
     # independently editable spellings of two literals is how a rule drifts, and
@@ -273,9 +273,11 @@ def test_the_two_spellings_of_the_skip_markers_agree():
     source = _source()
 
     engine_side = {name: _const_value(source, name) for name in SKIP_MARKER_CONSTANTS}
-    python_side = {name: getattr(resource, name) for name in SKIP_MARKER_CONSTANTS}
+    python_side = {
+        name: getattr(import_evidence, name) for name in SKIP_MARKER_CONSTANTS
+    }
 
     assert engine_side == python_side, (
         f"the skip markers must read the same on both sides of the seam; "
-        f"operations.gd says {engine_side}, resource.py says {python_side}"
+        f"operations.gd says {engine_side}, import_evidence.py says {python_side}"
     )

--- a/tests/resource/import_artifacts.py
+++ b/tests/resource/import_artifacts.py
@@ -1,0 +1,68 @@
+"""Import-cache artifacts, built the way the engine writes them.
+
+Both halves of ``resource import``'s coverage stand on the same trees: the
+adapter tests read them through ``gda.import_evidence``, the command tests drive
+them through the CLI. The builders live here rather than in either module so the
+two cannot drift apart on what a ``cached`` or ``stale`` tree looks like — the
+shape a receipt or a sidecar has is the fixture, not the assertion (#741).
+"""
+
+import hashlib
+from pathlib import Path
+
+from tests.support import minimal_project
+
+
+def icon_project(tmp_path: Path) -> Path:
+    """The shared minimum, plus the one asset the import pass has to see."""
+    project = minimal_project(tmp_path)
+    (project / "icon.png").write_bytes(b"\x89PNG fake bytes")
+    return project
+
+
+def sidecar(
+    project: Path,
+    asset: str,
+    dest_rel: str | None,
+    valid: bool = True,
+    importer: str = "texture",
+    uid: bool = True,
+    source_file: str | None = None,
+) -> None:
+    """A sidecar shaped like the engine writes it (uid + source_file included:
+    the reimport-test adapter reads both, #738 review)."""
+    lines = [f'[remap]\n\nimporter="{importer}"\n']
+    if not valid:
+        lines.append("valid=false\n")
+    if uid:
+        lines.append('uid="uid://test"\n')
+    lines.append("\n[deps]\n\n")
+    source = source_file if source_file is not None else f"res://{asset}"
+    lines.append(f'source_file="{source}"\n')
+    if dest_rel is not None:
+        lines.append(f'dest_files=["res://{dest_rel}"]\n')
+    (project / f"{asset}.import").write_text("".join(lines), encoding="utf-8")
+
+
+def receipt_path(project: Path, asset: str) -> Path:
+    """The engine's per-asset receipt, at the PATH-derived import base:
+    .godot/imported/<filename>-<md5 of the res:// path>.md5 — how
+    ResourceFormatImporter::get_import_base_path derives it."""
+    digest = hashlib.md5(f"res://{asset}".encode()).hexdigest()
+    return project / ".godot" / "imported" / f"{Path(asset).name}-{digest}.md5"
+
+
+def md5_companion(project: Path, dest_rel: str, source_rel: str) -> None:
+    """The engine's freshness receipt for ``source_rel``, recording source_md5."""
+    digest = hashlib.md5((project / source_rel).read_bytes()).hexdigest()
+    receipt = receipt_path(project, source_rel)
+    receipt.parent.mkdir(parents=True, exist_ok=True)
+    receipt.write_text(f'source_md5="{digest}"\n', encoding="utf-8")
+
+
+def cached_asset(project: Path, asset: str, dest_rel: str) -> None:
+    """A fully intact cache: sidecar + dest + the engine's md5 receipt."""
+    (project / dest_rel).parent.mkdir(parents=True, exist_ok=True)
+    (project / dest_rel).write_bytes(b"ctex")
+    sidecar(project, asset, dest_rel)
+    md5_companion(project, dest_rel, asset)

--- a/tests/resource/test_import_evidence.py
+++ b/tests/resource/test_import_evidence.py
@@ -1,0 +1,307 @@
+"""`gda.import_evidence` — the reimport-test adapter, read directly (#741).
+
+Every verdict here is a question about PROJECT ARTIFACTS: given this sidecar,
+this cache file and this `.md5` receipt, what would
+`EditorFileSystem::_test_for_reimport` decide? Asking it of `asset_state` costs
+a temp tree and a function call; the same question used to pay the whole Typer +
+JSON-envelope toll, which is what made the adapter's seam worth cutting.
+
+What stays on the CLI side (`test_resource_import_commands`) is everything the
+COMMAND decides on top of a verdict: whether a pass runs, the before/after
+accounting, the settlement vocabulary, the request refusals, the render — plus a
+dry-run smoke per evidence state, so the wire ABI keeps its own cover.
+"""
+
+import hashlib
+
+from gda.import_evidence import (
+    CACHE_ROOT_REL,
+    asset_state,
+    classify_created_file,
+    project_import_gaps,
+)
+from tests.resource.import_artifacts import (
+    cached_asset,
+    icon_project,
+    md5_companion,
+    receipt_path,
+    sidecar,
+)
+
+DEST = ".godot/imported/icon.png-" + "a" * 32 + ".ctex"
+
+
+# --- the four evidence states, from the artifacts alone -------------------------
+
+
+def test_keep_importer_sidecar_counts_as_cached(tmp_path):
+    project = icon_project(tmp_path)
+    sidecar(project, "icon.png", None, importer="keep")
+
+    assert asset_state(project, "res://icon.png").status == "cached"
+
+
+def test_stale_source_is_stale_not_cached(tmp_path):
+    # #738 review [P1]: freshness rides the engine's own md5 receipt — a source
+    # that hashes differently from the recorded source_md5 would be re-imported
+    # by the engine, so gda agrees.
+    project = icon_project(tmp_path)
+    cached_asset(project, "icon.png", DEST)
+    (project / "icon.png").write_bytes(b"\x89PNG different bytes")
+
+    assert asset_state(project, "res://icon.png").status == "stale"
+
+
+def test_minimal_sidecar_is_stale_not_cached(tmp_path):
+    # #738 re-review 2 [P1]: a parseable sidecar with only a uid line proved
+    # nothing, yet fell through to cached and suppressed the pass the engine
+    # would run. A CACHED verdict needs positive evidence.
+    project = icon_project(tmp_path)
+    (project / "icon.png.import").write_text('uid="uid://test"\n', encoding="utf-8")
+
+    assert asset_state(project, "res://icon.png").status == "stale"
+
+
+def test_sidecar_without_an_importer_line_is_stale(tmp_path):
+    # The engine's importer-existence check re-imports a sidecar whose
+    # importer cannot be resolved; a missing declaration proves nothing.
+    project = icon_project(tmp_path)
+    (project / "icon.png.import").write_text(
+        'uid="uid://test"\nsource_file="res://icon.png"\n', encoding="utf-8"
+    )
+
+    assert asset_state(project, "res://icon.png").status == "stale"
+
+
+def test_copied_sidecar_naming_another_source_is_stale(tmp_path):
+    # #738 review [P1], the alias reproduction: copying icon.png + its sidecar
+    # to alias2.png leaves source_file="res://icon.png" inside the copy — the
+    # engine re-imports that; a destination-exists heuristic called it cached.
+    project = icon_project(tmp_path)
+    cached_asset(project, "icon.png", DEST)
+    (project / "alias2.png").write_bytes((project / "icon.png").read_bytes())
+    (project / "alias2.png.import").write_text(
+        (project / "icon.png.import").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+    assert asset_state(project, "res://alias2.png").status == "stale"
+
+
+def test_no_destination_sidecar_with_matching_receipt_is_cached(tmp_path):
+    # #738 re-review 4 [P1]: a sidecar declaring no destinations, whose
+    # path-derived receipt exists and matches, is CURRENT to the engine
+    # (there is nothing to check and the receipts pass) — the pass leaves it
+    # untouched, so gda must not spend a pass on it or settle it failed.
+    project = icon_project(tmp_path)
+    sidecar(project, "icon.png", None)  # importer=texture, uid, source_file
+    md5_companion(project, "", "icon.png")
+
+    evidence = asset_state(project, "res://icon.png")
+
+    assert evidence.status == "cached"
+    assert evidence.sidecar == "res://icon.png.import"
+    assert evidence.dest_files == []
+
+
+# --- the .md5 receipt: the engine's own freshness proof -------------------------
+
+
+def test_missing_md5_receipt_is_stale_not_cached(tmp_path):
+    # #738 review [P1]: without the receipt the engine cannot prove freshness
+    # and re-imports; gda must not claim a hit the engine would not.
+    project = icon_project(tmp_path)
+    cached_asset(project, "icon.png", DEST)
+    receipt_path(project, "icon.png").unlink()
+
+    assert asset_state(project, "res://icon.png").status == "stale"
+
+
+def test_receipt_lacking_source_md5_is_stale_not_invalid(tmp_path):
+    # The boundary NEXT to the parse error: a receipt that PARSES but lacks
+    # source_md5 is the engine's "Lacks md5, so just reimport" — a pass
+    # state, not the deliberate skip.
+    project = icon_project(tmp_path)
+    cached_asset(project, "icon.png", DEST)
+    receipt_path(project, "icon.png").write_text(
+        'dest_md5="' + "a" * 32 + '"\n', encoding="utf-8"
+    )
+
+    assert asset_state(project, "res://icon.png").status == "stale"
+
+
+def test_dest_md5_mismatch_is_stale(tmp_path):
+    # The engine's receipt also digests the DESTINATION bytes (one MD5 over
+    # every dest, in order); a tampered cache file must not stay a hit.
+    project = icon_project(tmp_path)
+    cached_asset(project, "icon.png", DEST)
+    receipt = receipt_path(project, "icon.png")
+    dest_digest = hashlib.md5(b"OTHER BYTES").hexdigest()
+    receipt.write_text(
+        receipt.read_text(encoding="utf-8") + f'dest_md5="{dest_digest}"\n',
+        encoding="utf-8",
+    )
+
+    assert asset_state(project, "res://icon.png").status == "stale"
+
+
+# --- the receipt grammar: gda's VariantParser-compatible subset -----------------
+
+
+def test_receipt_uses_the_last_source_md5_assignment(tmp_path):
+    # #738 re-review 6 [P1]: VariantParser consumes every assignment, so a
+    # later source_md5 replaces an earlier value. Taking the first value spends
+    # a pass the engine would skip.
+    project = icon_project(tmp_path)
+    cached_asset(project, "icon.png", DEST)
+    source_digest = hashlib.md5((project / "icon.png").read_bytes()).hexdigest()
+    receipt_path(project, "icon.png").write_text(
+        f'source_md5="{"0" * 32}"\nsource_md5="{source_digest}"\n',
+        encoding="utf-8",
+    )
+
+    assert asset_state(project, "res://icon.png").status == "cached"
+
+
+def test_receipt_last_source_md5_mismatch_is_stale(tmp_path):
+    project = icon_project(tmp_path)
+    cached_asset(project, "icon.png", DEST)
+    source_digest = hashlib.md5((project / "icon.png").read_bytes()).hexdigest()
+    receipt_path(project, "icon.png").write_text(
+        f'source_md5="{source_digest}"\nsource_md5="{"0" * 32}"\n',
+        encoding="utf-8",
+    )
+
+    assert asset_state(project, "res://icon.png").status == "stale"
+
+
+def test_receipt_uses_the_last_dest_md5_assignment(tmp_path):
+    project = icon_project(tmp_path)
+    cached_asset(project, "icon.png", DEST)
+    source_digest = hashlib.md5((project / "icon.png").read_bytes()).hexdigest()
+    dest_digest = hashlib.md5((project / DEST).read_bytes()).hexdigest()
+    receipt_path(project, "icon.png").write_text(
+        f'source_md5="{source_digest}"\n'
+        f'dest_md5="{"0" * 32}"\n'
+        f'dest_md5="{dest_digest}"\n',
+        encoding="utf-8",
+    )
+
+    assert asset_state(project, "res://icon.png").status == "cached"
+
+
+def test_receipt_accepts_spacing_comments_and_escaped_string_values(tmp_path):
+    # VariantParser accepts spacing, semicolon comments, and quoted-string
+    # escapes even though the engine's own writer emits a canonical subset.
+    project = icon_project(tmp_path)
+    cached_asset(project, "icon.png", DEST)
+    source_digest = hashlib.md5((project / "icon.png").read_bytes()).hexdigest()
+    receipt_path(project, "icon.png").write_text(
+        "; retained hand-written comment\n"
+        'note = "escaped \\"quote\\"" ; ignored assignment\n'
+        f'source_md5 = "{source_digest}" ; current source\n',
+        encoding="utf-8",
+    )
+
+    assert asset_state(project, "res://icon.png").status == "cached"
+
+
+def test_receipt_lone_surrogate_escape_is_invalid_not_stale(tmp_path):
+    # #738 review follow-up: json.loads accepts a LONE UTF-16 surrogate
+    # escape, but VariantParser rejects it ("unpaired lead surrogate") — the
+    # engine's deliberate parse-error skip. Classifying it stale would spend
+    # a pass the engine would not run.
+    project = icon_project(tmp_path)
+    cached_asset(project, "icon.png", DEST)
+    receipt_path(project, "icon.png").write_text(
+        'source_md5="\\ud800"\n', encoding="utf-8"
+    )
+
+    assert asset_state(project, "res://icon.png").status == "invalid"
+
+
+def test_receipt_paired_surrogate_escape_still_parses(tmp_path):
+    # The boundary pin: a PAIRED surrogate escape decodes to one real code
+    # point on both sides (json.loads and VariantParser agree), so it stays
+    # inside the subset — with a matching source_md5 the asset is cached.
+    project = icon_project(tmp_path)
+    cached_asset(project, "icon.png", DEST)
+    source_digest = hashlib.md5((project / "icon.png").read_bytes()).hexdigest()
+    receipt_path(project, "icon.png").write_text(
+        'note="\\ud83d\\ude00"\n' + f'source_md5="{source_digest}"\n',
+        encoding="utf-8",
+    )
+
+    assert asset_state(project, "res://icon.png").status == "cached"
+
+
+# --- the project-wide gap scan --------------------------------------------------
+
+
+def test_no_destination_sidecar_is_excluded_from_the_gap_scan(tmp_path):
+    # A state the pass leaves untouched must not be listed as work it will do.
+    project = icon_project(tmp_path)
+    sidecar(project, "icon.png", None)
+    md5_companion(project, "", "icon.png")
+    (project / "fresh.png").write_bytes(b"\x89PNG fresh")
+
+    assert project_import_gaps(project, {"res://fresh.png"}) == []
+
+
+def test_malformed_receipt_neighbor_is_excluded_from_the_gap_scan(tmp_path):
+    # The engine's deliberate parse-error skip, seen from the inventory side:
+    # an `invalid` neighbour is never pass work when ANOTHER asset triggers it.
+    project = icon_project(tmp_path)
+    cached_asset(project, "icon.png", DEST)
+    receipt_path(project, "icon.png").write_text("source_md5=[\n", encoding="utf-8")
+    (project / "fresh.png").write_bytes(b"\x89PNG fresh")
+
+    assert asset_state(project, "res://icon.png").status == "invalid"
+    assert project_import_gaps(project, {"res://fresh.png"}) == []
+
+
+def test_the_gap_scan_skips_every_directory_the_engines_scan_never_reaches(tmp_path):
+    # #804: the prediction must not promise work the engine's pass never does.
+    # `EditorFileSystem::_should_skip_directory` skips a directory holding a
+    # `project.godot` or a `.gdignore`, so a stale sidecar under one is never
+    # re-imported — the gap scan reads the project's files directly and used to
+    # report both. A stale asset in an ordinary directory is still a gap, so this
+    # narrows the scan rather than emptying it.
+    #
+    # The DOT-prefixed directory is the third case, and the one the marker clauses
+    # alone still got wrong (#808 review): `_scan_new_dir` drops such a directory
+    # BEFORE it consults the skip rule, so `res://.hidden/pic.png` is unreachable
+    # too. Measured against a real pass, which re-imported the ordinary asset and
+    # left the hidden one's sidecar and cache artefacts untouched.
+    project = icon_project(tmp_path)
+    for directory, marker in (("nested", "project.godot"), ("ignored", ".gdignore")):
+        (project / directory).mkdir()
+        (project / directory / marker).write_text("", encoding="utf-8")
+        (project / directory / "pic.png").write_bytes(b"\x89PNG skipped")
+        sidecar(project, f"{directory}/pic.png", None)
+    for hidden in (".hidden", "sub/.hidden"):
+        (project / hidden).mkdir(parents=True)
+        (project / hidden / "pic.png").write_bytes(b"\x89PNG hidden")
+        sidecar(project, f"{hidden}/pic.png", None)
+    (project / "ordinary").mkdir()
+    (project / "ordinary" / "pic.png").write_bytes(b"\x89PNG reached")
+    sidecar(project, "ordinary/pic.png", None)
+
+    gaps = project_import_gaps(project, {"res://icon.png"})
+
+    assert gaps == ["res://ordinary/pic.png"], gaps
+
+
+# --- the created-file classification the command and #839 share -----------------
+
+
+def test_created_files_are_classified_against_the_cache_root(tmp_path):
+    # The one-line rule `resource import` applied inline until #741, named once
+    # so `export run`'s tree-mutation report (#839) reuses it. The input is the
+    # project-relative posix path `_project_files` yields.
+    assert CACHE_ROOT_REL == ".godot"
+    assert classify_created_file(".godot") == "cache_owned"
+    assert classify_created_file(".godot/imported/icon.png-a.ctex") == "cache_owned"
+    assert classify_created_file("icon.png.import") == "source_adjacent"
+    assert classify_created_file("scripts/tool.gd.uid") == "source_adjacent"
+    # A sibling whose name only STARTS with the cache root is not under it.
+    assert classify_created_file(".godotignore") == "source_adjacent"

--- a/tests/resource/test_import_evidence.py
+++ b/tests/resource/test_import_evidence.py
@@ -106,6 +106,20 @@ def test_no_destination_sidecar_with_matching_receipt_is_cached(tmp_path):
 # --- the .md5 receipt: the engine's own freshness proof -------------------------
 
 
+def test_an_asset_with_no_sidecar_is_missing(tmp_path):
+    # The fourth evidence state asked of the adapter directly: no `.import`
+    # sidecar at all is `missing` — a pass would run — with no sidecar facts to
+    # report. (The CLI smoke covers the same state through the wire; this pins
+    # the adapter's own branch so a later per-state `reason` (#853) has a home.)
+    project = icon_project(tmp_path)
+
+    evidence = asset_state(project, "res://icon.png")
+
+    assert evidence.status == "missing"
+    assert evidence.sidecar is None
+    assert evidence.dest_files == []
+
+
 def test_missing_md5_receipt_is_stale_not_cached(tmp_path):
     # #738 review [P1]: without the receipt the engine cannot prove freshness
     # and re-imports; gda must not claim a hit the engine would not.

--- a/tests/resource/test_import_evidence.py
+++ b/tests/resource/test_import_evidence.py
@@ -64,10 +64,16 @@ def test_minimal_sidecar_is_stale_not_cached(tmp_path):
 
 def test_sidecar_without_an_importer_line_is_stale(tmp_path):
     # The engine's importer-existence check re-imports a sidecar whose
-    # importer cannot be resolved; a missing declaration proves nothing.
+    # importer cannot be resolved; a missing declaration proves nothing. The
+    # tree is otherwise CACHEABLE — destination present, receipt matching — so
+    # the missing declaration alone decides (PR #882 review round 3: the old
+    # fixture fell through to a missing receipt and pinned nothing).
     project = icon_project(tmp_path)
+    cached_asset(project, "icon.png", DEST)
     (project / "icon.png.import").write_text(
-        'uid="uid://test"\nsource_file="res://icon.png"\n', encoding="utf-8"
+        f'[remap]\n\nuid="uid://test"\n\n[deps]\n\nsource_file="res://icon.png"\n'
+        f'dest_files=["res://{DEST}"]\n',
+        encoding="utf-8",
     )
 
     assert asset_state(project, "res://icon.png").status == "stale"
@@ -77,14 +83,37 @@ def test_copied_sidecar_naming_another_source_is_stale(tmp_path):
     # #738 review [P1], the alias reproduction: copying icon.png + its sidecar
     # to alias2.png leaves source_file="res://icon.png" inside the copy — the
     # engine re-imports that; a destination-exists heuristic called it cached.
+    # The alias has its OWN matching receipt, so the tree is cacheable except
+    # for the source name — only that check can produce the verdict (PR #882
+    # review round 3: without the receipt the fixture fell through to stale).
     project = icon_project(tmp_path)
     cached_asset(project, "icon.png", DEST)
     (project / "alias2.png").write_bytes((project / "icon.png").read_bytes())
     (project / "alias2.png.import").write_text(
         (project / "icon.png.import").read_text(encoding="utf-8"), encoding="utf-8"
     )
+    md5_companion(project, DEST, "alias2.png")
 
     assert asset_state(project, "res://alias2.png").status == "stale"
+
+
+def test_wrong_source_beside_a_malformed_receipt_is_invalid_not_stale(tmp_path):
+    # Engine order (PR #882 review round 3): _test_for_reimport reads the .md5
+    # receipt BEFORE it compares source_file, and a receipt parse error is the
+    # deliberate skip — so a copied sidecar whose receipt is malformed is left
+    # alone by the engine. Checking the source name first reported stale and
+    # spent a pass the engine would not.
+    project = icon_project(tmp_path)
+    cached_asset(project, "icon.png", DEST)
+    (project / "alias2.png").write_bytes((project / "icon.png").read_bytes())
+    (project / "alias2.png.import").write_text(
+        (project / "icon.png.import").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    receipt = receipt_path(project, "alias2.png")
+    receipt.parent.mkdir(parents=True, exist_ok=True)
+    receipt.write_text('source_md5="unterminated\n', encoding="utf-8")
+
+    assert asset_state(project, "res://alias2.png").status == "invalid"
 
 
 def test_no_destination_sidecar_with_matching_receipt_is_cached(tmp_path):

--- a/tests/resource/test_import_evidence.py
+++ b/tests/resource/test_import_evidence.py
@@ -103,9 +103,6 @@ def test_no_destination_sidecar_with_matching_receipt_is_cached(tmp_path):
     assert evidence.dest_files == []
 
 
-# --- the .md5 receipt: the engine's own freshness proof -------------------------
-
-
 def test_an_asset_with_no_sidecar_is_missing(tmp_path):
     # The fourth evidence state asked of the adapter directly: no `.import`
     # sidecar at all is `missing` — a pass would run — with no sidecar facts to
@@ -118,6 +115,9 @@ def test_an_asset_with_no_sidecar_is_missing(tmp_path):
     assert evidence.status == "missing"
     assert evidence.sidecar is None
     assert evidence.dest_files == []
+
+
+# --- the .md5 receipt: the engine's own freshness proof -------------------------
 
 
 def test_missing_md5_receipt_is_stale_not_cached(tmp_path):

--- a/tests/resource/test_resource_import_commands.py
+++ b/tests/resource/test_resource_import_commands.py
@@ -1,13 +1,19 @@
 """`gda resource import` — the scoped import surface, engine-free (#668).
 
-The cache-verdict logic is pure Python (sidecar + dest-file checks), so the
-dry-run and all-cached paths run with NO fake at all against a real temp
+What the COMMAND decides, driven through the CLI: whether the pass runs, the
+before/after accounting, the settlement vocabulary, the request refusals, and
+the render. The cache-verdict logic is pure Python (sidecar + dest-file checks),
+so the dry-run and all-cached paths run with NO fake at all against a real temp
 project tree. The engine pass is exercised through the launch seam
 (``gda.commands.resource.launch``, the scene/script channels' pattern): a fake
 launch simulates the pass's file effects, so the re-verdict, the before/after
 accounting, and the classification are covered without an engine. The real
 engine round trip (GDA-DF-010's preload failure healed by the import) is the
 e2e in ``test_e2e_resource_import``.
+
+The verdicts themselves belong to ``gda.import_evidence`` since #741 and are
+tested against it directly in ``test_import_evidence``; what stays here is one
+dry-run smoke per evidence state, so the wire ABI keeps its own cover.
 """
 
 import json
@@ -18,68 +24,15 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.runner import LaunchFailure, RunResult, TimeoutBound
+from tests.resource.import_artifacts import (
+    cached_asset,
+    icon_project,
+    receipt_path,
+    sidecar,
+)
 from tests.support import minimal_project
 
 runner_cli = CliRunner()
-
-
-def _project(tmp_path: Path) -> Path:
-    """The shared minimum, plus the one asset the import pass has to see."""
-    project = minimal_project(tmp_path)
-    (project / "icon.png").write_bytes(b"\x89PNG fake bytes")
-    return project
-
-
-def _sidecar(
-    project: Path,
-    asset: str,
-    dest_rel: str | None,
-    valid: bool = True,
-    importer: str = "texture",
-    uid: bool = True,
-    source_file: str | None = None,
-) -> None:
-    """A sidecar shaped like the engine writes it (uid + source_file included:
-    the reimport-test adapter reads both, #738 review)."""
-    lines = [f'[remap]\n\nimporter="{importer}"\n']
-    if not valid:
-        lines.append("valid=false\n")
-    if uid:
-        lines.append('uid="uid://test"\n')
-    lines.append("\n[deps]\n\n")
-    source = source_file if source_file is not None else f"res://{asset}"
-    lines.append(f'source_file="{source}"\n')
-    if dest_rel is not None:
-        lines.append(f'dest_files=["res://{dest_rel}"]\n')
-    (project / f"{asset}.import").write_text("".join(lines), encoding="utf-8")
-
-
-def _receipt_path(project: Path, asset: str) -> Path:
-    """The engine's per-asset receipt, at the PATH-derived import base:
-    .godot/imported/<filename>-<md5 of the res:// path>.md5 — how
-    ResourceFormatImporter::get_import_base_path derives it."""
-    import hashlib
-
-    digest = hashlib.md5(f"res://{asset}".encode()).hexdigest()
-    return project / ".godot" / "imported" / f"{Path(asset).name}-{digest}.md5"
-
-
-def _md5_companion(project: Path, dest_rel: str, source_rel: str) -> None:
-    """The engine's freshness receipt for ``source_rel``, recording source_md5."""
-    import hashlib
-
-    digest = hashlib.md5((project / source_rel).read_bytes()).hexdigest()
-    receipt = _receipt_path(project, source_rel)
-    receipt.parent.mkdir(parents=True, exist_ok=True)
-    receipt.write_text(f'source_md5="{digest}"\n', encoding="utf-8")
-
-
-def _cached_asset(project: Path, asset: str, dest_rel: str) -> None:
-    """A fully intact cache: sidecar + dest + the engine's md5 receipt."""
-    (project / dest_rel).parent.mkdir(parents=True, exist_ok=True)
-    (project / dest_rel).write_bytes(b"ctex")
-    _sidecar(project, asset, dest_rel)
-    _md5_companion(project, dest_rel, asset)
 
 
 def _run(project: Path, *args: str):
@@ -99,7 +52,7 @@ def _tree(project: Path) -> set[str]:
 
 
 def test_dry_run_reports_missing_and_predictions_and_writes_nothing(tmp_path):
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
     before = _tree(project)
 
     result = _run(project, "res://icon.png", "--dry-run")
@@ -125,9 +78,9 @@ def test_dry_run_reports_missing_and_predictions_and_writes_nothing(tmp_path):
 
 
 def test_dry_run_cached_when_sidecar_dest_files_exist(tmp_path):
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
     dest = ".godot/imported/icon.png-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.ctex"
-    _cached_asset(project, "icon.png", dest)
+    cached_asset(project, "icon.png", dest)
 
     result = _run(project, "res://icon.png", "--dry-run")
 
@@ -140,8 +93,8 @@ def test_dry_run_cached_when_sidecar_dest_files_exist(tmp_path):
 
 
 def test_dry_run_stale_when_a_dest_file_is_absent(tmp_path):
-    project = _project(tmp_path)
-    _sidecar(
+    project = icon_project(tmp_path)
+    sidecar(
         project,
         "icon.png",
         ".godot/imported/icon.png-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.ctex",
@@ -153,16 +106,6 @@ def test_dry_run_stale_when_a_dest_file_is_absent(tmp_path):
     # It HAS a sidecar, so no sidecar-creation prediction for it.
     assert data["predicted_source_adjacent"] == []
     assert data["engine_pass"] is True
-
-
-def test_dry_run_keep_importer_sidecar_counts_as_cached(tmp_path):
-    project = _project(tmp_path)
-    _sidecar(project, "icon.png", None, importer="keep")
-
-    data = json.loads(_run(project, "res://icon.png", "--dry-run").stdout)
-
-    assert data["assets"][0]["status"] == "cached"
-    assert data["engine_pass"] is False
 
 
 # --- the engine pass, through the launch seam ---------------------------------
@@ -183,10 +126,10 @@ def _fake_pass(project: Path, effects):
 def test_missing_asset_runs_the_pass_and_reports_created_classified(
     monkeypatch, tmp_path
 ):
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
 
     def effects(p: Path) -> None:
-        _cached_asset(
+        cached_asset(
             p,
             "icon.png",
             ".godot/imported/icon.png-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.ctex",
@@ -220,8 +163,8 @@ def test_missing_asset_runs_the_pass_and_reports_created_classified(
 
 
 def test_all_cached_runs_no_pass(monkeypatch, tmp_path):
-    project = _project(tmp_path)
-    _cached_asset(
+    project = icon_project(tmp_path)
+    cached_asset(
         project,
         "icon.png",
         ".godot/imported/icon.png-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.ctex",
@@ -239,7 +182,7 @@ def test_all_cached_runs_no_pass(monkeypatch, tmp_path):
 
 
 def test_pass_that_settles_no_sidecar_is_not_importable(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
     (project / "script.gd").write_text("extends Node\n", encoding="utf-8")
 
     calls, fake_launch = _fake_pass(project, lambda p: None)
@@ -252,10 +195,10 @@ def test_pass_that_settles_no_sidecar_is_not_importable(monkeypatch, tmp_path):
 
 
 def test_pass_that_leaves_dest_missing_is_failed(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
 
     def effects(p: Path) -> None:
-        _sidecar(p, "icon.png", ".godot/imported/never-written.ctex")
+        sidecar(p, "icon.png", ".godot/imported/never-written.ctex")
 
     calls, fake_launch = _fake_pass(project, effects)
     monkeypatch.setattr("gda.commands.resource.launch", fake_launch)
@@ -267,7 +210,7 @@ def test_pass_that_leaves_dest_missing_is_failed(monkeypatch, tmp_path):
 
 
 def test_launch_failures_classify_through_the_shared_prefix(monkeypatch, tmp_path):
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
 
     def timed_out(binary, args, *, cwd, timeout, timeout_label="Godot", watch=None):
         return RunResult(
@@ -294,7 +237,7 @@ def test_the_import_pass_declares_its_own_timeout_label(monkeypatch, tmp_path):
     # and it is what tells an agent WHICH launch gave up when three of them report
     # the same code. Pinned at the call site, because nothing else would notice it
     # silently reverting to the sentinel channel's bare "Godot".
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
     seen: dict[str, object] = {}
 
     def recording(binary, args, *, cwd, timeout, timeout_label="Godot", watch=None):
@@ -322,11 +265,11 @@ def test_engine_invalid_sidecar_is_never_a_hit_and_settles_failed(
     # #738 review [P1]: the ENGINE marked the import failed (valid=false); gda
     # must not call that cached — nor rewrite it to "imported" after a pass
     # that leaves it invalid.
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
 
     calls, fake_launch = _fake_pass(project, lambda p: None)
     monkeypatch.setattr("gda.commands.resource.launch", fake_launch)
-    _sidecar(project, "icon.png", None, valid=False)
+    sidecar(project, "icon.png", None, valid=False)
 
     data = json.loads(_run(project, "res://icon.png").stdout)
 
@@ -336,152 +279,16 @@ def test_engine_invalid_sidecar_is_never_a_hit_and_settles_failed(
     assert calls == []
 
 
-def test_stale_source_is_stale_not_cached(tmp_path):
-    # #738 review [P1]: freshness rides the engine's own md5 receipt — a source
-    # that hashes differently from the recorded source_md5 would be re-imported
-    # by the engine, so gda agrees: missing, and a pass would run.
-    project = _project(tmp_path)
-    dest = ".godot/imported/icon.png-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.ctex"
-    _cached_asset(project, "icon.png", dest)
-    (project / "icon.png").write_bytes(b"\x89PNG different bytes")
-
-    data = json.loads(_run(project, "res://icon.png", "--dry-run").stdout)
-
-    assert data["assets"][0]["status"] == "stale"
-    assert data["engine_pass"] is True
-
-
-def test_receipt_uses_the_last_source_md5_assignment(tmp_path):
-    # #738 re-review 6 [P1]: VariantParser consumes every assignment, so a
-    # later source_md5 replaces an earlier value. Taking the first value spends
-    # a pass the engine would skip.
-    import hashlib
-
-    project = _project(tmp_path)
-    dest = ".godot/imported/icon.png-" + "a" * 32 + ".ctex"
-    _cached_asset(project, "icon.png", dest)
-    source_digest = hashlib.md5((project / "icon.png").read_bytes()).hexdigest()
-    _receipt_path(project, "icon.png").write_text(
-        f'source_md5="{"0" * 32}"\nsource_md5="{source_digest}"\n',
-        encoding="utf-8",
-    )
-
-    data = json.loads(_run(project, "res://icon.png", "--dry-run").stdout)
-
-    assert data["assets"][0]["status"] == "cached"
-    assert data["engine_pass"] is False
-
-
-def test_receipt_last_source_md5_mismatch_is_stale(tmp_path):
-    import hashlib
-
-    project = _project(tmp_path)
-    dest = ".godot/imported/icon.png-" + "a" * 32 + ".ctex"
-    _cached_asset(project, "icon.png", dest)
-    source_digest = hashlib.md5((project / "icon.png").read_bytes()).hexdigest()
-    _receipt_path(project, "icon.png").write_text(
-        f'source_md5="{source_digest}"\nsource_md5="{"0" * 32}"\n',
-        encoding="utf-8",
-    )
-
-    data = json.loads(_run(project, "res://icon.png", "--dry-run").stdout)
-
-    assert data["assets"][0]["status"] == "stale"
-    assert data["engine_pass"] is True
-
-
-def test_receipt_uses_the_last_dest_md5_assignment(tmp_path):
-    import hashlib
-
-    project = _project(tmp_path)
-    dest = ".godot/imported/icon.png-" + "a" * 32 + ".ctex"
-    _cached_asset(project, "icon.png", dest)
-    source_digest = hashlib.md5((project / "icon.png").read_bytes()).hexdigest()
-    dest_digest = hashlib.md5((project / dest).read_bytes()).hexdigest()
-    _receipt_path(project, "icon.png").write_text(
-        f'source_md5="{source_digest}"\n'
-        f'dest_md5="{"0" * 32}"\n'
-        f'dest_md5="{dest_digest}"\n',
-        encoding="utf-8",
-    )
-
-    data = json.loads(_run(project, "res://icon.png", "--dry-run").stdout)
-
-    assert data["assets"][0]["status"] == "cached"
-    assert data["engine_pass"] is False
-
-
-def test_receipt_accepts_spacing_comments_and_escaped_string_values(tmp_path):
-    # VariantParser accepts spacing, semicolon comments, and quoted-string
-    # escapes even though the engine's own writer emits a canonical subset.
-    import hashlib
-
-    project = _project(tmp_path)
-    dest = ".godot/imported/icon.png-" + "a" * 32 + ".ctex"
-    _cached_asset(project, "icon.png", dest)
-    source_digest = hashlib.md5((project / "icon.png").read_bytes()).hexdigest()
-    _receipt_path(project, "icon.png").write_text(
-        "; retained hand-written comment\n"
-        'note = "escaped \\"quote\\"" ; ignored assignment\n'
-        f'source_md5 = "{source_digest}" ; current source\n',
-        encoding="utf-8",
-    )
-
-    data = json.loads(_run(project, "res://icon.png", "--dry-run").stdout)
-
-    assert data["assets"][0]["status"] == "cached"
-    assert data["engine_pass"] is False
-
-
-def test_receipt_lone_surrogate_escape_is_invalid_not_stale(tmp_path):
-    # #738 review follow-up: json.loads accepts a LONE UTF-16 surrogate
-    # escape, but VariantParser rejects it ("unpaired lead surrogate") — the
-    # engine's deliberate parse-error skip. Classifying it stale would spend
-    # a pass the engine would not run.
-    project = _project(tmp_path)
-    dest = ".godot/imported/icon.png-" + "a" * 32 + ".ctex"
-    _cached_asset(project, "icon.png", dest)
-    _receipt_path(project, "icon.png").write_text(
-        'source_md5="\\ud800"\n', encoding="utf-8"
-    )
-
-    data = json.loads(_run(project, "res://icon.png", "--dry-run").stdout)
-
-    assert data["assets"][0]["status"] == "invalid"
-    assert data["engine_pass"] is False
-
-
-def test_receipt_paired_surrogate_escape_still_parses(tmp_path):
-    # The boundary pin: a PAIRED surrogate escape decodes to one real code
-    # point on both sides (json.loads and VariantParser agree), so it stays
-    # inside the subset — with a matching source_md5 the asset is cached.
-    import hashlib
-
-    project = _project(tmp_path)
-    dest = ".godot/imported/icon.png-" + "a" * 32 + ".ctex"
-    _cached_asset(project, "icon.png", dest)
-    source_digest = hashlib.md5((project / "icon.png").read_bytes()).hexdigest()
-    _receipt_path(project, "icon.png").write_text(
-        'note="\\ud83d\\ude00"\n' + f'source_md5="{source_digest}"\n',
-        encoding="utf-8",
-    )
-
-    data = json.loads(_run(project, "res://icon.png", "--dry-run").stdout)
-
-    assert data["assets"][0]["status"] == "cached"
-    assert data["engine_pass"] is False
-
-
 def test_malformed_receipt_is_invalid_and_spends_no_pass(monkeypatch, tmp_path):
     # #738 re-review 5 [P1]: the engine parses the receipt with VariantParser
     # and treats a parse error as the same deliberate skip as valid=false —
     # "skip and let user attempt manual reimport to avoid reimport loop",
     # never a re-import. gda must not spend a pass the engine would not run,
     # and must not settle the asset failed AFTER spending one.
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
     dest = ".godot/imported/icon.png-" + "a" * 32 + ".ctex"
-    _cached_asset(project, "icon.png", dest)
-    _receipt_path(project, "icon.png").write_text("source_md5=[\n", encoding="utf-8")
+    cached_asset(project, "icon.png", dest)
+    receipt_path(project, "icon.png").write_text("source_md5=[\n", encoding="utf-8")
 
     dry = json.loads(_run(project, "res://icon.png", "--dry-run").stdout)
     assert dry["assets"][0]["status"] == "invalid"
@@ -496,95 +303,12 @@ def test_malformed_receipt_is_invalid_and_spends_no_pass(monkeypatch, tmp_path):
     assert calls == []
 
 
-def test_malformed_receipt_neighbor_is_excluded_from_the_gap_scan(tmp_path):
-    # ...and the same skip state must not be predicted as pass work when
-    # ANOTHER asset triggers the pass.
-    project = _project(tmp_path)
-    dest = ".godot/imported/icon.png-" + "a" * 32 + ".ctex"
-    _cached_asset(project, "icon.png", dest)
-    _receipt_path(project, "icon.png").write_text("source_md5=[\n", encoding="utf-8")
-    (project / "fresh.png").write_bytes(b"\x89PNG fresh")
-
-    data = json.loads(_run(project, "res://fresh.png", "--dry-run").stdout)
-
-    assert data["assets"][0]["status"] == "missing"
-    assert data["pass_will_also_import"] == []
-
-
-def test_receipt_lacking_source_md5_is_stale_not_invalid(tmp_path):
-    # The boundary NEXT to the parse error: a receipt that PARSES but lacks
-    # source_md5 is the engine's "Lacks md5, so just reimport" — a pass
-    # state, not the deliberate skip.
-    project = _project(tmp_path)
-    dest = ".godot/imported/icon.png-" + "a" * 32 + ".ctex"
-    _cached_asset(project, "icon.png", dest)
-    _receipt_path(project, "icon.png").write_text(
-        'dest_md5="' + "a" * 32 + '"\n', encoding="utf-8"
-    )
-
-    data = json.loads(_run(project, "res://icon.png", "--dry-run").stdout)
-
-    assert data["assets"][0]["status"] == "stale"
-    assert data["engine_pass"] is True
-
-
-def test_missing_md5_receipt_is_stale_not_cached(tmp_path):
-    # #738 review [P1]: without the receipt the engine cannot prove freshness
-    # and re-imports; gda must not claim a hit the engine would not.
-    project = _project(tmp_path)
-    dest = ".godot/imported/icon.png-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.ctex"
-    _cached_asset(project, "icon.png", dest)
-    _receipt_path(project, "icon.png").unlink()
-
-    data = json.loads(_run(project, "res://icon.png", "--dry-run").stdout)
-
-    assert data["assets"][0]["status"] == "stale"
-
-
-def test_copied_sidecar_naming_another_source_is_stale(tmp_path):
-    # #738 review [P1], the alias reproduction: copying icon.png + its sidecar
-    # to alias2.png leaves source_file="res://icon.png" inside the copy — the
-    # engine re-imports that; a destination-exists heuristic called it cached.
-    project = _project(tmp_path)
-    dest = ".godot/imported/icon.png-" + "a" * 32 + ".ctex"
-    _cached_asset(project, "icon.png", dest)
-    (project / "alias2.png").write_bytes((project / "icon.png").read_bytes())
-    (project / "alias2.png.import").write_text(
-        (project / "icon.png.import").read_text(encoding="utf-8"), encoding="utf-8"
-    )
-
-    data = json.loads(_run(project, "res://alias2.png", "--dry-run").stdout)
-
-    assert data["assets"][0]["status"] == "stale"
-    assert data["engine_pass"] is True
-
-
-def test_dest_md5_mismatch_is_stale(tmp_path):
-    # The engine's receipt also digests the DESTINATION bytes (one MD5 over
-    # every dest, in order); a tampered cache file must not stay a hit.
-    import hashlib
-
-    project = _project(tmp_path)
-    dest = ".godot/imported/icon.png-" + "a" * 32 + ".ctex"
-    _cached_asset(project, "icon.png", dest)
-    receipt = _receipt_path(project, "icon.png")
-    dest_digest = hashlib.md5(b"OTHER BYTES").hexdigest()
-    receipt.write_text(
-        receipt.read_text(encoding="utf-8") + f'dest_md5="{dest_digest}"\n',
-        encoding="utf-8",
-    )
-
-    data = json.loads(_run(project, "res://icon.png", "--dry-run").stdout)
-
-    assert data["assets"][0]["status"] == "stale"
-
-
 def test_human_dry_run_renders_the_project_wide_prediction(tmp_path):
     # #738 review [P2]: the default (non-JSON) dry run must carry the revised
     # contract's project-wide decidable inventory, not only the JSON form.
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
     (project / "other.png").write_bytes(b"\x89PNG other")
-    _sidecar(project, "other.png", ".godot/imported/other.png-" + "a" * 32 + ".ctex")
+    sidecar(project, "other.png", ".godot/imported/other.png-" + "a" * 32 + ".ctex")
 
     result = runner_cli.invoke(
         app,
@@ -603,70 +327,12 @@ def test_human_dry_run_renders_the_project_wide_prediction(tmp_path):
     assert "res://other.png" in result.stdout
 
 
-def test_no_destination_sidecar_with_matching_receipt_is_cached(tmp_path):
-    # #738 re-review 4 [P1]: a sidecar declaring no destinations, whose
-    # path-derived receipt exists and matches, is CURRENT to the engine
-    # (there is nothing to check and the receipts pass) — the pass leaves it
-    # untouched, so gda must not spend a pass on it or settle it failed.
-    project = _project(tmp_path)
-    _sidecar(project, "icon.png", None)  # importer=texture, uid, source_file
-    _md5_companion(project, "", "icon.png")
-
-    dry = json.loads(_run(project, "res://icon.png", "--dry-run").stdout)
-    assert dry["assets"][0]["status"] == "cached"
-    assert dry["engine_pass"] is False
-
-    real = json.loads(_run(project, "res://icon.png").stdout)
-    assert real["assets"][0]["status"] == "cached"
-    assert real["engine_pass"] is False
-
-
-def test_no_destination_sidecar_is_excluded_from_the_gap_scan(tmp_path):
-    # ...and the same state must not be falsely listed as something the pass
-    # will re-import when ANOTHER asset triggers it.
-    project = _project(tmp_path)
-    _sidecar(project, "icon.png", None)
-    _md5_companion(project, "", "icon.png")
-    (project / "fresh.png").write_bytes(b"\x89PNG fresh")
-
-    data = json.loads(_run(project, "res://fresh.png", "--dry-run").stdout)
-
-    assert data["assets"][0]["status"] == "missing"
-    assert data["pass_will_also_import"] == []
-
-
-def test_minimal_sidecar_is_stale_not_cached(tmp_path):
-    # #738 re-review 2 [P1]: a parseable sidecar with only a uid line proved
-    # nothing, yet fell through to cached and suppressed the pass the engine
-    # would run. A CACHED verdict needs positive evidence.
-    project = _project(tmp_path)
-    (project / "icon.png.import").write_text('uid="uid://test"\n', encoding="utf-8")
-
-    data = json.loads(_run(project, "res://icon.png", "--dry-run").stdout)
-
-    assert data["assets"][0]["status"] == "stale"
-    assert data["engine_pass"] is True
-
-
-def test_sidecar_without_an_importer_line_is_stale(tmp_path):
-    # The engine's importer-existence check re-imports a sidecar whose
-    # importer cannot be resolved; a missing declaration proves nothing.
-    project = _project(tmp_path)
-    (project / "icon.png.import").write_text(
-        'uid="uid://test"\nsource_file="res://icon.png"\n', encoding="utf-8"
-    )
-
-    data = json.loads(_run(project, "res://icon.png", "--dry-run").stdout)
-
-    assert data["assets"][0]["status"] == "stale"
-
-
 def test_relative_project_with_symlinked_asset_is_structured(tmp_path, monkeypatch):
     # #738 re-review 2 [P1]: a RELATIVE --project plus a symlinked-in asset
     # used to compare a relative candidate against an absolute project and
     # escape as a bare ValueError traceback. Both sides now share one
     # coordinate system; the verdict is structured either way.
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
     outside = tmp_path.parent / "linked-668.png"
     outside.write_bytes(b"\x89PNG linked")
     (project / "link.png").symlink_to(outside)
@@ -695,7 +361,7 @@ def test_non_res_engine_virtual_schemes_are_refused(tmp_path):
     # #738 re-review 2 [P2]: user:// and uid:// are engine-virtual but not the
     # project's res:// namespace — refused by name, never misread as literal
     # filesystem paths (which used to happen when such a file existed).
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
     (project / "user:").mkdir()
     (project / "user:" / "x.png").write_bytes(b"x")
 
@@ -725,7 +391,7 @@ def test_res_scheme_cannot_escape_the_project(tmp_path, spelling):
     # #738 review [P2]: res://../ must go through the same canonical
     # containment gate as filesystem input — which since #763 is literally the
     # ADR-0006 authority, not a second rule that agreed with it by coincidence.
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
     (tmp_path.parent / "outside-668.png").write_bytes(b"x")
 
     data = json.loads(_run(project, spelling, "--dry-run").stdout)
@@ -742,7 +408,7 @@ def test_an_asset_a_nested_project_owns_is_refused_before_the_pass(tmp_path):
     # at all. gda used to accept the request, spend an engine pass, and return
     # `not_importable`, while `--dry-run` predicted a sidecar that would never
     # appear. It now refuses up front and names the project that CAN import it.
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
     nested = minimal_project(project / "vendor")
     (nested / "pic.png").write_bytes(b"\x89PNG")
 
@@ -761,7 +427,7 @@ def test_a_res_path_that_collapses_back_inside_is_accepted(tmp_path):
     # resolves happily, so it is accepted here exactly as `script validate` and
     # `script run` accept it. This gate used to refuse ANY literal `..`, so one
     # input had two verdicts depending on which command read it.
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
     (project / "pic.png").write_bytes(b"\x89PNG")
 
     data = json.loads(_run(project, "res://foo/../pic.png", "--dry-run").stdout)
@@ -776,7 +442,7 @@ def test_a_res_path_with_a_leading_slash_is_accepted_as_the_engine_reads_it(tmp_
     # path does not contain, while both script commands accepted it. Godot's
     # `split("/", false)` drops the empty segment, so the engine reads it as
     # `res://pic.png` — and so does gda now, in one place.
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
     (project / "pic.png").write_bytes(b"\x89PNG")
 
     data = json.loads(_run(project, "res:///pic.png", "--dry-run").stdout)
@@ -792,7 +458,7 @@ def test_both_spellings_of_the_project_root_normalize_to_the_bare_scheme(tmp_pat
     # which then named it in the refusal. The root is still refused — it is a
     # directory, not an asset — but by its one real address, and identically from
     # the res:// and the filesystem spelling.
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
 
     for spelling in ("res://", "res://foo/..", ".", "foo/.."):
         data = json.loads(_run(project, spelling, "--dry-run").stdout)
@@ -805,7 +471,7 @@ def test_symlinked_in_asset_is_accepted_like_the_engine_walks_it(tmp_path):
     # a file linked INTO the project tree is addressable through the project's
     # res:// namespace — the engine walks the link — so it is accepted, for
     # both input forms, exactly as `script run` accepts it.
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
     outside = tmp_path.parent / "target-668.png"
     outside.write_bytes(b"\x89PNG linked")
     (project / "link.png").symlink_to(outside)
@@ -820,52 +486,20 @@ def test_dry_run_lists_what_the_pass_will_also_reimport(tmp_path):
     # #738 review: the project-wide pass WILL re-import other stale assets —
     # and will NOT retry an invalid one (the engine skips those), so the
     # prediction separates the two evidence states.
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
     (project / "other.png").write_bytes(b"\x89PNG other")
-    _sidecar(
+    sidecar(
         project,
         "other.png",
         ".godot/imported/other.png-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.ctex",
     )
     (project / "bad.png").write_bytes(b"\x89PNG bad")
-    _sidecar(project, "bad.png", None, valid=False)
+    sidecar(project, "bad.png", None, valid=False)
 
     data = json.loads(_run(project, "res://icon.png", "--dry-run").stdout)
 
     assert data["assets"][0]["path"] == "res://icon.png"
     assert data["pass_will_also_import"] == ["res://other.png"]
-
-
-def test_the_gap_scan_skips_every_directory_the_engines_scan_never_reaches(tmp_path):
-    # #804: the prediction must not promise work the engine's pass never does.
-    # `EditorFileSystem::_should_skip_directory` skips a directory holding a
-    # `project.godot` or a `.gdignore`, so a stale sidecar under one is never
-    # re-imported — the gap scan reads the project's files directly and used to
-    # report both. A stale asset in an ordinary directory is still a gap, so this
-    # narrows the scan rather than emptying it.
-    #
-    # The DOT-prefixed directory is the third case, and the one the marker clauses
-    # alone still got wrong (#808 review): `_scan_new_dir` drops such a directory
-    # BEFORE it consults the skip rule, so `res://.hidden/pic.png` is unreachable
-    # too. Measured against a real pass, which re-imported the ordinary asset and
-    # left the hidden one's sidecar and cache artefacts untouched.
-    project = _project(tmp_path)
-    for directory, marker in (("nested", "project.godot"), ("ignored", ".gdignore")):
-        (project / directory).mkdir()
-        (project / directory / marker).write_text("", encoding="utf-8")
-        (project / directory / "pic.png").write_bytes(b"\x89PNG skipped")
-        _sidecar(project, f"{directory}/pic.png", None)
-    for hidden in (".hidden", "sub/.hidden"):
-        (project / hidden).mkdir(parents=True)
-        (project / hidden / "pic.png").write_bytes(b"\x89PNG hidden")
-        _sidecar(project, f"{hidden}/pic.png", None)
-    (project / "ordinary").mkdir()
-    (project / "ordinary" / "pic.png").write_bytes(b"\x89PNG reached")
-    _sidecar(project, "ordinary/pic.png", None)
-
-    data = json.loads(_run(project, "res://icon.png", "--dry-run").stdout)
-
-    assert data["pass_will_also_import"] == ["res://ordinary/pic.png"], data
 
 
 # --- request validation --------------------------------------------------------
@@ -876,7 +510,7 @@ def test_asset_outside_the_project_is_the_shared_containment_refusal(tmp_path):
     # while `script validate` reported `project_not_found` and `script run`
     # `invalid_path` for the very same "this target is not in the resolved
     # project" — three answers an agent could not branch on once.
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
     outside = tmp_path.parent / "elsewhere.png"
 
     data = json.loads(_run(project, str(outside)).stdout)
@@ -891,7 +525,7 @@ def test_asset_outside_the_project_is_the_shared_containment_refusal(tmp_path):
 
 
 def test_absent_asset_is_invalid_params(tmp_path):
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
 
     data = json.loads(_run(project, "res://nope.png").stdout)
 
@@ -900,7 +534,7 @@ def test_absent_asset_is_invalid_params(tmp_path):
 
 
 def test_relative_filesystem_path_is_project_relative(tmp_path):
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
 
     data = json.loads(_run(project, "icon.png", "--dry-run").stdout)
 
@@ -908,7 +542,7 @@ def test_relative_filesystem_path_is_project_relative(tmp_path):
 
 
 def test_no_assets_is_a_usage_error(tmp_path):
-    project = _project(tmp_path)
+    project = icon_project(tmp_path)
 
     result = _run(project)
 


### PR DESCRIPTION
## Summary

`resource import`'s faithful mirror of `EditorFileSystem::_test_for_reimport` —
the read that decides `cached` / `missing` / `stale` / `invalid` — lived as
module-level regexes and private helpers inside the resource command group, so
its only interface was the CLI and every evidence question in the unit suite paid
the full Typer + JSON-envelope toll. This lifts it into the core module
`gda/import_evidence.py`.

ADR-0040 placement: the group keeps its whole command slice (params/result
models, render, recipe, command body) and the core hosts the non-command engine
knowledge, as `binary` and `display` already do. Dependency direction is
commands → core only — the new module imports `hashlib`, `json`, `re`,
`dataclasses`, `pathlib` and `typing`, and nothing from `gda`.

What the module owns: the receipt grammar (`_parse_receipt_assignments`), the
sidecar/receipt regexes, `asset_state`, `project_import_gaps`, `CACHE_ROOT_REL`,
`classify_created_file` + `CreatedFileClass`, and `EvidenceStatus` +
`AssetEvidence`. The `_test_for_reimport` parity contract moved **intact** out of
`_asset_state`'s docstring into the module docstring — remainder and one-way
direction included, re-indented and not reworded.

What stayed in the command: request normalization (`_asset_res_path`), the
created-file **accounting** (`_project_files`, the before/after diff,
`_summarize`), the settlement mapping (`imported` / `not_importable` / `failed`),
and the wire models. `asset_state` returns the narrowed `AssetEvidence`, whose
`EvidenceStatus` is four-valued: the adapter can never return a settlement. A
thin `_asset_record` maps evidence onto the wire `ResourceImportAsset`.

Closes #741

## Surface diff

**byte-identical.** The same harness the ADR-0040 restructure used, with the
baseline generated in a separate clean checkout at the base commit `cfcb8658e`
(never via `git stash` in the working worktree).

| Artifact | Base sha256 | Head sha256 |
| --- | --- | --- |
| `gda schema` | `abb4a866bd22e5fde0fb101217d9aea3a43d9f56eb69a99dcf6eae0b225aa6c3` | `abb4a866bd22e5fde0fb101217d9aea3a43d9f56eb69a99dcf6eae0b225aa6c3` |
| every `--help` page (93 pages, whole live Typer tree, `COLUMNS=80`) | `d3c64bf50a4bd1190cca934ac2129bb2b4cddb4107256987d22e89fe19a74cc7` | `d3c64bf50a4bd1190cca934ac2129bb2b4cddb4107256987d22e89fe19a74cc7` |

The help sweep walks the live command tree rather than a hand-listed set, so
`gda resource import --help` is covered along with the other 92 pages — the move
could not silently reword a neighbour.

**CONTEXT.md**: gains the `Import evidence` term in the *Operations* section,
between `Startup preflight` and `Engine session`, with the issue's text adjusted
only for the glossary's `**Term**:` / body / `_Avoid_:` shape and its wrap width.
No other entry touched.

## Test migration map

18 evidence-verdict tests move from `tests/resource/test_resource_import_commands.py`
(CLI, `json.loads(_run(...).stdout)`) to `tests/resource/test_import_evidence.py`
(direct, `asset_state(...)` / `project_import_gaps(...)`). Names are unchanged
except where the old name carried the CLI framing.

| Old test (CLI) | New test (adapter) |
| --- | --- |
| `test_dry_run_keep_importer_sidecar_counts_as_cached` | `test_keep_importer_sidecar_counts_as_cached` |
| `test_stale_source_is_stale_not_cached` | same name |
| `test_minimal_sidecar_is_stale_not_cached` | same name |
| `test_sidecar_without_an_importer_line_is_stale` | same name |
| `test_copied_sidecar_naming_another_source_is_stale` | same name |
| `test_no_destination_sidecar_with_matching_receipt_is_cached` | same name |
| `test_missing_md5_receipt_is_stale_not_cached` | same name |
| `test_receipt_lacking_source_md5_is_stale_not_invalid` | same name |
| `test_dest_md5_mismatch_is_stale` | same name |
| `test_receipt_uses_the_last_source_md5_assignment` | same name |
| `test_receipt_last_source_md5_mismatch_is_stale` | same name |
| `test_receipt_uses_the_last_dest_md5_assignment` | same name |
| `test_receipt_accepts_spacing_comments_and_escaped_string_values` | same name |
| `test_receipt_lone_surrogate_escape_is_invalid_not_stale` | same name |
| `test_receipt_paired_surrogate_escape_still_parses` | same name |
| `test_no_destination_sidecar_is_excluded_from_the_gap_scan` | same name |
| `test_malformed_receipt_neighbor_is_excluded_from_the_gap_scan` | same name |
| `test_the_gap_scan_skips_every_directory_the_engines_scan_never_reaches` | same name |
| — (new) | `test_created_files_are_classified_against_the_cache_root` |

Each moved test keeps its rationale comment — verbatim, except three reworded to stand alone because their comment continued a sibling that did not move with them or named a dropped assertion (`test_stale_source_is_stale_not_cached`, `test_no_destination_sidecar_is_excluded_from_the_gap_scan`, `test_malformed_receipt_neighbor_is_excluded_from_the_gap_scan`) — and its artifact tree
unchanged; what it drops is the assertion on `engine_pass`, which is a pure
function of the status (`needs_pass = any(status in ("missing", "stale"))`) and
stays pinned CLI-side by the four smokes below plus `test_all_cached_runs_no_pass`.
`test_no_destination_sidecar_with_matching_receipt_is_cached` moved whole for the
same reason: its command-side half asserted the composition *cached ⇒ no pass*,
which `test_all_cached_runs_no_pass` already pins.

**The CLI module keeps the ABI covered** — one dry-run smoke per evidence state,
plus everything the command decides (the pass decision, the launch seam, the
timeout label, the settlements, the refusals, the render, the schema):

| Evidence state | CLI smoke that still asserts it |
| --- | --- |
| `missing` | `test_dry_run_reports_missing_and_predictions_and_writes_nothing` |
| `cached` | `test_dry_run_cached_when_sidecar_dest_files_exist` |
| `stale` | `test_dry_run_stale_when_a_dest_file_is_absent` |
| `invalid` | `test_malformed_receipt_is_invalid_and_spends_no_pass` |

Net count: 2501 → 2502 (−18 moved, +18 re-homed, +1 new classification test); 2503 after round 1 added the direct `missing`-state test.
The 20 adapter tests (19 at the reviewed head) run in **0.19 s**; the same questions through Typer cost
roughly an order of magnitude more.

## Validation

Host: macOS 15.6 (Darwin 25.6.0), Godot 4.6.3 at `$GDA_GODOT` (machine-local,
passed per invocation, never hardcoded). All commands run from the worktree with
the repository runtime (`uv run --frozen`).

| Gate | Command | Result |
| --- | --- | --- |
| Fast suite | `uv run --frozen pytest tests -m "not e2e" -q -p no:cacheprovider` | `2502 passed, 666 deselected in 49.13s` (base: 2501) |
| Fast suite, as CI runs it | `uv run --frozen pytest -m "not e2e" -n 4 --dist loadgroup -q` | `2502 passed, 1 warning in 19.48s` (the warning is the pre-existing `os.fork()` one in `test_daemon_socket_lifecycle`) |
| Lint | `uv run --frozen ruff check .` | `All checks passed!` |
| Format | `uv run --frozen ruff format --check .` | `512 files already formatted` |
| Types | `uv run --frozen pyright` | `0 errors, 0 warnings, 0 informations` |
| Schema byte-diff | `diff` vs the base checkout's `gda schema` | identical (sha256 above) |
| Help byte-diff | `diff` vs the base checkout's 93-page sweep | identical (sha256 above) |
| Harness guard | `python scripts/harness_version_guard.py origin/feat/gda-dogfooding-dev HEAD` | `harness version transition is valid` (no harness bytes touched) |
| Real-engine e2e | `python e2e-lock.py uv run --frozen pytest tests/resource -m e2e -rs -q` | `40 passed, 90 deselected in 118.93s` |

The e2e run went through the machine-wide lock, so no other worktree spawned
Godot concurrently. `GDA_USER_DATA_ROOT` was **not** exported for the run.

## Requirement conformance

| Acceptance criterion | Proof |
| --- | --- |
| AC1 — the module owns the receipt grammar, the regexes, `asset_state`, `project_import_gaps`, `CACHE_ROOT_REL`, `classify_created_file` + `CreatedFileClass`; docstring carries the `_test_for_reimport` contract moved intact | `src/gda/import_evidence.py`; the contract is the former `_asset_state` docstring, de-indented and otherwise byte-for-byte (see the diff — every deleted docstring line reappears). `ImportCreatedFile.classification` is computed through `classify_created_file` at `commands/resource.py`. |
| AC2 — only the four evidence states; settlements stay command-side; wire model and schema unchanged | `EvidenceStatus = Literal["cached", "missing", "stale", "invalid"]`; `AssetEvidence` cannot carry a settlement, and pyright checks the mapping. The settle loop stays in `run_resource_import_operation`. `ResourceImportAsset` and the published schema are unchanged (byte-identical schema). |
| AC3 — `commands/resource.py` keeps its ADR-0040 role and consumes the adapter; direction commands → core only; `_asset_res_path` and the accounting stay | The group module keeps its models, renders, descriptor, command body and `register`. `import_evidence` imports nothing from `gda`. `_asset_res_path`, `_project_files`, the before/after diff and `_summarize` are untouched. |
| AC4 — evidence tests move to a direct adapter module; CLI keeps ≥1 dry-run smoke per state; resource-import e2e untouched and green, serial | The migration map above; `tests/resource/test_e2e_resource_import.py` has **no diff**; `40 passed` under the lock. |
| AC5 — `gda schema` and `--help` byte-identical; full fast suite, pyright, ruff clean | The surface-diff table and the validation table. |
| AC6 — CONTEXT.md gains the `Import evidence` term | The CONTEXT.md diff (one entry added, nothing else touched). |
| AC7 — out of scope: the declared remainder, the perf-budget seam, `_json_integer`; no public-API export of the adapter | None touched. `gda/__init__.py` is unchanged: the module is reachable only by import path, which ADR-0011 does not treat as public ABI. |

## Disclosed extras / boundary crossings

1. **`_engine_skips_directory_of` and the two skip-marker constants moved too.**
   AC1 names `project_import_gaps`, and that function's only caller-private
   helper is `_engine_skips_directory_of` (with `NESTED_PROJECT_MARKER` /
   `GDIGNORE_MARKER`), so it had to travel with it. Forced follow-ups, all
   citation-level:
   - `tests/project/test_project_walk.py` — the cross-language guard
     `test_the_two_spellings_of_the_skip_markers_agree` now reads the constants
     from `gda.import_evidence` instead of `gda.commands.resource` (import, the
     `getattr`, one comment, one assertion message). Still the same guard, still
     green. This file is in `tests/project/`, adjacent to #843's area, but #843
     owns `src/gda/project.py` / `src/gda/commands/project.py` /
     `src/gda/harness/install.py`, not this test.
   - `src/gda/ops/operations.gd` — **one comment line**, the path in the citation
     of its Python twin. No GDScript behaviour, no harness bytes (the harness
     guard passes), and no W2 slice owns this file.
   - `docs/adr/0006` cites the symbol by name without a path, so it needed no
     edit.
2. **`asset_state` now reads `CACHE_ROOT_REL` where it used to spell `".godot"`
   inline** for the receipt's import base. One token, inside the moved function;
   without it the module would declare a single authority for the cache layout
   and then contradict it two screens down.
3. **`ImportCreatedFile.classification` is annotated `CreatedFileClass`** instead
   of an inline `Literal[...]`. Same two members, same generated schema (proven
   byte-identical), one owner.
4. **New `tests/resource/import_artifacts.py`.** Both test modules build the same
   sidecars, cache files and `.md5` receipts. Duplicating those builders would
   leave two independently editable spellings of "what a cached tree looks like"
   — the exact drift shape this repo guards against elsewhere — so they moved to
   one package-local support module (not collected: no `test_` prefix) and lost
   their leading underscores. That renames the call sites in the CLI module
   (`_project` → `icon_project`, `_sidecar` → `sidecar`, …), which is most of
   that file's remaining diff.
5. **Three docstring touch-ups, no behaviour**: `commands/resource.py`'s module
   docstring now names `gda.import_evidence` in the list of what it imports
   downward, and both test modules' docstrings state which half of the coverage
   they hold.

Nothing here contradicts the issue, so no amendment was filed. Files owned by the
other W2 slices (`commands/project.py`, `project.py`, `harness/install.py`,
`commands/export.py`, `errors.py`, ADR-0004, `commands/input.py`,
`commands/game.py`, the harness) are untouched.

## Guards on PR CI vs the e2e tier

**Runs on this PR** (`.github/workflows/ci.yml`, `pull_request`): ruff check, ruff
format, pyright (`src` + `tests` + `scripts`), the unit suite
(`pytest -m "not e2e" -n 4 --dist loadgroup`), the package build, the harness
version guard, and the gda-balancing scope classifier. That covers the whole
migration map, the adapter module and the CONTEXT/`operations.gd`-adjacent guard
test.

**Does not run on this PR:** every Godot-spawning test. The e2e tier is
schedule-only (nightly `24 3 * * *`) or `workflow_dispatch` with `run-e2e`, so
`tests/resource/test_e2e_resource_import.py` and `test_e2e_resource.py` are
evidenced here **only** by the local real-engine run in the validation table
(`40 passed`, Godot 4.6.3, serialized through the machine lock). Neither the
byte-identical schema/help harness nor the baseline sha256 comparison runs in CI
either — it is a PR-time probe against a clean checkout of the base commit, and
the numbers above are its record.

## Review round 1 (`4a1881f0a`)

Independent adversarial review at `63634d8a5` (four axes + mutation) returned CHANGES REQUIRED —
0 P1 / 1 P2 / 3 P3, all adopted:

1. **P2** — the adapter test module asked `asset_state` for three of its four states; mutant
   "`missing` branch unreachable" survived all 19 adapter tests (only the CLI smoke caught it).
   `test_an_asset_with_no_sidecar_is_missing` pins it directly (status, no sidecar, no
   destinations) — the home a per-state `reason` (#853) will need.
2. **P3** — "rationale comment verbatim" overstated for three tests; the map above now says which
   and why.
3. **P3** — the module docstring stacked two summaries; one transition line now precedes the
   moved contract, which stays byte-for-byte intact.
4. **P3** — `sidecar: "str | None"` lost quotes it did not need (no forward reference).

Test-only and docstring-only: the byte-identity harness needs no re-run (schema/help cannot
move); `tests/resource` 91 passed, ruff/format/pyright clean on this head. The reviewer
independently confirmed schema sha256 `abb4a866…` on both trees, 93 help pages identical, four
dry-run shapes and a real-engine `resource import` byte-identical, and e2e resource+project 149
passed.

## Review round 2 (`310f77aba`)

The second independent review at `4a1881f0a` reproduced all four round-1 fixes (the `missing` test
kills the mutant in the adapter tier; the moved contract is byte-for-byte the base docstring;
the annotation; the three-comment map) and byte identity on every channel (schema
`abb4a866…`, 93 help pages, five dry-run fixtures in JSON and human, a real-engine import), and
returned 0 P1 / 1 P2 / 4 P3, all adopted by the orchestrator (prose and a test move — the
byte-identity harness needs no re-run):

1. **P2** — the `CACHE_ROOT_REL` comment claimed "the single authority for that layout, read by
   every consumer"; `gda.project` models both `.godot`/`godot` from
   `use_hidden_project_data_directory` and `operations.gd` carries `ENGINE_CACHE_DIR`. Behaviour
   is the base's; the claim was new and false. The comment now says what the constant IS the
   authority for (gda's cache-layout reads, with the engine DEFAULT) and names the other two.
2. **P3** — `classify_created_file`'s docstring states the root itself is `cache_owned`, that a
   `res://` or absolute spelling reads `source_adjacent`, and that the input is the
   `_project_files` form.
3. **P3** — `test_an_asset_with_no_sidecar_is_missing` moved under the four-states banner.
4. **P3** — the counts above corrected (2503; 20 adapter tests).

Observed by the reviewer: the `source_file` mismatch check was unpinned at the base too (mutant
survived on both trees) — pinned in round 3 below; `AssetEvidence`'s `frozen` flag is unpinned (low
value). On `310f77aba`: `tests/resource` + the walk guard 97 passed, ruff/format/
pyright clean.

## Review round 3 (`0d8546c0f`)

The third review at `3d674dd68` returned CHANGES REQUIRED — 2 P1 / 1 P3, all adopted:

1. **P1 (engine order)** — the adapter compared `source_file` before it read the `.md5` receipt.
   Godot 4.6.3's `_test_for_reimport` (`editor/file_system/editor_file_system.cpp` at
   `4.6.3-stable`) parses the receipt FIRST, and a parse error is its deliberate skip — so a copied
   sidecar beside a malformed receipt was reported `stale` and spent a pass the engine would not.
   The comparison now sits after the receipt has parsed. **This is the one behaviour change in the
   PR**: a fix to the moved code, in its own commit. The schema/help byte identity is untouched
   (nothing on the surface moves) and every other verdict is the base's.
2. **P1 (coverage)** — the source-name and missing-importer fixtures fell through to a missing
   receipt, so removing either branch left all tests green. Each tree is now cacheable except for
   the one condition it names, and the combined malformed-receipt / wrong-source case is pinned as
   `invalid`. Mutants re-run on this head: no source-mismatch branch →
   `test_copied_sidecar_naming_another_source_is_stale` fails; no missing-importer branch →
   `test_sidecar_without_an_importer_line_is_stale` fails; the old order → the combined case fails.
3. **P3** — issue #741's interface block called `CACHE_ROOT_REL` "the single authority for the
   engine cache layout"; the issue carries a dated amendment (the authority for gda's cache-layout
   READS; the engine's name is configurable; `operations.gd` carries `ENGINE_CACHE_DIR`).

On `0d8546c0f`: `tests/resource` + the walk guard 138 passed (unit and real-engine e2e),
ruff/format/pyright clean.
