### PR TITLE
chore(repo): classify .gd files as GDScript

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# All .gd files in this repository are GDScript.
+*.gd linguist-language=GDScript


### PR DESCRIPTION
GitHub classifies `src/gda/harness/gda_harness.gd` as GAP: its 114,154 bytes account for the entire GAP language total. Linguist's GAP heuristic for `.gd` matches `Declare` inside a diagnostic string before checking the GDScript heuristic.

Add a root `.gitattributes` rule that classifies all `.gd` files as GDScript. This corrects the current file and applies to future GDScript files throughout the repository.

Validation:
- `git check-attr` confirms all 125 tracked `.gd` files resolve to `linguist-language: GDScript`.
- Compared all attributes across the 990 tracked paths before and after the change; only the expected language attributes changed. Existing generated-file and Git LFS attributes are preserved.
- `git diff --cached --check` passed before committing.

GitHub's language bar will refresh through its background analysis after this change reaches `main`.
