### PR TITLE
fix(gda-balancing): share Formula evaluation and preserve refusal charges

### DIFF
--- a/libs/gda-balancing/docs/refactor/current-language/FORMULA-RUNTIME.md
+++ b/libs/gda-balancing/docs/refactor/current-language/FORMULA-RUNTIME.md
@@ -36,8 +36,25 @@ moving the shared Event helpers would add relocation without changing ownership.
 
 Inline Event Formula instructions retain their existing per-instruction total,
 Event and Operation counters and exact failure index. Extracting the program
-function does not replace this ledger with a bulk charge or change the published
-refusal counters, committed prefix or rollback boundary.
+function does not replace this ledger with a bulk charge. The committed prefix
+and rollback boundary remain unchanged.
+
+## Confirmed fault-charge correction
+
+Public runs with admitted Runtime profile node limits of 5 and 20 expose a
+pre-existing failure in the Event and observation Formula fault paths. Both the
+development baseline and the initial extraction return an internal error when
+publication rejects the prepared terminal audit. The call assigning
+`total_steps = _evaluate_initialization_programs(...)` never receives a result
+when the function raises, so the callers report their pre-call counter. The
+independent artifact validator correctly requires the attempted Formula charge.
+
+The shared fault now carries consumed steps. Both callers must retain that value
+before constructing the refusal audit. This repairs conformance to the existing
+charge and audit laws; it does not weaken the validator or change the language,
+resource policy or public refusal schema. Previously valid artifacts retain their
+behavior. The affected runs now publish the required typed refusal instead of an
+internal publication failure. Permanent public tests cover both cases.
 
 ## Consumers and refusal scope
 
@@ -78,7 +95,9 @@ general-purpose program admission implementation.
    domain architecture independently before integration into dev.
 
 The byte comparison preserves Kernel/LDB identities, RIR meaning, admitted Formula
-semantics and semantic execution artifacts. Under the
+semantics and previously valid semantic execution artifacts. The two confirmed
+fault-charge failures above require a separate before/after result, since the
+baseline could not publish a valid refusal artifact. Under the
 [execution identity contract](EXECUTION-IDENTITY.md), source changes must update
 the evaluator implementation fingerprint. Producer manifests and publication
 records that identify their bytes therefore change truthfully. Enumerate those

