### PR TITLE
fix(gda): export names both template directories when --user-data-root hides the host's (#840)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -141,7 +141,10 @@ attributable to the environment instead of read as a game regression (#850). Onl
 there: a run that ends in an `Error envelope` — `--strict`'s `script_failed`, a
 `launch_timeout` — keeps its pre-#850 shape, since disclosing a fact on a failure
 means entering `Failure evidence`'s producer set, which is a separate ADR-0004
-decision. Headless only: a live `Engine session`'s log is daemon-owned (ADR-0022).
+decision. The engine's export-template lookup follows the same placement, so a
+redirected export can miss templates the host holds — `export run` says so and
+`export get` reports both roots (#840). Headless only: a live `Engine session`'s log
+is daemon-owned (ADR-0022).
 _Avoid_: log redirect, user dir, sandbox
 
 **Raw run**:

--- a/docs/adr/0004-schema-flag-self-description.md
+++ b/docs/adr/0004-schema-flag-self-description.md
@@ -270,6 +270,21 @@ status: accepted
 > all, rather than a partially invented triple — which is the omitted-never-null
 > rule applied to a producer, not an exception to it.
 >
+> **Addendum (2026-09-06, #840): an eighth producer, and the count above stands as
+> the record of what this amendment decided.** `export_templates_missing_failure`
+> joins the set with `templates_root_checked` and `templates_root_host` — the
+> export-templates directory a run checked, and the host one holding the templates a
+> `--user-data-root` redirect hid from it. Godot reads the templates from the data
+> directory that option relocates, so the ONE code has two shapes needing opposite
+> remedies: drop the redirect, or install the templates. Both paths pass the
+> criterion — each is already computed on the failure path (the engine-side check
+> composes them), neither is recoverable from the envelope without reading the
+> message, and which shape it is decides what the caller does next. Like the two
+> `target_outside_project` refusals it reports on no run: it is the pre-export
+> preflight's verdict. The omitted-never-null rule holds at the producer too — a
+> reply naming no directory yields no `evidence` key rather than an empty object.
+> The asserted set in `tests/cli/test_error_registry.py` is now eight.
+>
 > **Answering ADR-0002's open pointer (#717): the ceiling's PROVENANCE is declined, on
 > the criterion.** That note left the question here — whether a `launch_timeout`'s
 > ceiling was the caller's `--timeout` or one of gda's own fixed bounds "belongs on

--- a/docs/adr/0004-schema-flag-self-description.md
+++ b/docs/adr/0004-schema-flag-self-description.md
@@ -279,9 +279,10 @@ status: accepted
 > remedies: drop the redirect, or install the templates. Both paths pass the
 > criterion — each is already computed on the failure path (the engine-side check
 > composes them), neither is recoverable from the envelope without reading the
-> message, and which shape it is decides what the caller does next. Like the two
-> `target_outside_project` refusals it reports on no run: it is the pre-export
-> preflight's verdict. The omitted-never-null rule holds at the producer too — a
+> message, and which shape it is decides what the caller does next. Its evidence is
+> not a run's residue — the two directories come from the `export get` op's reply —
+> and it is the pre-export preflight's verdict, as the two `target_outside_project`
+> refusals are pre-launch ones. The omitted-never-null rule holds at the producer too — a
 > reply naming no directory yields no `evidence` key rather than an empty object.
 > The asserted set in `tests/cli/test_error_registry.py` is now eight.
 >

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -1196,6 +1196,18 @@ before the native export and reported in `created_dirs`, outermost to innermost;
 an uncreatable parent is reported as `export_output_parent_failed` before Godot
 runs.
 
+Export-template discovery follows the user-data placement (#840). Godot reads the
+templates from its data directory, and `--user-data-root` relocates exactly that,
+so a release/debug run under an isolated root finds none even where the host has
+them installed. `gda export get` therefore reports `templates_root` — the
+export-templates directory checked, which holds the `templates_version` directory
+— and `templates_root_host`, the host's directory when the redirect hid installed
+templates there (null otherwise). The `export_templates_missing` failure names the
+same two directories in its message, gives the two remedies (run without the
+redirect, or `--mode pack`, which needs no templates), and carries them typed on
+`evidence` as `templates_root_checked` / `templates_root_host` — the second key
+present only in the hidden case, which is how the two shapes are told apart.
+
 ### Asset-file groups (create/edit files; headless)
 
 These create or edit resource files (`.gdshader`, `.tres`) and so are headless.

--- a/src/gda/commands/export.py
+++ b/src/gda/commands/export.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import Annotated, Optional
 
 import typer
-from pydantic import AfterValidator, BaseModel, Field
+from pydantic import AfterValidator, BaseModel, Field, model_validator
 
 from gda import dispatch
 from gda.binary import resolve_godot_binary
@@ -50,7 +50,7 @@ from gda.headless import (
     params_json_option,
     project_option,
 )
-from gda.runner import RunResult
+from gda.runner import RunResult, engine_data_path
 
 
 def normalize_export_output_path(path: str) -> str:
@@ -118,17 +118,60 @@ class ExportListResult(BaseModel):
     presets: list[ListedPreset]
 
 
+def host_data_path() -> str | None:
+    """The host's Godot data directory, resolved over gda's OWN environment (#840).
+
+    The default of :attr:`ExportGetParams.host_data_path`, and the whole mechanism
+    behind #840's disclosure. ``--user-data-root`` redirects the CHILD engine's
+    data directory, never gda's own environment, so this stays the directory an
+    unredirected run would use — exactly the one the engine cannot see from inside
+    the redirect, and therefore the one worth passing in.
+
+    ``None`` when the platform's own variable is unset, which is what
+    :func:`gda.runner.engine_data_path` answers rather than fabricating a path; the
+    operation then reports no host directory instead of comparing against a guess.
+    """
+    resolved = engine_data_path()
+    return str(resolved) if resolved is not None else None
+
+
 class ExportGetParams(BaseModel):
-    """The operation params of ``gda export get`` (issue #114).
+    """The operation params of ``gda export get`` (issue #114, #840).
 
     ``preset`` addresses an export preset by its display name (as ``export
     list`` reports it). An unknown name is the ``export_preset_not_found``
     failure. The project is process context (``--project``, ADR-0006).
+
+    ``host_data_path`` is a COMPUTED param, the same shape ``script set``'s
+    ``mode`` has: the model stamps it from the host environment so the engine-side
+    check can name templates a ``--user-data-root`` redirect hid (#840), and a
+    value passed in is ignored. Computed model-side rather than pasted in by the
+    argv body because ADR-0015 makes the model the single source of truth for a
+    request's shape — a ``--params-json`` caller that names only ``preset`` has to
+    reach the operation with the identical params, and it is not a fact a caller
+    is in any position to supply.
     """
 
     preset: str = Field(
         description="The export preset's display name, as 'gda export list' reports it."
     )
+    host_data_path: str | None = Field(
+        default=None,
+        description=(
+            "The host's Godot data directory, so the check can name export "
+            "templates a --user-data-root redirect hides. Resolved model-side "
+            "from gda's own environment; a value passed in is ignored."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _resolve_host_data_path(self) -> "ExportGetParams":
+        # Stamped on BOTH input channels (ADR-0015): the argv body and
+        # `--params-json` build this same model, so neither can reach the operation
+        # without the host directory and neither can reach it with a caller's guess
+        # at one.
+        self.host_data_path = host_data_path()
+        return self
 
 
 class ExportGetResult(BaseModel):
@@ -142,6 +185,15 @@ class ExportGetResult(BaseModel):
     #121); ``templates_version`` names the version directory that was checked
     (e.g. ``4.6.3.stable``), so the agent knows which templates to install when
     they are missing.
+
+    ``templates_root`` says WHERE it looked (#840) — the export-templates
+    directory that holds the version directory. It is reported because that
+    location is not fixed: Godot reads the templates from its data directory, and
+    ``--user-data-root`` relocates exactly that, so a redirected run reports none
+    installed on a host whose templates are correctly installed.
+    ``templates_root_host`` names the host's directory in that case and ONLY in
+    that case, so the two situations — hidden by a redirect, versus genuinely not
+    installed anywhere — are told apart before an export is ever attempted.
     """
 
     index: int = Field(
@@ -167,6 +219,18 @@ class ExportGetResult(BaseModel):
         description=(
             "The export-templates version directory checked for installation "
             "(e.g. 4.6.3.stable), matching the running engine version."
+        )
+    )
+    templates_root: str = Field(
+        description=(
+            "The export-templates directory that was checked; the "
+            "templates_version directory is looked up inside it."
+        )
+    )
+    templates_root_host: str | None = Field(
+        description=(
+            "The host's export-templates directory, when a --user-data-root "
+            "redirect hid templates that ARE installed there; null otherwise."
         )
     )
 
@@ -268,15 +332,26 @@ def render_export_list(listed: "ExportListResult") -> str:
 
 
 def render_export_get(got: "ExportGetResult") -> str:
-    """Render one preset's details plus its export-template readiness."""
+    """Render one preset's details plus its export-template readiness.
+
+    The template line names the directory that was checked, and — when a
+    ``--user-data-root`` redirect hid installed templates — a second line names
+    where they really are (#840), so the human channel says exactly what the JSON
+    one does.
+    """
     runnable = " [runnable]" if got.runnable else ""
     header = f"{got.name} ({got.platform}){runnable}"
-    templates = (
-        f"templates installed ({got.templates_version})"
-        if got.templates_installed
-        else f"templates missing ({got.templates_version})"
-    )
-    return "\n".join([header, f"  export_path: {got.export_path}", f"  {templates}"])
+    state = "installed" if got.templates_installed else "missing"
+    lines = [
+        header,
+        f"  export_path: {got.export_path}",
+        f"  templates {state} ({got.templates_version}) in {got.templates_root}",
+    ]
+    if got.templates_root_host:
+        lines.append(
+            f"  hidden by --user-data-root; host templates: {got.templates_root_host}"
+        )
+    return "\n".join(lines)
 
 
 def render_export_run(ran: "ExportRunResult") -> str:
@@ -536,7 +611,16 @@ def run_export_operation(
     if not output_path:
         return export_path_unset_failure(got.name)
     if mode is not ExportRunMode.PACK and not got.templates_installed:
-        return export_templates_missing_failure(got.name, got.templates_version)
+        # Both directories ride the failure (#840): the one the engine checked, and
+        # — when a --user-data-root redirect hid installed templates — the host's,
+        # which is what turns "install the templates" into "you already have them,
+        # this run cannot see them".
+        return export_templates_missing_failure(
+            got.name,
+            got.templates_version,
+            got.templates_root,
+            got.templates_root_host,
+        )
     created_dirs = _ensure_output_parent_dirs(output_path)
     if isinstance(created_dirs, Failure):
         return created_dirs
@@ -740,6 +824,12 @@ def run_export(
     preset ``export_path`` values keep Godot's project-relative convention. The
     reported ``output_path`` is the resolved artifact path, and missing output
     parent directories are created and reported in ``created_dirs`` (#402/#403).
+
+    Export-template discovery follows ``--user-data-root``: Godot reads the export
+    templates from the data directory that option relocates, so a release/debug run
+    under it finds none installed unless you put templates there. The failure then
+    names both directories and the remedies; ``--mode pack`` needs no export
+    templates at all.
     """
     # Build the params model from the argv options (the single source of truth,
     # ADR-0015): ExportRunParams.output is an ExportOutputPath, so argv and

--- a/src/gda/commands/export.py
+++ b/src/gda/commands/export.py
@@ -762,7 +762,14 @@ def get_preset(
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
-    """Report one preset's details plus export-template install status."""
+    """Report one preset's details plus export-template install status.
+
+    ``templates_root`` names the export-templates directory that was checked.
+    Godot reads the templates from its data directory and ``--user-data-root``
+    relocates that, so a redirected run can report none installed on a host
+    that has them; ``templates_root_host`` names the host's directory in
+    exactly that case.
+    """
     dispatch_domain(
         EXPORT_GET_COMMAND,
         ExportGetParams(preset=preset),
@@ -825,11 +832,11 @@ def run_export(
     reported ``output_path`` is the resolved artifact path, and missing output
     parent directories are created and reported in ``created_dirs`` (#402/#403).
 
-    Export-template discovery follows ``--user-data-root``: Godot reads the export
-    templates from the data directory that option relocates, so a release/debug run
-    under it finds none installed unless you put templates there. The failure then
-    names both directories and the remedies; ``--mode pack`` needs no export
-    templates at all.
+    Export-template discovery follows ``--user-data-root``: Godot reads the
+    templates from the data directory that option relocates, so a release or
+    debug run under it finds none installed unless you put templates there.
+    The failure then names both directories and the remedies; ``--mode pack``
+    needs no export templates at all.
     """
     # Build the params model from the argv options (the single source of truth,
     # ADR-0015): ExportRunParams.output is an ExportOutputPath, so argv and

--- a/src/gda/commands/export.py
+++ b/src/gda/commands/export.py
@@ -118,10 +118,10 @@ class ExportListResult(BaseModel):
     presets: list[ListedPreset]
 
 
-def host_data_path() -> str | None:
+def resolve_host_data_path() -> str | None:
     """The host's Godot data directory, resolved over gda's OWN environment (#840).
 
-    The default of :attr:`ExportGetParams.host_data_path`, and the whole mechanism
+    The value stamped on :attr:`ExportGetParams.host_data_path`, and the whole mechanism
     behind #840's disclosure. ``--user-data-root`` redirects the CHILD engine's
     data directory, never gda's own environment, so this stays the directory an
     unredirected run would use — exactly the one the engine cannot see from inside
@@ -170,7 +170,7 @@ class ExportGetParams(BaseModel):
         # `--params-json` build this same model, so neither can reach the operation
         # without the host directory and neither can reach it with a caller's guess
         # at one.
-        self.host_data_path = host_data_path()
+        self.host_data_path = resolve_host_data_path()
         return self
 
 

--- a/src/gda/commands/export.py
+++ b/src/gda/commands/export.py
@@ -349,7 +349,8 @@ def render_export_get(got: "ExportGetResult") -> str:
     ]
     if got.templates_root_host:
         lines.append(
-            f"  hidden by --user-data-root; host templates: {got.templates_root_host}"
+            "  hidden by the user-data redirect (--user-data-root / "
+            f"$GDA_USER_DATA_ROOT); host templates: {got.templates_root_host}"
         )
     return "\n".join(lines)
 

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -714,8 +714,13 @@ def export_path_unset_failure(preset: str) -> Failure:
     )
 
 
-def export_templates_missing_failure(preset: str, templates_version: str) -> Failure:
-    """The ``export_templates_missing`` failure from the structured preflight (issue #121, #170).
+def export_templates_missing_failure(
+    preset: str,
+    templates_version: str,
+    templates_root: str = "",
+    templates_root_host: str | None = None,
+) -> Failure:
+    """The ``export_templates_missing`` failure from the structured preflight (issue #121, #170, #840).
 
     A release/debug export needs the platform export templates for the running
     engine version installed (``pack`` does not — it produces project data only,
@@ -726,12 +731,49 @@ def export_templates_missing_failure(preset: str, templates_version: str) -> Fai
     configuration errors" stderr (which ADR-0002 forbids, and which also fires for
     a merely-misconfigured preset). Names the ``templates_version`` directory the
     agent must install.
+
+    TWO shapes, not one (#840). Godot reads the export templates from the data
+    directory ``--user-data-root`` relocates, so a redirected run reports none
+    installed on a host whose templates are correctly installed — the failure that
+    kept reading as "install the templates" when the templates were already there.
+    ``templates_root`` is the directory that was checked and ``templates_root_host``
+    the host's, set only when the redirect really did hide installed templates. With
+    both in hand the message names both directories and the two remedies (drop the
+    redirect, or ``--mode pack``, which needs no templates); with only the first it
+    stays the plain "not installed here". No ``hint``: that key is contractually one
+    corrected invocation from the curated near-miss table (``gda.hints``) and this is
+    not a near miss.
+
+    Both paths also ride ``evidence`` as typed facts, so an agent branches on the
+    shape rather than on the prose (ADR-0004 amendment, #687 — this builder is the
+    eighth producer on that axis). When neither is known the object would say
+    nothing, so no ``evidence`` key is emitted at all rather than an empty one.
     """
+    message = (
+        f'export preset "{preset}" cannot be exported: the export templates for '
+        f"the running engine version ({templates_version}) are not installed"
+    )
+    if templates_root:
+        message += f" in {templates_root}"
+    if templates_root_host:
+        message += (
+            f", where --user-data-root moved the lookup; they are installed in the "
+            f"host's {templates_root_host}. Run the export without "
+            f"--user-data-root, or use --mode pack, which needs no export templates"
+        )
+    evidence = (
+        FailureEvidence(
+            templates_root_checked=templates_root or None,
+            templates_root_host=templates_root_host,
+        )
+        if templates_root or templates_root_host
+        else None
+    )
     return make_failure(
         "export_templates_missing",
-        f'export preset "{preset}" cannot be exported: the export templates for '
-        f"the running engine version ({templates_version}) are not installed",
+        message,
         "",
+        evidence=evidence,
     )
 
 

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -717,8 +717,8 @@ def export_path_unset_failure(preset: str) -> Failure:
 def export_templates_missing_failure(
     preset: str,
     templates_version: str,
-    templates_root: str = "",
-    templates_root_host: str | None = None,
+    templates_root: str,
+    templates_root_host: str | None,
 ) -> Failure:
     """The ``export_templates_missing`` failure from the structured preflight (issue #121, #170, #840).
 
@@ -757,9 +757,10 @@ def export_templates_missing_failure(
         message += f" in {templates_root}"
     if templates_root_host:
         message += (
-            f", where --user-data-root moved the lookup; they are installed in the "
-            f"host's {templates_root_host}. Run the export without "
-            f"--user-data-root, or use --mode pack, which needs no export templates"
+            f", where --user-data-root (or $GDA_USER_DATA_ROOT) moved the lookup; "
+            f"they are installed in the host's {templates_root_host}. Run the export "
+            f"without the user-data redirect, or use --mode pack, which needs no "
+            f"export templates"
         )
     evidence = (
         FailureEvidence(

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -201,6 +201,27 @@ class FailureEvidence(BaseModel):
             "--project. Set only when gda found one above the target."
         ),
     )
+    # The two export-templates directories a `--user-data-root` redirect puts at
+    # odds (#840). Godot reads the templates from the data directory the redirect
+    # relocates, so `export_templates_missing` has two shapes that need different
+    # remedies, and the message alone cannot be branched on: `templates_root_host`
+    # is present exactly when the templates ARE installed somewhere this run could
+    # not see, and absent when they are genuinely missing.
+    templates_root_checked: str | None = Field(
+        default=None,
+        description=(
+            "The export-templates directory this run checked — the one the "
+            "engine's data directory resolved to, which --user-data-root moves."
+        ),
+    )
+    templates_root_host: str | None = Field(
+        default=None,
+        description=(
+            "The host's export-templates directory, when it holds the templates a "
+            "--user-data-root redirect hid from this run. Set only then: its "
+            "absence means the templates are missing on the host too."
+        ),
+    )
 
     @field_serializer("script_errors")
     def _keep_the_published_script_error_shape(

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -3312,7 +3312,12 @@ func _op_export_list(_params: Dictionary) -> void:
 # reports it); an unknown name is the export_preset_not_found failure. Beyond the
 # preset's own fields it reports whether the export templates for the running
 # engine version are installed — the readiness check an agent makes before a
-# future export run (issue #121) — and the version directory it checked.
+# future export run (issue #121) — the version directory it checked, and the
+# export-templates directory that version was looked for in. When the optional
+# "host_data_path" param names a data directory other than this run's own, and that
+# one DOES hold the version's templates, the reply names it too: --user-data-root
+# moves the directory Godot reads the templates from, so a redirected run reports
+# none installed on a host that has them (#840).
 func _op_export_get(params: Dictionary) -> void:
 	_diag("running operation: export-get")
 	if not _has_project():
@@ -3334,8 +3339,13 @@ func _op_export_get(params: Dictionary) -> void:
 			var summary := _export_preset_summary(config, section, entry["index"])
 			summary["export_path"] = String(config.get_value(section, "export_path", ""))
 			var version_dir := _export_templates_version_dir()
+			var templates_root := _export_templates_root(OS.get_data_dir())
 			summary["templates_version"] = version_dir
-			summary["templates_installed"] = _export_templates_installed(version_dir)
+			summary["templates_root"] = templates_root
+			summary["templates_installed"] = _export_templates_installed(templates_root, version_dir)
+			summary["templates_root_host"] = _hidden_host_templates_root(
+				_string_param(params, "host_data_path"), templates_root, version_dir
+			)
 			_succeed(summary)
 			return
 
@@ -3408,19 +3418,46 @@ func _export_templates_version_dir() -> String:
 	return "%s.%s" % [dir, v.status]
 
 
+# The export-templates directory under one data directory: <data_dir>/<godot-dir>/
+# export_templates. Headless --script runs have no EditorPaths singleton, so the
+# path is composed from the data dir (the same root the editor uses) plus the
+# "<godot-dir>/export_templates" layout, where <godot-dir> is the engine's
+# per-platform user-dir name (see _godot_user_dir_name — lowercase "godot" on
+# case-sensitive Linux, NOT the macOS/Windows "Godot"). Taking the data dir as an
+# ARGUMENT is what keeps the layout rule in ONE place while two directories are
+# compared (#840): the engine's own OS.get_data_dir(), which a --user-data-root
+# redirect MOVES, and the host's, which gda passes in.
+func _export_templates_root(data_dir: String) -> String:
+	return data_dir.path_join(_godot_user_dir_name()).path_join("export_templates")
+
+
 # Whether the export templates for the running engine version are installed:
-# their per-version directory exists under the user data dir's
-# <godot-dir>/export_templates/. Headless --script runs have no EditorPaths
-# singleton, so the path is derived from OS.get_data_dir() (the same root the editor
-# uses) plus the "<godot-dir>/export_templates/<version>" layout, where <godot-dir>
-# is the engine's per-platform user-dir name (see _godot_user_dir_name — lowercase
-# "godot" on case-sensitive Linux, NOT the macOS/Windows "Godot"). This is the
-# readiness signal an agent checks before a future export run (issue #121); it does
-# not verify per-platform template files, only that the version's templates are
-# present at all.
-func _export_templates_installed(version_dir: String) -> bool:
-	var templates_root := OS.get_data_dir().path_join(_godot_user_dir_name()).path_join("export_templates")
+# their per-version directory exists under the given export-templates root. This is
+# the readiness signal an agent checks before a future export run (issue #121); it
+# does not verify per-platform template files, only that the version's templates
+# are present at all.
+func _export_templates_installed(templates_root: String, version_dir: String) -> bool:
 	return DirAccess.dir_exists_absolute(templates_root.path_join(version_dir))
+
+
+# The HOST's export-templates directory, but only when it holds templates this run
+# cannot see (#840). Godot reads the templates from OS.get_data_dir(), which
+# --user-data-root relocates, so a redirected run reports none installed even on a
+# host whose templates are correctly installed. gda passes the host data directory
+# (it resolves it over its own, unredirected environment) so this reply can name the
+# second directory — and it is named ONLY when there is really something there:
+# null when no host directory was passed, when the redirect is not in play (the two
+# roots are the same directory), and when the host has no templates for this version
+# either, which is a plain missing-templates run with nothing to disclose.
+func _hidden_host_templates_root(host_data_dir: String, templates_root: String, version_dir: String) -> Variant:
+	if host_data_dir.is_empty():
+		return null
+	var host_root := _export_templates_root(host_data_dir)
+	if host_root.simplify_path() == templates_root.simplify_path():
+		return null
+	if not _export_templates_installed(host_root, version_dir):
+		return null
+	return host_root
 
 
 # The engine's per-platform user-data directory name. macOS and Windows capitalize it

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -3342,9 +3342,10 @@ func _op_export_get(params: Dictionary) -> void:
 			var templates_root := _export_templates_root(OS.get_data_dir())
 			summary["templates_version"] = version_dir
 			summary["templates_root"] = templates_root
-			summary["templates_installed"] = _export_templates_installed(templates_root, version_dir)
+			var installed := _export_templates_installed(templates_root, version_dir)
+			summary["templates_installed"] = installed
 			summary["templates_root_host"] = _hidden_host_templates_root(
-				_string_param(params, "host_data_path"), templates_root, version_dir
+				_string_param(params, "host_data_path"), templates_root, version_dir, installed
 			)
 			_succeed(summary)
 			return
@@ -3445,12 +3446,14 @@ func _export_templates_installed(templates_root: String, version_dir: String) ->
 # --user-data-root relocates, so a redirected run reports none installed even on a
 # host whose templates are correctly installed. gda passes the host data directory
 # (it resolves it over its own, unredirected environment) so this reply can name the
-# second directory — and it is named ONLY when there is really something there:
-# null when no host directory was passed, when the redirect is not in play (the two
-# roots are the same directory), and when the host has no templates for this version
-# either, which is a plain missing-templates run with nothing to disclose.
-func _hidden_host_templates_root(host_data_dir: String, templates_root: String, version_dir: String) -> Variant:
-	if host_data_dir.is_empty():
+# second directory — and it is named ONLY when something is really HIDDEN: null when
+# no host directory was passed, when the checked root already holds this version
+# (nothing is hidden, whatever the host holds — a redirected root a caller populated
+# is a healthy run, PR #883 review round 3), when the redirect is not in play (the
+# two roots are the same directory), and when the host has no templates for this
+# version either, which is a plain missing-templates run with nothing to disclose.
+func _hidden_host_templates_root(host_data_dir: String, templates_root: String, version_dir: String, installed: bool) -> Variant:
+	if host_data_dir.is_empty() or installed:
 		return null
 	var host_root := _export_templates_root(host_data_dir)
 	if host_root.simplify_path() == templates_root.simplify_path():

--- a/src/gda/render.py
+++ b/src/gda/render.py
@@ -153,6 +153,10 @@ def _evidence_lines(evidence: FailureEvidence) -> list[str]:
         body.append(f"  project root: {evidence.project_root}")
     if evidence.owning_project is not None:
         body.append(f"  owning project: {evidence.owning_project}")
+    if evidence.templates_root_checked is not None:
+        body.append(f"  templates root checked: {evidence.templates_root_checked}")
+    if evidence.templates_root_host is not None:
+        body.append(f"  host templates root: {evidence.templates_root_host}")
     return ["evidence:", *body] if body else []
 
 

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -55,9 +55,12 @@ commands (no group).
   failed save as a game bug; a FAILURE envelope (`--strict`, a timeout) does not
   carry them. Two limits: Godot reads the **export templates** from that same
   directory, so a `release`/`debug` `export run` under it reports none installed
-  unless you put templates there — `--mode pack` needs no templates and works
-  normally; and Engine sessions are unaffected either way — the daemon owns their
-  log.
+  unless you put templates there — the `export_templates_missing` failure then names
+  both directories and carries them as `evidence.templates_root_checked` /
+  `evidence.templates_root_host`, and that second key is how you tell "hidden by the
+  redirect" (drop it, or use `--mode pack`, which needs no templates) from "not
+  installed anywhere" (install them); and Engine sessions are unaffected either way —
+  the daemon owns their log.
 
 ## Structured output & errors
 
@@ -180,7 +183,7 @@ JSON — use `gda help <command> --json` for a structured payload), and the flag
 | `script` | `create`, `get`, `list`, `set`, `delete`, `attach`, `validate`, `run` (`.gd` files; `validate` takes SEVERAL paths at once — one engine launch for the whole batch, one aggregate `valid` plus a per-file entry under `scripts` — or `--all` for every script in the project; `run` executes a project script one-shot (address it project-relative or as `res://` — the two portable forms, which `script validate` takes too; `run` alone refuses absolute paths) and passes its `exit_status`/`stdout`/`stderr` through — `stdout` above 64 KiB is truncated to its leading bytes with the COMPLETE stream spilled to the file named in `stdout_file` (`stdout_bytes`/`stdout_truncated` disclose it; a spill gda cannot write is the typed `stdout_spill_failed`, never an unbounded result), and a non-zero `quit()` is still success, so read `exit_status`, or pass `--strict` to get a `script_failed` failure (exit 4) whose `diagnostics` carries the script's own stdout and stderr; a script that never ran — missing, or a failed parse/compile — always fails; `--timeout <s>` sets the ceiling (default 120) and a run that reaches it fails with `launch_timeout` carrying the captured partial output, the elapsed seconds and a termination phase; add `--completion-marker <line>` naming a line your script prints when its work is done — a caller-declared liveness contract, not a death detector: gda ends the run once it observes a recognized error attributable to the entry script, no marker line yet, and then silence on both streams — `script_aborted` (exit 4) with the captured error, in seconds rather than at the ceiling; declaring the marker asserts the script keeps printing until that line, so have it print progress during quiet stretches longer than ~3s, or omit the marker; a script that writes `user://` belongs under `gda --user-data-root DIR script run …` (see Setup) — the result then names `user_data_root` and `log_file` beside the always-present `engine_data_path`) |
 | `project` | `info`, `get`, `set`, `list`, `add-autoload`, `remove-autoload`, `add-input-action`, `remove-input-action`, `find-references`, `dependencies`, `find-unused-resources`, `statistics` |
 | `resource` | `create`, `get`, `set`, `delete`, `uid`, `import` (`.tres` files and project assets; `import` ensures importable assets — PNGs and other files the engine imports — are in the project cache: clean-worktree loading; a script needs no import and reports `not_importable`) |
-| `export` | `list`, `get`, `run` (export a preset by name; `--mode` release/debug/pack) |
+| `export` | `list`, `get`, `run` (export a preset by name; `--mode` release/debug/pack; `get` also reports `templates_root`, the export-templates directory it checked, and `templates_root_host`, set when a `--user-data-root` redirect hid templates installed on the host) |
 | `shader` | `create`, `get`, `set` (`.gdshader` files) |
 | `theme` | `create` (a loadable `.tres` Theme) |
 

--- a/tests/cli/test_error_registry.py
+++ b/tests/cli/test_error_registry.py
@@ -251,6 +251,15 @@ def test_no_registered_code_grows_a_key_by_defaulting_the_optional_context():
 #: two `target_outside_project` refusals report a project-context mismatch gda decides
 #: before anything is launched, so their coordinates are the whole cause rather than a
 #: run's residue. ADR-0004's paragraph carries the same two names.
+#:
+#: The eighth arrives with #840: `export_templates_missing_failure` types the two
+#: export-templates directories a `--user-data-root` redirect puts at odds — the one
+#: the engine checked and the host one that holds the templates it could not see.
+#: Also not reporting on a run (it is the pre-export preflight's verdict), and it
+#: passes the criterion the same way: both paths are already in hand on the failure
+#: path, neither is recoverable from the envelope without parsing prose, and which of
+#: the two shapes it is decides whether the caller drops the redirect or installs
+#: templates. ADR-0004's paragraph carries this name too.
 _EVIDENCE_PRODUCERS = {
     "launch_timeout_failure",
     "script_did_not_run_failure",
@@ -259,6 +268,7 @@ _EVIDENCE_PRODUCERS = {
     "script_run_aborted_failure",
     "target_outside_project_failure",
     "target_owned_by_another_project_failure",
+    "export_templates_missing_failure",
 }
 
 

--- a/tests/cli/test_error_registry.py
+++ b/tests/cli/test_error_registry.py
@@ -300,8 +300,12 @@ def test_no_producer_can_emit_an_empty_evidence_object():
     # The fourth state the amendment's argument does not cover: `FailureEvidence()`
     # with every field unset serializes to `"evidence": {}` — a key that says nothing,
     # on a failure that byte-identity says should carry no key at all. Unreachable
-    # through the five producers today, but only incidentally, so it is pinned rather
-    # than assumed. Each producer is called with the LEAST it can be given.
+    # through the first five producers today, but only incidentally, so it is pinned
+    # rather than assumed. Producers six to eight (the two `target_*` refusals and
+    # `export_templates_missing_failure`) are not in this list because their builders
+    # cannot be called with nothing; each pins the same rule in a dedicated test
+    # (e.g. `test_no_evidence_at_all_when_no_directory_was_reported`). Each producer
+    # is called with the LEAST it can be given.
     raw = RunResult(
         stdout="", stderr="", exit_code=124, launch_failure=LaunchFailure.TIMEOUT
     )

--- a/tests/cli/test_human_failure_output.py
+++ b/tests/cli/test_human_failure_output.py
@@ -213,6 +213,8 @@ _EVIDENCE_SAMPLES = {
     "target_location": "/tmp/outer/inner/main.gd",
     "project_root": "/tmp/outer",
     "owning_project": "/tmp/outer/inner",
+    "templates_root_checked": "/iso/data/Godot/export_templates",
+    "templates_root_host": "/home/dev/data/Godot/export_templates",
 }
 
 

--- a/tests/cli/test_human_failure_output.py
+++ b/tests/cli/test_human_failure_output.py
@@ -219,7 +219,7 @@ _EVIDENCE_SAMPLES = {
 
 
 def test_the_sample_table_covers_every_field_the_model_publishes():
-    # The half that reds when `FailureEvidence` grows a sixth field.
+    # The half that reds when `FailureEvidence` grows a field.
     assert set(_EVIDENCE_SAMPLES) == set(FailureEvidence.model_fields)
 
 

--- a/tests/cli/test_human_output.py
+++ b/tests/cli/test_human_output.py
@@ -440,10 +440,12 @@ HUMAN_CASES = [
             "export_path": "build/index.html",
             "templates_installed": True,
             "templates_version": "4.6.3.stable",
+            "templates_root": "/host/data/Godot/export_templates",
+            "templates_root_host": None,
         },
         "Web (Web)\n"
         "  export_path: build/index.html\n"
-        "  templates installed (4.6.3.stable)",
+        "  templates installed (4.6.3.stable) in /host/data/Godot/export_templates",
     ),
     (
         # templates missing branch + runnable suffix.
@@ -457,10 +459,33 @@ HUMAN_CASES = [
             "export_path": "",
             "templates_installed": False,
             "templates_version": "4.6.3.stable",
+            "templates_root": "/host/data/Godot/export_templates",
+            "templates_root_host": None,
         },
         "Linux/X11 (Linux/X11) [runnable]\n"
         "  export_path: \n"
-        "  templates missing (4.6.3.stable)",
+        "  templates missing (4.6.3.stable) in /host/data/Godot/export_templates",
+    ),
+    (
+        # #840: the redirect branch adds the line naming where they really are.
+        "export-get-templates-hidden-by-redirect",
+        ["export", "get", "--preset", "Linux/X11"],
+        {
+            "index": 0,
+            "name": "Linux/X11",
+            "platform": "Linux/X11",
+            "runnable": True,
+            "export_path": "",
+            "templates_installed": False,
+            "templates_version": "4.6.3.stable",
+            "templates_root": "/iso/data/Godot/export_templates",
+            "templates_root_host": "/host/data/Godot/export_templates",
+        },
+        "Linux/X11 (Linux/X11) [runnable]\n"
+        "  export_path: \n"
+        "  templates missing (4.6.3.stable) in /iso/data/Godot/export_templates\n"
+        "  hidden by --user-data-root; host templates: "
+        "/host/data/Godot/export_templates",
     ),
     # --- meta ---------------------------------------------------------------
     (

--- a/tests/cli/test_human_output.py
+++ b/tests/cli/test_human_output.py
@@ -484,7 +484,8 @@ HUMAN_CASES = [
         "Linux/X11 (Linux/X11) [runnable]\n"
         "  export_path: \n"
         "  templates missing (4.6.3.stable) in /iso/data/Godot/export_templates\n"
-        "  hidden by --user-data-root; host templates: "
+        "  hidden by the user-data redirect (--user-data-root / $GDA_USER_DATA_ROOT); "
+        "host templates: "
         "/host/data/Godot/export_templates",
     ),
     # --- meta ---------------------------------------------------------------

--- a/tests/cli/test_models.py
+++ b/tests/cli/test_models.py
@@ -278,6 +278,11 @@ def test_every_evidence_field_is_optional_in_the_published_schema():
         "target_location",
         "project_root",
         "owning_project",
+        # The two export-templates directories a --user-data-root redirect puts at
+        # odds (#840): the one this run checked, and the host one holding the
+        # templates it could not see.
+        "templates_root_checked",
+        "templates_root_host",
     }
 
 
@@ -830,9 +835,9 @@ def test_export_list_result_round_trips_a_project_with_no_presets():
 def test_export_get_result_round_trips_preset_details_and_template_status():
     # export get reports one preset's details plus export-template readiness
     # (issue #114): the preset's index/name/platform/runnable and export_path,
-    # then whether the running engine version's templates are installed and which
-    # version directory was checked — the readiness an agent asserts before an
-    # export run.
+    # then whether the running engine version's templates are installed, which
+    # version directory was checked and which directory it was looked for in
+    # (#840) — the readiness an agent asserts before an export run.
     payload = {
         "index": 1,
         "name": "Web",
@@ -841,6 +846,11 @@ def test_export_get_result_round_trips_preset_details_and_template_status():
         "export_path": "build/index.html",
         "templates_installed": True,
         "templates_version": "4.6.3.stable",
+        "templates_root": "/home/dev/data/Godot/export_templates",
+        # Nothing is hidden on an unredirected run, and the key is still emitted
+        # (as null) rather than dropped — the success half publishes its full key
+        # set, unlike the failure envelope's optional keys.
+        "templates_root_host": None,
     }
 
     got = ExportGetResult.model_validate(payload)
@@ -850,6 +860,8 @@ def test_export_get_result_round_trips_preset_details_and_template_status():
     assert got.export_path == "build/index.html"
     assert got.templates_installed is True
     assert got.templates_version == "4.6.3.stable"
+    assert got.templates_root == "/home/dev/data/Godot/export_templates"
+    assert got.templates_root_host is None
     assert json.loads(got.model_dump_json()) == payload
 
 
@@ -864,12 +876,19 @@ def test_export_get_result_round_trips_missing_templates():
         "export_path": "",
         "templates_installed": False,
         "templates_version": "4.6.3.stable",
+        # #840: the directory checked, and the host one whose templates a
+        # --user-data-root redirect hid — the pair that tells this shape ("hidden
+        # from this run") from the plain one below.
+        "templates_root": "/iso/data/Godot/export_templates",
+        "templates_root_host": "/home/dev/data/Godot/export_templates",
     }
 
     got = ExportGetResult.model_validate(payload)
 
     assert got.templates_installed is False
     assert got.export_path == ""
+    assert got.templates_root == "/iso/data/Godot/export_templates"
+    assert got.templates_root_host == "/home/dev/data/Godot/export_templates"
     assert json.loads(got.model_dump_json()) == payload
 
 

--- a/tests/export/test_e2e_export.py
+++ b/tests/export/test_e2e_export.py
@@ -16,7 +16,7 @@ import json
 
 import pytest
 
-from tests.support import Gda
+from tests.support import Gda, templates_installed
 
 # Two presets in the canonical format Godot writes export_presets.cfg: a
 # runnable Linux preset and a non-runnable Web preset, each with its sibling
@@ -153,6 +153,50 @@ def test_export_get_reports_preset_details_and_template_status(godot_project):
     assert data["templates_version"] == _expected_templates_version(), data[
         "templates_version"
     ]
+    # #840: and WHERE it checked — the export-templates directory holding that
+    # version directory, derived engine-side from OS.get_data_dir(). An absolute
+    # path ending in `export_templates`, whatever this host's data directory is.
+    templates_root = data["templates_root"]
+    assert templates_root.startswith("/") or ":" in templates_root, templates_root
+    assert templates_root.endswith("export_templates"), templates_root
+    # No redirect is in play here, so the host directory IS the one checked and
+    # there is nothing hidden to report.
+    assert data["templates_root_host"] is None, data["templates_root_host"]
+
+
+@pytest.mark.e2e
+def test_export_get_names_the_host_templates_a_user_data_redirect_hides(
+    godot_project, tmp_path
+):
+    # #840 END TO END, one command before the export. `--user-data-root` relocates
+    # Godot's data directory, and Godot reads the export templates from exactly
+    # that directory, so a redirected run sees none even when the host has them
+    # installed. `export get` now reports BOTH directories: the redirected one it
+    # checked, and the host's, which is where the templates it cannot see are.
+    #
+    # The redirect is passed PER INVOCATION, never exported for the run: exporting
+    # it hides the host's templates from every other test too (PITFALLS.md).
+    (godot_project / "export_presets.cfg").write_text(
+        EXPORT_PRESETS_CFG, encoding="utf-8"
+    )
+    gda = Gda(godot_project)
+    if not templates_installed(gda, preset="Web"):
+        pytest.skip(
+            "this host has no export templates installed, so there is nothing for "
+            "a --user-data-root redirect to hide"
+        )
+    isolated = tmp_path / "iso"
+
+    data = gda.json(
+        "--user-data-root", str(isolated), "export", "get", "--preset", "Web"
+    )
+
+    assert data["templates_installed"] is False, data
+    # The directory checked moved under the isolated root; the host's did not.
+    assert str(isolated) in data["templates_root"], data["templates_root"]
+    assert data["templates_root_host"], data
+    assert str(isolated) not in data["templates_root_host"], data
+    assert data["templates_root_host"].endswith("export_templates"), data
 
 
 @pytest.mark.e2e

--- a/tests/export/test_e2e_export_run.py
+++ b/tests/export/test_e2e_export_run.py
@@ -174,6 +174,61 @@ def test_export_run_writes_to_configured_export_path(godot_project):
 
 
 @pytest.mark.e2e
+def test_export_run_under_a_redirect_names_both_template_directories(
+    godot_project, tmp_path
+):
+    # #840 ACCEPTANCE, live. A release export under `--user-data-root` fails with
+    # export_templates_missing even on a host whose templates are correctly
+    # installed, because Godot reads the templates from the data directory the
+    # redirect relocated. The failure now says so at the point it happens: the
+    # message names the directory that was checked AND the host directory holding
+    # the templates, plus the two remedies, and `evidence` carries the same two
+    # paths as typed facts.
+    #
+    # The redirect is per invocation, never exported for the run — exporting it
+    # would hide the host's templates from every other test (PITFALLS.md).
+    (godot_project / "export_presets.cfg").write_text(
+        EXPORT_PRESETS_CFG, encoding="utf-8"
+    )
+    (godot_project / "main.gd").write_text(
+        "extends Node\n\nfunc _ready() -> void:\n\tpass\n", encoding="utf-8"
+    )
+    gda = Gda(godot_project)
+    if not templates_installed(gda):
+        pytest.skip(
+            "this host has no export templates installed, so there is nothing for "
+            "a --user-data-root redirect to hide"
+        )
+    isolated = tmp_path / "iso"
+    artifact = godot_project / "build/game.x86_64"
+
+    run = gda(
+        "--user-data-root",
+        str(isolated),
+        "export",
+        "run",
+        "--preset",
+        "Linux/X11",
+        "--json",
+    )
+
+    assert run.returncode == 4, run.stdout + run.stderr
+    err = json.loads(run.stdout)["error"]
+    assert err["code"] == "export_templates_missing", run.stdout + run.stderr
+    assert str(isolated) in err["message"], err["message"]
+    assert "--user-data-root" in err["message"], err["message"]
+    assert "--mode pack" in err["message"], err["message"]
+    # Not a near miss, so no corrected invocation rides along.
+    assert "hint" not in err, err
+    evidence = err["evidence"]
+    assert str(isolated) in evidence["templates_root_checked"], evidence
+    assert evidence["templates_root_host"].endswith("export_templates"), evidence
+    assert str(isolated) not in evidence["templates_root_host"], evidence
+    # The preflight fired first, so nothing was exported.
+    assert not artifact.exists(), "no artifact when the preflight fails fast"
+
+
+@pytest.mark.e2e
 def test_export_run_pack_writes_pck_without_templates(godot_project):
     # #170 PROOF: `--mode pack --output <path>.pck` runs Godot's native
     # --export-pack to the OVERRIDDEN path (not the preset's configured

--- a/tests/export/test_e2e_export_run.py
+++ b/tests/export/test_e2e_export_run.py
@@ -262,6 +262,50 @@ def test_export_get_under_a_redirect_with_a_template_less_host_names_no_host_roo
 
 
 @pytest.mark.e2e
+def test_export_get_under_a_redirect_whose_root_holds_the_templates_names_no_host_root(
+    godot_project, tmp_path
+):
+    # Both roots populated (PR #883 review round 3): the redirect is in play and
+    # the host has this version, but the CHECKED root has it too — so nothing is
+    # hidden, the reply says installed, and `templates_root_host` stays null. The
+    # engine-side check used to compare only the two roots and the host's
+    # contents, so a healthy redirected root read as hiding templates and the
+    # human line said "installed" and "hidden by" in one breath. The isolated
+    # root's layout is learned from the plain redirected reply rather than spelled
+    # here; the version directory only has to EXIST for the engine's own check.
+    (godot_project / "export_presets.cfg").write_text(
+        EXPORT_PRESETS_CFG, encoding="utf-8"
+    )
+    gda = Gda(godot_project)
+    if not templates_installed(gda):
+        pytest.skip(
+            "this host has no export templates installed, so both roots cannot "
+            "hold this version"
+        )
+    isolated = tmp_path / "iso"
+    plain = gda.json(
+        "--user-data-root", str(isolated), "export", "get", "--preset", "Linux/X11"
+    )
+    assert plain["templates_installed"] is False, plain
+    assert plain["templates_root_host"] is not None, plain
+    (Path(plain["templates_root"]) / plain["templates_version"]).mkdir(parents=True)
+
+    got = gda.json(
+        "--user-data-root", str(isolated), "export", "get", "--preset", "Linux/X11"
+    )
+    human = gda(
+        "--user-data-root", str(isolated), "export", "get", "--preset", "Linux/X11"
+    )
+
+    assert got["templates_installed"] is True, got
+    assert str(isolated) in got["templates_root"], got
+    assert got["templates_root_host"] is None, got
+    assert human.returncode == 0, human.stdout + human.stderr
+    assert "templates installed" in human.stdout, human.stdout
+    assert "hidden by" not in human.stdout, human.stdout
+
+
+@pytest.mark.e2e
 def test_export_run_pack_writes_pck_without_templates(godot_project):
     # #170 PROOF: `--mode pack --output <path>.pck` runs Godot's native
     # --export-pack to the OVERRIDDEN path (not the preset's configured

--- a/tests/export/test_e2e_export_run.py
+++ b/tests/export/test_e2e_export_run.py
@@ -217,6 +217,8 @@ def test_export_run_under_a_redirect_names_both_template_directories(
     assert err["code"] == "export_templates_missing", run.stdout + run.stderr
     assert str(isolated) in err["message"], err["message"]
     assert "--user-data-root" in err["message"], err["message"]
+    assert "$GDA_USER_DATA_ROOT" in err["message"], err["message"]
+    assert "without the user-data redirect" in err["message"], err["message"]
     assert "--mode pack" in err["message"], err["message"]
     # Not a near miss, so no corrected invocation rides along.
     assert "hint" not in err, err
@@ -226,6 +228,37 @@ def test_export_run_under_a_redirect_names_both_template_directories(
     assert str(isolated) not in evidence["templates_root_host"], evidence
     # The preflight fired first, so nothing was exported.
     assert not artifact.exists(), "no artifact when the preflight fails fast"
+
+
+@pytest.mark.e2e
+def test_export_get_under_a_redirect_with_a_template_less_host_names_no_host_root(
+    godot_project, tmp_path
+):
+    # Clause 3 of the engine-side check (#840): the redirect is in play and the two
+    # roots differ, but the host has no templates for this version EITHER — so
+    # nothing is hidden and the plain shape must come back (no host root), not a
+    # false "they are installed in the host's …" remedy. The host root is resolved
+    # over gda's OWN environment, so that environment is pointed at an empty home
+    # for this one invocation; the child engine's data goes under the isolated
+    # root as before. The redirect is never exported for the run (PITFALLS.md).
+    (godot_project / "export_presets.cfg").write_text(
+        EXPORT_PRESETS_CFG, encoding="utf-8"
+    )
+    empty_home = tmp_path / "home"
+    empty_home.mkdir()
+    isolated = tmp_path / "iso"
+    gda = Gda(
+        godot_project,
+        extra_env={"HOME": str(empty_home), "XDG_DATA_HOME": str(empty_home / "share")},
+    )
+
+    got = gda.json(
+        "--user-data-root", str(isolated), "export", "get", "--preset", "Linux/X11"
+    )
+
+    assert got["templates_installed"] is False, got
+    assert str(isolated) in got["templates_root"], got
+    assert got["templates_root_host"] is None, got
 
 
 @pytest.mark.e2e

--- a/tests/export/test_export_commands.py
+++ b/tests/export/test_export_commands.py
@@ -13,7 +13,7 @@ import json
 from typer.testing import CliRunner
 
 from gda.cli import app
-from gda.runner import RunResult
+from gda.runner import RunResult, engine_data_path, set_user_data_root
 from tests.support import (
     EXPORT_GET_RESULT as GET_RESULT,
     EXPORT_LIST_RESULT as LIST_RESULT,
@@ -22,6 +22,12 @@ from tests.support import (
     recording_runner,
     sentinel,
 )
+
+
+def _host_data_path() -> str | None:
+    """The host data directory gda hands the export-get op (#840), as JSON."""
+    resolved = engine_data_path()
+    return str(resolved) if resolved is not None else None
 
 
 def test_export_list_json_enumerates_presets_and_exit_zero(monkeypatch, tmp_path):
@@ -82,8 +88,11 @@ def test_export_get_json_reports_preset_details_and_template_status(monkeypatch)
     assert data["export_path"] == "build/index.html"
     assert data["templates_installed"] is True
     assert data["templates_version"] == "4.6.3.stable"
-    # The preset name rides through as the typed param.
-    assert fake.calls == [("export-get", {"preset": "Web"})]
+    # The preset name rides through as the typed param, beside the host data
+    # directory gda resolves for the templates comparison (#840).
+    assert fake.calls == [
+        ("export-get", {"preset": "Web", "host_data_path": _host_data_path()})
+    ]
 
 
 def test_export_get_missing_preset_flag_is_a_usage_error(monkeypatch):
@@ -112,3 +121,124 @@ def test_export_get_templates_missing_rides_through_false(monkeypatch):
     data = json.loads(result.stdout)
     assert data["templates_installed"] is False
     assert data["templates_version"] == "4.6.3.stable"
+
+
+def test_export_get_reports_the_templates_directory_it_checked(monkeypatch):
+    # #840: `templates_installed` alone never said WHERE the engine looked, and a
+    # `--user-data-root` redirect MOVES that directory (Godot reads the templates
+    # from the same data directory the redirect relocates). `export get` therefore
+    # reports `templates_root` — the export-templates directory checked, inside
+    # which the `templates_version` directory is looked up — so the hidden case is
+    # readable before an export ever runs.
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["export", "get", "--preset", "Web", "--json"],
+        stdout=sentinel(GET_RESULT),
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["templates_root"] == "/host/data/Godot/export_templates"
+    # Nothing is hidden on an unredirected run, so the host key is null rather
+    # than a repeat of the directory that was checked.
+    assert data["templates_root_host"] is None
+
+
+def test_export_get_reports_the_host_templates_a_redirect_hides(monkeypatch):
+    # The interaction #840 is about, made readable one command earlier than the
+    # export: under a redirect the checked directory has no templates while the
+    # host's standard one does, and `templates_root_host` names the second. The
+    # two directories together are what tells "not installed anywhere" from
+    # "installed, but out of this run's sight".
+    payload = {
+        **GET_RESULT,
+        "templates_installed": False,
+        "templates_root": "/iso/Library/Application Support/Godot/export_templates",
+        "templates_root_host": "/home/dev/Library/Application Support/Godot/export_templates",
+    }
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["export", "get", "--preset", "Web", "--json"],
+        stdout=sentinel(payload),
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["templates_installed"] is False
+    assert data["templates_root"] == (
+        "/iso/Library/Application Support/Godot/export_templates"
+    )
+    assert data["templates_root_host"] == (
+        "/home/dev/Library/Application Support/Godot/export_templates"
+    )
+
+
+def test_export_get_human_render_names_the_checked_and_hidden_directories(monkeypatch):
+    # The human channel says the same thing as the JSON one: which directory was
+    # checked, and — when a redirect hid them — where the templates really are.
+    payload = {
+        **GET_RESULT,
+        "templates_installed": False,
+        "templates_root": "/iso/data/Godot/export_templates",
+        "templates_root_host": "/home/dev/data/Godot/export_templates",
+    }
+    result, _ = invoke_cli(
+        monkeypatch,
+        ["export", "get", "--preset", "Web"],
+        stdout=sentinel(payload),
+    )
+
+    assert result.exit_code == 0
+    assert "/iso/data/Godot/export_templates" in result.stdout
+    assert "/home/dev/data/Godot/export_templates" in result.stdout
+
+
+def test_export_get_hands_the_operation_the_host_data_path(monkeypatch, tmp_path):
+    # MECHANISM (#840). The templates check runs ENGINE-side against
+    # `OS.get_data_dir()`, so a redirected engine cannot see the host's directory,
+    # and the templates layout rule (the `godot`/`Godot` directory name, the
+    # version directory without a `.0` patch) lives only in operations.gd. gda
+    # therefore resolves the HOST data directory over its OWN environment — which
+    # `--user-data-root` never touches, it redirects the CHILD's — and passes it as
+    # an op param, so the layout rule stays where it is and no CLI-side copy of it
+    # appears. The redirect must NOT change what gda passes: that value IS the
+    # thing being compared against.
+    try:
+        result, fake = invoke_cli(
+            monkeypatch,
+            [
+                "--user-data-root",
+                str(tmp_path / "iso"),
+                "export",
+                "get",
+                "--preset",
+                "Web",
+                "--json",
+            ],
+            stdout=sentinel(GET_RESULT),
+        )
+    finally:
+        # The root option is process-wide config (gda.runner), so a CLI invocation
+        # that sets it must not leak into the next test.
+        set_user_data_root(None)
+
+    assert result.exit_code == 0
+    assert fake.calls == [
+        ("export-get", {"preset": "Web", "host_data_path": _host_data_path()})
+    ]
+
+
+def test_the_host_data_path_reaches_the_operation_through_params_json(monkeypatch):
+    # ADR-0015: argv and `--params-json` build the SAME params model, so the host
+    # data path cannot be something an argv command body pastes in — it is a
+    # DEFAULT of the model, and a JSON caller that names only `preset` gets it too.
+    result, fake = invoke_cli(
+        monkeypatch,
+        ["export", "get", "--params-json", '{"preset": "Web"}', "--json"],
+        stdout=sentinel(GET_RESULT),
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert fake.calls == [
+        ("export-get", {"preset": "Web", "host_data_path": _host_data_path()})
+    ]

--- a/tests/export/test_export_commands.py
+++ b/tests/export/test_export_commands.py
@@ -13,7 +13,8 @@ import json
 from typer.testing import CliRunner
 
 from gda.cli import app
-from gda.runner import RunResult, engine_data_path, set_user_data_root
+from gda.commands.export import resolve_host_data_path
+from gda.runner import RunResult, set_user_data_root
 from tests.support import (
     EXPORT_GET_RESULT as GET_RESULT,
     EXPORT_LIST_RESULT as LIST_RESULT,
@@ -24,10 +25,9 @@ from tests.support import (
 )
 
 
-def _host_data_path() -> str | None:
-    """The host data directory gda hands the export-get op (#840), as JSON."""
-    resolved = engine_data_path()
-    return str(resolved) if resolved is not None else None
+# The host data directory gda hands the export-get op (#840): the production
+# resolver, so the assertion follows the host it runs on.
+_host_data_path = resolve_host_data_path
 
 
 def test_export_list_json_enumerates_presets_and_exit_zero(monkeypatch, tmp_path):
@@ -230,11 +230,31 @@ def test_export_get_hands_the_operation_the_host_data_path(monkeypatch, tmp_path
 
 def test_the_host_data_path_reaches_the_operation_through_params_json(monkeypatch):
     # ADR-0015: argv and `--params-json` build the SAME params model, so the host
-    # data path cannot be something an argv command body pastes in — it is a
-    # DEFAULT of the model, and a JSON caller that names only `preset` gets it too.
+    # data path cannot be something an argv command body pastes in — the model's
+    # validator STAMPS it, and a JSON caller that names only `preset` gets it too.
     result, fake = invoke_cli(
         monkeypatch,
         ["export", "get", "--params-json", '{"preset": "Web"}', "--json"],
+        stdout=sentinel(GET_RESULT),
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert fake.calls == [
+        ("export-get", {"preset": "Web", "host_data_path": _host_data_path()})
+    ]
+
+    # And a value pasted in is IGNORED, as the schema description promises: the
+    # property is computed, so a caller (or an MCP client reading the same
+    # schema) cannot point the engine-side check at a directory of its choosing.
+    result, fake = invoke_cli(
+        monkeypatch,
+        [
+            "export",
+            "get",
+            "--params-json",
+            '{"preset": "Web", "host_data_path": "/pasted/by/the/caller"}',
+            "--json",
+        ],
         stdout=sentinel(GET_RESULT),
     )
 

--- a/tests/export/test_export_commands.py
+++ b/tests/export/test_export_commands.py
@@ -9,6 +9,7 @@ real Godot. This slice never runs an actual export (that is issue #121).
 """
 
 import json
+import sys
 
 from typer.testing import CliRunner
 
@@ -26,8 +27,31 @@ from tests.support import (
 
 
 # The host data directory gda hands the export-get op (#840): the production
-# resolver, so the assertion follows the host it runs on.
+# resolver, so the dispatch assertions below follow the host they run on. Those
+# assertions prove the PLUMBING (what gda computed reaches the op unchanged); the
+# VALUE is pinned separately, against an oracle that is not the resolver itself —
+# see test_the_host_data_path_resolver_reads_the_host_environment.
 _host_data_path = resolve_host_data_path
+
+
+def test_the_host_data_path_resolver_reads_the_host_environment(monkeypatch):
+    # The resolver is the whole #840 mechanism: with it returning None the engine
+    # would never learn the host directory and the disclosure would silently
+    # vanish, while every dispatch test above stayed green (they compare gda's
+    # request against this same function). So the value is pinned here against
+    # the engine's own rule (OS::get_data_path per platform) over a monkeypatched
+    # environment, which is gda's OWN environment — never the redirect.
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    monkeypatch.setenv("HOME", "/tmp/gda-host-home")
+    monkeypatch.setenv("APPDATA", "C:\\Users\\host\\AppData\\Roaming")
+    if sys.platform == "darwin":
+        expected = "/tmp/gda-host-home/Library/Application Support"
+    elif sys.platform.startswith("win"):
+        expected = "C:\\Users\\host\\AppData\\Roaming"
+    else:
+        expected = "/tmp/gda-host-home/.local/share"
+
+    assert resolve_host_data_path() == expected
 
 
 def test_export_list_json_enumerates_presets_and_exit_zero(monkeypatch, tmp_path):

--- a/tests/export/test_export_run_commands.py
+++ b/tests/export/test_export_run_commands.py
@@ -681,6 +681,19 @@ def test_export_run_help_documents_output_resolution():
     assert "invoker's current working directory" in normalized
 
 
+def test_export_run_help_states_that_templates_follow_the_redirected_root(monkeypatch):
+    # #840: the root `--user-data-root` help already warns that a release/debug
+    # export under it finds no installed templates; nothing at the export itself
+    # did. `export run --help` — the page an agent reads when it picks the
+    # command — now states the same boundary.
+    result = CliRunner().invoke(app, ["export", "run", "--help"])
+
+    assert result.exit_code == 0
+    normalized = " ".join(plain_text(result.stdout).split())
+    assert "--user-data-root" in normalized
+    assert "export templates" in normalized
+
+
 def test_export_run_human_output_echoes_artifact(monkeypatch, tmp_path):
     # Without --json the command renders a human line naming the artifact.
     minimal_project(tmp_path)

--- a/tests/export/test_export_run_commands.py
+++ b/tests/export/test_export_run_commands.py
@@ -50,6 +50,10 @@ GET_RESULT = {
     "export_path": "build/game.x86_64",
     "templates_installed": True,
     "templates_version": "4.6.3.stable",
+    # #840: where the engine looked, and (null here — no redirect) the host
+    # directory holding templates it could not see.
+    "templates_root": "/host/data/Godot/export_templates",
+    "templates_root_host": None,
 }
 
 

--- a/tests/export/test_export_run_operation.py
+++ b/tests/export/test_export_run_operation.py
@@ -26,6 +26,7 @@ from gda.commands.export import (  # EXPORT_RUN_COMMAND: the single fully-bound 
     EXPORT_RUN_COMMAND,
     ExportRunMode,
     ExportRunResult,
+    host_data_path,
     run_export_operation,
 )
 from gda.errors import Failure
@@ -41,6 +42,10 @@ from tests.support import (
     sentinel,
 )
 
+
+# The host data directory gda hands the export-get op (#840), computed by the
+# production default so the assertion follows the host it runs on.
+_HOST_DATA_PATH = host_data_path()
 
 # The two export-templates directories of #840: the one an isolated
 # ``--user-data-root`` makes the engine check, and the host's standard one.
@@ -123,7 +128,9 @@ def test_success_returns_typed_result_to_configured_path(tmp_path):
     assert outcome.warnings == []
     # Phase sequencing: export-get ran first, then the native export to the
     # configured path keyed on the export-get-resolved name.
-    assert get_runner.calls == [("export-get", {"preset": "Linux/X11"})]
+    assert get_runner.calls == [
+        ("export-get", {"preset": "Linux/X11", "host_data_path": _HOST_DATA_PATH})
+    ]
     assert export_runner.calls == [("Linux/X11", "release", expected)]
 
 
@@ -150,7 +157,9 @@ def test_export_run_reports_native_export_progress_on_stderr(capsys, tmp_path):
         created_dirs=[str(project / "build")],
         warnings=[],
     )
-    assert get_runner.calls == [("export-get", {"preset": "Linux/X11"})]
+    assert get_runner.calls == [
+        ("export-get", {"preset": "Linux/X11", "host_data_path": _HOST_DATA_PATH})
+    ]
     assert export_runner.calls == [("Linux/X11", "release", expected_output)]
 
 

--- a/tests/export/test_export_run_operation.py
+++ b/tests/export/test_export_run_operation.py
@@ -16,6 +16,7 @@ surface, complementary to the command tests in
 ``tests/export/test_export_run_commands.py`` (the zero-behavior-change safety net).
 """
 
+import json
 from pathlib import Path
 
 import pytest
@@ -30,6 +31,7 @@ from gda.commands.export import (  # EXPORT_RUN_COMMAND: the single fully-bound 
 from gda.errors import Failure
 from gda.execution import ExecutionKind
 from gda.harness.install import install_harness, uninstall_harness
+from gda.models import GdaErrorEnvelope
 from gda.runner import RunResult
 from tests.support import (
     ENGINE_BANNER,
@@ -38,6 +40,12 @@ from tests.support import (
     error_sentinel,
     sentinel,
 )
+
+
+# The two export-templates directories of #840: the one an isolated
+# ``--user-data-root`` makes the engine check, and the host's standard one.
+ISO_TEMPLATES_ROOT = "/iso/Library/Application Support/Godot/export_templates"
+HOST_TEMPLATES_ROOT = "/home/dev/Library/Application Support/Godot/export_templates"
 
 
 def test_export_run_command_is_the_native_export_channel():
@@ -57,6 +65,9 @@ GET_RESULT = {
     "export_path": "build/game.x86_64",
     "templates_installed": True,
     "templates_version": "4.6.3.stable",
+    # #840: where the engine looked, and (null here) where a redirect hid them.
+    "templates_root": HOST_TEMPLATES_ROOT,
+    "templates_root_host": None,
 }
 
 
@@ -379,6 +390,105 @@ def test_templates_missing_for_release_and_debug():
         assert "4.6.3.stable" in outcome.error.message, mode
         # The preflight fired before any native run.
         assert export_runner.calls == [], mode
+
+
+def test_templates_hidden_by_a_redirect_name_both_directories_and_the_remedies():
+    # THE #840 CASE. Under `--user-data-root` the engine checks the redirected
+    # directory, which has no templates, while the host's standard directory does
+    # — so the templates are not missing, they are out of sight. The failure has to
+    # say that at the point it happens: it names BOTH directories, states that
+    # `--user-data-root` moved the lookup, and gives the two remedies (drop the
+    # redirect, or `--mode pack`, which needs no templates).
+    get_runner = _get_runner(
+        {
+            **GET_RESULT,
+            "templates_installed": False,
+            "templates_root": ISO_TEMPLATES_ROOT,
+            "templates_root_host": HOST_TEMPLATES_ROOT,
+        }
+    )
+    export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
+
+    outcome = _run(get_runner=get_runner, export_runner=export_runner)
+
+    assert isinstance(outcome, Failure)
+    error = outcome.error
+    assert error.code == "export_templates_missing"
+    assert ISO_TEMPLATES_ROOT in error.message
+    assert HOST_TEMPLATES_ROOT in error.message
+    assert "--user-data-root" in error.message
+    assert "--mode pack" in error.message
+    # Not a near miss: `hint` is contractually one corrected invocation from the
+    # curated table (CONTEXT.md `Near-miss hint`), and this is not one.
+    assert error.hint is None
+    # The same two directories ride the envelope as typed facts, so an agent
+    # branches without parsing the prose (ADR-0004 amendment, #687).
+    assert error.evidence is not None
+    assert error.evidence.templates_root_checked == ISO_TEMPLATES_ROOT
+    assert error.evidence.templates_root_host == HOST_TEMPLATES_ROOT
+    # Still a preflight: nothing was exported.
+    assert export_runner.calls == []
+
+
+def test_templates_genuinely_absent_name_only_the_directory_checked():
+    # The other shape, and the one an agent must be able to tell from the first:
+    # with no redirect in play the host directory IS the directory checked, so
+    # there is no second one to name and no redirect remedy to offer. The two
+    # shapes are distinguished by the PRESENCE of `templates_root_host`, which is
+    # omitted here rather than emitted as null.
+    get_runner = _get_runner(
+        {
+            **GET_RESULT,
+            "templates_installed": False,
+            "templates_root": HOST_TEMPLATES_ROOT,
+            "templates_root_host": None,
+        }
+    )
+    export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
+
+    outcome = _run(get_runner=get_runner, export_runner=export_runner)
+
+    assert isinstance(outcome, Failure)
+    error = outcome.error
+    assert error.code == "export_templates_missing"
+    assert HOST_TEMPLATES_ROOT in error.message
+    assert "--user-data-root" not in error.message
+    assert error.evidence is not None
+    assert error.evidence.templates_root_checked == HOST_TEMPLATES_ROOT
+    assert error.evidence.templates_root_host is None
+    emitted = json.loads(
+        GdaErrorEnvelope(error=error).model_dump_json(exclude_none=True)
+    )
+    assert emitted["error"]["evidence"] == {
+        "templates_root_checked": HOST_TEMPLATES_ROOT
+    }
+
+
+def test_no_evidence_at_all_when_no_directory_was_reported():
+    # The omitted-never-null rule applied to this producer: an engine reply that
+    # names no directory (an older payload, a projectless oddity) leaves the
+    # builder with nothing to type, and it emits NO `evidence` key rather than the
+    # empty object `{}` — which would be a key that says nothing on a failure whose
+    # envelope should look exactly as it did before #840.
+    get_runner = _get_runner(
+        {
+            **GET_RESULT,
+            "templates_installed": False,
+            "templates_root": "",
+            "templates_root_host": None,
+        }
+    )
+    export_runner = FakeExportRunner(RunResult(stdout="", stderr="", exit_code=0))
+
+    outcome = _run(get_runner=get_runner, export_runner=export_runner)
+
+    assert isinstance(outcome, Failure)
+    assert outcome.error.code == "export_templates_missing"
+    assert outcome.error.evidence is None
+    emitted = json.loads(
+        GdaErrorEnvelope(error=outcome.error).model_dump_json(exclude_none=True)
+    )
+    assert "evidence" not in emitted["error"]
 
 
 def test_pack_is_exempt_from_templates_preflight(tmp_path):

--- a/tests/export/test_export_run_operation.py
+++ b/tests/export/test_export_run_operation.py
@@ -26,7 +26,7 @@ from gda.commands.export import (  # EXPORT_RUN_COMMAND: the single fully-bound 
     EXPORT_RUN_COMMAND,
     ExportRunMode,
     ExportRunResult,
-    host_data_path,
+    resolve_host_data_path,
     run_export_operation,
 )
 from gda.errors import Failure
@@ -45,7 +45,7 @@ from tests.support import (
 
 # The host data directory gda hands the export-get op (#840), computed by the
 # production default so the assertion follows the host it runs on.
-_HOST_DATA_PATH = host_data_path()
+_HOST_DATA_PATH = resolve_host_data_path()
 
 # The two export-templates directories of #840: the one an isolated
 # ``--user-data-root`` makes the engine check, and the host's standard one.

--- a/tests/export/test_export_run_operation.py
+++ b/tests/export/test_export_run_operation.py
@@ -44,7 +44,8 @@ from tests.support import (
 
 
 # The host data directory gda hands the export-get op (#840), computed by the
-# production default so the assertion follows the host it runs on.
+# production resolver (the model's validator stamps it) so the assertion follows
+# the host it runs on.
 _HOST_DATA_PATH = resolve_host_data_path()
 
 # The two export-templates directories of #840: the one an isolated

--- a/tests/export/test_export_run_operation.py
+++ b/tests/export/test_export_run_operation.py
@@ -427,6 +427,11 @@ def test_templates_hidden_by_a_redirect_name_both_directories_and_the_remedies()
     assert ISO_TEMPLATES_ROOT in error.message
     assert HOST_TEMPLATES_ROOT in error.message
     assert "--user-data-root" in error.message
+    # Both spellings of the redirect are named, and the remedy names the redirect
+    # rather than one spelling — the exported-variable case is the common trigger
+    # (PITFALLS.md), where the caller never typed the flag.
+    assert "$GDA_USER_DATA_ROOT" in error.message
+    assert "without the user-data redirect" in error.message
     assert "--mode pack" in error.message
     # Not a near miss: `hint` is contractually one corrected invocation from the
     # curated table (CONTEXT.md `Near-miss hint`), and this is not one.

--- a/tests/meta/test_schema_aggregate.py
+++ b/tests/meta/test_schema_aggregate.py
@@ -362,7 +362,14 @@ _IGNORED_VALUE_MARKER = "a value passed in is ignored"
 
 # …and the properties it excuses today. Pinned so the phrase cannot become a
 # quiet escape hatch: a new computed property has to be acknowledged here.
-_COMPUTED_PROPERTIES = {"script set: mode", "shader set: mode"}
+_COMPUTED_PROPERTIES = {
+    "script set: mode",
+    "shader set: mode",
+    # #840: the host data directory the export-templates check compares against.
+    # gda resolves it from its own environment — the one thing a caller inside a
+    # redirected run cannot know — so it is stamped model-side like the two modes.
+    "export get: host_data_path",
+}
 
 
 def test_every_directly_supplyable_input_property_has_an_argv_binding():

--- a/tests/meta/test_schema_command.py
+++ b/tests/meta/test_schema_command.py
@@ -86,6 +86,11 @@ def test_the_published_error_schema_declares_the_optional_evidence_key():
         "target_location",
         "project_root",
         "owning_project",
+        # The two export-templates directories a --user-data-root redirect puts at
+        # odds (#840): the one this run checked, and the host one holding the
+        # templates it could not see.
+        "templates_root_checked",
+        "templates_root_host",
     }
     assert doc["error"]["$defs"]["TerminationPhase"]["enum"] == [
         "launched",

--- a/tests/support.py
+++ b/tests/support.py
@@ -923,6 +923,11 @@ EXPORT_GET_RESULT = {
     "export_path": "build/index.html",
     "templates_installed": True,
     "templates_version": "4.6.3.stable",
+    # #840: the directory the engine actually checked, plus the host directory
+    # holding templates a `--user-data-root` redirect hid (null when none is
+    # hidden — the common, unredirected case this payload stands for).
+    "templates_root": "/host/data/Godot/export_templates",
+    "templates_root_host": None,
 }
 
 # Canned ``gda project <command> --json`` analysis result payloads (issue #178).


### PR DESCRIPTION
## Summary

Godot reads the export templates from the data directory `--user-data-root`
relocates, so a `release`/`debug` `export run` under an isolated root failed with
`export_templates_missing` on a host whose templates were correctly installed —
and named no directory at all, so the remedy read as "install the templates" when
they were already there (GDA-DF-073, PIPE-DF-164).

The check stays engine-side, where the templates layout rule (the `godot`/`Godot`
directory name, the version directory without a `.0` patch) already lives.
`operations.gd` now composes the export-templates root from a data directory given
as an ARGUMENT, so `export-get` can check two of them: the run's own
`OS.get_data_dir()`, and the host's, which gda stamps on the params model from its
own — never redirected — environment. It reports `templates_root` always, and
`templates_root_host` only when the redirect really did hide installed templates.

The preflight hands both to `export_templates_missing_failure`: the message names
both directories and the two remedies, and `evidence` carries
`templates_root_checked` / `templates_root_host`, so the two shapes are told apart
without parsing prose. No `hint` — this is not a near miss.

Live, on this host:

```
$ gda --user-data-root /tmp/…/iso840 export run --preset "Linux/X11" --json   # exit 4
{"error":{"category":"operation","code":"export_templates_missing",
 "message":"export preset \"Linux/X11\" cannot be exported: the export templates for the
  running engine version (4.6.3.stable) are not installed in /tmp/…/iso840/Library/
  Application Support/Godot/export_templates, where --user-data-root (or $GDA_USER_DATA_ROOT) moved the lookup;
  they are installed in the host's /Users/…/Library/Application Support/Godot/
  export_templates. Run the export without the user-data redirect, or use --mode pack, which
  needs no export templates","diagnostics":"",
 "evidence":{"templates_root_checked":"/tmp/…/iso840/Library/Application Support/Godot/
  export_templates","templates_root_host":"/Users/…/Library/Application Support/Godot/
  export_templates"}}}
```

Closes #840

## Surface diff

`gda schema`: 1,058,760 → 1,105,818 bytes (+47,058, +4.4%). Byte-diffed against the
BASE generated in a separate checkout at `cfcb8658e`; every leaf enumerated, nothing
removed:

| Where | Change |
| --- | --- |
| `FailureEvidence` (×76, the one shared `error` schema per command) | `+ templates_root_checked`, `+ templates_root_host` — both optional, defaulted null, ADR-0004's documented per-command payload cost |
| `export get` `input` | `+ host_data_path` (optional string; COMPUTED — a value passed in is ignored, registered in `_COMPUTED_PROPERTIES` beside `script set`/`shader set`'s `mode`, so the "every supplyable property has an argv binding" invariant still holds) |
| `export get` `output` | `+ templates_root` (required string), `+ templates_root_host` (required key, nullable value — the `engine_data_path` shape) |
| `export get` / `export run` `description`, `export get` `input`/`output` `description` | the docstring sentences below |
| `gda export run --help` | + 5 lines: template discovery follows `--user-data-root`; the failure names both directories and the remedies; `--mode pack` needs none |
| `gda export get --help` | + 5 lines: what `templates_root` is, and when `templates_root_host` is set |
| `docs/command-catalog.md` | + one paragraph under `### export`: the two result keys, the two message remedies, the two evidence keys and which one discriminates |
| `src/gda/skill/SKILL.md` | the `--user-data-root` "two limits" bullet now names the evidence keys and how to read them; the `export` row notes `get`'s two new keys |
| `docs/adr/0004-…` | dated addendum to "Who carries it today" (appended; the paragraph's "Seven builders" stays as the record of what #687 decided) |
| `README.md` | **untouched** — it documents neither export templates nor `--user-data-root`'s limits today, so no behavioral boundary it carries changed. No `docs/README.*.md` restamp needed. |

`export get --schema`'s `argv` is byte-identical (the new input property is computed,
so it binds to no flag).

## Red-proof evidence

Tests first, with ONLY test files modified, at `origin/feat/gda-dogfooding-dev`
(`cfcb8658e`) — commit `83278df66`:

```
FAILED tests/export/test_export_commands.py::test_export_get_json_reports_preset_details_and_template_status
FAILED tests/export/test_export_commands.py::test_export_get_reports_the_templates_directory_it_checked
FAILED tests/export/test_export_commands.py::test_export_get_reports_the_host_templates_a_redirect_hides
FAILED tests/export/test_export_commands.py::test_export_get_human_render_names_the_checked_and_hidden_directories
FAILED tests/export/test_export_commands.py::test_export_get_hands_the_operation_the_host_data_path
FAILED tests/export/test_export_commands.py::test_the_host_data_path_reaches_the_operation_through_params_json
FAILED tests/export/test_export_run_commands.py::test_export_run_help_states_that_templates_follow_the_redirected_root
FAILED tests/export/test_export_run_operation.py::test_templates_hidden_by_a_redirect_name_both_directories_and_the_remedies
FAILED tests/export/test_export_run_operation.py::test_templates_genuinely_absent_name_only_the_directory_checked
FAILED tests/cli/test_error_registry.py::test_only_the_recorded_producers_put_evidence_on_the_envelope
10 failed, 79 passed, 18 deselected in 1.82s
```

Two representative failure lines:

```
assert '/home/dev/Library/Application Support/Godot/export_templates' in
  'export preset "Linux/X11" cannot be exported: the export templates for the running
   engine version (4.6.3.stable) are not installed'

AssertionError: assert {'launch_time...failure', ...} == {'export_temp...failure', ...}
  Extra items in the right set: 'export_templates_missing_failure'
```

`test_no_evidence_at_all_when_no_directory_was_reported` passed at the base by
construction (no producer emitted evidence there); it is a guard on the
omitted-never-null rule, not a red-proof test.

## Validation

Host: macOS (Darwin 25.6.0), Godot 4.6.3 at `$GDA_GODOT`, export templates
installed in the real data directory. All from the worktree with the repository
runtime (`uv run --frozen …`).

| Gate | Command | Result |
| --- | --- | --- |
| Unit suite | `pytest tests -m "not e2e" -q -p no:cacheprovider` | `2513 passed, 668 deselected in 46.13s` (base 2501 → +12) |
| Lint | `ruff check .` | `All checks passed!` |
| Format | `ruff format --check .` | `509 files already formatted` |
| Types | `pyright` (src+tests) | `0 errors, 0 warnings, 0 informations` |
| Schema/help byte-diff | `gda schema`, `export run --help`, `export get --help`, `export get --schema` vs the base checkout | only the diffs enumerated above; 0 leaves removed |
| Export e2e (real engine, serialized) | `pytest tests/export -m e2e -rs -q` | `17 passed, 1 skipped in 23.46s` (the skip is the pre-existing Linux-only `XDG_DATA_HOME` test) |
| Adjacent e2e | `pytest tests/harness tests/meta -m e2e -q` | `8 passed` |
| Adjacent e2e (user-data placement) | `pytest tests/runtime -m e2e -q` | `33 passed in 92.26s` |
| Live manual | `gda --user-data-root … export run/get` on a scratch project, both channels | the JSON envelope above; the human channel renders `evidence:` with both paths |

Every Godot-spawning run went through the machine-wide serial lock. The redirect
was passed PER INVOCATION, never exported for a run (PITFALLS.md: exporting
`GDA_USER_DATA_ROOT` hides the host's templates from unrelated tests — notably
`test_templates_installed_is_true_when_host_templates_are_on_disk`, which passed).

## Requirement conformance

| Acceptance criterion | Proof |
| --- | --- |
| Templates on the host + an isolated root with none → `export_templates_missing` naming both directories and both remedies, `evidence` carrying `templates_root_checked` and `templates_root_host` | e2e `test_export_run_under_a_redirect_names_both_template_directories`; unit `test_templates_hidden_by_a_redirect_name_both_directories_and_the_remedies`; the live run quoted above |
| The same failure with no redirect names ONE directory and no host one; the shapes differ by the presence of `templates_root_host` | unit `test_templates_genuinely_absent_name_only_the_directory_checked` — asserts `--user-data-root` is absent from the message and that the emitted evidence object is exactly `{"templates_root_checked": …}` |
| `export get --json` reports `templates_root` | e2e `test_export_get_reports_preset_details_and_template_status` (shape, real engine) and `test_export_get_names_the_host_templates_a_user_data_redirect_hides` (redirected, real engine); unit `test_export_get_reports_the_templates_directory_it_checked` |
| `export run --help` states the effect on template discovery | `test_export_run_help_states_that_templates_follow_the_redirected_root`, plus the help byte-diff above |
| Unit coverage for the hidden-by-redirect branch; the existing missing-templates e2e keeps passing; the layout rule is not duplicated CLI-side | the two operation tests + four `export get` tests; `tests/export -m e2e` is green including the two pre-existing missing-templates paths; the only place `<godot-dir>/export_templates` is composed is `operations.gd::_export_templates_root`, now taking the data dir as an argument — gda passes a data DIRECTORY, never a templates path |
| No `hint` on this failure | asserted in both the unit test (`error.hint is None`) and the e2e (`"hint" not in err`) |

## Disclosed extras and boundary crossings

- **Eighth `Failure evidence` producer.** `export_templates_missing_failure` joins
  the axis, so ADR-0004's "Who carries it today" gets a dated addendum (appended,
  not rewritten — the "Seven builders" count stays as the record of what #687
  decided) and `_EVIDENCE_PRODUCERS` in `tests/cli/test_error_registry.py` gains
  the name. It is the second producer that reports on no run: it is the pre-export
  preflight's verdict. The omitted-never-null rule holds at the producer — a reply
  naming no directory yields no `evidence` key rather than `{}` (pinned by
  `test_no_evidence_at_all_when_no_directory_was_reported`). It is NOT added to
  `test_no_producer_can_emit_an_empty_evidence_object`, which indexes
  `["evidence"]` unconditionally and is scoped to the original five; the dedicated
  test above covers the same rule for this builder.
- **`FailureEvidence` publishes two more fields, so the human failure renderer
  grew two branches** (`gda/render.py`) — the hand-written renderer is kept
  exhaustive by `test_the_sample_table_covers_every_field_the_model_publishes`,
  which reds when the model grows a field.
- **`export get` gains a COMPUTED input property**, not just result fields. The
  issue prescribes passing the host data path "into the op as a param"; making it
  a model field with a `model_validator` (rather than something the argv body
  pastes in) is what keeps ADR-0015's rule that argv and `--params-json` build the
  same model — `--params-json '{"preset": "X"}'` reaches the operation with the
  identical params, asserted by
  `test_the_host_data_path_reaches_the_operation_through_params_json`. A value
  passed in is ignored, which is the existing declared exemption
  (`script set`/`shader set`'s `mode`) rather than a new one.
- **`export get --help` also gained a sentence**, beyond the `export run --help`
  the issue asks for. `export get` is the command that gained `templates_root`, so
  leaving its own help silent about it would have put the disclosure only in the
  catalog.
- **Considered and declined: rewording the `export_templates_missing` registry
  `Meaning`.** Both shapes are the same code with the same cause from the run's
  point of view (the templates are not in the directory it reads), so the
  `error_codes.py` row and the ADR-0002 table are left byte-identical and the
  registry-consistency test needs no change.
- **Out of scope, as the issue decided:** mirroring the host's
  `export_templates/<version>` into the isolated root.

## Guards on PR CI vs the Godot e2e tier

PR CI runs NO Godot e2e, so on a PR run these guards fire:

- every unit test above — the two failure shapes, the evidence contents and the
  emitted-envelope shape, the four `export get` result/param tests, both help
  assertions, the schema-surface invariants
  (`test_every_directly_supplyable_input_property_has_an_argv_binding`,
  `test_the_published_error_schema_declares_the_optional_evidence_key`,
  `test_every_evidence_field_is_optional_in_the_published_schema`), the
  human-render tables, and the AST-read producer set.

Only in the Godot e2e tier (nightly / dispatch):

- `test_export_run_under_a_redirect_names_both_template_directories` and
  `test_export_get_names_the_host_templates_a_user_data_redirect_hides` — both
  SKIP on a runner with no export templates installed, since there is then nothing
  for the redirect to hide. The CI runner does install templates (#301), so both
  RUN there.
- `test_export_get_reports_preset_details_and_template_status`'s new
  `templates_root` shape assertions — no skip, they run wherever the tier runs.
- The pre-existing `test_export_run_without_templates_yields_export_templates_missing`
  stays Linux-only (it forces missing templates through `XDG_DATA_HOME`, which
  only the Linux/BSD engine honours) and still asserts the PLAIN shape there:
  `extra_env` reaches gda's own process too, so gda's host data path resolves to
  the same empty directory and `templates_root_host` is null — no new skip, and
  its assertions are unchanged.

## Review round 1 (`8cf2c7b9c`)

Independent adversarial review at `db6564ced` (four axes + 10 mutants, byte-diff regenerated from
a clean base tree, both remedies exercised on a real engine) returned CHANGES REQUIRED — 0 P1 /
1 P2 / 5 P3, all adopted:

1. **P2** — the message and remedy named `--user-data-root` alone; `$GDA_USER_DATA_ROOT` is the
   same switch and the exported-variable case is the common trigger (PITFALLS), where the caller
   never typed the flag. The message now says `--user-data-root (or $GDA_USER_DATA_ROOT) moved
   the lookup` and the remedy `Run the export without the user-data redirect`; the quoted
   samples above are updated; every existing `"--user-data-root" in message` assertion holds.
2. **P3** — the builder's two speculative defaults dropped (its one caller passes both;
   `ExportGetResult.templates_root` is a required `str`).
3. **P3** — surviving mutant: nothing pinned that a pasted `host_data_path` is ignored. The
   params-json parity test now also passes `"host_data_path": "/pasted/by/the/caller"` and
   asserts the op still receives the resolved host path (reachable via `--params-json` and MCP).
4. **P3** — stale "computed by the production default" comment; the tests now import the one
   resolver instead of re-deriving it; the adjacent pre-existing "grows a sixth field" comment
   corrected.

On `8cf2c7b9c`: `tests/export` + `tests/cli` 480 passed, ruff/format/pyright clean, export e2e
17 passed + the pre-existing Linux-only skip (Godot 4.6.3, macOS, load 3.5). Reviewer-verified
and unchanged by the fix: 774 leaves added / 0 removed / 4 changed; layout rule engine-side only;
host path resolved over the unredirected environment even with `GDA_USER_DATA_ROOT` set; plain
shape omits `templates_root_host` on both renderings; ADR-0002 table + `error_codes.py`
byte-identical; the Linux-only e2e still asserts the plain shape by construction.

## Review round 2 (`9f15cbb19`)

The second independent review at `8cf2c7b9c` re-drove all five ACs and both remedies on a real
engine under both spellings of the redirect and both renderings, regenerated the schema/help
byte-diff (774 / 0 / 4, `argv` byte-identical), and returned 0 P1 / 1 P2 / 6 P3, all adopted by
the orchestrator:

1. **P2** — the round-1 test change aliased the helper to `resolve_host_data_path`, so the three
   dispatch assertions compared gda's request against the function that produced it: a resolver
   returning `None` (the whole #840 mechanism disabled) passed the unit tier. The resolver now
   has its own oracle, `test_the_host_data_path_resolver_reads_the_host_environment`, pinning
   the engine's per-platform rule over a monkeypatched environment; the dispatch tests keep
   proving the plumbing.
2. **P3** — the round-1 message change had no assertion of its own (dropping
   `(or $GDA_USER_DATA_ROOT)` or reverting the remedy survived); both halves are asserted in the
   unit and the live test.
3. **P3** — clause three of the engine-side check (redirect in play, roots differ, host has no
   templates either → plain shape, no host root) had no test at any tier; a live case points
   gda's own environment at an empty home under an isolated root and asserts
   `templates_root_host` is null.
4. **P3** — `export get`'s human line said `hidden by --user-data-root`; it now names the
   redirect with both spellings.
5. **P3** — the registry test's comment names why producers six to eight pin the empty-evidence
   rule in dedicated tests; the ADR-0004 addendum says where the two directories come from (the
   `export get` op's reply) instead of "reports on no run"; CONTEXT.md's `User-data placement`
   entry states that export-template discovery follows the placement (#840).

On this head: export/cli/meta/repo unit 823 passed, ruff/format/pyright clean, export e2e 18 passed
+ the pre-existing Linux-only skip (macOS, Godot 4.6.3, lock-serialized). Commit authorship on the
branch was rewritten to the repository owner's identity (`9e2deb49d` → `9f15cbb19`, trees identical).

## Review round 3 (`ee5de4027`)

The third review at `9f15cbb19` returned CHANGES REQUIRED — 1 P2, adopted:

1. **P2** — `_hidden_host_templates_root` compared the two roots and looked at the host's contents
   but never at the root it reported on, so a redirected root that already held this version read
   as `templates_installed: true` AND `templates_root_host: <host>`, and the human line said
   "installed" and "hidden by" together (reviewer-reproduced on Godot 4.6.3; the renderer treats
   any non-null host root as proof of hiding, which is the field's contract). The op now hands the
   already-computed `templates_installed` to the check, which answers null when nothing is hidden:
   the published predicate is host evidence iff the checked root lacks the version and the host
   has it. New real-engine case
   `test_export_get_under_a_redirect_whose_root_holds_the_templates_names_no_host_root` populates
   both roots and pins installed true / host null / no "hidden by" line; it fails on the previous
   head.

On `ee5de4027`: export unit + e2e 88 passed + the pre-existing Linux-only skip (macOS, Godot 4.6.3,
lock-serialized), ruff/format and `git diff --check` clean.
