### PR TITLE
fix(gda-balancing): reuse immutable Model preparation and specialize by value

### DIFF
--- a/libs/gda-balancing/docs/ARCHITECTURE.md
+++ b/libs/gda-balancing/docs/ARCHITECTURE.md
@@ -1013,6 +1013,11 @@ The public compilation pipeline is:
 - The **Authoring AST** preserves source structure after parsing.
 - **Typed HIR** resolves names, types, units, package symbols, and static effects while retaining
   enough structure for useful diagnostics.
+  A checked Model owns one immutable private preparation of those facts. Compilation and Template
+  facts reuse it; specialization explicitly derives each Operation and its package-closure view.
+  Post-specialization checks, independent imported-artifact admission and publication validation
+  retain their own boundaries. This adds no persisted or public IR
+  ([S4 implementation](refactor/current-language/MODEL-PREPARATION.md)).
 - The **RIR semantic payload** is the canonical, public semantic normal form. Its
   `semantic_identity` excludes Formula `expression` text; the complete canonical RIR JSON has a
   separate `content_identity` for wire integrity. Equivalent admitted source must lower to the same

--- a/libs/gda-balancing/docs/badr/0028-current-language-refactor-and-pre-1.0-retirement.md
+++ b/libs/gda-balancing/docs/badr/0028-current-language-refactor-and-pre-1.0-retirement.md
@@ -53,6 +53,16 @@ Whole-LDB and Build-receipt execution prerequisites still require closure in #87
 mandatory field/gate/propagation/fallback deletion in #875. Policy contents and their actual checks
 remain binding.
 
+## Model preparation delivery (#873, 2026-09-07)
+
+One checked request now retains immutable Typed HIR preparation and its admitted authority context.
+The compiler reuses that complete snapshot and explicitly derives specialized Operation and
+package-closure views. Duplicate preparation and authority re-admission fallback are removed;
+post-specialization checks, independent imported-artifact admission and publication validation
+remain. The [S4 record](../refactor/current-language/MODEL-PREPARATION.md) maps regression witnesses,
+current resource boundaries, unchanged artifact evidence and rollback. This creates no public IR
+or shared cache and makes no unmeasured performance claim. #612, #874 and #875 retain their scopes.
+
 ## Context and evidence
 
 The project owner states that gda-balancing has not had a formal product release: existing

--- a/libs/gda-balancing/docs/refactor/current-language/MODEL-PREPARATION.md
+++ b/libs/gda-balancing/docs/refactor/current-language/MODEL-PREPARATION.md
@@ -27,7 +27,7 @@ declarations, lowering rules, Source rows, Formula bindings/debug entries and th
 unspecialized projection. No optional preparation or re-preparation fallback remains.
 
 The Model compiler consumes that snapshot. Template facts reuse its resolved Source
-rows. Specialization owns each Operation through its namespace and local id, then
+rows. Specialization separately copies each namespace/local-id Operation definition, then
 explicitly derives both the Operation and package-closure views, including provenance.
 It no longer relies on mutations propagating through object aliases. The existing
 immutable-container utility isolates request state; writable output copies cannot
@@ -44,15 +44,19 @@ candidate afresh, retaining the mutations and expected observations.
 ## Acceptance witnesses
 
 The permanent [preparation regressions](../../../tests/test_model_preparation.py)
-provide eight cases. At the baseline, five fail on duplicate preparation, alias
-dependence or mutation leakage, while three resource-boundary cases pass. With S4,
-all eight pass. These tests observe real public calls without replacing the compiler
-or admission implementation.
+provide nine cases. Of the initial eight at the pre-S4 baseline, five fail on duplicate
+preparation, alias dependence or mutation leakage, while three resource-boundary cases
+pass. The ninth case comes from independent review of the first S4 implementation:
+a legal admitted graph contains equal Operation definitions under `game.effect` and
+`test.effectcopy`. Sharing only their Python definition object leaves input values and
+canonical bytes unchanged but incorrectly specializes the unbound owner too. A copy
+per owner fixes that confirmed counterexample before either output view is derived.
+These tests observe real public calls without replacing the compiler or admission implementation.
 
 | Acceptance | Evidence and retained obligation |
 | --- | --- |
 | Single preparation | Public check/build each resolve Source rows, lowering inputs, Formulas and unspecialized projection once; independent admission remains one/two times respectively. All eight published artifact classes are compared. |
-| Explicit projections | Two maintained examples compare entire specialization outputs after a JSON roundtrip, including closure definitions and instruction provenance. |
+| Explicit projections | Two maintained examples and an independently admitted cross-owner clone compare entire specialization outputs after alias changes and a JSON roundtrip, including closure definitions and instruction provenance. The unbound owner's complete definition must stay unchanged. |
 | Snapshot isolation | Mutating original Source, inspected request data or nested emitted artifacts cannot alter the old request; new and concurrent requests reflect their distinct inputs. |
 | Diagnostics and admission | All 34 current Model vectors retain their full observations: 13 admitted eight-artifact sets and 21 complete refusal reports. Existing Model CLI/lowerer tests retain tamper, nominal/role/domain, Formula and call-closure refusals. |
 | Resource and publication | The current minimal fixture consumes 233 projection steps: 232 refuses with the full recorded diagnostic, 233/234 admit through independent validation. Progression consumes 318. Existing public Experiment tests retain initialization refusal, Event rollback and Formula resource/cache accounting; Model tests retain explanation/debug publication and inspection. |
@@ -63,9 +67,9 @@ own pinned graph. They are not a requirement to force the current graph back to
 197 steps. S4 preserves the freshly measured 232/233/234 boundary without changing
 machine laws, resource limits, authority bytes or maintained authored examples.
 
-The eight new tests join the existing required `model` CI shard and logical inventory.
+The nine new tests join the existing required `model` CI shard and logical inventory.
 All prior required test ids, vectors, allowed skips and process bounds remain.
-The full collection is 1,516 cases with no missing, overlapping or unassigned cases;
+The full collection is 1,517 cases with no missing, overlapping or unassigned cases;
 313 active package-vector obligations remain. Collection closure is not a test-pass
 claim: the PR must record final required CI results and independent Standards, Spec
 and domain-architecture reviews before integration.

