### PR TITLE
refactor(balancing): derive current namespace dependency closure

### DIFF
--- a/libs/gda-balancing/docs/agents/testing.md
+++ b/libs/gda-balancing/docs/agents/testing.md
@@ -21,7 +21,7 @@ uv run --frozen pytest tests -q
 ```
 
 `tools/ci.py` remains the existing authority for CI scope classification,
-static shard membership, and inventory closure. Reproduce one shard with:
+deterministic shard membership, and inventory closure. Reproduce one shard with:
 
 ```bash
 uv run --no-project --python 3.13 python \
@@ -71,7 +71,7 @@ rejects `xfail(strict=False)` before execution.
 
 CI also runs the existing outcome check on each JUnit file; undeclared skips
 and xfails fail the job. Balancing-affecting or unknown paths run inventory,
-all six required shards, the separate smoke shard, and the stable
+all seven required shards, the separate smoke shard, and the stable
 `gda-balancing required` result. Each test process retains the existing
 eight-minute bound and fifteen-minute job timeout. Scheduled validation uses
 this complete inventory-closed matrix; it does not run the whole suite in one
@@ -94,10 +94,12 @@ Two repeated setup costs were removed without weakening the tested contracts:
 
 No test, parameter case, assertion, or packaged vector was removed.
 
-## Static CI shards
+## CI shards
 
-The complete suite is partitioned by file. The `smoke` shard remains a separate
-real-subprocess and end-to-end job. The other six shards feed the stable
+The complete suite is partitioned by file except for Experiment CLI, whose test
+definitions are divided deterministically between two shards. Parameter cases
+from one definition stay together. The `smoke` shard remains a separate
+real-subprocess and end-to-end job. The other seven shards feed the stable
 `gda-balancing required` check.
 
 | Shard | Main ownership |
@@ -106,24 +108,31 @@ real-subprocess and end-to-end job. The other six shards feed the stable
 | `authority` | authority CLI |
 | `language` | language bootstrap and formula CLI |
 | `model` | model CLI and independent lowerer |
-| `experiment` | experiment CLI |
+| `experiment` | alternating Experiment CLI test definitions, first group |
+| `experiment-continuation` | alternating Experiment CLI test definitions, second group |
 | `composition` | CLI conformance, composition bootstrap, and templates |
 | `smoke` | end-to-end CLI paths |
 
-Shard membership is deliberately static and reviewable; the existing partition
-test proves that files neither overlap nor fall outside the matrix. The `model`
-and `experiment` files are measured indivisible hotspots. Giving each a matrix
-entry keeps the largest local required shard near 114 seconds instead of
-combining files into partitions near 172 and 197 seconds. The workflow already
-derives its matrix from `REQUIRED_TEST_SHARDS`, so the split costs two additional
-standard matrix executions but adds no custom runner or new aggregator, timer,
-inventory, or artifact protocol. Moving the two independently selectable
-bootstrap files to `fast` separates them from the authority CLI hotspot.
+`tools/ci.py` derives Experiment selectors from sorted top-level test definitions
+in the existing file; there is no separately maintained test list. CI-policy tests
+compare collected IDs from both groups against the complete file, requiring an
+exact union, no overlap, and no split parameterized definition. The existing
+inventory check verifies membership across the complete matrix. The workflow
+derives its matrix from `REQUIRED_TEST_SHARDS`; the additional Experiment group
+adds one standard matrix execution without changing the runner, aggregator,
+process bound, job timeout, or test assertions.
 
