### PR TITLE
docs(gda): restore the translated add-input-action rows the #861 rebase dropped

### DIFF
--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -452,7 +452,7 @@ identifica el archivo y solo `preflight` detecta un fallo en el primer fotograma
 | `project set` | Define un ajuste del proyecto, forzando el valor a su tipo declarado. |
 | `project add-autoload` | Registra un singleton autoload (nombre → script/escena). |
 | `project remove-autoload` | Cancela el registro de un singleton autoload por nombre. |
-| `project add-input-action` | Registra una acción del InputMap vinculada a teclas (`--key` nombre o keycode, `--deadzone`, `--physical`). |
+| `project add-input-action` | Registra una acción del InputMap vinculada a teclas y/o a un mando (`--key`, `--joy-button`, `--joy-axis` como `<eje>[:<signo>]`, `--device`, `--deadzone`, `--physical`); se requiere al menos una vinculación. |
 | `project remove-input-action` | Cancela el registro de una acción del InputMap por nombre. |
 | `project find-references` | Encuentra todos los archivos del proyecto que referencian un recurso dado. |
 | `project dependencies` | Mapea cada escena/recurso a los recursos de los que depende. |

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -448,7 +448,7 @@ Headless 検証はプロジェクトの実行準備を確認し、Live 操作は
 | `project set` | プロジェクト設定を設定します。値は宣言された型に変換されます。 |
 | `project add-autoload` | オートロードのシングルトンを登録します(名前 → スクリプト/シーン)。 |
 | `project remove-autoload` | オートロードのシングルトンを名前で指定して登録解除します。 |
-| `project add-input-action` | キーに割り当てた InputMap アクションを登録します(`--key` はキー名またはキーコード、`--deadzone`、`--physical`)。 |
+| `project add-input-action` | キーやコントローラーに割り当てた InputMap アクションを登録します(`--key`、`--joy-button`、`--joy-axis` は `<軸>[:<符号>]` 形式、`--device`、`--deadzone`、`--physical`)。バインドは 1 つ以上必要です。 |
 | `project remove-input-action` | InputMap アクションを名前で指定して登録解除します。 |
 | `project find-references` | 指定したリソースを参照するすべてのプロジェクトファイルを見つけます。 |
 | `project dependencies` | 各シーン/リソースを、それが依存するリソースに対応付けます。 |

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -428,7 +428,7 @@ Headless 验证确认项目就绪状态；Live 操作返回用于验证实际行
 | `project set` | 设置一个项目设置，并把值强制转换为它声明的类型。 |
 | `project add-autoload` | 注册一个 autoload 单例（名称 → 脚本/场景）。 |
 | `project remove-autoload` | 按名称注销一个 autoload 单例。 |
-| `project add-input-action` | 注册一个绑定按键的 InputMap 动作（`--key` 键名或键码、`--deadzone`、`--physical`）。 |
+| `project add-input-action` | 注册一个绑定按键和/或手柄的 InputMap 动作（`--key`、`--joy-button`、`--joy-axis` 形如 `<轴>[:<符号>]`、`--device`、`--deadzone`、`--physical`）；至少需要一个绑定。 |
 | `project remove-input-action` | 按名称注销一个 InputMap 动作。 |
 | `project find-references` | 找出引用了给定资源的每一个项目文件。 |
 | `project dependencies` | 把每个场景/资源映射到它所依赖的资源。 |


### PR DESCRIPTION
## Summary

PR #859 translated the `project add-input-action` README row (joypad bindings) into zh-CN, es and ja. When PR #861 was rebased onto dev after #859, its only conflict was the translation stamp line — but the conflict was resolved by taking #861's whole copy of each translation file, which discarded the auto-merged #859 row and kept the pre-#859 key-only wording. The regression is on dev and, through the W1 promotion (#863), on `main`.

This restores the three rows byte-for-byte from `e997cd7ba` (dev after #859). The stamp line is unchanged, since `README.md` is. Docs-only; no source or test change. Found by PR #900's independent review.

## Validation

- `tests/repo/test_readme_i18n_sync.py` passes; `scripts/update_readme_i18n.py` is a no-op on the restored files.
- `git diff origin/feat/gda-dogfooding-dev -- docs/README.*.md` shows exactly one row per file.

Process fix recorded in the wave plan: a translation-stamp conflict is resolved on the conflict hunk only, never by `git checkout --ours/--theirs` on the whole file.