--- a/libs/gda-balancing/docs/refactor/current-language/MODEL-PREPARATION.md
+++ b/libs/gda-balancing/docs/refactor/current-language/MODEL-PREPARATION.md
@@ -1,0 +1,85 @@
+# Request-owned Model preparation
+
+Issue: [#873](https://github.com/aigengame/godot-agent/issues/873), stage S4.
+The starting development commit is `645aeb9ee0375ad6cd1164998ea451aaba9bf68e`
+(#872). GitHub owns final review, CI and integration status.
+
+## Problem and retained boundary
+
+The baseline public Model check/build path resolves Source symbols four times,
+prepares lowering inputs three times, and resolves Formulas and unspecialized
+Runtime projections twice within Source preparation. Independent compiled-artifact
+admission additionally derives its own projection once for check and twice for a
+fresh build publication. Those admission boundaries are necessary checks.
+
+Specialization also relied on shared Python objects: equal projections with equal
+canonical bytes produced different package closures after JSON serialization
+broke aliases. The progression/periodic example changed Operation bodies and
+instruction provenance; the Roguelike example differed in provenance alone.
+Comparing only final numeric values or Operation bodies would miss that defect.
+
+## Implementation and ownership
+
+`ModelSourceContext` carries incomplete resolution inputs. Only successful Model
+checking creates a `CheckedModel` with its admitted authority context and complete
+private `_TypedHIR`. The request retains immutable Source, selected Package Lock,
+declarations, lowering rules, Source rows, Formula bindings/debug entries and the
+unspecialized projection. No optional preparation or re-preparation fallback remains.
+
+The Model compiler consumes that snapshot. Template facts reuse its resolved Source
+rows. Specialization owns each Operation through its namespace and local id, then
+explicitly derives both the Operation and package-closure views, including provenance.
+It no longer relies on mutations propagating through object aliases. The existing
+immutable-container utility isolates request state; writable output copies cannot
+modify it. This is a private compiler representation, with no new public schema,
+persisted IR, shared cache or Runtime evaluator.
+
+Post-specialization entrypoint and callsite checks still run. Imported artifacts
+independently resolve and validate their semantic closure, and publication still
+validates the emitted Artifact Set. The reference consumer remains separately
+implemented; it uses the incomplete input carrier without production preparation.
+Old test fixtures that replaced an already checked authority now check their mutated
+candidate afresh, retaining the mutations and expected observations.
+
+## Acceptance witnesses
+
+The permanent [preparation regressions](../../../tests/test_model_preparation.py)
+provide eight cases. At the baseline, five fail on duplicate preparation, alias
+dependence or mutation leakage, while three resource-boundary cases pass. With S4,
+all eight pass. These tests observe real public calls without replacing the compiler
+or admission implementation.
+
+| Acceptance | Evidence and retained obligation |
+| --- | --- |
+| Single preparation | Public check/build each resolve Source rows, lowering inputs, Formulas and unspecialized projection once; independent admission remains one/two times respectively. All eight published artifact classes are compared. |
+| Explicit projections | Two maintained examples compare entire specialization outputs after a JSON roundtrip, including closure definitions and instruction provenance. |
+| Snapshot isolation | Mutating original Source, inspected request data or nested emitted artifacts cannot alter the old request; new and concurrent requests reflect their distinct inputs. |
+| Diagnostics and admission | All 34 current Model vectors retain their full observations: 13 admitted eight-artifact sets and 21 complete refusal reports. Existing Model CLI/lowerer tests retain tamper, nominal/role/domain, Formula and call-closure refusals. |
+| Resource and publication | The current minimal fixture consumes 233 projection steps: 232 refuses with the full recorded diagnostic, 233/234 admit through independent validation. Progression consumes 318. Existing public Experiment tests retain initialization refusal, Event rollback and Formula resource/cache accounting; Model tests retain explanation/debug publication and inspection. |
+| Bounded claims | Six maintained public builds produce 48 artifact files byte-identical to the pre-S4 baseline. This is behavior and byte-preservation evidence, not a speed or memory benchmark. #612 continues to own the real Formula Runtime conformance seam. |
+
+The earlier E5 probe's 196/197/198 observations remain historical evidence at its
+own pinned graph. They are not a requirement to force the current graph back to
+197 steps. S4 preserves the freshly measured 232/233/234 boundary without changing
+machine laws, resource limits, authority bytes or maintained authored examples.
+
+The eight new tests join the existing required `model` CI shard and logical inventory.
+All prior required test ids, vectors, allowed skips and process bounds remain.
+The full collection is 1,516 cases with no missing, overlapping or unassigned cases;
+313 active package-vector obligations remain. Collection closure is not a test-pass
+claim: the PR must record final required CI results and independent Standards, Spec
+and domain-architecture reviews before integration.
+
+## Rollback and following work
+
+To undo S4, revert its integration commit after reverting dependent work, restoring
+the complete package subtree at `645aeb9ee0375ad6cd1164998ea451aaba9bf68e`.
+Restore code, tests, CI selection and this delivery record together. Authority,
+authored source and build bytes are unchanged by S4; the six baseline builds and
+34 baseline vector observations establish the coherent pre-S4 behavior. A rollback
+reopens #873 and its known alias/mutation defects; it does not authorize a fallback
+inside the new compiler. Final accumulated rollback verification remains #879.
+
+S4 enables execution-dependency closure #874, followed by mandatory deletion #875.
+It does not remove the remaining whole-LDB/Build execution prerequisites, complete
+the non-RPG witness #878, or replace those issues' terminal acceptance criteria.

--- a/libs/gda-balancing/docs/refactor/current-language/README.md
+++ b/libs/gda-balancing/docs/refactor/current-language/README.md
@@ -20,5 +20,6 @@ Start with the [accepted decision](../../badr/0028-current-language-refactor-and
 | [Namespace expansion](NAMESPACE-EXPAND.md) | Integration boundary, derived namespace view, mandatory transition deletion and handoff for #870–#872 |
 | [Wire migration](WIRE-MIGRATION.md) | Native forms, declaration ownership, deletion boundaries and ordered verification for #871 |
 | [Namespace contract](NAMESPACE-CONTRACT.md) | Final S3 transition dispositions, acceptance witnesses, retained meanings and whole-stage rollback for #872 |
+| [Model preparation](MODEL-PREPARATION.md) | One request snapshot, alias-independent specialization, retained admission/resource checks and S4 rollback for #873 |
 
 GitHub owns live acceptance and task status; bADR-0028 owns the adopted policy; the plan owns delivery sequencing. Matrices preserve exact captured requirement text as provenance. Current issue amendments supersede the identified historical clauses. Evidence is confirmed only within its stated bounds, and no disposable probe establishes full production conformance, genre completion or automatic formal-release/claim activation.

--- a/libs/gda-balancing/src/gda_balancing/domain/model/_admission.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/model/_admission.py
@@ -46,7 +46,7 @@ from gda_balancing.domain.operation_call_domains import (
 )
 
 from gda_balancing.domain.model._resolution import (
-    CheckedModel,
+    ModelSourceContext,
     _formula_contexts,
     _formula_policy,
     _inventory_values,
@@ -1850,12 +1850,11 @@ def admit_resolved_model(
         selection = resolve_current_namespaces(
             context.current_namespace_packages(), root_requirements
         )
-        synthetic = CheckedModel(
+        synthetic = ModelSourceContext(
             source={requirements_member: root_requirements},
             source_identity="unbound-for-semantic-admission",
             kernel=kernel,
             language_bundle=ldb,
-            authority_context=context,
             namespace_selection=selection,
         )
         expected_lock = _package_lock(synthetic)

--- a/libs/gda-balancing/src/gda_balancing/domain/model/_checking.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/model/_checking.py
@@ -29,6 +29,7 @@ from gda_balancing.infrastructure.input_bytes import (
 )
 from gda_balancing.domain.model._resolution import (
     CheckedModel,
+    ModelSourceContext,
     _bounded_refusal,
     _formula_pair_diagnostics,
     _language,
@@ -42,6 +43,7 @@ from gda_balancing.domain.model._resolution import (
     _strict_object,
     _unique_reason,
 )
+from gda_balancing.domain.model._preparation import _TypedHIR
 from gda_balancing.domain.model._lowering import (
     _EntrypointBindingError,
     _FormulaResolutionError,
@@ -233,7 +235,7 @@ def _check_model_source_bytes(
         if refusal is not None:
             return refusal
     try:
-        _resolved_source_symbols(source, ldb)
+        source_rows = _resolved_source_symbols(source, ldb)
     except (KeyError, TypeError, ValueError) as err:
         source_contract_reason = reason_by_id(
             ldb,
@@ -246,12 +248,11 @@ def _check_model_source_bytes(
             f"Model Source name resolution failed: {err}",
             ldb,
         )
-    checked = CheckedModel(
+    context = ModelSourceContext(
         source=source,
         source_identity=source_identity,
         kernel=kernel,
         language_bundle=ldb,
-        authority_context=authority_context,
         namespace_selection=admit_namespace_selection(namespace_projection),
     )
     invalid_policy_pointer = _invalid_source_value_policy_pointer(source, ldb)
@@ -268,14 +269,17 @@ def _check_model_source_bytes(
             ldb,
         )
     try:
-        _lock, formula_declarations, _lowering, _rows = lowering_inputs(checked)
+        lock, declarations, admitted_lowering, source_rows = lowering_inputs(
+            context, source_rows
+        )
         (
             resolved_formulas,
             resolved_formula_bindings,
-            _formula_debug_entries,
+            formula_debug_entries,
         ) = _resolved_formulas_and_bindings(
-            checked,
-            cast(list[dict[str, Any]], formula_declarations),
+            context,
+            cast(list[dict[str, Any]], declarations),
+            lock,
         )
     except (KeyError, TypeError, ValueError) as err:
         message = str(err)
@@ -305,7 +309,6 @@ def _check_model_source_bytes(
     if formula_pair_refusal is not None:
         return formula_pair_refusal
     try:
-        lock, declarations, admitted_lowering, _source_rows = lowering_inputs(checked)
         selected_semantics = _runtime_projection(
             lock,
             declarations,
@@ -313,7 +316,7 @@ def _check_model_source_bytes(
             _runtime_projection_budget(kernel, ldb),
         )
         _resolved_entrypoints(
-            checked,
+            context,
             cast(list[dict[str, Any]], declarations),
             selected_semantics,
             cast(list[dict[str, Any]], resolved_formulas),
@@ -362,4 +365,21 @@ def _check_model_source_bytes(
             f"Model entrypoint resolution failed: {err}",
             ldb,
         )
-    return checked
+    return CheckedModel(
+        source=source,
+        source_identity=source_identity,
+        kernel=kernel,
+        language_bundle=ldb,
+        namespace_selection=context.namespace_selection,
+        authority_context=authority_context,
+        hir=_TypedHIR(
+            package_lock=lock,
+            declarations=declarations,
+            lowering=admitted_lowering,
+            source_rows=source_rows,
+            formulas=resolved_formulas,
+            formula_bindings=resolved_formula_bindings,
+            formula_debug_entries=formula_debug_entries,
+            runtime_projection=selected_semantics,
+        ),
+    )

--- a/libs/gda-balancing/src/gda_balancing/domain/model/_compilation.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/model/_compilation.py
@@ -1,12 +1,11 @@
 """Compile an already checked Model Source into resolved artifacts."""
 
+from copy import deepcopy
 from typing import Any, cast
 
 from gda_balancing.domain.artifacts import _identified_artifact
-from gda_balancing.domain.authority.admission import BootstrapAdmission
 from gda_balancing.domain.authority.context import (
     AdmittedAuthorityContext,
-    admit_authority_context,
 )
 from gda_balancing.domain.canonical import JsonValue
 from gda_balancing.domain.model._resolution import (
@@ -23,12 +22,8 @@ from gda_balancing.domain.model._lowering import (
     _composition_policy,
     _formula_operation_identity,
     _identified_rir_artifact,
-    lowering_inputs,
     _resolved_call_sites,
     _resolved_entrypoints,
-    _resolved_formulas_and_bindings,
-    _runtime_projection,
-    _runtime_projection_budget,
     _specialize_operation_formula_slots,
 )
 from gda_balancing.domain.model._admission import (
@@ -56,12 +51,7 @@ def compile_checked_model(
 
 def authority_context_for_checked(checked: CheckedModel) -> AdmittedAuthorityContext:
     """Return the exact admitted authority carried by a checked Model."""
-    if checked.authority_context is not None:
-        return checked.authority_context
-    context = admit_authority_context(checked.kernel, checked.language_bundle)
-    if isinstance(context, BootstrapAdmission):
-        raise RuntimeError("checked Model authorities failed admission")
-    return context
+    return checked.authority_context
 
 
 def model_build_command_input_identity(checked: CheckedModel) -> str:
@@ -346,42 +336,19 @@ def _capability_manifest(
 def lower_checked_model(checked: CheckedModel) -> dict[str, dict[str, JsonValue]]:
     """Lower one checked source to the semantic and provenance artifacts."""
     context = checked.authority_context
-    if (
-        context is None
-        or context.kernel is not checked.kernel
-        or context.language_bundle is not checked.language_bundle
-    ):
-        resolved_context = admit_authority_context(
-            checked.kernel,
-            checked.language_bundle,
-        )
-        if isinstance(resolved_context, BootstrapAdmission):
-            raise ValueError("lowerer received authorities that failed admission")
-        context = resolved_context
-        checked = CheckedModel(
-            source=checked.source,
-            source_identity=checked.source_identity,
-            kernel=context.kernel,
-            language_bundle=context.language_bundle,
-            authority_context=context,
-            namespace_selection=checked.namespace_selection,
-        )
-    if not context.admission.admitted:
-        raise ValueError("lowerer received authorities that failed admission")
-    lock, declarations, lowering, source_rows = lowering_inputs(checked)
-    formulas, formula_bindings, formula_debug_entries = _resolved_formulas_and_bindings(
-        checked, cast(list[dict[str, Any]], declarations)
-    )
+    hir = checked.hir
+    lock = deepcopy(hir.package_lock)
+    declarations = deepcopy(hir.declarations)
+    lowering = hir.lowering
+    source_rows = hir.source_rows
+    formulas = deepcopy(hir.formulas)
+    formula_bindings = deepcopy(hir.formula_bindings)
+    formula_debug_entries = hir.formula_debug_entries
     profile = _resolution_profile(
         checked.language_bundle, cast(str, lowering["resolution_profile"])
     )
     output_member = cast(str, lowering["output_member"])
-    selected_semantics = _runtime_projection(
-        lock,
-        declarations,
-        lowering,
-        _runtime_projection_budget(checked.kernel, checked.language_bundle),
-    )
+    selected_semantics = deepcopy(hir.runtime_projection)
     initialization_programs = _compile_initialization_programs(
         selected_semantics,
         cast(list[dict[str, JsonValue]], formulas),

--- a/libs/gda-balancing/src/gda_balancing/domain/model/_lowering.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/model/_lowering.py
@@ -43,6 +43,7 @@ from gda_balancing.domain.structured_values import (
 
 from gda_balancing.domain.model._resolution import (
     CheckedModel,
+    ModelSourceContext,
     _FORMULA_REASON,
     _formula_contexts,
     _formula_policy,
@@ -66,7 +67,8 @@ _LOWERER_IMPLEMENTATION_IDENTITY = "gda-balancing.python-lowerer-v1"
 
 
 def lowering_inputs(
-    checked: CheckedModel,
+    checked: ModelSourceContext,
+    source_rows: list[tuple[dict[str, Any], tuple[object, ...]]],
 ) -> tuple[
     dict[str, Any],
     list[dict[str, JsonValue]],
@@ -77,7 +79,6 @@ def lowering_inputs(
     lock = _package_lock(checked)
     language = _language(checked.language_bundle)
     lowering = _model_lowering(checked.language_bundle)
-    source_rows = _resolved_source_symbols(checked.source, checked.language_bundle)
     declarations: list[dict[str, JsonValue]] = []
     for fields, _source_pointer in source_rows:
         structured = fields.get("value_kind") == "nominal-structured"
@@ -144,9 +145,7 @@ def checked_model_template_facts(checked: CheckedModel) -> dict[str, JsonValue]:
         package.namespace for package in checked.namespace_selection.packages
     ]
     source_symbols = []
-    for fields, _source_pointer in _resolved_source_symbols(
-        checked.source, checked.language_bundle
-    ):
+    for fields, _source_pointer in checked.hir.source_rows:
         resolved = cast(dict[str, str], fields["resolved_symbol"])
         source_symbols.append(
             {
@@ -571,10 +570,11 @@ def _reachable_derived_formula_sites(
 
 
 def _resolved_formula_programs_and_bindings_impl(
-    checked: CheckedModel,
+    checked: ModelSourceContext,
     declarations: list[dict[str, Any]],
     policy: dict[str, Any],
     failure_context: list[str],
+    lock: dict[str, Any],
 ) -> tuple[
     list[dict[str, JsonValue]],
     list[dict[str, JsonValue]],
@@ -754,7 +754,6 @@ def _resolved_formula_programs_and_bindings_impl(
         visit(key)
 
     resolved_by_key: dict[tuple[str, str], dict[str, JsonValue]] = {}
-    lock = _package_lock(checked)
     operations_by_coordinate = {
         (
             cast(str, row["package"]),
@@ -1587,9 +1586,10 @@ def _resolved_formula_programs_and_bindings_impl(
 
 
 def _resolved_formula_programs_and_bindings(
-    checked: CheckedModel,
+    checked: ModelSourceContext,
     declarations: list[dict[str, Any]],
     policy: dict[str, Any],
+    lock: dict[str, Any],
 ) -> tuple[
     list[dict[str, JsonValue]],
     list[dict[str, JsonValue]],
@@ -1602,6 +1602,7 @@ def _resolved_formula_programs_and_bindings(
             declarations,
             policy,
             failure_context,
+            lock,
         )
     except _FormulaResolutionError:
         raise
@@ -1632,8 +1633,9 @@ def _resolved_formula_programs_and_bindings(
 
 
 def _resolved_formulas_and_bindings(
-    checked: CheckedModel,
+    checked: ModelSourceContext,
     declarations: list[dict[str, Any]],
+    lock: dict[str, Any],
 ) -> tuple[
     list[dict[str, JsonValue]],
     list[dict[str, JsonValue]],
@@ -1676,12 +1678,11 @@ def _resolved_formulas_and_bindings(
                 changed = True
                 break
     normalized = (
-        CheckedModel(
+        ModelSourceContext(
             source=normalized_source,
             source_identity=checked.source_identity,
             kernel=checked.kernel,
             language_bundle=checked.language_bundle,
-            authority_context=checked.authority_context,
             namespace_selection=checked.namespace_selection,
         )
         if changed
@@ -1691,6 +1692,7 @@ def _resolved_formulas_and_bindings(
         normalized,
         declarations,
         policy,
+        lock,
     )
 
 
@@ -2258,6 +2260,14 @@ def _specialize_operation_formula_slots(
                 evaluation_site_identity=site_identity,
             )
             shift += len(compiled) - length
+    for closure in cast(list[dict[str, Any]], specialized["package_semantic_closures"]):
+        package = cast(str, closure["package"])
+        for entry in cast(list[dict[str, Any]], closure["definitions"]):
+            if entry["authority_path"] == "language.operations":
+                entry["definitions"] = [
+                    deepcopy(operations[(package, definition["id"])])
+                    for definition in entry["definitions"]
+                ]
     return cast(dict[str, JsonValue], specialized)
 
 
@@ -2915,7 +2925,7 @@ def _reachable_operation_formula_dependencies(
 
 
 def _resolved_entrypoints(
-    checked: CheckedModel,
+    checked: ModelSourceContext,
     declarations: list[dict[str, Any]],
     selected_semantics: dict[str, Any],
     formulas: list[dict[str, Any]] | None = None,
@@ -3858,7 +3868,7 @@ def _resolved_call_sites(
     )
 
 
-def _package_lock(checked: CheckedModel) -> dict[str, JsonValue]:
+def _package_lock(checked: ModelSourceContext) -> dict[str, JsonValue]:
     language = _language(checked.language_bundle)
     lowering = _model_lowering(checked.language_bundle)
     profile = _resolution_profile(

--- a/libs/gda-balancing/src/gda_balancing/domain/model/_lowering.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/model/_lowering.py
@@ -1958,13 +1958,11 @@ def _specialize_operation_formula_slots(
         list[dict[str, Any]],
         specialized["operations"],
     )
-    operations = {
-        (
-            cast(str, row["package"]),
-            cast(str, cast(dict[str, Any], row["definition"])["id"]),
-        ): cast(dict[str, Any], row["definition"])
-        for row in operation_rows
-    }
+    operations: dict[tuple[str, str], dict[str, Any]] = {}
+    for row in operation_rows:
+        definition = deepcopy(cast(dict[str, Any], row["definition"]))
+        row["definition"] = definition
+        operations[cast(str, row["package"]), cast(str, definition["id"])] = definition
     formulas_by_identity = {
         cast(str, formula["identity"]): cast(dict[str, Any], formula)
         for formula in formulas

--- a/libs/gda-balancing/src/gda_balancing/domain/model/_preparation.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/model/_preparation.py
@@ -1,0 +1,28 @@
+"""Private, immutable meaning owned by one checked Model request."""
+
+from dataclasses import dataclass, fields
+from typing import Any
+
+from gda_balancing.domain.authority.context import _deep_freeze
+from gda_balancing.domain.canonical import JsonValue
+
+
+@dataclass(frozen=True)
+class _TypedHIR:
+    package_lock: dict[str, Any]
+    declarations: list[dict[str, JsonValue]]
+    lowering: dict[str, Any]
+    source_rows: list[tuple[dict[str, Any], tuple[object, ...]]]
+    formulas: list[dict[str, JsonValue]]
+    formula_bindings: list[dict[str, JsonValue]]
+    formula_debug_entries: list[tuple[str, str]]
+    runtime_projection: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        for member in fields(self):
+            object.__setattr__(
+                self, member.name, _deep_freeze(getattr(self, member.name))
+            )
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> "_TypedHIR":
+        return self

--- a/libs/gda-balancing/src/gda_balancing/domain/model/_resolution.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/model/_resolution.py
@@ -10,6 +10,7 @@ import jsonschema
 
 from gda_balancing.domain.authority.context import (
     AdmittedAuthorityContext,
+    _deep_freeze,
 )
 from gda_balancing.domain.authority.graph import (
     NamespaceClosureProjection,
@@ -36,6 +37,7 @@ from gda_balancing.domain.formula.notation import (
     admit_formula_pair,
 )
 from gda_balancing.domain.operation_program import closed_operation_coordinates
+from gda_balancing.domain.model._preparation import _TypedHIR
 
 _RESOLVER_IMPLEMENTATION_IDENTITY = "gda-balancing.python-exact-resolver-v1"
 _RelationBindings: TypeAlias = dict[str, tuple[Any, tuple[object, ...] | None]]
@@ -104,13 +106,32 @@ MODEL_REFUSAL_CATALOG = refusal_catalog_for_reasons(MODEL_REFUSAL_REASONS)
 
 
 @dataclass(frozen=True)
-class CheckedModel:
+class ModelSourceContext:
+    """Inputs for resolution; these alone do not authorize compilation."""
+
     source: dict[str, Any]
     source_identity: str
     kernel: dict[str, Any]
     language_bundle: dict[str, Any]
     namespace_selection: NamespaceSelection
-    authority_context: AdmittedAuthorityContext | None = None
+
+
+@dataclass(frozen=True)
+class CheckedModel(ModelSourceContext):
+    """One admitted source snapshot with its complete static preparation."""
+
+    authority_context: AdmittedAuthorityContext
+    hir: _TypedHIR
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.hir, _TypedHIR):
+            raise TypeError("checked Model requires complete static preparation")
+        if (
+            self.kernel is not self.authority_context.kernel
+            or self.language_bundle is not self.authority_context.language_bundle
+        ):
+            raise ValueError("checked Model must retain its admitted authority context")
+        object.__setattr__(self, "source", _deep_freeze(self.source))
 
 
 class _ResolutionResourceExhausted(Exception):

--- a/libs/gda-balancing/tests/schema2-test-inventory-v1.json
+++ b/libs/gda-balancing/tests/schema2-test-inventory-v1.json
@@ -41,7 +41,7 @@
     "tests/test_cli_conformance.py::TestPerDescriptorRows::test_verdict_row[template list]",
     "tests/test_cli_conformance.py::TestPerDescriptorRows::test_verdict_row[version]"
   ],
-  "description": "Required logical behavior inventory after Schema 1 retirement, current-package union and #871 native namespace migration. Explicit obligation dispositions preserve negative admission and retained behavior; the complete current collection must also belong to exactly one CI shard.",
+  "description": "Required logical behavior inventory after Schema 1 retirement, current-package union, #871 native namespace migration and #873 request preparation. Explicit obligation dispositions preserve negative admission and retained behavior; the complete current collection must also belong to exactly one CI shard.",
   "package_vector_ids": [
     "core.quantity:model.compile.boundary-max-symbols",
     "core.quantity:model.compile.boundary-max-symbols-plus-one",
@@ -340,6 +340,14 @@
     "tests/test_isolation.py::test_vocabulary_gate_catches_each_denylisted_term[unreal]",
     "tests/test_isolation.py::test_vocabulary_gate_catches_each_denylisted_term[warp]",
     "tests/test_isolation.py::test_vocabulary_gate_catches_each_denylisted_term[wine]",
+    "tests/test_model_preparation.py::test_checked_request_and_all_artifact_outputs_are_isolated_from_mutation",
+    "tests/test_model_preparation.py::test_preparation_keeps_exact_projection_charge_and_complete_refusal[232]",
+    "tests/test_model_preparation.py::test_preparation_keeps_exact_projection_charge_and_complete_refusal[233]",
+    "tests/test_model_preparation.py::test_preparation_keeps_exact_projection_charge_and_complete_refusal[234]",
+    "tests/test_model_preparation.py::test_public_model_request_prepares_once_and_keeps_artifact_admission[build]",
+    "tests/test_model_preparation.py::test_public_model_request_prepares_once_and_keeps_artifact_admission[check]",
+    "tests/test_model_preparation.py::test_specialization_is_value_based_in_operations_and_package_closures[progression-periodic-effect]",
+    "tests/test_model_preparation.py::test_specialization_is_value_based_in_operations_and_package_closures[roguelike-reward-build]",
     "tests/test_schema2_authority_cli.py::test_authority_decode_failure_is_a_typed_ingress_refusal",
     "tests/test_schema2_authority_cli.py::test_authority_loader_identity_is_independent_of_physical_member_location",
     "tests/test_schema2_authority_cli.py::test_authority_loader_refuses_an_unreadable_declared_child[packages/core-quantity/core.quantity.conformance-vectors.json-language-bundle.package_descriptors.0.conformance_vectors]",

--- a/libs/gda-balancing/tests/schema2-test-inventory-v1.json
+++ b/libs/gda-balancing/tests/schema2-test-inventory-v1.json
@@ -346,6 +346,7 @@
     "tests/test_model_preparation.py::test_preparation_keeps_exact_projection_charge_and_complete_refusal[234]",
     "tests/test_model_preparation.py::test_public_model_request_prepares_once_and_keeps_artifact_admission[build]",
     "tests/test_model_preparation.py::test_public_model_request_prepares_once_and_keeps_artifact_admission[check]",
+    "tests/test_model_preparation.py::test_specialization_does_not_bind_a_value_equal_operation_in_another_namespace",
     "tests/test_model_preparation.py::test_specialization_is_value_based_in_operations_and_package_closures[progression-periodic-effect]",
     "tests/test_model_preparation.py::test_specialization_is_value_based_in_operations_and_package_closures[roguelike-reward-build]",
     "tests/test_schema2_authority_cli.py::test_authority_decode_failure_is_a_typed_ingress_refusal",

--- a/libs/gda-balancing/tests/test_model_preparation.py
+++ b/libs/gda-balancing/tests/test_model_preparation.py
@@ -13,6 +13,7 @@ from typing import Any, cast
 
 import pytest
 
+from gda_balancing.domain.authority.admission import admit_authorities
 from gda_balancing.domain.canonical import canonical_bytes
 from gda_balancing.domain.diagnostics import Schema2RefusalReport
 from gda_balancing.domain.model import (
@@ -22,7 +23,11 @@ from gda_balancing.domain.model import (
 )
 from gda_balancing.domain.model import _admission, _compilation, _lowering
 from schema2_authority_support import mutable_authorities
-from test_schema2_model_cli import _model_source, _reidentify_language_bundle
+from test_schema2_model_cli import (
+    _model_source,
+    _package_vector_set,
+    _reidentify_language_bundle,
+)
 
 
 _EXAMPLES = Path(__file__).parents[1] / "examples" / "schema2"
@@ -215,6 +220,173 @@ def test_specialization_is_value_based_in_operations_and_package_closures(fixtur
     assert changed > 0
     # Admission must independently reproduce the same specialization from RIR.
     assert _artifact_bytes(checked)
+
+
+def _effect_copy_candidate():
+    """Keep two legal, value-equal Operations under distinct namespace owners."""
+    kernel, language_bundle = mutable_authorities()
+    language = language_bundle["language"]
+    original = next(row for row in language["packages"] if row["id"] == "game.effect")
+    copied = deepcopy(original)
+    copied["id"] = "test.effectcopy"
+    copied["runtime_semantic_excluded_extensions"] = []
+    copied["capabilities"]["provided"] = ["test.effectcopy.periodic"]
+    copied["dependencies"]["required"].append("game.effect")
+    capability = deepcopy(
+        next(
+            row
+            for row in language["capabilities"]
+            if row["id"] == "game.effect.periodic"
+        )
+    )
+    capability["id"] = "test.effectcopy.periodic"
+    language["capabilities"].append(capability)
+    vectors = deepcopy(
+        next(
+            row["vector_definitions"]
+            for row in language_bundle.package_conformance_vector_sets
+            if row["package_id"] == "game.effect"
+        )
+    )
+    vector_ids = {row["id"]: "test.copy." + row["id"] for row in vectors}
+
+    def probe(value, path):
+        for segment in path.split("."):
+            value = value[segment]
+        return deepcopy(value)
+
+    for vector in vectors:
+        vector["id"] = vector_ids[vector["id"]]
+        if vector["kind"] == "package-contract":
+            vector["expect"] = probe(copied, vector["probe"]["path"])
+    # Both equivalent definitions declare the union of their actual vector
+    # witnesses; each namespace still owns its distinct, complete vector set.
+    operation_groups = [
+        [
+            row
+            for row in language["operations"]
+            if row["id"] in copied["exports"]["operations"]
+        ],
+        *[
+            entry["definitions"]
+            for package in (original, copied)
+            for entry in package["semantic_closure"]
+            if entry["authority_path"] == "language.operations"
+        ],
+    ]
+    for operations in operation_groups:
+        for operation in operations:
+            operation["vectors"] += [
+                vector_ids[identifier]
+                for identifier in operation["vectors"]
+                if identifier in vector_ids
+            ]
+    for entry in copied["semantic_closure"]:
+        if entry["authority_path"] == "language.capabilities":
+            entry["definitions"] = [deepcopy(capability)]
+        elif entry["authority_path"] == "language.operations":
+            for operation in entry["definitions"]:
+                # The global Formula notation has one provider; copying its
+                # spelling would invalidate the authority before this witness.
+                operation.get("extensions", {}).pop("standard.formula-notation", None)
+                if operation not in language["operations"]:
+                    language["operations"].append(deepcopy(operation))
+    copied_operations = {
+        operation["id"]: operation
+        for entry in copied["semantic_closure"]
+        if entry["authority_path"] == "language.operations"
+        for operation in entry["definitions"]
+    }
+    for vector in vectors:
+        if vector["kind"] == "operation-contract":
+            vector["expect"] = probe(
+                copied_operations[vector["operation"]], vector["probe"]["path"]
+            )
+    language["packages"].append(copied)
+    language_bundle.package_conformance_vector_sets.append(
+        _package_vector_set(copied["id"], vectors)
+    )
+    _reidentify_language_bundle(language_bundle)
+    return kernel, language_bundle
+
+
+def test_specialization_does_not_bind_a_value_equal_operation_in_another_namespace():
+    kernel, language_bundle = _effect_copy_candidate()
+    admission = admit_authorities(kernel, language_bundle)
+    assert admission.admitted, admission.diagnostics
+    source = json.loads(
+        (_EXAMPLES / "progression-periodic-effect" / "model-source.json").read_bytes()
+    )
+    source["package_requirements"].append("test.effectcopy")
+    source_before = canonical_bytes(source)
+    authority_before = canonical_bytes(language_bundle)
+    with _observe_preparation() as trace:
+        checked = check_model_source_value(
+            source, kernel=kernel, language_bundle=language_bundle
+        )
+    assert isinstance(checked, CheckedModel), checked
+    assert set(_artifact_bytes(checked)) == _ARTIFACTS
+    formulas, bindings, _ = trace.formula_results[0]
+    reference = next(
+        binding["site"]["operation"]
+        for binding in bindings
+        if binding["site"]["kind"] == "operation-slot"
+        and binding["site"]["operation"]["package"] == "game.effect"
+    )
+    assert not any(
+        binding["site"]["kind"] == "operation-slot"
+        and binding["site"]["operation"]["package"] == "test.effectcopy"
+        for binding in bindings
+    )
+
+    def operation(projection, namespace):
+        return next(
+            row
+            for row in projection["operations"]
+            if row["package"] == namespace
+            and row["definition"]["id"] == reference["id"]
+        )
+
+    independent = trace.projections[0]
+    bound = operation(independent, "game.effect")["definition"]
+    unbound = operation(independent, "test.effectcopy")["definition"]
+    assert bound == unbound and bound is not unbound
+    aliased = deepcopy(independent)
+    operation(aliased, "test.effectcopy")["definition"] = operation(
+        aliased, "game.effect"
+    )["definition"]
+    inputs = [independent, aliased, json.loads(canonical_bytes(aliased))]
+    before = canonical_bytes(independent)
+    assert all(
+        value == independent and canonical_bytes(value) == before for value in inputs
+    )
+    outputs = [
+        cast(
+            dict[str, Any],
+            _lowering._specialize_operation_formula_slots(value, formulas, bindings),
+        )
+        for value in inputs
+    ]
+    assert all(canonical_bytes(value) == before for value in inputs)
+    assert canonical_bytes(source) == source_before
+    assert canonical_bytes(language_bundle) == authority_before
+    for output in outputs:
+        assert operation(output, "game.effect")["definition"] != bound
+        # The complete unbound definition, including body and provenance, must
+        # remain unchanged in both projections even if its input was aliased.
+        assert operation(output, "test.effectcopy")["definition"] == unbound
+        closure_definition = next(
+            definition
+            for closure in output["package_semantic_closures"]
+            if closure["package"] == "test.effectcopy"
+            for entry in closure["definitions"]
+            if entry["authority_path"] == "language.operations"
+            for definition in entry["definitions"]
+            if definition["id"] == reference["id"]
+        )
+        assert closure_definition == unbound
+    assert outputs[0] == outputs[1] == outputs[2]
+    assert len({canonical_bytes(value) for value in outputs}) == 1
 
 
 def test_checked_request_and_all_artifact_outputs_are_isolated_from_mutation():

--- a/libs/gda-balancing/tests/test_model_preparation.py
+++ b/libs/gda-balancing/tests/test_model_preparation.py
@@ -52,6 +52,7 @@ class _PreparationTrace:
             function.__code__: function.__name__
             for function in (
                 _lowering.lowering_inputs,
+                _lowering._resolved_source_symbols,
                 _lowering._resolved_formulas_and_bindings,
                 _lowering._runtime_projection,
                 _lowering._specialize_operation_formula_slots,
@@ -154,11 +155,13 @@ def test_public_model_request_prepares_once_and_keeps_artifact_admission(
     assert {
         name: trace.calls["source", name]
         for name in (
+            "_resolved_source_symbols",
             "lowering_inputs",
             "_resolved_formulas_and_bindings",
             "_runtime_projection",
         )
     } == {
+        "_resolved_source_symbols": 1,
         "lowering_inputs": 1,
         "_resolved_formulas_and_bindings": 1,
         "_runtime_projection": 1,

--- a/libs/gda-balancing/tests/test_model_preparation.py
+++ b/libs/gda-balancing/tests/test_model_preparation.py
@@ -1,0 +1,307 @@
+"""Request preparation reuse and alias-independent Model specialization (#873)."""
+
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from copy import deepcopy
+import json
+from pathlib import Path
+import sys
+from threading import Barrier
+from types import FrameType
+from typing import Any, cast
+
+import pytest
+
+from gda_balancing.domain.canonical import canonical_bytes
+from gda_balancing.domain.diagnostics import Schema2RefusalReport
+from gda_balancing.domain.model import (
+    CheckedModel,
+    check_model_source_value,
+    compile_checked_model,
+)
+from gda_balancing.domain.model import _admission, _compilation, _lowering
+from schema2_authority_support import mutable_authorities
+from test_schema2_model_cli import _model_source, _reidentify_language_bundle
+
+
+_EXAMPLES = Path(__file__).parents[1] / "examples" / "schema2"
+_ARTIFACTS = {
+    "build-receipt",
+    "capability-manifest",
+    "debug-map",
+    "model-explanation",
+    "package-lock",
+    "resolution-receipt",
+    "resolved-model",
+    "rir-semantic-payload",
+}
+
+
+class _PreparationTrace:
+    """Observe real calls without replacing a compiler or admission implementation."""
+
+    def __init__(self) -> None:
+        self.calls: Counter[tuple[str, str]] = Counter()
+        self.projections: list[dict[str, Any]] = []
+        self.formula_results: list[tuple[Any, Any, Any]] = []
+        self.charges: list[tuple[str, int, int]] = []
+        self.specialized = False
+        self.post_specialization_checks: set[str] = set()
+        self._watched = {
+            function.__code__: function.__name__
+            for function in (
+                _lowering.lowering_inputs,
+                _lowering._resolved_formulas_and_bindings,
+                _lowering._runtime_projection,
+                _lowering._specialize_operation_formula_slots,
+                _lowering._resolved_entrypoints,
+                _lowering._resolved_call_sites,
+                _admission.admit_resolved_model,
+                _compilation.validate_compiled_artifacts,
+            )
+        }
+
+    def profile(self, frame: FrameType, event: str, result: Any) -> None:
+        name = self._watched.get(frame.f_code)
+        if name is None:
+            return
+        parent = frame
+        owner = "source"
+        while parent is not None:
+            if parent.f_code is _admission.admit_resolved_model.__code__:
+                owner = "imported-artifact"
+                break
+            parent = parent.f_back
+        if event == "call":
+            self.calls[owner, name] += 1
+            if owner == "source" and self.specialized:
+                self.post_specialization_checks.add(name)
+        elif event == "return":
+            if name == "_specialize_operation_formula_slots" and owner == "source":
+                self.specialized = True
+            if name == "_runtime_projection":
+                budget = frame.f_locals["budget"]
+                self.charges.append((owner, budget.used, budget.limit))
+                if owner == "source" and result is not None:
+                    self.projections.append(deepcopy(result))
+            elif name == "_resolved_formulas_and_bindings" and owner == "source":
+                self.formula_results.append(deepcopy(result))
+
+
+@contextmanager
+def _observe_preparation():
+    trace = _PreparationTrace()
+    previous = sys.getprofile()
+    sys.setprofile(trace.profile)
+    try:
+        yield trace
+    finally:
+        sys.setprofile(previous)
+
+
+def _checked(source: dict[str, Any]) -> CheckedModel:
+    checked = check_model_source_value(source)
+    assert isinstance(checked, CheckedModel), checked
+    return checked
+
+
+def _artifact_bytes(checked: CheckedModel) -> dict[str, bytes]:
+    artifacts = compile_checked_model(checked)
+    assert set(artifacts) == _ARTIFACTS
+    return {name: canonical_bytes(value) for name, value in artifacts.items()}
+
+
+@pytest.mark.parametrize("command", ["check", "build"])
+def test_public_model_request_prepares_once_and_keeps_artifact_admission(
+    command, run_cli, tmp_path
+):
+    source_path = _EXAMPLES / "progression-periodic-effect" / "model-source.json"
+    expected = _artifact_bytes(_checked(json.loads(source_path.read_bytes())))
+    argv = ["model", command, str(source_path)]
+    if command == "build":
+        argv += ["--out", str(tmp_path / "artifacts"), "--invocation-key", "c7" * 32]
+
+    with _observe_preparation() as trace:
+        code, stdout, stderr = run_cli(argv)
+
+    assert (code, stderr) == (0, ""), stdout
+    if command == "build":
+        receipt = json.loads(stdout)
+        published = {
+            row["logical_name"]: Path(row["locator"]).read_bytes()
+            for row in receipt["member_locators"]
+        }
+        assert published == expected
+    # Compilation always self-admits; a fresh publication validates again.
+    independent_boundaries = 1 if command == "check" else 2
+    assert (
+        trace.calls["imported-artifact", "admit_resolved_model"]
+        == independent_boundaries
+    )
+    assert (
+        trace.calls["imported-artifact", "_runtime_projection"]
+        == independent_boundaries
+    )
+    assert (
+        trace.calls["source", "validate_compiled_artifacts"] == independent_boundaries
+    )
+    assert {
+        "_resolved_entrypoints",
+        "_resolved_call_sites",
+    } <= trace.post_specialization_checks
+    assert {used for _, used, _ in trace.charges} == {318}
+    assert {
+        name: trace.calls["source", name]
+        for name in (
+            "lowering_inputs",
+            "_resolved_formulas_and_bindings",
+            "_runtime_projection",
+        )
+    } == {
+        "lowering_inputs": 1,
+        "_resolved_formulas_and_bindings": 1,
+        "_runtime_projection": 1,
+    }
+
+
+@pytest.mark.parametrize(
+    "fixture", ["progression-periodic-effect", "roguelike-reward-build"]
+)
+def test_specialization_is_value_based_in_operations_and_package_closures(fixture):
+    source = json.loads((_EXAMPLES / fixture / "model-source.json").read_bytes())
+    before_source = canonical_bytes(source)
+    with _observe_preparation() as trace:
+        checked = _checked(source)
+    original = trace.projections[0]
+    formulas, bindings, _ = trace.formula_results[0]
+    before_authority = canonical_bytes(checked.language_bundle)
+    inputs = [original, deepcopy(original), json.loads(canonical_bytes(original))]
+    before = canonical_bytes(original)
+    assert all(
+        value == original and canonical_bytes(value) == before for value in inputs
+    )
+    outputs = [
+        _lowering._specialize_operation_formula_slots(value, formulas, bindings)
+        for value in inputs
+    ]
+    assert all(canonical_bytes(value) == before for value in inputs)
+    assert canonical_bytes(source) == before_source
+    assert canonical_bytes(checked.language_bundle) == before_authority
+    # The roguelike counterexample changes provenance only: body-only comparison
+    # would miss it. Require the entire output and both emitted definition views.
+    assert outputs[0] == outputs[1] == outputs[2]
+    assert len({canonical_bytes(value) for value in outputs}) == 1
+    specialized = cast(dict[str, Any], outputs[0])
+    closures = {
+        (closure["package"], definition["id"]): definition
+        for closure in specialized["package_semantic_closures"]
+        for entry in closure["definitions"]
+        if entry["authority_path"] == "language.operations"
+        for definition in entry["definitions"]
+    }
+    changed = 0
+    for row, prior in zip(
+        specialized["operations"], original["operations"], strict=True
+    ):
+        definition = row["definition"]
+        assert closures[row["package"], definition["id"]] == definition
+        if definition != prior["definition"]:
+            changed += 1
+            assert "standard.instruction-provenance" in definition["extensions"]
+    assert changed > 0
+    # Admission must independently reproduce the same specialization from RIR.
+    assert _artifact_bytes(checked)
+
+
+def test_checked_request_and_all_artifact_outputs_are_isolated_from_mutation():
+    source = _model_source()
+    checked = _checked(source)
+    expected = _artifact_bytes(checked)
+    source["modules"][0]["symbols"][0]["value_policy"]["value"] = 2
+    assert _artifact_bytes(checked) == expected
+    assert _artifact_bytes(_checked(source)) != expected
+
+    # A caller may inspect an old CheckedModel; mutable views must not become a
+    # back door into its prepared meaning. Immutable views may reject the write.
+    try:
+        checked.source["modules"][0]["symbols"][0]["value_policy"]["value"] = 99
+    except TypeError:
+        pass
+    assert _artifact_bytes(checked) == expected
+    emitted = compile_checked_model(checked)
+    assert set(emitted) == _ARTIFACTS
+    for artifact in emitted.values():
+        artifact.clear()
+    assert _artifact_bytes(checked) == expected
+
+    sources = [deepcopy(source), deepcopy(source)]
+    for value, candidate in enumerate(sources, start=3):
+        candidate["modules"][0]["symbols"][0]["value_policy"]["value"] = value
+    sequential = [_artifact_bytes(_checked(candidate)) for candidate in sources]
+    assert sequential[0] != sequential[1]
+    barrier = Barrier(2)
+
+    def compile_concurrently(candidate):
+        barrier.wait(timeout=10)
+        return _artifact_bytes(_checked(candidate))
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        concurrent = list(executor.map(compile_concurrently, sources))
+    assert concurrent == sequential
+    assert _artifact_bytes(checked) == expected
+
+
+@pytest.mark.parametrize("limit", [232, 233, 234])
+def test_preparation_keeps_exact_projection_charge_and_complete_refusal(limit):
+    kernel, language_bundle = mutable_authorities()
+    language_bundle["resources"]["max_runtime_projection_steps"] = limit
+    for identifier, value in (
+        ("model.accept.runtime-projection-step-boundary", limit),
+        ("model.refuse.runtime-projection-step-budget", limit + 1),
+    ):
+        vector = next(
+            row for row in language_bundle["vectors"] if row["id"] == identifier
+        )
+        vector["input"]["value"] = value
+    _reidentify_language_bundle(language_bundle)
+
+    with _observe_preparation() as trace:
+        checked = check_model_source_value(
+            _model_source(), kernel=kernel, language_bundle=language_bundle
+        )
+        if isinstance(checked, CheckedModel):
+            artifacts = _artifact_bytes(checked)
+            assert artifacts
+
+    if limit == 232:
+        assert isinstance(checked, Schema2RefusalReport)
+        assert checked.model_dump(mode="json") == {
+            "stage": "static",
+            "variant": None,
+            "diagnostics": [
+                {
+                    "code": "language.resource_exhausted",
+                    "message": "Model Source runtime projection exhausted its admitted step budget",
+                    "primary": {
+                        "kind": "artifact",
+                        "content_identity": "sha256:a16a065314a420f1403e008d961a77a35004b17a518d8de94a26bbf37300b00b",
+                        "pointer": "",
+                    },
+                    "related": [],
+                }
+            ],
+            "truncated": False,
+            "terminal_audit": None,
+        }
+        assert trace.calls["imported-artifact", "admit_resolved_model"] == 0
+    else:
+        assert isinstance(checked, CheckedModel), checked
+        assert trace.calls["imported-artifact", "admit_resolved_model"] == 1
+        assert ("source", 233, limit) in trace.charges
+        assert ("imported-artifact", 233, limit) in trace.charges
+    assert trace.charges
+    assert all(
+        used == min(limit, 233) and admitted_limit == limit
+        for _, used, admitted_limit in trace.charges
+    )

--- a/libs/gda-balancing/tests/test_model_preparation.py
+++ b/libs/gda-balancing/tests/test_model_preparation.py
@@ -235,6 +235,13 @@ def test_checked_request_and_all_artifact_outputs_are_isolated_from_mutation():
     emitted = compile_checked_model(checked)
     assert set(emitted) == _ARTIFACTS
     for artifact in emitted.values():
+        for member in artifact.values():
+            if isinstance(member, (dict, list)):
+                try:
+                    member.clear()
+                except TypeError:
+                    pass
+                break
         artifact.clear()
     assert _artifact_bytes(checked) == expected
 

--- a/libs/gda-balancing/tests/test_schema2_model_cli.py
+++ b/libs/gda-balancing/tests/test_schema2_model_cli.py
@@ -6858,13 +6858,12 @@ def test_lowerer_executes_the_admitted_ldb_rule_instead_of_copying_source_fields
     )
     _reidentify_language_bundle(candidate_ldb)
     assert admit_authorities(checked.kernel, candidate_ldb).admitted is True
-    candidate = model_module.CheckedModel(
-        source=checked.source,
-        source_identity=checked.source_identity,
+    candidate = model_checking_module.check_model_source_value(
+        checked.source,
         kernel=checked.kernel,
         language_bundle=candidate_ldb,
-        namespace_selection=checked.namespace_selection,
     )
+    assert isinstance(candidate, model_module.CheckedModel)
 
     artifacts = model_compilation_module.lower_checked_model(candidate)
 
@@ -6968,7 +6967,9 @@ def test_rir_identity_binds_the_reachable_selected_runtime_semantics(tmp_path):
     )
     _reidentify_language_bundle(candidate_ldb)
     assert admit_authorities(checked.kernel, candidate_ldb).admitted is True
-    candidate = replace(checked, language_bundle=candidate_ldb)
+    candidate = _check_with_candidate_ldb(
+        checked.source, checked.kernel, cast(LanguageBundleIndex, candidate_ldb)
+    )
 
     mutated = model_compilation_module.lower_checked_model(candidate)
 
@@ -7443,7 +7444,9 @@ def test_compile_only_package_authority_does_not_change_rir_semantics(tmp_path):
     candidate_ldb["language"]["model_checks"].reverse()
     _reidentify_language_bundle(candidate_ldb)
     assert admit_authorities(checked.kernel, candidate_ldb).admitted is True
-    candidate = replace(checked, language_bundle=candidate_ldb)
+    candidate = _check_with_candidate_ldb(
+        checked.source, checked.kernel, cast(LanguageBundleIndex, candidate_ldb)
+    )
 
     mutated = model_compilation_module.lower_checked_model(candidate)
 
@@ -7473,7 +7476,9 @@ def test_vector_only_package_change_reidentifies_exact_wrappers_not_rir(tmp_path
     vector_set["vector_definitions"].reverse()
     _reidentify_language_bundle(candidate_ldb)
     assert admit_authorities(checked.kernel, candidate_ldb).admitted is True
-    candidate = replace(checked, language_bundle=candidate_ldb)
+    candidate = _check_with_candidate_ldb(
+        checked.source, checked.kernel, cast(LanguageBundleIndex, candidate_ldb)
+    )
 
     mutated = model_compilation_module.lower_checked_model(candidate)
 
@@ -7518,7 +7523,9 @@ def test_unreachable_runtime_operation_does_not_change_rir_semantics(tmp_path):
     resource_vector["expect"] += 1
     _reidentify_language_bundle(candidate_ldb)
     assert admit_authorities(checked.kernel, candidate_ldb).admitted is True
-    candidate = replace(checked, language_bundle=candidate_ldb)
+    candidate = _check_with_candidate_ldb(
+        checked.source, checked.kernel, cast(LanguageBundleIndex, candidate_ldb)
+    )
 
     mutated = model_compilation_module.lower_checked_model(candidate)
 
@@ -7895,9 +7902,10 @@ def test_unreachable_package_semantics_do_not_change_rir(
     _reidentify_language_bundle(candidate_ldb)
     assert admit_authorities(checked.kernel, candidate_ldb).admitted is True
 
-    mutated = model_compilation_module.lower_checked_model(
-        replace(checked, language_bundle=candidate_ldb)
+    candidate = _check_with_candidate_ldb(
+        checked.source, checked.kernel, cast(LanguageBundleIndex, candidate_ldb)
     )
+    mutated = model_compilation_module.lower_checked_model(candidate)
 
     assert original["rir-semantic-payload"] == mutated["rir-semantic-payload"]
     assert original["package-lock"] != mutated["package-lock"]

--- a/libs/gda-balancing/tests/test_schema2_model_lowerer_conformance.py
+++ b/libs/gda-balancing/tests/test_schema2_model_lowerer_conformance.py
@@ -36,8 +36,10 @@ from gda_balancing.domain.model import (
     CheckedModel,
     admit_resolved_model,
     check_model_source,
+    check_model_source_value,
 )
 from gda_balancing.domain.model._compilation import lower_checked_model
+from gda_balancing.domain.model._resolution import ModelSourceContext
 from schema2_authority_support import (
     refresh_package_semantic_closures,
     mutable_authorities,
@@ -515,7 +517,7 @@ def _reference_check_source(
     source: dict[str, Any],
     kernel: dict[str, Any],
     language_bundle: dict[str, Any],
-) -> tuple[tuple[str, str], ...] | CheckedModel:
+) -> tuple[tuple[str, str], ...] | ModelSourceContext:
     """Independently interpret the admitted source schema and model-check relation."""
     language = language_bundle["language"]
     source_schema = next(
@@ -903,7 +905,7 @@ def _reference_check_source(
             return ((resource_diagnostic, ""),)
         if stage_diagnostics:
             return tuple(dict.fromkeys(stage_diagnostics))
-    checked = CheckedModel(
+    checked = ModelSourceContext(
         source=source,
         source_identity=_reference_content_identity(
             profile["source_identity_domain"], source
@@ -1037,7 +1039,7 @@ def _reference_apply(
     }
 
 
-def _reference_resolved_symbols(checked: CheckedModel) -> list[dict[str, Any]]:
+def _reference_resolved_symbols(checked: ModelSourceContext) -> list[dict[str, Any]]:
     language = checked.language_bundle["language"]
     lowering = _reference_lowering(language)
     profile = next(
@@ -1109,7 +1111,7 @@ def _reference_resolved_symbols(checked: CheckedModel) -> list[dict[str, Any]]:
 
 
 def _reference_artifact(
-    checked: CheckedModel, artifact_kind: str, payload: dict[str, Any]
+    checked: ModelSourceContext, artifact_kind: str, payload: dict[str, Any]
 ) -> dict[str, Any]:
     language = checked.language_bundle["language"]
     contract = next(
@@ -1147,7 +1149,7 @@ def _reference_artifact(
     return artifact
 
 
-def _reference_package_lock(checked: CheckedModel) -> dict[str, Any]:
+def _reference_package_lock(checked: ModelSourceContext) -> dict[str, Any]:
     language = checked.language_bundle["language"]
     lowering = _reference_lowering(language)
     profile = next(
@@ -1396,7 +1398,7 @@ def _reference_formula_contract_matches_operation(
 
 
 def _reference_selected_operation_coordinates(
-    checked: CheckedModel,
+    checked: ModelSourceContext,
     lock: dict[str, Any],
 ) -> set[tuple[str, str]]:
 
@@ -1435,7 +1437,7 @@ def _reference_selected_operation_coordinates(
 
 
 def _reference_formulas_and_bindings(
-    checked: CheckedModel,
+    checked: ModelSourceContext,
     declarations: list[dict[str, Any]],
     lock: dict[str, Any],
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
@@ -2262,7 +2264,7 @@ def _reference_initialization_programs(
     selected_semantics: dict[str, Any],
     formulas: list[dict[str, Any]],
     bindings: list[dict[str, Any]],
-    checked: CheckedModel,
+    checked: ModelSourceContext,
 ) -> list[dict[str, Any]]:
     """Independently compile derived bindings to generic value programs."""
 
@@ -2540,7 +2542,7 @@ def _reference_initialization_programs(
 
 
 def _reference_rir(
-    checked: CheckedModel, lock: dict[str, Any] | None = None
+    checked: ModelSourceContext, lock: dict[str, Any] | None = None
 ) -> dict[str, Any]:
     language = checked.language_bundle["language"]
     lowering = _reference_lowering(language)
@@ -2634,7 +2636,7 @@ def _reference_value_contract_matches(
 def _reference_literal_context(
     value: Any,
     formal: dict[str, Any],
-    checked: CheckedModel,
+    checked: ModelSourceContext,
     selected_semantics: dict[str, Any],
 ) -> dict[str, Any] | None:
     if (
@@ -2728,7 +2730,7 @@ def _reference_alias_rows(
 
 
 def _reference_entrypoints(
-    checked: CheckedModel,
+    checked: ModelSourceContext,
     declarations: list[dict[str, Any]],
     selected_semantics: dict[str, Any],
     formula_bindings: list[dict[str, Any]],
@@ -3210,7 +3212,7 @@ def _reference_operation_contract_matches(
 
 
 def _reference_call_sites(
-    checked: CheckedModel,
+    checked: ModelSourceContext,
     selected_semantics: dict[str, Any],
     lowering: dict[str, Any],
 ) -> list[dict[str, Any]]:
@@ -3514,7 +3516,7 @@ def _reference_call_sites(
 
 
 def _reference_runtime_projection(
-    checked: CheckedModel,
+    checked: ModelSourceContext,
     lock: dict[str, Any],
     declarations: list[dict[str, Any]],
     lowering: dict[str, Any],
@@ -3769,7 +3771,9 @@ def _reference_pointer(parts: list[object]) -> str:
     )
 
 
-def _reference_debug_map(checked: CheckedModel, rir: dict[str, Any]) -> dict[str, Any]:
+def _reference_debug_map(
+    checked: ModelSourceContext, rir: dict[str, Any]
+) -> dict[str, Any]:
     language = checked.language_bundle["language"]
     lowering = _reference_lowering(language)
     profile = next(
@@ -3838,7 +3842,7 @@ def _reference_debug_map(checked: CheckedModel, rir: dict[str, Any]) -> dict[str
 
 
 def _reference_semantic_artifacts(
-    checked: CheckedModel,
+    checked: ModelSourceContext,
 ) -> dict[str, dict[str, Any]]:
     lock = _reference_package_lock(checked)
     rir = _reference_rir(checked, lock)
@@ -3862,7 +3866,7 @@ def _reference_semantic_artifacts(
 
 
 def _reference_admits_semantic_artifacts(
-    candidate: dict[str, dict[str, Any]], checked: CheckedModel
+    candidate: dict[str, dict[str, Any]], checked: ModelSourceContext
 ) -> bool:
     expected = _reference_semantic_artifacts(checked)
     return all(
@@ -4048,7 +4052,7 @@ def test_permanent_model_program_vectors_close_both_compiler_pipelines(tmp_path)
             continue
 
         assert isinstance(production_checked, CheckedModel)
-        assert isinstance(reference_checked, CheckedModel)
+        assert isinstance(reference_checked, ModelSourceContext)
         production = lower_checked_model(production_checked)
         reference = _reference_semantic_artifacts(reference_checked)
         assert all(
@@ -4176,7 +4180,7 @@ def test_independent_lowerers_mutually_consume_byte_identical_rir(tmp_path):
     checked = check_model_source(str(path))
     reference_checked = _reference_check_source(source, kernel, language_bundle)
     assert isinstance(checked, CheckedModel)
-    assert isinstance(reference_checked, CheckedModel)
+    assert isinstance(reference_checked, ModelSourceContext)
 
     production = lower_checked_model(checked)
     reference = _reference_semantic_artifacts(reference_checked)
@@ -4230,7 +4234,7 @@ def test_independent_lowerers_close_recursive_nominal_types_by_owner(
     production_checked = check_model_source(str(path))
     reference_checked = _reference_check_source(source, kernel, language_bundle)
     assert isinstance(production_checked, CheckedModel)
-    assert isinstance(reference_checked, CheckedModel)
+    assert isinstance(reference_checked, ModelSourceContext)
     production = lower_checked_model(production_checked)
     reference = _reference_semantic_artifacts(reference_checked)
     for name in ("package-lock", "rir-semantic-payload", "resolved-model", "debug-map"):
@@ -4280,7 +4284,7 @@ def test_independent_lowerers_close_the_rpg_entrypoint_and_nested_call_graph():
     checked = check_model_source(str(path))
     reference_checked = _reference_check_source(source, kernel, language_bundle)
     assert isinstance(checked, CheckedModel)
-    assert isinstance(reference_checked, CheckedModel)
+    assert isinstance(reference_checked, ModelSourceContext)
 
     production = lower_checked_model(checked)
     reference = _reference_semantic_artifacts(reference_checked)
@@ -4431,7 +4435,7 @@ def test_independent_lowerers_treat_empty_collection_exclusion_as_noop(monkeypat
     checked = check_model_source(str(path))
     reference_checked = _reference_check_source(source, kernel, candidate_ldb)
     assert isinstance(checked, CheckedModel)
-    assert isinstance(reference_checked, CheckedModel)
+    assert isinstance(reference_checked, ModelSourceContext)
 
     production = lower_checked_model(checked)
     reference = _reference_semantic_artifacts(reference_checked)
@@ -4484,7 +4488,7 @@ def test_nested_integer_literal_is_identical_across_lowerers(
     checked = check_model_source(str(path))
     reference_checked = _reference_check_source(source, kernel, candidate_ldb)
     assert isinstance(checked, CheckedModel)
-    assert isinstance(reference_checked, CheckedModel)
+    assert isinstance(reference_checked, ModelSourceContext)
 
     production = lower_checked_model(checked)
     reference = _reference_semantic_artifacts(reference_checked)
@@ -4979,7 +4983,7 @@ def test_model_source_routing_follows_the_selected_ldb_profile_without_host_toke
     checked = check_model_source(str(path))
     reference_checked = _reference_check_source(source, kernel, candidate_ldb)
     assert isinstance(checked, CheckedModel)
-    assert isinstance(reference_checked, CheckedModel)
+    assert isinstance(reference_checked, ModelSourceContext)
 
     production = lower_checked_model(checked)
     reference = _reference_semantic_artifacts(reference_checked)
@@ -5021,18 +5025,10 @@ def test_rir_output_member_follows_the_ldb_lowering_and_wire_schema(tmp_path):
     ]
     _reidentify_language_bundle(candidate_ldb)
     assert admit_authorities(kernel, candidate_ldb).admitted
-    profile = language["resolution_profiles"][0]
-    checked = CheckedModel(
-        source=source,
-        source_identity=_reference_content_identity(
-            profile["source_identity_domain"], source
-        ),
-        kernel=kernel,
-        language_bundle=candidate_ldb,
-        namespace_selection=_reference_namespace_selection(
-            source, kernel, candidate_ldb
-        ),
+    checked = check_model_source_value(
+        source, kernel=kernel, language_bundle=candidate_ldb
     )
+    assert isinstance(checked, CheckedModel)
 
     production = lower_checked_model(checked)["rir-semantic-payload"]
     reference = _reference_rir(checked)
@@ -5122,15 +5118,10 @@ def test_lowerers_follow_renamed_ldb_rule_and_judgment_tokens_without_host_chang
         vector["input"]["judgment"] = judgment
     _reidentify_language_bundle(candidate_ldb)
     assert admit_authorities(checked.kernel, candidate_ldb).admitted
-    candidate = CheckedModel(
-        source=checked.source,
-        source_identity=checked.source_identity,
-        kernel=checked.kernel,
-        language_bundle=candidate_ldb,
-        namespace_selection=_reference_namespace_selection(
-            checked.source, checked.kernel, candidate_ldb
-        ),
+    candidate = check_model_source_value(
+        checked.source, kernel=checked.kernel, language_bundle=candidate_ldb
     )
+    assert isinstance(candidate, CheckedModel)
 
     artifacts = lower_checked_model(candidate)
     production = artifacts["rir-semantic-payload"]
@@ -5268,18 +5259,10 @@ def test_resolved_admission_follows_a_renamed_ldb_diagnostic_without_host_change
         "language.resolved_authority_mismatch",
     )
     source = _source([_symbol("health", "state")])
-    profile = candidate_ldb["language"]["resolution_profiles"][0]
-    checked = CheckedModel(
-        source=source,
-        source_identity=_reference_content_identity(
-            profile["source_identity_domain"], source
-        ),
-        kernel=kernel,
-        language_bundle=candidate_ldb,
-        namespace_selection=_reference_namespace_selection(
-            source, kernel, candidate_ldb
-        ),
+    checked = check_model_source_value(
+        source, kernel=kernel, language_bundle=candidate_ldb
     )
+    assert isinstance(checked, CheckedModel)
     artifacts = lower_checked_model(checked)
     semantic_artifacts: dict[str, dict[str, Any]] = {
         name: deepcopy(artifacts[name])

--- a/libs/gda-balancing/tools/ci.py
+++ b/libs/gda-balancing/tools/ci.py
@@ -66,6 +66,7 @@ SHARDS: Final[dict[str, tuple[str, ...]]] = {
     ),
     "model": (
         "test_exact_resolved_model_binding.py",
+        "test_model_preparation.py",
         "test_operation_call_domains.py",
         "test_schema2_model_cli.py",
         "test_schema2_model_lowerer_conformance.py",


### PR DESCRIPTION
Model checking and building repeated Source preparation, while Formula-slot specialization relied on Python aliases to update package closures. Equal-value projections could therefore specialize differently after serialization or cross-namespace sharing, and mutating a checked Source could alter later output from that request.

This change retains one immutable private Typed HIR per checked request and uses it in compilation and Template facts. Specialization separately copies each namespace/id Operation definition, then derives both Operation and package-closure views from that owner. Incomplete resolution inputs no longer masquerade as a fully checked Model. Independent artifact admission, post-specialization entrypoint/callsite checks and fresh-publication validation remain; no optional preparation fallback, public IR or shared cache is added.

Refs #873, parent #865. Target: `codex/gda-balancing-refactor-delete-dev`. Base: `645aeb9ee0375ad6cd1164998ea451aaba9bf68e`. Reviewed head: `2d366beb00a9495299e5943f8a5ab1459cdff8f0`.

## Validation

- **Nine permanent preparation cases pass.** They cover once-per-request Source resolution/lowering/Formula/projection, complete alias/provenance outputs, original/request/nested-output mutation, concurrency and exact resource/refusal boundaries. The initial eight distinguish five pre-S4 failures; the ninth independently admitted cross-owner case also rejects the old specializer after real authority/Source admission and eight-artifact compilation.
- Independent artifact admission still occurs once for check and twice for fresh build publication; post-specialization checks execute in the observed public path.
- Fresh clean-head comparison of six actual maintained public builds: all **48 artifact files byte-identical** to the base. All **34 Model vectors** retain their full observations: 13 complete eight-artifact sets and 21 full refusal reports.
- Current projection boundary **232 refuses, 233/234 admit**, with unchanged complete diagnostic/accounting; the plan's earlier 197-step result remains historical probe evidence. Existing Runtime initialization, Event rollback, cache/resource, artifact tamper and explanation/debug tests remain required.
- [Final CI](https://github.com/aigengame/godot-agent/actions/runs/34081083023) passed every required job, including all eight test shards and wheel/subprocess smoke. Actual JUnit parsing verifies **1,517 unique cases: 1,492 passed, 25 declared skips, zero failures/errors**. Inventory has no missing, overlapping or unassigned cases and retains 313 active vector obligations. No required ids, skip rules or process bounds are relaxed. Ruff, Pyright, sealed authorities, package build and co-install pass. Root Godot E2E is conditionally skipped.
- Independent Standards, Spec and domain-architecture reviews have **zero unresolved findings** at this head. The confirmed Spec P2 cross-owner alias defect is fixed by owner-local copying and covered by the ninth regression. Each axis rechecked the correction independently.

## Design and rollback

[S4 record](https://github.com/aigengame/godot-agent/blob/2d366beb00a9495299e5943f8a5ab1459cdff8f0/libs/gda-balancing/docs/refactor/current-language/MODEL-PREPARATION.md) maps ownership, each acceptance witness and rollback. Restore the complete pre-S4 package at `645aeb9ee0375ad6cd1164998ea451aaba9bf68e` after reverting dependents; code, tests, CI policy and documentation move together. Machine authority and maintained authored inputs are unchanged.

No speed or memory improvement is claimed without measurement. #612 retains the Formula Runtime seam, and #874 must precede mandatory binding deletion in #875. This PR delivers only #873 into dev; it does not merge to main, complete #879 consumer integration or publish a formal release.