-## Local evidence
+In [#896](https://github.com/aigengame/godot-agent/pull/896), the original
+191-case Experiment shard reached its 480-second process bound in two remote
+attempts. A complete local run passed in 272.30 seconds; the two derived groups
+passed all 96 and 95 cases in 139.25 and 142.20 seconds respectively. These are
+single-run diagnostic measurements, not a repeated performance comparison.
 
-The accepted clean base is commit `2b81e2e`. Each measurement used an already
-installed frozen environment and a fresh pytest process. Pytest cumulative
+## Historical local evidence (#597)
+
+The following measurements describe the earlier six-shard partition, before the
+Experiment definition split. The accepted clean base was commit `2b81e2e`.
+Each measurement used an already installed frozen environment and a fresh pytest process. Pytest cumulative
 time comes from JUnit; wall time comes from `/usr/bin/time -p`.
 
 | Measurement | Clean base median | Optimized median | Change |
@@ -135,11 +144,11 @@ time comes from JUnit; wall time comes from `/usr/bin/time -p`.
 All three optimized runs collected 1,409 tests and finished with 1,382 passed
 and 27 skipped. Their wall times were 636.840 s, 643.920 s, and 632.840 s.
 
-The remaining largest file medians are experiment CLI (about 114 s), end-to-end
+The remaining largest file medians were experiment CLI (about 114 s), end-to-end
 CLI (about 97 s), authority CLI (about 93 s), and language bootstrap (about 79 s).
 These values explain the shard split; they are not new test policy.
 
-## CI acceptance
+## Historical CI acceptance (#597)
 
 Before #597, three required-CI runs at the clean base took 483 s, 496 s, and
 483 s from the scope job start to the stable required check, for a 483 s
@@ -152,7 +161,7 @@ median. Three successful six-shard runs produced these results:
 | [Attempt 4](https://github.com/aigengame/godot-agent/actions/runs/30927209932/attempts/4) | 229 s |
 
 The median was 268 s, a 44.5% improvement, with a 277 s maximum. These runs
-establish the accepted six-shard partition. Review-fix heads require ordinary
+established the earlier six-shard partition. Review-fix heads require ordinary
 CI before merge, but unchanged shard membership does not require another
 three-run performance sample. #597 uses this fixed comparison; the rolling
 20-run p95 protocol introduced with #587 is not a standing gate for this

--- a/libs/gda-balancing/docs/refactor/current-language/NAMESPACE-EXPAND.md
+++ b/libs/gda-balancing/docs/refactor/current-language/NAMESPACE-EXPAND.md
@@ -1,0 +1,72 @@
+# Current namespace resolution: expand and handoff
+
+Issue: [#870](https://github.com/aigengame/godot-agent/issues/870), stage S3-expand.
+Common base: `ef0eba2d89c2487979ea7fa785172b3129958c38`, after #869 integration.
+The issue branch is `codex/gda-balancing-870-current-namespace-resolution`; its target is
+`codex/gda-balancing-refactor-delete-dev`. The [implementation workflow](IMPLEMENTATION.md)
+governs review and integration. The issue PR records the validated and integrated commits;
+this document does not assert completion or contain a self-referential integration SHA.
+
+The sequence is #870 expand → [#871 migrate](https://github.com/aigengame/godot-agent/issues/871)
+→ [#872 contract](https://github.com/aigengame/godot-agent/issues/872). Expand is an
+integration-only witness pending production consumer migration. Existing public wire contracts
+and machine admission remain unchanged at this stage. Neither intermediate issue merges
+independently into `main`; #872 owns mandatory deletion and the final coherent public contract.
+
+## One authored graph
+
+The existing attached, admitted package graph remains the sole authored authority.
+`AdmittedAuthorityContext.current_namespace_packages()` temporarily projects its exact current
+manifests into `CurrentPackage` values. `NamespaceSelection` and `resolve_current_namespaces`
+in [graph.py](../../../src/gda_balancing/domain/authority/graph.py) provide namespace selection
+from that derived view. There is no separately editable graph, package registry or release solver.
+
+Ownership is `(namespace, authority path, definition key)`. It is derived from each attached
+package's owned definitions and the admitted ownership contract, never reconstructed from the
+flattened `language` collections. Equal-shaped definitions in different namespaces retain
+distinct nominal identities; duplicate namespace ownership is refused before building a lookup.
+
+Selection follows required dependencies transitively and binds capabilities only within that
+selected closure. Missing dependencies, required cycles, duplicate dependency declarations, and
+missing or multiple selected providers must not disappear through deduplication or global provider
+lookup. Optional references remain validated but are not automatically selected. Namespace and
+dependency enumeration is deterministic; authored Operation body order remains semantic.
+Existing graph admission, content verification and resource bounds remain in force.
+
+## Temporary surfaces and deletion owners
+
+| Surface | #871 handoff | Mandatory #872 endpoint |
+| --- | --- | --- |
+| `AdmittedAuthorityContext.current_namespace_packages()` and `graph.py::project_current_namespace_packages()` bridge from exact manifests | Feed migrating consumers from the one current graph | Remove the transition projection; derive namespace selection directly from the contracted authored graph |
+| Separate dependency traversals in `model/_resolution.py::_resolution_relations` and `model/_lowering.py::_package_lock` | Replace both with the common namespace selection result | Delete the old coordinate traversal and conflicting-release branches |
+| Exact package catalog selection and coordinate schema projections in `authority/package_catalog.py` and `authority/package_projection.py` | Migrate catalog consumers and their public contracts together | Remove historical selectors and obsolete coordinate fields and validators |
+| Version-bearing requirements, imports, dependency references, nominal/Operation references and generated Lock projections | Migrate their current producers and consumers as one traced set | Delete obsolete package-version fields, bridges and fallback forms from code, contracts, sources and tests |
+
+These are transition obligations, not a permanent compatibility policy. Any additional bridge
+introduced during #871 must be added to its handoff inventory and deleted by #872. Namespace
+ownership, nominal distinction and dependency/capability closure survive contraction. Unrelated
+Schema, Template or extension metadata must be assessed by its own meaning rather than a blanket
+deletion of every member named `version`.
+
+## Validation and handoff receipt
+
+Before #870 closes, its PR must identify the common base, reviewed expand commit, integration
+commit consumed by #871, validation commands and results, and any unresolved scope. The namespace
+witness must cover ordering, transitive closure, missing/cyclic/duplicate ownership, selected
+capability failures and nominal distinction. Existing public Model, Experiment, CLI/HTTP and
+packaged-resource checks must remain green. A test of the derived view alone does not establish
+production consumer migration or satisfy the parent version-deletion acceptance criteria.
+
+#871 receives this temporary-surface inventory and the exact integrated expand commit. #872 must
+prove that every transition form is removed and that current public paths use the contracted
+graph. Execution dependency closure #874 and mandatory broad-binding deletion #875 retain their
+separate acceptance criteria; namespace expansion cannot close either obligation.
+
+## Rollback
+
+Revert the coherent #870 issue change on the development branch, including its derived view,
+projection, witness tests and documentation. The common base above preserves the completed #869
+capability union and its existing public contract. If #871 or #872 already depends on this change,
+restore those dependent slices together to a coherent reviewed boundary. Do not combine mismatched
+graph, source, contract or evidence revisions, or add a historical fallback to conceal the mismatch.
+A rollback reopens the affected slice while preserving the accepted deletion endpoint.

--- a/libs/gda-balancing/docs/refactor/current-language/README.md
+++ b/libs/gda-balancing/docs/refactor/current-language/README.md
@@ -17,5 +17,6 @@ Start with the [accepted decision](../../badr/0028-current-language-refactor-and
 | [Implementation workflow](IMPLEMENTATION.md) | Authorized development branch, per-issue review, integration and delegated decisions |
 | [Schema 1 retirement](RETIREMENT.md) | Bounded named-source disposition, removed input path, retained coverage and rollback for #868 |
 | [Current capability union](CAPABILITY-UNION.md) | Retained package behavior, deleted release/vector copies, composed public path and rollback for #869 |
+| [Namespace expansion](NAMESPACE-EXPAND.md) | Integration boundary, derived namespace view, mandatory transition deletion and handoff for #870–#872 |
 
 GitHub owns live acceptance and task status; bADR-0028 owns the adopted policy; the plan owns delivery sequencing. Matrices preserve exact captured requirement text as provenance. Current issue amendments supersede the identified historical clauses. Evidence is confirmed only within its stated bounds, and no disposable probe establishes full production conformance, genre completion or automatic formal-release/claim activation.

--- a/libs/gda-balancing/src/gda_balancing/domain/authority/context.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/authority/context.py
@@ -18,9 +18,11 @@ from typing import Any, Never, cast
 
 from gda_balancing.infrastructure.package_resources import read_package_resource
 from gda_balancing.domain.authority.graph import (
+    CurrentPackage,
     LanguageBundleGraph,
     LanguageBundleIndex,
     derive_language_index,
+    project_current_namespace_packages,
 )
 from gda_balancing.domain.authority.admission import (
     BootstrapAdmission,
@@ -329,6 +331,17 @@ class AdmittedAuthorityContext:
         if not isinstance(language_bundle, LanguageBundleIndex):
             raise TypeError("admitted authority context has no sealed LDB graph")
         return deepcopy(self.kernel), language_bundle
+
+    def current_namespace_packages(self) -> tuple[CurrentPackage, ...]:
+        """Derive the #870 integration view from this admitted immutable graph.
+
+        Existing public consumers migrate in #871. This opt-in view must not make
+        the current exact-coordinate admission path silently accept another wire
+        contract. #872 removes the temporary coordinate projection.
+        """
+        return project_current_namespace_packages(
+            self.kernel, cast(LanguageBundleIndex, self.language_bundle)
+        )
 
 
 AuthorityProviderValue = (

--- a/libs/gda-balancing/src/gda_balancing/domain/authority/graph.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/authority/graph.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping, Sequence
 from copy import deepcopy
+from dataclasses import dataclass
+from graphlib import CycleError, TopologicalSorter
+from types import MappingProxyType
 from typing import Any
 
 
@@ -245,3 +249,162 @@ def derive_language_index(
         package_byte_sizes=package_byte_sizes,
         vector_set_byte_sizes=vector_set_byte_sizes,
     )
+
+
+@dataclass(frozen=True)
+class CurrentPackage:
+    """Namespace selection data referencing admitted definitions without copying them.
+
+    This is a derived view, not another authoring format. Only set-valued selection
+    members are normalized; definition and Operation body order stay authored.
+    """
+
+    namespace: str
+    required: tuple[str, ...] = ()
+    optional: tuple[str, ...] = ()
+    provides: tuple[str, ...] = ()
+    requires: tuple[str, ...] = ()
+    definitions: tuple[tuple[str, str, Any], ...] = ()
+
+    def __post_init__(self) -> None:
+        for member in ("required", "optional", "provides", "requires"):
+            object.__setattr__(self, member, tuple(sorted(getattr(self, member))))
+
+
+@dataclass(frozen=True)
+class NamespaceSelection:
+    """One selected current closure; definition keys include their nominal owner."""
+
+    packages: tuple[CurrentPackage, ...]
+    dependency_edges: tuple[tuple[str, str], ...]
+    capability_bindings: tuple[tuple[str, str], ...]
+    definitions: Mapping[tuple[str, str, str], Any]
+
+
+def resolve_current_namespaces(
+    packages: Sequence[CurrentPackage], roots: Iterable[str]
+) -> NamespaceSelection:
+    """Select required dependencies from one graph with unique namespace owners.
+
+    Graph membership is closed even for optional edges, which do not select a
+    provider. Capability requirements are checked only in the selected closure.
+    These internal errors are not public Model diagnostics: #871 migrates that
+    boundary with its owning Kernel/LDB contracts.
+    """
+    by_namespace: dict[str, CurrentPackage] = {}
+    definitions: dict[tuple[str, str, str], Any] = {}
+    for package in sorted(packages, key=lambda item: item.namespace):
+        if package.namespace in by_namespace:
+            raise ValueError(f"duplicate namespace owner: {package.namespace}")
+        by_namespace[package.namespace] = package
+        for path, key, definition in package.definitions:
+            owner = (package.namespace, path, key)
+            if owner in definitions:
+                raise ValueError(f"duplicate definition owner: {owner}")
+            definitions[owner] = definition
+
+    for namespace, package in by_namespace.items():
+        dependencies = (*package.required, *package.optional)
+        if len(dependencies) != len(set(dependencies)):
+            raise ValueError(f"duplicate dependency in namespace: {namespace}")
+        for dependency in sorted(dependencies):
+            if dependency not in by_namespace:
+                raise ValueError(f"missing dependency: {namespace} -> {dependency}")
+    try:
+        TopologicalSorter(
+            {name: package.required for name, package in by_namespace.items()}
+        ).prepare()
+    except CycleError as error:
+        raise ValueError("cyclic required namespace dependencies") from error
+
+    pending = sorted(set(roots), reverse=True)
+    selected: set[str] = set()
+    while pending:
+        namespace = pending.pop()
+        if namespace not in by_namespace:
+            raise ValueError(f"missing root namespace: {namespace}")
+        if namespace in selected:
+            continue
+        selected.add(namespace)
+        pending.extend(reversed(by_namespace[namespace].required))
+    selected_packages = tuple(by_namespace[name] for name in sorted(selected))
+
+    providers: dict[str, str] = {}
+    for package in selected_packages:
+        for capability in package.provides:
+            if capability in providers:
+                raise ValueError(
+                    f"selected capability has multiple providers: {capability}"
+                )
+            providers[capability] = package.namespace
+    for package in selected_packages:
+        for capability in package.requires:
+            if capability not in providers:
+                raise ValueError(f"selected capability has no provider: {capability}")
+
+    return NamespaceSelection(
+        packages=selected_packages,
+        dependency_edges=tuple(
+            (package.namespace, dependency)
+            for package in selected_packages
+            for dependency in package.required
+        ),
+        capability_bindings=tuple(sorted(providers.items())),
+        definitions=MappingProxyType(
+            {key: definitions[key] for key in sorted(definitions) if key[0] in selected}
+        ),
+    )
+
+
+def project_current_namespace_packages(
+    kernel: dict[str, Any], graph: LanguageBundleIndex
+) -> tuple[CurrentPackage, ...]:
+    """Temporary #870 projection of an admitted, frozen exact-coordinate graph.
+
+    The caller owns admission and lifetime. Do not infer owners from the flattened
+    language index or silently discard conflicting release coordinates. #872 must
+    remove this coordinate bridge after the authored graph and consumers migrate.
+    """
+    releases = sorted(graph.package_releases, key=lambda package: package["id"])
+    by_namespace: dict[str, dict[str, Any]] = {}
+    for release in releases:
+        namespace = release["id"]
+        if namespace in by_namespace:
+            raise ValueError(f"duplicate namespace owner: {namespace}")
+        by_namespace[namespace] = release
+
+    projections = kernel["meta_format"]["package_release"]["semantic_closure"][
+        "projections"
+    ]
+    packages: list[CurrentPackage] = []
+    for release in releases:
+        for dependency in (
+            *release["dependencies"]["required"],
+            *release["dependencies"]["optional"],
+        ):
+            target = by_namespace.get(dependency["id"])
+            if target is None or target["version"] != dependency["version"]:
+                raise ValueError("current namespace projection has no exact dependency")
+        definitions: list[tuple[str, str, Any]] = []
+        for entry, projection in zip(
+            release["semantic_closure"], projections, strict=True
+        ):
+            for definition in entry["definitions"]:
+                member = projection["key_member"]
+                key = definition if member is None else definition[member]
+                definitions.append((projection["authority_path"], key, definition))
+        packages.append(
+            CurrentPackage(
+                namespace=release["id"],
+                required=tuple(
+                    item["id"] for item in release["dependencies"]["required"]
+                ),
+                optional=tuple(
+                    item["id"] for item in release["dependencies"]["optional"]
+                ),
+                provides=tuple(release["capabilities"]["provided"]),
+                requires=tuple(release["capabilities"]["required"]),
+                definitions=tuple(definitions),
+            )
+        )
+    return tuple(packages)

--- a/libs/gda-balancing/tests/test_ci_policy.py
+++ b/libs/gda-balancing/tests/test_ci_policy.py
@@ -69,19 +69,34 @@ def test_shards_pairwise_partition_every_balancing_test_file():
     expected = {
         path.name for path in (_ROOT / "libs/gda-balancing/tests").glob("test_*.py")
     }
-    assert union == expected
+    assert {selector.partition("::")[0] for selector in union} == expected
     assert ci.REQUIRED_TEST_SHARDS == (
         "fast",
         "authority",
         "language",
         "model",
         "experiment",
+        "experiment-continuation",
         "composition",
     )
     assert ci.PROCESS_TIMEOUT_SECONDS == {
         "required": 480,
         "unfiltered": 900,
     }
+
+
+def test_experiment_shards_preserve_every_collected_case_exactly_once():
+    full = ci.collect_node_ids((ci.TEST_ROOT / "test_schema2_experiment_cli.py",))
+    first = ci.collect_node_ids(ci.shard_paths("experiment"))
+    second = ci.collect_node_ids(ci.shard_paths("experiment-continuation"))
+
+    assert first and second
+    assert not first & second
+    assert first | second == full
+    # Parameterized cases keep their common fixture lifecycle in one process.
+    first_definitions = {node.split("[", 1)[0] for node in first}
+    second_definitions = {node.split("[", 1)[0] for node in second}
+    assert not first_definitions & second_definitions
 
 
 def test_declared_bootstrap_migration_normalizes_only_the_moved_test():

--- a/libs/gda-balancing/tests/test_current_namespace_resolution.py
+++ b/libs/gda-balancing/tests/test_current_namespace_resolution.py
@@ -1,0 +1,498 @@
+"""Current namespace closure without historical package-version selection."""
+
+from __future__ import annotations
+
+import json
+from itertools import combinations, permutations, product
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from gda_balancing.domain.authority.context import packaged_authority_context
+from gda_balancing.domain.authority.graph import (
+    CurrentPackage,
+    resolve_current_namespaces,
+)
+
+
+def _package(
+    namespace: str,
+    *,
+    required: tuple[str, ...] = (),
+    optional: tuple[str, ...] = (),
+    provides: tuple[str, ...] = (),
+    requires: tuple[str, ...] = (),
+    definitions: tuple[tuple[str, str, Any], ...] = (),
+) -> CurrentPackage:
+    return CurrentPackage(
+        namespace, required, optional, provides, requires, definitions
+    )
+
+
+@pytest.mark.parametrize("edge_mask", range(64))
+def test_every_three_namespace_graph_has_order_independent_required_closure(edge_mask):
+    names = ("alpha", "beta", "gamma")
+    possible_edges = tuple(
+        (left, right) for left in names for right in names if left != right
+    )
+    edges = {edge for bit, edge in enumerate(possible_edges) if edge_mask & (1 << bit)}
+    packages = tuple(
+        _package(
+            name, required=tuple(right for left, right in sorted(edges) if left == name)
+        )
+        for name in names
+    )
+
+    # Boolean transitive closure is an independent oracle for the selected graph.
+    reachable = {
+        (left, right): (left, right) in edges for left in names for right in names
+    }
+    for middle in names:
+        for left in names:
+            for right in names:
+                reachable[left, right] |= (
+                    reachable[left, middle] and reachable[middle, right]
+                )
+    cyclic = any(reachable[name, name] for name in names)
+    root_sets = (
+        (names,)
+        if cyclic
+        else tuple(roots for size in range(1, 4) for roots in combinations(names, size))
+    )
+
+    for package_order in permutations(packages):
+        for roots in root_sets:
+            expected = set(roots) | {
+                name for root in roots for name in names if reachable[root, name]
+            }
+            for root_order in permutations(roots):
+                if cyclic:
+                    with pytest.raises(ValueError, match="cycl"):
+                        resolve_current_namespaces(package_order, root_order)
+                    continue
+                selected = resolve_current_namespaces(package_order, root_order)
+                assert tuple(
+                    package.namespace for package in selected.packages
+                ) == tuple(sorted(expected))
+                assert selected.dependency_edges == tuple(
+                    sorted(edge for edge in edges if edge[0] in expected)
+                )
+                assert selected.capability_bindings == ()
+                assert dict(selected.definitions) == {}
+
+
+def test_diamond_closure_coalesces_shared_dependencies_and_canonicalizes_set_order():
+    leaf = _package("leaf", provides=("read", "write"))
+    other = _package("other")
+    auxiliary = _package("auxiliary")
+    unused = _package("unused", provides=("read", "write"))
+    left = _package("left", required=("leaf",))
+    right = _package("right", required=("leaf",))
+    baseline = None
+    for required, optional, provided, needed in product(
+        permutations(("left", "right")),
+        permutations(("other", "auxiliary")),
+        permutations(("root.read", "root.write")),
+        permutations(("read", "write")),
+    ):
+        root = _package(
+            "root",
+            required=required,
+            optional=optional,
+            provides=provided,
+            requires=needed,
+        )
+        selected = resolve_current_namespaces(
+            (unused, other, right, root, auxiliary, leaf, left),
+            (name for name in ("root", "root")),
+        )
+        assert tuple(package.namespace for package in selected.packages) == (
+            "leaf",
+            "left",
+            "right",
+            "root",
+        )
+        assert selected.dependency_edges == (
+            ("left", "leaf"),
+            ("right", "leaf"),
+            ("root", "left"),
+            ("root", "right"),
+        )
+        assert selected.capability_bindings == (
+            ("read", "leaf"),
+            ("root.read", "root"),
+            ("root.write", "root"),
+            ("write", "leaf"),
+        )
+        if baseline is None:
+            baseline = selected
+        else:
+            assert selected == baseline
+
+
+@pytest.mark.parametrize("missing", ("root", "required", "optional"))
+def test_missing_namespace_is_refused_at_the_declared_boundary(missing):
+    packages = (
+        _package(
+            "root",
+            required=("absent",) if missing == "required" else (),
+            optional=("absent",) if missing == "optional" else (),
+        ),
+    )
+    roots = ("absent",) if missing == "root" else ("root",)
+    with pytest.raises(ValueError, match="absent"):
+        resolve_current_namespaces(packages, roots)
+
+
+def test_available_optional_namespace_is_never_automatically_selected():
+    packages = (_package("root", optional=("optional",)), _package("optional"))
+    selected = resolve_current_namespaces(packages, ("root",))
+    assert tuple(package.namespace for package in selected.packages) == ("root",)
+    assert selected.packages[0].optional == ("optional",)
+    assert selected.dependency_edges == ()
+    both = resolve_current_namespaces(packages, ("root", "optional"))
+    assert tuple(package.namespace for package in both.packages) == ("optional", "root")
+    assert both.dependency_edges == ()
+
+
+@pytest.mark.parametrize(
+    ("required", "optional"),
+    ((("leaf", "leaf"), ()), ((), ("leaf", "leaf")), (("leaf",), ("leaf",))),
+    ids=("required", "optional", "required-and-optional"),
+)
+def test_duplicate_dependency_declarations_are_refused(required, optional):
+    with pytest.raises(ValueError, match="duplicate"):
+        resolve_current_namespaces(
+            (_package("root", required=required, optional=optional), _package("leaf")),
+            ("root",),
+        )
+
+
+@pytest.mark.parametrize(
+    "packages",
+    (
+        (_package("root", required=("root",)),),
+        (_package("root", required=("child",)), _package("child", required=("root",))),
+    ),
+    ids=("self", "indirect"),
+)
+def test_required_cycles_refuse_instead_of_returning_a_partial_selection(packages):
+    with pytest.raises(ValueError, match="cycl"):
+        resolve_current_namespaces(packages, ("root",))
+
+
+def test_unselected_required_cycle_still_breaks_graph_closure():
+    packages = (
+        _package("root"),
+        _package("left", required=("right",)),
+        _package("right", required=("left",)),
+    )
+    with pytest.raises(ValueError, match="cycl"):
+        resolve_current_namespaces(packages, ("root",))
+
+
+def test_optional_edges_do_not_create_required_cycles():
+    packages = (
+        _package("root", optional=("child",)),
+        _package("child", optional=("root",)),
+    )
+    selected = resolve_current_namespaces(packages, ("root",))
+    assert tuple(package.namespace for package in selected.packages) == ("root",)
+    assert selected.dependency_edges == ()
+
+
+@pytest.mark.parametrize("selected_duplicate", (False, True))
+def test_equal_duplicate_namespace_records_are_never_silently_coalesced(
+    selected_duplicate,
+):
+    duplicate = _package("duplicate")
+    with pytest.raises(ValueError, match="duplicate"):
+        resolve_current_namespaces(
+            (_package("root"), duplicate, duplicate),
+            ("duplicate",) if selected_duplicate else ("root",),
+        )
+
+
+def test_capability_provider_must_be_in_the_selected_required_closure():
+    requester = _package("requester", requires=("calculate",))
+    provider = _package("provider", provides=("calculate",))
+    with pytest.raises(ValueError, match="calculate"):
+        resolve_current_namespaces((requester, provider), ("requester",))
+    selected = resolve_current_namespaces(
+        (requester, provider), ("requester", "provider")
+    )
+    assert selected.capability_bindings == (("calculate", "provider"),)
+    assert selected.dependency_edges == ()
+
+
+def test_selected_capability_ambiguity_is_refused_and_unselected_providers_are_ignored():
+    packages = (
+        _package("requester", required=("chosen",), requires=("calculate",)),
+        _package("chosen", provides=("calculate",)),
+        _package("alternative", provides=("calculate",)),
+    )
+    for order in permutations(packages):
+        selected = resolve_current_namespaces(order, ("requester",))
+        assert selected.capability_bindings == (("calculate", "chosen"),)
+        with pytest.raises(ValueError, match="calculate"):
+            resolve_current_namespaces(order, ("requester", "alternative"))
+
+
+def test_equal_nominal_definitions_keep_namespace_and_collection_identity():
+    shape = {"kind": "record", "fields": []}
+    packages = (
+        _package("alpha", definitions=(("language.nominal_types", "Shared", shape),)),
+        _package(
+            "beta",
+            definitions=(
+                ("language.nominal_types", "Shared", shape),
+                ("language.operations", "Shared", shape),
+            ),
+        ),
+    )
+    selected = resolve_current_namespaces(packages, ("beta", "alpha"))
+    assert set(selected.definitions) == {
+        ("alpha", "language.nominal_types", "Shared"),
+        ("beta", "language.nominal_types", "Shared"),
+        ("beta", "language.operations", "Shared"),
+    }
+    assert all(value == shape for value in selected.definitions.values())
+
+
+@pytest.mark.parametrize("equal_payload", (False, True))
+def test_duplicate_definition_owner_refuses_even_when_payloads_are_equal(equal_payload):
+    first = {"kind": "record", "fields": []}
+    second = first if equal_payload else {"kind": "scalar"}
+    duplicate = _package(
+        "owner",
+        definitions=(
+            ("language.nominal_types", "Shared", first),
+            ("language.nominal_types", "Shared", second),
+        ),
+    )
+    with pytest.raises(ValueError, match="duplicate"):
+        resolve_current_namespaces((duplicate,), ("owner",))
+
+
+def test_definition_and_operation_body_order_remains_authored_order():
+    body = [{"node": "copy", "target": "z"}, {"node": "copy", "target": "a"}]
+    definitions = (
+        ("language.operations", "z-operation", {"body": body}),
+        ("language.operations", "a-operation", {"body": list(reversed(body))}),
+    )
+    selected = resolve_current_namespaces(
+        (_package("owner", definitions=definitions),), ("owner",)
+    )
+    assert [name for _path, name, _value in selected.packages[0].definitions] == [
+        "z-operation",
+        "a-operation",
+    ]
+    assert set(selected.definitions) == {
+        ("owner", "language.operations", "z-operation"),
+        ("owner", "language.operations", "a-operation"),
+    }
+    assert (
+        selected.definitions["owner", "language.operations", "z-operation"]["body"]
+        == body
+    )
+    assert selected.definitions["owner", "language.operations", "a-operation"][
+        "body"
+    ] == list(reversed(body))
+
+
+_CURRENT_REQUIRED = {
+    "core.quantity": {"standard.compiler"},
+    "game.build": {
+        "core.quantity",
+        "game.generation",
+        "standard.runtime",
+        "standard.schema",
+    },
+    "game.check": {"core.quantity", "standard.runtime"},
+    "game.combat": {"core.quantity", "game.check", "game.resource", "standard.runtime"},
+    "game.effect": {"core.quantity", "standard.runtime"},
+    "game.generation": {"core.quantity", "standard.runtime", "standard.schema"},
+    "game.progression": {"core.quantity"},
+    "game.resource": {"core.quantity", "standard.runtime"},
+    "standard.compiler": set(),
+    "standard.conformance.structured": {
+        "core.quantity",
+        "standard.runtime",
+        "standard.schema",
+    },
+    "standard.experiment": set(),
+    "standard.runtime": set(),
+    "standard.schema": set(),
+}
+
+
+@pytest.mark.parametrize(
+    ("example", "expected_namespaces"),
+    (
+        (
+            "progression-periodic-effect",
+            {
+                "core.quantity",
+                "game.effect",
+                "game.progression",
+                "standard.compiler",
+                "standard.runtime",
+            },
+        ),
+        (
+            "roguelike-reward-build",
+            {
+                "core.quantity",
+                "game.build",
+                "game.generation",
+                "standard.compiler",
+                "standard.runtime",
+                "standard.schema",
+            },
+        ),
+        (
+            "rpg-combat-cast",
+            {
+                "core.quantity",
+                "game.check",
+                "game.combat",
+                "game.resource",
+                "standard.compiler",
+                "standard.runtime",
+            },
+        ),
+        (
+            "rpg-periodic-effect",
+            {
+                "core.quantity",
+                "game.check",
+                "game.combat",
+                "game.effect",
+                "game.resource",
+                "standard.compiler",
+                "standard.runtime",
+            },
+        ),
+        (
+            "rpg-stat-composition",
+            {
+                "core.quantity",
+                "game.build",
+                "game.check",
+                "game.combat",
+                "game.effect",
+                "game.generation",
+                "game.progression",
+                "game.resource",
+                "standard.compiler",
+                "standard.runtime",
+                "standard.schema",
+            },
+        ),
+        (
+            "structured-selection",
+            {
+                "core.quantity",
+                "standard.compiler",
+                "standard.conformance.structured",
+                "standard.runtime",
+                "standard.schema",
+            },
+        ),
+    ),
+)
+def test_maintained_sources_resolve_the_expected_current_namespace_closure(
+    example, expected_namespaces
+):
+    context = packaged_authority_context()
+    packages = context.current_namespace_packages()
+    assert {
+        package.namespace: set(package.required) for package in packages
+    } == _CURRENT_REQUIRED
+    source_path = (
+        Path(__file__).parents[1]
+        / "examples"
+        / "schema2"
+        / example
+        / "model-source.json"
+    )
+    source = json.loads(source_path.read_text(encoding="utf-8"))
+    roots = [requirement["id"] for requirement in source["package_requirements"]]
+
+    selected = resolve_current_namespaces(packages, roots)
+
+    assert {package.namespace for package in selected.packages} == expected_namespaces
+    assert set(selected.dependency_edges) == {
+        (namespace, dependency)
+        for namespace in expected_namespaces
+        for dependency in _CURRENT_REQUIRED[namespace]
+    }
+    assert dict(selected.capability_bindings)["quantity.lower"] == "core.quantity"
+    if "standard.schema" in expected_namespaces:
+        assert (
+            dict(selected.capability_bindings)["structured.lower"] == "standard.schema"
+        )
+
+
+def test_current_projection_retains_complete_operations_and_cannot_mutate_admitted_bodies():
+    context = packaged_authority_context()
+    original_bytes = context.canonical_language_bundle_bytes
+    packages = context.current_namespace_packages()
+    selected = resolve_current_namespaces(packages, ("game.build", "game.effect"))
+    expected_operations = {
+        "core.quantity": {
+            "quantity.add",
+            "quantity.floor-divide",
+            "quantity.floor-zero",
+            "quantity.identity",
+            "quantity.less-than",
+            "quantity.maximum",
+            "quantity.minimum",
+            "quantity.multiply",
+            "quantity.subtract",
+        },
+        "game.build": {"game.build.contribution@1", "game.build.replace-reward-v1"},
+        "game.effect": {
+            "game.effect.apply-live-periodic-v1",
+            "game.effect.apply-snapshot-periodic-v1",
+            "game.effect.contribute@1",
+            "game.effect.expire-periodic-v1",
+            "game.effect.tick-live-periodic-v1",
+            "game.effect.tick-snapshot-periodic-v1",
+        },
+    }
+    for namespace, operations in expected_operations.items():
+        assert {
+            name
+            for owner, path, name in selected.definitions
+            if owner == namespace and path == "language.operations"
+        } == operations
+        owner = next(
+            package
+            for package in context.language_bundle["language"]["packages"]
+            if package["id"] == namespace
+        )
+        authored_operations = next(
+            entry["definitions"]
+            for entry in owner["semantic_closure"]
+            if entry["authority_path"] == "language.operations"
+        )
+        for operation in authored_operations:
+            projected = selected.definitions[
+                namespace, "language.operations", operation["id"]
+            ]
+            assert projected["body"] == operation["body"]
+
+    key = ("core.quantity", "language.operations", "quantity.add")
+    operation = selected.definitions[key]
+    assert operation["body"][0]["node"] == "add"
+    with pytest.raises(TypeError):
+        cast(Any, selected.definitions)[key] = {"body": []}
+    with pytest.raises(TypeError):
+        cast(Any, operation)["body"][0]["node"] = "subtract"
+    assert context.canonical_language_bundle_bytes == original_bytes
+    fresh = resolve_current_namespaces(
+        context.current_namespace_packages(), ("core.quantity",)
+    )
+    assert fresh.definitions[key]["body"][0]["node"] == "add"

--- a/libs/gda-balancing/tools/ci.py
+++ b/libs/gda-balancing/tools/ci.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import hashlib
 import json
 import subprocess
@@ -17,6 +18,25 @@ REPO_ROOT: Final = Path(__file__).resolve().parents[3]
 TEST_ROOT: Final = MEMBER_ROOT / "tests"
 BASELINE_PATH: Final = TEST_ROOT / "schema2-test-inventory-v1.json"
 MIGRATION_PATH: Final = TEST_ROOT / "schema2-bootstrap-migration-map.json"
+
+
+def _experiment_test_selectors() -> tuple[str, ...]:
+    """Split the slow module by test definition, keeping parameters together."""
+    filename = "test_schema2_experiment_cli.py"
+    module = ast.parse((TEST_ROOT / filename).read_text(encoding="utf-8"))
+    names = sorted(
+        node.name
+        for node in module.body
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name.startswith("test_")
+        )
+        or (isinstance(node, ast.ClassDef) and node.name.startswith("Test"))
+    )
+    return tuple(f"{filename}::{name}" for name in names)
+
+
+_EXPERIMENT_TESTS: Final = _experiment_test_selectors()
 
 SHARDS: Final[dict[str, tuple[str, ...]]] = {
     "fast": (
@@ -50,7 +70,8 @@ SHARDS: Final[dict[str, tuple[str, ...]]] = {
         "test_schema2_model_cli.py",
         "test_schema2_model_lowerer_conformance.py",
     ),
-    "experiment": ("test_schema2_experiment_cli.py",),
+    "experiment": _EXPERIMENT_TESTS[::2],
+    "experiment-continuation": _EXPERIMENT_TESTS[1::2],
     "composition": (
         "test_current_package_composition.py",
         "test_cli_conformance.py",

--- a/libs/gda-balancing/tools/ci.py
+++ b/libs/gda-balancing/tools/ci.py
@@ -21,6 +21,7 @@ MIGRATION_PATH: Final = TEST_ROOT / "schema2-bootstrap-migration-map.json"
 SHARDS: Final[dict[str, tuple[str, ...]]] = {
     "fast": (
         "test_ci_policy.py",
+        "test_current_namespace_resolution.py",
         "test_emit.py",
         "test_envelope_schema.py",
         "test_execution_service_language.py",


### PR DESCRIPTION
Current Model consumers still select exact package versions in separate traversals. This adds the namespace-selection basis for their coordinated migration: one derived view of the attached admitted graph, unique namespace/definition ownership, required dependency closure, and capability bindings limited to the selected packages. Equal-shaped nominal definitions keep distinct owners, and Operation bodies keep authored order.

The public wire contracts, machine authority bytes, maintained inputs and current Model/Experiment consumers remain unchanged during this expand stage. The projection is opt-in and explicitly temporary; #871 migrates producers/consumers and #872 must remove the exact-coordinate bridge, old traversals, selectors and transitional forms. This PR targets `codex/gda-balancing-refactor-delete-dev` and cannot merge independently into main.

Validation: 91 new cases pass, including all 64 three-namespace directed graphs checked against an independent transitive-closure oracle, ordering/diamond and refusal cases, six maintained source closures, and immutable references to the current package definitions. Another 38 existing lifecycle, layer, CLI/HTTP composition and exact-version-conflict cases pass. Ruff, Pyright and logical inventory closure pass (1,472 collected tests; 313 current vectors; no missing tests/vectors, uncovered tests or overlapping shards). Full required CI and independent Standards/Spec/DDMA review pass at the final head.

Two CI attempts at the initial expand head reached the unchanged 480-second Experiment shard limit after 180 and 190 progress marks. The complete local file passes all 191 cases. The follow-up derives two disjoint groups from those same test definitions (96 and 95 cases), keeps parameterized definitions together, and verifies their exact collected union. It changes no Experiment test body or timeout and adds no dependency. Twelve CI-policy tests pass. Both local groups pass all cases in 139.25 and 142.20 seconds. Independent Standards, Spec and DDMA review passes with zero remaining findings at final head `f89551d46a2bf1a834fba97a542ba7108db5a9b5`; final-head CI passes. The reviewed tree is integrated into dev at `08fd871aa9ab63a4410d43e86002122941e2d093`.

The common base is `ef0eba2d89c2487979ea7fa785172b3129958c38`. `docs/refactor/current-language/NAMESPACE-EXPAND.md` records the migration/deletion inventory and coherent rollback; the issue integration receipt identifies the exact dev commit handed to #871. This does not complete parent version deletion or execution-binding deletion.

Refs #870; parent #865.