--- a/libs/gda-balancing/docs/refactor/current-language/FORMULA-RUNTIME.md
+++ b/libs/gda-balancing/docs/refactor/current-language/FORMULA-RUNTIME.md
@@ -1,0 +1,98 @@
+# Formula Runtime conformance seam
+
+This record defines the implementation and validation scope of [#612](https://github.com/aigengame/godot-agent/issues/612),
+the existing prerequisite of #876. The development baseline is
+`aa94ec79d63b0595e5d6af8bce6180aba9d5b397`, which integrates #875 through PR #906.
+The issue and its pull request own live acceptance status. This plan does not claim
+that the implementation or its verification is complete.
+
+## Problem and boundary
+
+The shipped `_evaluate_value_program_vector` function is called only by tests.
+It implements its own charge, cache key, numeric refusal and result projection.
+Normal initialization, Event and observation Formula execution uses a different
+program loop. Sharing the instruction interpreter alone does not prove that the
+vectors exercise the execution path used by an Experiment.
+
+A baseline probe replaced the normal lifecycle evaluator with an unconditional
+failure. Both vector consumers still matched all ten shipped value-program
+expectations. This establishes a conformance-evidence gap; it does not establish
+that a maintained public Experiment produces an incorrect result.
+
+Extract one identified program evaluation inside the existing Runtime execution
+module. The existing coordinator keeps graph reachability, operand resolution,
+lifecycle frame construction and target writes. The shared function owns:
+
+- selected Kernel instruction dispatch and numeric semantics;
+- the declared `resource_bounds.max_steps` charge before a cache lookup;
+- the program, site, frame, operands and numeric contract in the cache key;
+- the admitted value and updated consumed steps; and
+- precise program, evaluation-site, frame and charge information on a fault.
+
+The input uses the existing compiled program and explicit selected contracts.
+There is no new public IR, wire artifact, registry, implicit authority lookup or
+test-only Runtime branch. A separate Formula module is unnecessary for this cut:
+moving the shared Event helpers would add relocation without changing ownership.
+
+Inline Event Formula instructions retain their existing per-instruction total,
+Event and Operation counters and exact failure index. Extracting the program
+function does not replace this ledger with a bulk charge or change the published
+refusal counters, committed prefix or rollback boundary.
+
+## Consumers and refusal scope
+
+Normal nonempty initialization, Event and observation programs call the shared
+function. A test-side adapter translates each vector into the same request and
+projects the returned value or fault. It may orchestrate the requested repeated
+evaluations, but it does not calculate charges, construct a second cache key or
+interpret generic numeric exceptions. Delete the shipped vector-only entry point.
+
+Keep the reference vector consumer and independent artifact replay independently
+implemented. Each vector consumer compares its observation with the shipped
+expectation; agreement between the consumers alone is insufficient.
+
+The Kernel requires a positive divisor domain, and current public admission
+enforces that precondition. Preserve the negative division vectors through a
+narrow internal domain failure from the shared instruction path. Do not convert
+arbitrary `ValueError` exceptions into `invalid-domain`, add a selected reason or
+expand the public refusal protocol for an input public admission already rejects.
+Malformed, unknown and context-incompatible direct requests must fail without
+cache insertion or a partially published result. This does not require a second
+general-purpose program admission implementation.
+
+## Verification and implementation order
+
+1. Capture the post-#875 public artifact baseline and a discriminating failure
+   showing that the existing vectors do not depend on normal Formula evaluation.
+2. Extract the charged single-program function and connect the three lifecycle
+   callers while preserving the Event ledger and existing public fault projection.
+3. Move vector adaptation under tests and delete the production vector entry point.
+   Retain all ten expectations and the separately implemented reference consumer.
+4. Exercise real public paths with nonempty shared-function calls in each lifecycle.
+   Check charge before cache hits, a declared charge larger than instruction count,
+   different Snapshot frames with equal operands, numeric/resource boundaries,
+   exact fault provenance and atomic refusal. A spy on an empty coordinator is not
+   evidence that a program was evaluated.
+5. Compare public artifacts, verify independent consumer imports and required test
+   inventory, and run the package checks and full CI. Review Standards, Spec and
+   domain architecture independently before integration into dev.
+
+The byte comparison preserves Kernel/LDB identities, RIR meaning, admitted Formula
+semantics and semantic execution artifacts. Under the
+[execution identity contract](EXECUTION-IDENTITY.md), source changes must update
+the evaluator implementation fingerprint. Producer manifests and publication
+records that identify their bytes therefore change truthfully. Enumerate those
+differences in the validation evidence; do not freeze fingerprints or exclude
+unrelated result differences from comparison.
+
+## Rollback and completion
+
+Rollback restores code, test adapters and this issue's documentation together to
+the development baseline. No compatibility entry point or alternate evaluator
+remains for rollback. Verify the reverse patch and execute the restored public
+baseline before closing #612.
+
+Completion requires the shared production path, deletion of the vector-only
+function, independent expectation checks, preserved public behavior and complete
+review/CI evidence. It does not delete the value alias or maximum primitive: #876
+owns those separately adopted language and resource-contract changes.

--- a/libs/gda-balancing/docs/refactor/current-language/FORMULA-RUNTIME.md
+++ b/libs/gda-balancing/docs/refactor/current-language/FORMULA-RUNTIME.md
@@ -8,7 +8,8 @@ that the implementation or its verification is complete.
 
 ## Problem and boundary
 
-The shipped `_evaluate_value_program_vector` function is called only by tests.
+At the development baseline, the shipped `_evaluate_value_program_vector`
+function is called only by tests.
 It implements its own charge, cache key, numeric refusal and result projection.
 Normal initialization, Event and observation Formula execution uses a different
 program loop. Sharing the instruction interpreter alone does not prove that the
@@ -115,3 +116,45 @@ Completion requires the shared production path, deletion of the vector-only
 function, independent expectation checks, preserved public behavior and complete
 review/CI evidence. It does not delete the value alias or maximum primitive: #876
 owns those separately adopted language and resource-contract changes.
+
+## Recorded implementation evidence
+
+The production source is confined to `domain/runtime/execution.py`. The tested
+source has SHA-256 `3084f48a17a7cd5f00bfce8b53ec059469998d0b4bc1121f2db7a8c7d20d7050`.
+An isolated before/after capture ran 26 actual CLI subprocess calls: six maintained
+Model builds, eight Experiment checks and runs, and two additional numeric-refusal
+build/run pairs. All 28 authority files, eight Model artifact sets, eight successful
+behavior artifact sets, nine resolved Runtime profiles and the inline Formula
+terminal audit stayed byte-identical. Fresh task-owned stores and fixed paths and
+invocation keys prevented publication reuse from hiding execution changes.
+
+The complete changed-file set was nine evaluator manifests, nine dependent
+publication manifests and nine receipt envelopes. The evaluator build identity
+changed from `8c64e8e9d055a7a55fa463656dcf8611b3b8852ee25de9467c212f7935510a70`
+to `6bd51724cf80f41f8c9600c68cef10b5d029b3307fc9c222dc4d7f66c556b30b`.
+Every changed JSON leaf was an evaluator build identity, its manifest content
+identity or a dependent publication/receipt identity; no general normalization was
+used. The source fingerprint was independently reconstructed from Domain files.
+
+Separate public build/check/run probes confirmed the resource-refusal correction:
+Event limit 5 changed from an invalid audit with 3 steps and exit 4 to a valid
+audit with 6 steps and exit 2. Observation limit 20 changed from an invalid audit
+with 18 steps and exit 4 to a valid audit with 21 steps and exit 2. Both preserved
+the exact committed prefix and refusal site. These are corrected failures, not
+part of the previously valid byte-equivalence claim.
+
+Permanent reproduction is in `tests/test_formula_runtime_seam.py`,
+`tests/test_public_formula_runtime_seam.py`, and
+`test_package_value_program_vectors_execute_in_two_consumers` in
+`tests/test_schema2_experiment_cli.py`. Together they pass 24 collected cases;
+the vector case checks all ten shipped expectations independently in both
+consumers, with the production consumer evaluated in each lifecycle phase.
+The public cache-hit case explicitly instruments prewarming; it does not claim
+a naturally occurring hit. These tests use real in-process CLI dispatch, while
+the byte capture above used subprocesses. Neither establishes wheel or Godot
+validation.
+
+Inventory closure accounts for all 1,741 current tests in nine disjoint shards,
+including all 849 required baseline test IDs and 313 current package vectors.
+Ruff, Pyright and sealed-LDB checks pass. These local results do not replace the
+full CI and independent review required by the issue.

--- a/libs/gda-balancing/docs/refactor/current-language/README.md
+++ b/libs/gda-balancing/docs/refactor/current-language/README.md
@@ -22,5 +22,7 @@ Start with the [accepted decision](../../badr/0028-current-language-refactor-and
 | [Namespace contract](NAMESPACE-CONTRACT.md) | Final S3 transition dispositions, acceptance witnesses, retained meanings and whole-stage rollback for #872 |
 | [Model preparation](MODEL-PREPARATION.md) | One request snapshot, alias-independent specialization, retained admission/resource checks and S4 rollback for #873 |
 | [Execution closure](EXECUTION-CLOSURE.md) | S5a dependency counterexample, selected execution and decoding boundaries, implementation status and mandatory S5b deletion |
+| [Execution identity](EXECUTION-IDENTITY.md) | S5b deletion, explicit RIR input, semantic execution identity and truthful producer provenance |
+| [Formula Runtime seam](FORMULA-RUNTIME.md) | Shared production evaluation, independent vectors, public behavior preservation and rollback for #612 |
 
 GitHub owns live acceptance and task status; bADR-0028 owns the adopted policy; the plan owns delivery sequencing. Matrices preserve exact captured requirement text as provenance. Current issue amendments supersede the identified historical clauses. Evidence is confirmed only within its stated bounds, and no disposable probe establishes full production conformance, genre completion or automatic formal-release/claim activation.

--- a/libs/gda-balancing/src/gda_balancing/domain/runtime/execution.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/runtime/execution.py
@@ -7,9 +7,6 @@ from collections.abc import Sequence
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, cast
-from gda_balancing.domain.authority.context import (
-    packaged_authority_context,
-)
 from gda_balancing.domain.canonical import (
     JsonValue,
     canonical_bytes,
@@ -59,7 +56,10 @@ from gda_balancing.domain.runtime.projections import (
     scheduler_contract as _scheduler_contract,
     unsupported_evaluator_requirement as _unsupported_evaluator_requirement,
 )
-from gda_balancing.domain.program_reachability import reachable_formula_programs
+from gda_balancing.domain.program_reachability import (
+    LIFECYCLE_PHASES,
+    reachable_formula_programs,
+)
 from gda_balancing.domain.runtime.scheduler import RuntimeScheduler
 from gda_balancing.domain.experiment import (
     CheckedExperiment,
@@ -122,6 +122,16 @@ class _RuntimeExecutionFault(Exception):
         self.instruction_index = instruction_index
 
 
+@dataclass(frozen=True)
+class _FormulaProgramResult:
+    value: int
+    consumed_steps: int
+
+
+class _NonpositiveDivisorError(ValueError):
+    """A scalar division input is outside the instruction's positive domain."""
+
+
 class _InitializationProgramFault(Exception):
     def __init__(
         self,
@@ -130,12 +140,14 @@ class _InitializationProgramFault(Exception):
         program: str,
         evaluation_site_identity: str,
         frame_identity: str,
+        consumed_steps: int,
     ) -> None:
         super().__init__(signal)
         self.signal = signal
         self.program = program
         self.evaluation_site_identity = evaluation_site_identity
         self.frame_identity = frame_identity
+        self.consumed_steps = consumed_steps
 
 
 def _runtime_continuation(
@@ -512,7 +524,7 @@ def _execute_value_instruction(
             variables[cast(str, instruction["right"])], structured_authority
         )
         if operator == "integer-floor-divide" and right <= 0:
-            raise ValueError("floor-divide divisor must be positive")
+            raise _NonpositiveDivisorError("floor-divide divisor must be positive")
         value = (
             left + right
             if operator == "integer-add"
@@ -622,91 +634,147 @@ def _execute_value_instruction(
     variables[cast(str, instruction["target"])] = value
 
 
-def _evaluate_value_program_vector(
-    vector: dict[str, Any],
-) -> dict[str, JsonValue]:
-    """Execute one package-owned generic value-program conformance vector."""
-    inp = cast(dict[str, Any], vector["input"])
-    numeric = cast(dict[str, Any], inp["numeric"])
-    instructions = cast(list[dict[str, Any]], inp["instructions"])
-    operands = {
-        cast(str, row["name"]): cast(int, row["value"])
-        for row in cast(list[dict[str, Any]], inp["operands"])
-    }
-    cache: dict[bytes, int] = {}
-    runtime_nodes = {
-        cast(str, row["id"]): row
-        for row in cast(
-            list[dict[str, Any]],
-            packaged_authority_context().kernel["meta_format"]["runtime_program"][
-                "nodes"
-            ],
+def _evaluate_formula_program(
+    program: dict[str, Any],
+    input_values: dict[str, int],
+    *,
+    numeric: dict[str, Any],
+    runtime_nodes: dict[str, dict[str, Any]],
+    frame_identity: str,
+    phase: str,
+    consumed_steps: int,
+    runtime_limit: int,
+    cache: dict[bytes, int] | None,
+) -> _FormulaProgramResult:
+    """Evaluate one identified pure program in its exact lifecycle frame."""
+    if not isinstance(program, dict):
+        raise ValueError("Formula program is not an admitted object")
+    site = program.get("site")
+    body = program.get("body")
+    bounds = program.get("resource_bounds")
+    result = program.get("result")
+    if (
+        not isinstance(site, dict)
+        or not isinstance(site.get("context"), dict)
+        or phase not in LIFECYCLE_PHASES
+        or site["context"].get("phase") != phase
+        or not isinstance(frame_identity, str)
+        or not frame_identity
+        or not isinstance(program.get("identity"), str)
+        or not program["identity"]
+        or not isinstance(site.get("identity"), str)
+        or not site["identity"]
+        or not isinstance(body, (list, tuple))
+        or not isinstance(bounds, dict)
+        or not isinstance(result, dict)
+        or not isinstance(result.get("name"), str)
+        or not result["name"]
+        or not isinstance(input_values, dict)
+        or any(not isinstance(name, str) or not name for name in input_values)
+        or any(not isinstance(value, int) for value in input_values.values())
+    ):
+        raise ValueError("Formula program or lifecycle frame is unavailable")
+    charge = bounds.get("max_steps")
+    if any(
+        not isinstance(value, int) or isinstance(value, bool) or value < 0
+        for value in (charge, consumed_steps, runtime_limit)
+    ):
+        raise ValueError("Formula program resource bound is unavailable")
+    if (
+        not isinstance(numeric, dict)
+        or any(
+            not isinstance(numeric.get(member), int)
+            or isinstance(numeric[member], bool)
+            for member in ("minimum", "maximum")
         )
-    }
-    charge = 0
-    result_value: int | None = None
-    signal: str | None = None
-    refusing_site = cast(str, inp["site"])
-    for _evaluation in range(cast(int, inp["evaluations"])):
-        charge += len(instructions)
-        if charge > cast(int, inp["resource_limit"]):
-            signal = "step-limit"
-            result_value = None
-            break
-        cache_key = canonical_bytes(
-            cast(
-                JsonValue,
-                {
-                    "instructions": instructions,
-                    "numeric": numeric,
-                    "operands": [
-                        {"name": name, "value": value}
-                        for name, value in sorted(operands.items())
-                    ],
-                    "result": inp["result"],
-                    "site": inp["site"],
-                },
+        or numeric["minimum"] > numeric["maximum"]
+        or not isinstance(runtime_nodes, dict)
+    ):
+        raise ValueError(
+            "Formula program numeric or instruction contracts are unavailable"
+        )
+    # Check the selected node shapes before a cache can conceal a malformed
+    # request. Model admission remains responsible for semantic closure.
+    for row in body:
+        if (
+            not isinstance(row, dict)
+            or not isinstance(row.get("evaluation_site_identity"), str)
+            or not row["evaluation_site_identity"]
+            or not isinstance(row.get("instruction"), dict)
+        ):
+            raise ValueError("Formula program instruction is unavailable")
+        instruction = row["instruction"]
+        node = instruction.get("node")
+        contract = runtime_nodes.get(node) if isinstance(node, str) else None
+        if (
+            not isinstance(contract, dict)
+            or contract.get("family") != "expression"
+            or not isinstance(contract.get("required_members"), (list, tuple))
+            or set(instruction) != set(contract["required_members"])
+            or not isinstance(instruction.get("target"), str)
+            or not instruction["target"]
+        ):
+            raise ValueError("Formula program instruction is not selected or supported")
+    consumed_steps += cast(int, charge)
+    program_identity = cast(str, program["identity"])
+    site_identity = cast(str, site["identity"])
+    if consumed_steps > runtime_limit:
+        raise _InitializationProgramFault(
+            signal="step-limit",
+            program=program_identity,
+            evaluation_site_identity=site_identity,
+            frame_identity=frame_identity,
+            consumed_steps=consumed_steps,
+        )
+    cache_key = canonical_bytes(
+        cast(
+            JsonValue,
+            {
+                "program": program_identity,
+                "site": site_identity,
+                "frame": frame_identity,
+                "operands": [
+                    {"name": name, "value": value}
+                    for name, value in sorted(input_values.items())
+                ],
+                "numeric": numeric,
+            },
+        )
+    )
+    if cache is not None and cache_key in cache:
+        return _FormulaProgramResult(cache[cache_key], consumed_steps)
+    variables = dict(input_values)
+    evaluation_site_identity = site_identity
+    try:
+        for row in body:
+            evaluation_site_identity = row["evaluation_site_identity"]
+            instruction = row["instruction"]
+            _execute_value_instruction(
+                instruction,
+                variables,
+                numeric,
+                runtime_nodes[instruction["node"]],
             )
-        )
-        if cast(bool, inp["cache"]) and cache_key in cache:
-            result_value = cache[cache_key]
-            continue
-        values = dict(operands)
-        for row in instructions:
-            try:
-                _execute_value_instruction(
-                    cast(dict[str, Any], row["instruction"]),
-                    values,
-                    numeric,
-                    runtime_nodes[cast(str, row["instruction"]["node"])],
-                )
-            except OverflowError:
-                signal = "numeric-overflow"
-                refusing_site = cast(str, row["evaluation_site_identity"])
-                result_value = None
-                break
-            except ValueError as error:
-                if str(error) != "floor-divide divisor must be positive":
-                    raise
-                signal = "invalid-domain"
-                refusing_site = cast(str, row["evaluation_site_identity"])
-                result_value = None
-                break
-        if signal is not None:
-            break
-        result_value = values[cast(str, inp["result"])]
-        if cast(bool, inp["cache"]):
-            cache[cache_key] = result_value
-    admitted = signal is None
-    return {
-        "cache_entries": len(cache),
-        "charge": charge,
-        "outcome": "admitted" if admitted else "refused",
-        "result": result_value,
-        "result_artifact": admitted,
-        "signal": signal,
-        "site": cast(str, inp["site"]) if admitted else refusing_site,
-    }
+        result_value = _admit_numeric(variables[result["name"]], numeric)
+    except (OverflowError, _NonpositiveDivisorError) as error:
+        raise _InitializationProgramFault(
+            signal=(
+                "invalid-domain"
+                if isinstance(error, _NonpositiveDivisorError)
+                else "numeric-overflow"
+            ),
+            program=program_identity,
+            evaluation_site_identity=evaluation_site_identity,
+            frame_identity=frame_identity,
+            consumed_steps=consumed_steps,
+        ) from error
+    except (KeyError, TypeError) as error:
+        raise ValueError(
+            "Formula program has an unavailable value or instruction"
+        ) from error
+    if cache is not None:
+        cache[cache_key] = result_value
+    return _FormulaProgramResult(result_value, consumed_steps)
 
 
 def _evaluate_initialization_programs(
@@ -801,65 +869,20 @@ def _evaluate_initialization_programs(
                 input_values[cast(str, row["name"])] = value
             if not ready:
                 continue
-            charge = cast(
-                int,
-                cast(dict[str, Any], program["resource_bounds"])["max_steps"],
+            evaluation = _evaluate_formula_program(
+                program,
+                input_values,
+                numeric=numeric,
+                runtime_nodes=runtime_nodes,
+                frame_identity=frame_identity,
+                phase=phase,
+                consumed_steps=consumed_steps,
+                runtime_limit=runtime_limit,
+                cache=cache,
             )
-            consumed_steps += charge
-            if consumed_steps > runtime_limit:
-                raise _InitializationProgramFault(
-                    signal="step-limit",
-                    program=cast(str, program["identity"]),
-                    evaluation_site_identity=cast(
-                        str, cast(dict[str, Any], program["site"])["identity"]
-                    ),
-                    frame_identity=frame_identity,
-                )
-            cache_key = canonical_bytes(
-                cast(
-                    JsonValue,
-                    {
-                        "program": program["identity"],
-                        "site": cast(dict[str, Any], program["site"])["identity"],
-                        "frame": frame_identity,
-                        "operands": [
-                            {"name": name, "value": value}
-                            for name, value in sorted(input_values.items())
-                        ],
-                        "numeric": numeric,
-                    },
-                )
-            )
-            if cache is not None and cache_key in cache:
-                result_value = cache[cache_key]
-            else:
-                variables = dict(input_values)
-                for row in cast(list[dict[str, Any]], program["body"]):
-                    try:
-                        _execute_value_instruction(
-                            cast(dict[str, Any], row["instruction"]),
-                            variables,
-                            numeric,
-                            runtime_nodes[cast(str, row["instruction"]["node"])],
-                        )
-                    except OverflowError as error:
-                        raise _InitializationProgramFault(
-                            signal="numeric-overflow",
-                            program=cast(str, program["identity"]),
-                            evaluation_site_identity=cast(
-                                str, row["evaluation_site_identity"]
-                            ),
-                            frame_identity=frame_identity,
-                        ) from error
-                result = cast(dict[str, Any], program["result"])
-                result_value = _admit_numeric(
-                    variables[cast(str, result["name"])],
-                    numeric,
-                )
-                if cache is not None:
-                    cache[cache_key] = result_value
+            consumed_steps = evaluation.consumed_steps
             target = canonical_bytes(cast(JsonValue, program["target"]))
-            actual_values[target] = result_value
+            actual_values[target] = evaluation.value
             pending.remove(program)
             progressed = True
         if not progressed:

--- a/libs/gda-balancing/src/gda_balancing/domain/runtime/execution.py
+++ b/libs/gda-balancing/src/gda_balancing/domain/runtime/execution.py
@@ -1894,6 +1894,7 @@ def evaluate_prepared_experiment(
                         phase="event",
                     )
                 except _InitializationProgramFault as fault:
+                    total_steps = fault.consumed_steps
                     event_formula_fault = _RuntimeExecutionFault(
                         signal=fault.signal,
                         operation=cast(str, operation["id"]),
@@ -2207,6 +2208,7 @@ def evaluate_prepared_experiment(
                     phase="observation",
                 )
             except _InitializationProgramFault as fault:
+                total_steps = fault.consumed_steps
                 reason = _reason_for_signal(checked, fault.signal, "runtime")
                 message = (
                     "Runtime program exhausted its exact step bound"

--- a/libs/gda-balancing/tests/schema2_value_program_production_support.py
+++ b/libs/gda-balancing/tests/schema2_value_program_production_support.py
@@ -1,0 +1,59 @@
+"""Translate package vectors into requests to the actual Formula evaluator."""
+
+from typing import Any
+
+import gda_balancing.domain.runtime.execution as runtime
+
+
+def evaluate_value_program_vector(
+    kernel: dict[str, Any], vector: dict[str, Any], *, phase: str
+) -> dict[str, Any]:
+    inp = vector["input"]
+    program = {
+        "identity": vector["id"],
+        "site": {"identity": inp["site"], "context": {"phase": phase}},
+        "body": inp["instructions"],
+        "result": {"name": inp["result"]},
+        # Legacy vectors declare one finite instruction list, not a compiled
+        # bound. This supplies its one-pass request bound; Runtime owns charges.
+        "resource_bounds": {"max_steps": len(inp["instructions"])},
+    }
+    operands = {row["name"]: row["value"] for row in inp["operands"]}
+    nodes = {
+        row["id"]: row for row in kernel["meta_format"]["runtime_program"]["nodes"]
+    }
+    cache: dict[bytes, int] | None = {} if inp["cache"] else None
+    consumed_steps = 0
+    value = None
+    signal = None
+    site = inp["site"]
+    for _ in range(inp["evaluations"]):
+        try:
+            result = runtime._evaluate_formula_program(
+                program,
+                operands,
+                numeric=inp["numeric"],
+                runtime_nodes=nodes,
+                frame_identity=inp["site"],
+                phase=phase,
+                consumed_steps=consumed_steps,
+                runtime_limit=inp["resource_limit"],
+                cache=cache,
+            )
+        except runtime._InitializationProgramFault as fault:
+            consumed_steps = fault.consumed_steps
+            signal = fault.signal
+            site = fault.evaluation_site_identity
+            value = None
+            break
+        consumed_steps = result.consumed_steps
+        value = result.value
+    return {
+        "cache_entries": len(cache) if cache is not None else 0,
+        "charge": consumed_steps,
+        "outcome": "admitted" if signal is None else "refused",
+        "result": value,
+        "result_artifact": signal is None,
+        "signal": signal,
+        "site": site,
+    }

--- a/libs/gda-balancing/tests/schema2_value_program_reference_support.py
+++ b/libs/gda-balancing/tests/schema2_value_program_reference_support.py
@@ -1,0 +1,97 @@
+"""Independent finite value-program interpretation for package vectors."""
+
+from typing import Any
+
+from gda_balancing.domain.canonical import canonical_bytes
+
+
+def reference_evaluate_value_program_vector(
+    vector: dict[str, Any],
+) -> dict[str, Any]:
+    inp = vector["input"]
+    instructions = inp["instructions"]
+    numeric = inp["numeric"]
+    operands = {row["name"]: row["value"] for row in inp["operands"]}
+    cache: dict[bytes, int] = {}
+    charge = 0
+    result = None
+    signal = None
+    site = inp["site"]
+    for _ in range(inp["evaluations"]):
+        charge += len(instructions)
+        if charge > inp["resource_limit"]:
+            signal = "step-limit"
+            result = None
+            break
+        key = canonical_bytes(
+            {
+                "instructions": instructions,
+                "numeric": numeric,
+                "operands": [
+                    {"name": name, "value": value}
+                    for name, value in sorted(operands.items())
+                ],
+                "result": inp["result"],
+                "site": inp["site"],
+            }
+        )
+        if inp["cache"] and key in cache:
+            result = cache[key]
+            continue
+        values = dict(operands)
+        for row in instructions:
+            instruction = row["instruction"]
+            node = instruction["node"]
+            if node == "constant":
+                value = instruction["literal"]
+            elif node == "copy":
+                value = values[instruction["value"]]
+            elif node == "add":
+                value = values[instruction["left"]] + values[instruction["right"]]
+            elif node == "subtract":
+                value = values[instruction["left"]] - values[instruction["right"]]
+            elif node == "multiply":
+                value = values[instruction["left"]] * values[instruction["right"]]
+            elif node == "floor-divide":
+                divisor = values[instruction["right"]]
+                if divisor <= 0:
+                    signal = "invalid-domain"
+                    site = row["evaluation_site_identity"]
+                    result = None
+                    break
+                value = values[instruction["left"]] // divisor
+            elif node == "maximum":
+                value = max(
+                    values[instruction["left"]],
+                    values[instruction["right"]],
+                )
+            else:
+                assert node == "if"
+                value = values[
+                    instruction[
+                        "when_true"
+                        if values[instruction["condition"]]
+                        else "when_false"
+                    ]
+                ]
+            if not numeric["minimum"] <= value <= numeric["maximum"]:
+                signal = "numeric-overflow"
+                site = row["evaluation_site_identity"]
+                result = None
+                break
+            values[instruction["target"]] = value
+        if signal is not None:
+            break
+        result = values[inp["result"]]
+        if inp["cache"]:
+            cache[key] = result
+    admitted = signal is None
+    return {
+        "cache_entries": len(cache),
+        "charge": charge,
+        "outcome": "admitted" if admitted else "refused",
+        "result": result,
+        "result_artifact": admitted,
+        "signal": signal,
+        "site": inp["site"] if admitted else site,
+    }

--- a/libs/gda-balancing/tests/test_formula_runtime_seam.py
+++ b/libs/gda-balancing/tests/test_formula_runtime_seam.py
@@ -1,0 +1,246 @@
+"""Formula conformance reaches the same evaluator and preserves frame semantics."""
+
+import ast
+from copy import deepcopy
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+import gda_balancing.domain.runtime.execution as runtime
+from gda_balancing.domain.authority.context import packaged_authority_context
+from gda_balancing.domain.authority.graph import LanguageBundleIndex
+from gda_balancing.domain.model import (
+    CheckedModel,
+    check_model_source_value,
+    compile_checked_model,
+)
+import schema2_value_program_reference_support as reference
+from schema2_value_program_production_support import evaluate_value_program_vector
+
+
+@pytest.fixture(scope="module")
+def compiled_programs():
+    source = (
+        Path(__file__).parents[1]
+        / "examples/schema2/progression-periodic-effect/model-source.json"
+    )
+    checked = check_model_source_value(json.loads(source.read_bytes()))
+    assert isinstance(checked, CheckedModel), checked
+    rir = cast(dict[str, Any], compile_checked_model(checked)["rir-semantic-payload"])
+    contract = rir["selected_semantics"]["execution_laws"]["runtime_program"]
+    return (
+        {p["site"]["context"]["phase"]: p for p in rir["initialization_programs"]},
+        contract["numeric"],
+        {row["id"]: row for row in contract["nodes"]},
+    )
+
+
+def test_vectors_observe_the_actual_formula_evaluator(monkeypatch):
+    context = packaged_authority_context()
+    bundle = cast(LanguageBundleIndex, context.language_bundle)
+    vector = next(
+        vector
+        for vector_set in bundle.package_conformance_vector_sets
+        if vector_set["package_id"] == "standard.runtime"
+        for vector in vector_set["vector_definitions"]
+        if vector["id"] == "formula.runtime.accept.initialization-and-event-frames"
+    )
+
+    def disabled_formula_evaluator(*args, **kwargs):
+        raise RuntimeError("actual Formula evaluator disabled")
+
+    monkeypatch.setattr(
+        runtime, "_evaluate_formula_program", disabled_formula_evaluator
+    )
+    with pytest.raises(RuntimeError, match="actual Formula evaluator disabled"):
+        evaluate_value_program_vector(context.kernel, vector, phase="initialization")
+    assert reference.reference_evaluate_value_program_vector(vector) == vector["expect"]
+
+
+@pytest.mark.parametrize("phase", ("initialization", "event", "observation"))
+def test_formula_charge_precedes_cache_and_uses_compiled_bound(
+    compiled_programs, phase
+):
+    programs, numeric, nodes = compiled_programs
+    program = programs[phase]
+    assert len(program["body"]) == 2
+    assert program["resource_bounds"]["max_steps"] == 3
+    cache = {}
+    kwargs: dict[str, Any] = dict(
+        numeric=numeric,
+        runtime_nodes=nodes,
+        phase=phase,
+        frame_identity="frame.first",
+        runtime_limit=8,
+        cache=cache,
+    )
+    operands = {"level": 2, "damage_per_level": 3}
+    first = runtime._evaluate_formula_program(
+        program, operands, consumed_steps=0, **kwargs
+    )
+    assert (first.value, first.consumed_steps, len(cache)) == (6, 3, 1)
+    second = runtime._evaluate_formula_program(
+        program, operands, consumed_steps=first.consumed_steps, **kwargs
+    )
+    assert (second.value, second.consumed_steps, len(cache)) == (6, 6, 1)
+    retained = deepcopy(cache)
+    with pytest.raises(runtime._InitializationProgramFault) as error:
+        runtime._evaluate_formula_program(
+            program, operands, consumed_steps=second.consumed_steps, **kwargs
+        )
+    fault = error.value
+    assert (fault.signal, fault.consumed_steps) == ("step-limit", 9)
+    assert fault.program == program["identity"]
+    assert fault.evaluation_site_identity == program["site"]["identity"]
+    assert fault.frame_identity == "frame.first"
+    assert cache == retained
+
+
+@pytest.mark.parametrize("phase", ("initialization", "event", "observation"))
+def test_same_formula_operands_in_new_frames_have_distinct_cache_entries(
+    compiled_programs, phase
+):
+    programs, numeric, nodes = compiled_programs
+    cache = {}
+    consumed = 0
+    for frame, expected_entries in (("first", 1), ("second", 2), ("first", 2)):
+        result = runtime._evaluate_formula_program(
+            programs[phase],
+            {"level": 2, "damage_per_level": 3},
+            numeric=numeric,
+            runtime_nodes=nodes,
+            frame_identity=frame,
+            phase=phase,
+            consumed_steps=consumed,
+            runtime_limit=9,
+            cache=cache,
+        )
+        consumed = result.consumed_steps
+        assert result.value == 6
+        assert len(cache) == expected_entries
+    assert consumed == 9
+
+
+def test_formula_numeric_refusal_preserves_the_actual_site_and_frame(compiled_programs):
+    programs, _numeric, nodes = compiled_programs
+    program = programs["event"]
+    cache = {}
+    with pytest.raises(runtime._InitializationProgramFault) as error:
+        runtime._evaluate_formula_program(
+            program,
+            {"level": 2, "damage_per_level": 3},
+            numeric={"minimum": 0, "maximum": 5},
+            runtime_nodes=nodes,
+            frame_identity="refusing-event",
+            phase="event",
+            consumed_steps=1,
+            runtime_limit=4,
+            cache=cache,
+        )
+    fault = error.value
+    assert (fault.signal, fault.consumed_steps) == ("numeric-overflow", 4)
+    assert fault.program == program["identity"]
+    assert (
+        fault.evaluation_site_identity == program["body"][0]["evaluation_site_identity"]
+    )
+    assert fault.frame_identity == "refusing-event"
+    assert cache == {}
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    (
+        "unknown-node",
+        "unsupported-node",
+        "missing-member",
+        "context",
+        "phase",
+        "frame",
+        "numeric",
+        "missing-value",
+    ),
+)
+def test_invalid_formula_requests_do_not_pollute_or_hide_behind_cache(
+    compiled_programs, mutation
+):
+    programs, numeric, nodes = compiled_programs
+    program = deepcopy(programs["initialization"])
+    operands = {"level": 2, "damage_per_level": 3}
+    cache = {}
+    kwargs: dict[str, Any] = dict(
+        numeric=numeric,
+        runtime_nodes=nodes,
+        frame_identity="frame",
+        phase="initialization",
+        consumed_steps=0,
+        runtime_limit=3,
+        cache=cache,
+    )
+    assert runtime._evaluate_formula_program(program, operands, **kwargs).value == 6
+    retained = deepcopy(cache)
+    if mutation == "unknown-node":
+        program["body"][0]["instruction"]["node"] = "unknown"
+    elif mutation == "unsupported-node":
+        program["body"][0]["instruction"]["node"] = next(
+            name
+            for name, contract in nodes.items()
+            if contract["family"] != "expression"
+        )
+    elif mutation == "missing-member":
+        del program["body"][0]["instruction"]["right"]
+    elif mutation == "context":
+        program["site"]["context"]["phase"] = "event"
+    elif mutation == "phase":
+        kwargs["phase"] = "unknown"
+    elif mutation == "frame":
+        kwargs["frame_identity"] = ""
+    elif mutation == "numeric":
+        kwargs["numeric"] = {"minimum": 2, "maximum": 1}
+    else:
+        assert mutation == "missing-value"
+        del operands["level"]
+    with pytest.raises(ValueError):
+        runtime._evaluate_formula_program(program, operands, **kwargs)
+    assert cache == retained
+
+
+def test_adapter_does_not_relabel_an_unexpected_numeric_error(monkeypatch):
+    context = packaged_authority_context()
+    bundle = cast(LanguageBundleIndex, context.language_bundle)
+    vector = next(
+        vector
+        for vector_set in bundle.package_conformance_vector_sets
+        if vector_set["package_id"] == "standard.runtime"
+        for vector in vector_set["vector_definitions"]
+        if vector["id"] == "formula.runtime.floor-divide.exact"
+    )
+
+    def unexpected_value_error(*args, **kwargs):
+        raise ValueError("floor-divide divisor must be positive")
+
+    monkeypatch.setattr(runtime, "_execute_value_instruction", unexpected_value_error)
+    with pytest.raises(ValueError, match="floor-divide divisor must be positive"):
+        evaluate_value_program_vector(context.kernel, vector, phase="event")
+
+
+def test_reference_value_program_consumer_has_no_runtime_or_admission_imports():
+    source = Path(reference.__file__).read_text(encoding="utf-8")
+    modules = [
+        node.module
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.ImportFrom)
+    ]
+    modules.extend(
+        alias.name
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    )
+    assert all(
+        not module.startswith("gda_balancing")
+        or module == "gda_balancing.domain.canonical"
+        for module in modules
+        if module is not None
+    )

--- a/libs/gda-balancing/tests/test_public_formula_runtime_seam.py
+++ b/libs/gda-balancing/tests/test_public_formula_runtime_seam.py
@@ -1,0 +1,400 @@
+"""Real CLI Formula lifecycle calls reach the production value-program evaluator."""
+
+from copy import deepcopy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import gda_balancing.domain.authority.context as authority
+import gda_balancing.domain.runtime.execution as runtime
+from gda_balancing.domain.canonical import canonical_bytes, content_identity
+from schema2_authority_support import mutable_authorities
+from test_schema2_model_cli import _reidentify_language_bundle
+from test_schema2_experiment_cli import (
+    _experiment,
+    _rpg_model_source,
+)
+
+
+_EXAMPLE = Path(__file__).parents[1] / "examples/schema2/progression-periodic-effect"
+
+
+def _members(receipt: dict[str, Any]) -> dict[str, Any]:
+    return {
+        row["logical_name"]: json.loads(Path(row["locator"]).read_bytes())
+        for row in receipt["member_locators"]
+    }
+
+
+def _build(tmp_path, run_cli, source: dict[str, Any] | None = None):
+    source_path = _EXAMPLE / "model-source.json"
+    if source is not None:
+        source_path = tmp_path / "source.json"
+        source_path.write_text(json.dumps(source))
+    code, stdout, stderr = run_cli(
+        [
+            "model",
+            "build",
+            str(source_path),
+            "--out",
+            str(tmp_path / "build"),
+            "--invocation-key",
+            "01" * 32,
+        ]
+    )
+    assert (code, stderr) == (0, ""), stdout
+    receipt = json.loads(stdout)
+    rir_path = next(
+        row["locator"]
+        for row in receipt["member_locators"]
+        if row["logical_name"] == "rir-semantic-payload"
+    )
+    return receipt, rir_path, _members(receipt)["rir-semantic-payload"]
+
+
+def _write_specification(tmp_path, run_cli, rir_path, value):
+    path = tmp_path / "experiment.json"
+    path.write_text(json.dumps(value))
+    code, stdout, stderr = run_cli(
+        ["experiment", "check", str(path), "--rir", rir_path]
+    )
+    assert (code, stderr) == (0, ""), stdout
+    assert json.loads(stdout)["checked"] is True
+    return path
+
+
+def _run(tmp_path, run_cli, spec_path, rir_path, key="02"):
+    return run_cli(
+        [
+            "experiment",
+            "run",
+            str(spec_path),
+            "--rir",
+            rir_path,
+            "--out",
+            str(tmp_path / f"run-{key}"),
+            "--invocation-key",
+            key * 32,
+        ]
+    )
+
+
+def _observe_programs(monkeypatch, *, prewarm=False):
+    evaluate = getattr(runtime, "_evaluate_formula_program")
+    calls = []
+
+    def observed(program, input_values, **kwargs):
+        assert program["body"], "an empty coordinator call is not Formula execution"
+        assert program["site"]["context"]["phase"] == kwargs["phase"]
+        assert program["identity"].startswith("sha256:")
+        assert all(
+            row["evaluation_site_identity"].startswith("sha256:")
+            for row in program["body"]
+        )
+        cache = kwargs["cache"]
+        assert isinstance(cache, dict)
+        # Instrumented cache-hit condition: evaluate the exact request once to
+        # populate the real cache, then let the ordinary call consume that hit.
+        # Only the ordinary call's charged result is returned to the caller.
+        if prewarm:
+            evaluate(program, input_values, **kwargs)
+        record = {
+            "program": program,
+            "inputs": dict(input_values),
+            "phase": kwargs["phase"],
+            "frame": kwargs["frame_identity"],
+            "before": kwargs["consumed_steps"],
+            "limit": kwargs["runtime_limit"],
+            "cache_before": len(cache),
+        }
+        calls.append(record)
+        try:
+            result = evaluate(program, input_values, **kwargs)
+        except runtime._InitializationProgramFault as fault:
+            record["fault"] = fault
+            record["after"] = fault.consumed_steps
+            raise
+        record.update(
+            value=result.value,
+            after=result.consumed_steps,
+            cache_growth=len(cache) - record["cache_before"],
+        )
+        return result
+
+    monkeypatch.setattr(runtime, "_evaluate_formula_program", observed)
+    return calls
+
+
+def _initial_frame(rir, specification):
+    values = {
+        canonical_bytes(row["target"]): row["value"]
+        for row in rir["entrypoints"][0]["scenario_input_contract"]["initializers"]
+    }
+    scenario = specification["scenarios"][0]
+    values.update(
+        {
+            canonical_bytes(row["target"]): row["value"]
+            for row in scenario["assignments"]
+        }
+    )
+    return content_identity(
+        "initialization-frame-v2",
+        {
+            "token": {"scenario": scenario["id"], "snapshot_index": 0},
+            "values": [
+                {"symbol": key.decode().rstrip("\n"), "value": value}
+                for key, value in sorted(values.items())
+            ],
+        },
+    )
+
+
+def test_public_nonempty_formula_phases_preserve_frames_charge_and_cached_results(
+    tmp_path, run_cli, monkeypatch
+):
+    _receipt, rir_path, rir = _build(tmp_path, run_cli)
+    specification = json.loads((_EXAMPLE / "experiment.json").read_bytes())
+    assert specification["model"] == {"rir_semantic_identity": rir["semantic_identity"]}
+    spec_path = _write_specification(tmp_path, run_cli, rir_path, specification)
+    results = []
+    for prewarm, key in ((False, "02"), (True, "03")):
+        with monkeypatch.context() as scoped:
+            calls = _observe_programs(scoped, prewarm=prewarm)
+            code, stdout, stderr = _run(tmp_path, run_cli, spec_path, rir_path, key)
+        assert (code, stderr) == (0, ""), stdout
+        members = _members(json.loads(stdout))
+        results.append(members)
+        events = [
+            row
+            for row in members["event-trace"]["events"]
+            if row["observation"] is None
+        ]
+        assert [row["outcome"]["id"] for row in events] == [
+            "applied",
+            "ticked",
+            "ticked",
+            "expired",
+        ]
+        assert [row["phase"] for row in calls] == [
+            "initialization",
+            "event",
+            "observation",
+            "event",
+            "observation",
+            "event",
+            "observation",
+            "event",
+            "observation",
+        ]
+        assert calls[0]["frame"] == _initial_frame(rir, specification)
+        for phase, member in (
+            ("event", "snapshot_before_identity"),
+            ("observation", "snapshot_after_identity"),
+        ):
+            assert [row["frame"] for row in calls if row["phase"] == phase] == [
+                row[member] for row in events
+            ]
+        programs = {row["identity"]: row for row in rir["initialization_programs"]}
+        assert {row["program"]["identity"] for row in calls} == set(programs)
+        for call in calls:
+            program = call["program"]
+            assert program == programs[program["identity"]]
+            assert len(program["body"]) == 2
+            assert program["resource_bounds"]["max_steps"] == 3
+            assert call["after"] - call["before"] == 3
+            assert call["inputs"] == {"damage_per_level": 17, "level": 5}
+            assert call["value"] == 85
+            assert call["cache_growth"] == (0 if prewarm else 1)
+        assert {
+            row["metric"]: row["value"] for row in members["metric-dataset"]["samples"]
+        } == {
+            "target_health_remaining": 70,
+            "effect_active_terminal": 0,
+            "effect_instance_id_terminal": 1507657888,
+        }
+    # The controlled cache-hit run must retain every semantic AND producer member.
+    # This in-memory observation changes no producer source bytes.
+    assert results[0] == results[1]
+
+
+def _limited_context(limit):
+    kernel, bundle = mutable_authorities()
+    profile = next(
+        row
+        for row in bundle["language"]["runtime_profiles"]
+        if row["id"] == "standard.exact-int64-event-v1"
+    )
+    profile["resource_bounds"]["max_node_steps"] = limit
+    _reidentify_language_bundle(bundle)
+    context = authority.admit_authority_context(kernel, bundle)
+    assert isinstance(context, authority.AdmittedAuthorityContext), context
+    return context
+
+
+@pytest.mark.parametrize(
+    ("phase", "limit", "committed"),
+    [
+        ("initialization", 2, 0),
+        ("event", 5, 0),
+        ("observation", 20, 1),
+    ],
+)
+def test_public_formula_budget_refusal_preserves_site_frame_and_atomic_prefix(
+    tmp_path, run_cli, monkeypatch, phase, limit, committed
+):
+    # Inject an actually admitted authority value at the normal context owner;
+    # no checked RIR or Runtime policy is replaced after admission.
+    monkeypatch.setattr(authority, "_PACKAGED_CONTEXT", _limited_context(limit))
+    _receipt, rir_path, rir = _build(tmp_path, run_cli)
+    specification = json.loads((_EXAMPLE / "experiment.json").read_bytes())
+    specification["model"] = {"rir_semantic_identity": rir["semantic_identity"]}
+    spec_path = _write_specification(tmp_path, run_cli, rir_path, specification)
+    calls = _observe_programs(monkeypatch)
+    code, stdout, stderr = _run(tmp_path, run_cli, spec_path, rir_path)
+    assert (code, stderr) == (2, ""), stdout
+    error = json.loads(stdout)["error"]
+    assert error["stage"] == "runtime"
+    last = calls[-1]
+    fault = last["fault"]
+    assert last["phase"] == phase
+    assert fault.signal == "step-limit"
+    assert fault.program == last["program"]["identity"]
+    assert fault.evaluation_site_identity == last["program"]["site"]["identity"]
+    assert fault.frame_identity == last["frame"]
+    assert last["after"] == last["before"] + 3 == limit + 1
+    diagnostic = error["diagnostics"][0]
+    assert diagnostic["code"] == "runtime.step_limit_exceeded"
+    if phase == "initialization":
+        assert diagnostic["primary"] == {
+            "kind": "runtime",
+            "subject": "formula-evaluation-site",
+            "identity": fault.evaluation_site_identity,
+        }
+        assert last["frame"] == _initial_frame(rir, specification)
+        assert diagnostic["related"][0] == {
+            "kind": "runtime",
+            "subject": "initialization-frame",
+            "identity": last["frame"],
+        }
+        assert "terminal_audit" not in error
+        assert not (tmp_path / "run-02").exists()
+    else:
+        members = _members(error["terminal_audit"])
+        assert set(members) == {
+            "evaluator-capability-manifest",
+            "resolved-runtime-profile",
+            "runtime-terminal-audit",
+        }
+        audit = members["runtime-terminal-audit"]
+        assert diagnostic["primary"] == {
+            "kind": "artifact",
+            "content_identity": audit["experiment_identity"],
+            "pointer": "/scenarios/0/entrypoint",
+        }
+        assert [row["outcome"]["id"] for row in audit["committed_trace_prefix"]] == (
+            ["applied"] if committed else []
+        )
+        assert audit["last_snapshot_record"]["values"] == [
+            {"name": "effect_active", "value": committed},
+            {
+                "name": "effect_instance_id",
+                "value": 1507657888 if committed else 0,
+            },
+            {"name": "target_health", "value": 100},
+        ]
+        assert audit["last_snapshot_identity"] == last["frame"]
+        assert audit["last_snapshot_record"]["index"] == committed
+        assert audit["rollback"] == {
+            "committed": False,
+            "state_before": audit["last_snapshot_record"]["values"],
+            "state_after": audit["last_snapshot_record"]["values"],
+        }
+        assert audit["budget_counters"]["node_steps"] == limit + 1
+        assert (
+            audit["refusing_event"]["evaluation_site_identity"]
+            == fault.evaluation_site_identity
+        )
+
+
+def test_public_numeric_formula_refusal_uses_the_real_instruction_site_before_snapshot_zero(
+    tmp_path, run_cli, monkeypatch
+):
+    source = _rpg_model_source()
+    bounds = {"minimum": -(1 << 63), "maximum": (1 << 63) - 1}
+    for symbol in source["modules"][0]["symbols"]:
+        if symbol["symbol"] in {"accuracy", "effective_accuracy"}:
+            symbol["domain"] = dict(bounds)
+    formula = next(
+        row
+        for row in source["modules"][0]["formulas"]
+        if row["id"] == "effective-accuracy"
+    )
+    formula["parameters"][0]["domain"] = dict(bounds)
+    formula["result"]["domain"] = dict(bounds)
+    formula["body"] = {
+        "nodes": [
+            {
+                "id": "underflow",
+                "node": "operation-call",
+                "operation": {"package": "core.quantity", "id": "quantity.subtract"},
+                "arguments": [
+                    {
+                        "port": "left",
+                        "operand": {"kind": "parameter", "parameter": "base"},
+                    },
+                    {"port": "right", "operand": {"kind": "literal", "value": 1}},
+                ],
+                "result": deepcopy(formula["result"]),
+            }
+        ],
+        "result": {"kind": "local", "local": "underflow"},
+    }
+    formula["expression"] = "let underflow = base - 1;\nunderflow"
+    receipt, rir_path, rir = _build(tmp_path, run_cli, source)
+    specification = _experiment(build_receipt=receipt, base_damage=24)
+    next(
+        row
+        for row in specification["scenarios"][0]["assignments"]
+        if row["target"]["name"] == "accuracy"
+    )["value"] = bounds["minimum"]
+    spec_path = _write_specification(tmp_path, run_cli, rir_path, specification)
+    calls = _observe_programs(monkeypatch)
+    code, stdout, stderr = _run(tmp_path, run_cli, spec_path, rir_path)
+    assert (code, stderr) == (2, ""), stdout
+    assert len(calls) == 1
+    call = calls[0]
+    program = next(
+        row
+        for row in rir["initialization_programs"]
+        if row["site"]["context"]["phase"] == "initialization"
+        and row["target"]["name"] == "effective_accuracy"
+    )
+    fault = call["fault"]
+    assert call["phase"] == "initialization"
+    assert call["program"] == program
+    assert fault.signal == "numeric-overflow"
+    assert fault.evaluation_site_identity == next(
+        row["evaluation_site_identity"]
+        for row in program["body"]
+        if row["instruction"]["node"] == "subtract"
+    )
+    assert fault.frame_identity == _initial_frame(rir, specification)
+    assert call["after"] == program["resource_bounds"]["max_steps"]
+    error = json.loads(stdout)["error"]
+    assert error["stage"] == "runtime"
+    diagnostic = error["diagnostics"][0]
+    assert diagnostic["code"] == "runtime.numeric_overflow"
+    assert diagnostic["primary"] == {
+        "kind": "runtime",
+        "subject": "formula-evaluation-site",
+        "identity": fault.evaluation_site_identity,
+    }
+    assert diagnostic["related"][0] == {
+        "kind": "runtime",
+        "subject": "initialization-frame",
+        "identity": fault.frame_identity,
+    }
+    assert "terminal_audit" not in error
+    assert not (tmp_path / "run-02").exists()

--- a/libs/gda-balancing/tests/test_schema2_experiment_cli.py
+++ b/libs/gda-balancing/tests/test_schema2_experiment_cli.py
@@ -72,6 +72,10 @@ from schema2_bootstrap_production_support import (
     _refresh_package_closure_and_reidentify,
 )
 from schema2_authority_support import mutable_authorities
+from schema2_value_program_production_support import evaluate_value_program_vector
+from schema2_value_program_reference_support import (
+    reference_evaluate_value_program_vector as _reference_evaluate_value_program_vector,
+)
 
 _EXAMPLE_DIR = Path(__file__).parents[1] / "examples" / "schema2" / "rpg-combat-cast"
 _PERIODIC_EXAMPLE_DIR = (
@@ -586,98 +590,6 @@ def _member(receipt: dict[str, Any], logical_name: str) -> dict[str, Any]:
     return json.loads(Path(locator).read_text(encoding="utf-8"))
 
 
-def _reference_evaluate_value_program_vector(
-    vector: dict[str, Any],
-) -> dict[str, Any]:
-    inp = vector["input"]
-    instructions = inp["instructions"]
-    numeric = inp["numeric"]
-    operands = {row["name"]: row["value"] for row in inp["operands"]}
-    cache: dict[bytes, int] = {}
-    charge = 0
-    result = None
-    signal = None
-    site = inp["site"]
-    for _ in range(inp["evaluations"]):
-        charge += len(instructions)
-        if charge > inp["resource_limit"]:
-            signal = "step-limit"
-            result = None
-            break
-        key = canonical_bytes(
-            {
-                "instructions": instructions,
-                "numeric": numeric,
-                "operands": [
-                    {"name": name, "value": value}
-                    for name, value in sorted(operands.items())
-                ],
-                "result": inp["result"],
-                "site": inp["site"],
-            }
-        )
-        if inp["cache"] and key in cache:
-            result = cache[key]
-            continue
-        values = dict(operands)
-        for row in instructions:
-            instruction = row["instruction"]
-            node = instruction["node"]
-            if node == "constant":
-                value = instruction["literal"]
-            elif node == "copy":
-                value = values[instruction["value"]]
-            elif node == "add":
-                value = values[instruction["left"]] + values[instruction["right"]]
-            elif node == "subtract":
-                value = values[instruction["left"]] - values[instruction["right"]]
-            elif node == "multiply":
-                value = values[instruction["left"]] * values[instruction["right"]]
-            elif node == "floor-divide":
-                divisor = values[instruction["right"]]
-                if divisor <= 0:
-                    signal = "invalid-domain"
-                    site = row["evaluation_site_identity"]
-                    result = None
-                    break
-                value = values[instruction["left"]] // divisor
-            elif node == "maximum":
-                value = max(
-                    values[instruction["left"]],
-                    values[instruction["right"]],
-                )
-            else:
-                assert node == "if"
-                value = values[
-                    instruction[
-                        "when_true"
-                        if values[instruction["condition"]]
-                        else "when_false"
-                    ]
-                ]
-            if not numeric["minimum"] <= value <= numeric["maximum"]:
-                signal = "numeric-overflow"
-                site = row["evaluation_site_identity"]
-                result = None
-                break
-            values[instruction["target"]] = value
-        if signal is not None:
-            break
-        result = values[inp["result"]]
-        if inp["cache"]:
-            cache[key] = result
-    admitted = signal is None
-    return {
-        "cache_entries": len(cache),
-        "charge": charge,
-        "outcome": "admitted" if admitted else "refused",
-        "result": result,
-        "result_artifact": admitted,
-        "signal": signal,
-        "site": inp["site"] if admitted else site,
-    }
-
-
 def _reference_evaluate_formula_document(
     formula: dict[str, Any], arguments: list[dict[str, Any]]
 ) -> int:
@@ -938,9 +850,14 @@ def _assert_observation_evidence_matches_package_vector(
         },
     ]
     assert projected_operands == vector["input"]["operands"]
-    production = experiment_runtime_module._evaluate_value_program_vector(vector)
+    production = evaluate_value_program_vector(
+        authority_module.packaged_authority_context().kernel,
+        vector,
+        phase="observation",
+    )
     reference = _reference_evaluate_value_program_vector(vector)
-    assert production == reference == vector["expect"]
+    assert production == vector["expect"]
+    assert reference == vector["expect"]
 
 
 def _experiment(
@@ -5535,6 +5452,7 @@ def test_observation_formula_refusal_preserves_the_committed_event_and_snapshot(
                     program="formula.observation",
                     evaluation_site_identity="sha256:" + "f" * 64,
                     frame_identity=frame_identity,
+                    consumed_steps=kwargs["consumed_steps"],
                 )
             cache = kwargs.get("cache")
             assert isinstance(cache, dict)
@@ -7409,7 +7327,7 @@ def test_scheduler_consumers_refuse_unknown_requested_mutations(consumer):
 
 
 def test_package_value_program_vectors_execute_in_two_consumers():
-    _kernel, ldb = mutable_authorities()
+    kernel, ldb = mutable_authorities()
     vectors = [
         vector
         for vector in next(
@@ -7432,13 +7350,15 @@ def test_package_value_program_vectors_execute_in_two_consumers():
         "formula.runtime.floor-divide.refuse.negative-divisor",
     }
     for vector in vectors:
-        production = experiment_runtime_module._evaluate_value_program_vector(vector)
         reference = _reference_evaluate_value_program_vector(vector)
-        assert production == reference == vector["expect"]
+        assert reference == vector["expect"]
+        for phase in ("initialization", "event", "observation"):
+            production = evaluate_value_program_vector(kernel, vector, phase=phase)
+            assert production == vector["expect"]
 
 
 def test_package_observation_lifecycle_vectors_execute_in_two_consumers():
-    _kernel, ldb = mutable_authorities()
+    kernel, ldb = mutable_authorities()
     vectors = [
         vector
         for vector in next(
@@ -7465,9 +7385,10 @@ def test_package_observation_lifecycle_vectors_execute_in_two_consumers():
     for vector in vectors:
         assert vector["kind"] == "value-program"
         assert vector["input"]["site"] in expected_sites
-        production = experiment_runtime_module._evaluate_value_program_vector(vector)
+        production = evaluate_value_program_vector(kernel, vector, phase="observation")
         reference = _reference_evaluate_value_program_vector(vector)
-        assert production == reference == vector["expect"]
+        assert production == vector["expect"]
+        assert reference == vector["expect"]
 
 
 def test_completed_negative_judgment_publishes_only_typed_verdict_set(

--- a/libs/gda-balancing/tools/ci.py
+++ b/libs/gda-balancing/tools/ci.py
@@ -88,7 +88,9 @@ SHARDS: Final[dict[str, tuple[str, ...]]] = {
     "composition": (
         "test_current_namespace_public.py",
         "test_current_package_composition.py",
+        "test_formula_runtime_seam.py",
         "test_public_execution_identity.py",
+        "test_public_formula_runtime_seam.py",
         "test_schema2_bootstrap_composition.py",
     ),
     "interfaces": (


### PR DESCRIPTION
## Problem and change

The shipped value-program vector helper had its own meter, cache and refusal loop, so passing conformance vectors did not prove that normal Formula execution used the same behavior. Initialization, derived Event and observation Formula programs now use one production-owned evaluation function; the vector adapter translates requests under tests, and the shipped vector-only helper is deleted. Independent reference evaluation and artifact replay remain independent. Inline Operation Formula keeps its existing per-instruction Event ledger.

Actual public low-budget runs also exposed a pre-existing fault: Event and observation callers lost charged steps when Formula evaluation raised, causing their terminal audits to fail semantic validation and return internal errors. Both callers now retain the fault charge. Limits 5 and 20 publish the existing typed refusal with 6 and 21 charged steps instead of invalid audits with 3 and 18 steps. No validator, Kernel/LDB, public schema or resource law is weakened or changed.

## Validation

- Integrated seam/public/vector checks: **24 passed**. Each of the ten shipped vectors is independently checked against its expectation by production and reference consumers; production runs in all three lifecycle contexts.
- Nonempty public build/check/run checks cover actual compiled programs, exact sites/frames, declared charge larger than body length, instrumented cache hits, numerical refusal and atomic resource-refusal prefixes.
- Real before/after capture: **26 CLI subprocess calls**, all **28 authority files** and previously valid semantic artifacts byte-identical. Only nine truthful evaluator manifests and their dependent publication/receipt identities change. Confirmed invalid baseline resource refusals are separately tested as repairs.
- Inventory: **1,741 tests**, nine disjoint shards, all **849** required baseline IDs and **313** current package vectors retained; no missing or overlapping tests.
- Ruff, Pyright and sealed-LDB checks pass. Full CI passed at `075a5aae74d257f8968c408faa4b4b304055f85b`: 17 successful checks and one intentionally skipped root Godot job. All nine package JUnit sets account for 1,741 tests: 1,718 passed, 23 existing allowed skips, zero failures or errors; actual executed IDs equal the complete collection and each shard digest. Independent review completion is recorded in the final acceptance comment.

The [Formula Runtime record](libs/gda-balancing/docs/refactor/current-language/FORMULA-RUNTIME.md) defines scope, source fingerprints, evidence limits, reproduction tests and rollback. Independent reversal of the complete issue diff restored all 436 package files and modes exactly to `aa94ec79d63b0595e5d6af8bce6180aba9d5b397`. Actual restored public build/check/run with explicit `--rir` passed; expected event order and final metrics were preserved. This rollback also restores the baseline resource-refusal defect.

Refs #612. This PR targets `codex/gda-balancing-refactor-delete-dev` under #865. It does not merge accumulated work into main, publish a formal release, or perform the primitive deletions owned by #876.
