### PR TITLE
docs(asset-pipeline): record supporting context architecture

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -7,3 +7,26 @@ override rules are declared in its own `AGENTS.md`.
 - [gda](CONTEXT.md) — the agent-facing Godot toolchain: `gda`, `gda-mcp`, `gda-daemon`.
 - [Panda Adventure](examples/platformer/panda-adventure/GAME-CONTEXT.md) — the 2D-platformer game demo.
 - [gda-balancing](libs/gda-balancing/BALANCING-CONTEXT.md) — the standalone numeric design & balancing toolkit.
+- [Asset Pipeline](libs/gda-assets/ASSETS-CONTEXT.md) — the internal supporting
+  context, physically carried by `libs/gda-assets` and exposed through the planned
+  `gda asset-pipeline` command group. The design is accepted; implementation is pending.
+
+## Asset Pipeline integration
+
+On the **pipeline service contract**, Asset Pipeline (`gda-assets`) is the upstream
+provider and the gda entry/integration is the downstream consumer. The gda host
+translates between the two models and injects implementations of the narrow Godot
+capability ports declared by Asset Pipeline. Godot operations and engine facts remain
+owned by gda. Runtime callbacks through those ports do not create reverse source
+imports: `gda-assets` never imports `gda` or invokes its CLI.
+
+Blender and image-generation systems are external producers. Asset Pipeline owns
+their outbound adapters and anti-corruption layers. Project recipes, art direction,
+and gameplay expectations are project-owned inputs. Panda Adventure is a one-time
+scaffold source for this work; it is not a runtime dependency or a migration target.
+Its planned archival does not mean that it has already been archived.
+
+The gda-side integration contract is owned by
+[ADR-0042](docs/adr/0042-asset-pipeline-supporting-context-integration.md);
+internal workflow design is owned by the
+[Asset Pipeline architecture](libs/gda-assets/docs/ARCHITECTURE.md).

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -21,9 +21,11 @@ owned by gda. Runtime callbacks through those ports do not create reverse source
 imports: `gda-assets` never imports `gda` or invokes its CLI.
 
 Blender and image-generation systems are external producers. Asset Pipeline owns
-their outbound adapters and anti-corruption layers. Project recipes, art direction,
-and gameplay expectations are project-owned inputs. Panda Adventure is a one-time
-scaffold source for this work; it is not a runtime dependency or a migration target.
+their outbound adapters and anti-corruption layers. Its application also owns
+prompt preparation and concept-reference handoff. Project recipes, prompts,
+selected concepts, art direction, and gameplay expectations are project-owned
+inputs. Panda Adventure is a one-time scaffold source for this work; it is not a
+runtime dependency or a migration target.
 Its planned archival does not mean that it has already been archived.
 
 The gda-side integration contract is owned by

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,8 +9,12 @@ programmatic consumption.
 ### Components
 
 **gda**:
-The agent-facing Godot CLI — the bottom layer that exposes Godot operations with
-structured output. Other components build on it.
+The agent-facing Godot toolchain and its single CLI entry point. Its core context
+owns Godot operations and engine facts with structured output. The product can
+also expose an internal supporting context through a command group: the accepted
+`asset-pipeline` integration delegates asset workflows to `gda-assets`
+(ADR-0042; implementation tracked separately). That assembly does not move
+producer-specific behavior or project asset policy into the Godot core.
 _Avoid_: the CLI, godot-cli
 
 **gda-mcp**:

--- a/docs/adr/0005-cli-command-taxonomy.md
+++ b/docs/adr/0005-cli-command-taxonomy.md
@@ -4,6 +4,12 @@ status: accepted
 
 # CLI command taxonomy: grouped by Godot domain object
 
+> **Extension (2026-09-07):**
+> [ADR-0042](0042-asset-pipeline-supporting-context-integration.md) accepts
+> `gda asset-pipeline` as the entry to an internal supporting context. This is a
+> workflow group, distinct from Godot object operations. It adds no synonymous
+> `asset` or `assets` CRUD group. The extension is designed, not yet implemented.
+
 `gda` will grow to many commands. We need a command structure that stays navigable
 at that scale, is intuitive to anyone who knows Godot, and maps cleanly onto
 `gda-mcp`'s tool surface.

--- a/docs/adr/0040-per-command-group-modules.md
+++ b/docs/adr/0040-per-command-group-modules.md
@@ -4,6 +4,15 @@ status: accepted
 
 # Per-command-group modules: vertical group slices over the shared descriptor core
 
+> **Scoped extension (2026-09-07):**
+> [ADR-0042](0042-asset-pipeline-supporting-context-integration.md) keeps the new
+> `asset-pipeline` group's gda params, rendering, descriptors, and dispatch together,
+> but delegates its cross-tool application workflow to the supporting context.
+> A gda integration adapter consumes that package's explicit API and implements its
+> Godot ports through one-way imports of returning gda operations. Existing group
+> ownership and the shared core's dependency direction remain in force. This is an
+> accepted design extension, pending implementation.
+
 > **Amendment (2026-08-20, #657):** the module-tree sketch below annotates
 > `daemon.py` as "recipe-backed, not LIVE". Since #657 the group carries ONE
 > `kind = LIVE` command — `daemon wait-ready`, which routes through the live

--- a/docs/adr/0042-asset-pipeline-supporting-context-integration.md
+++ b/docs/adr/0042-asset-pipeline-supporting-context-integration.md
@@ -1,0 +1,118 @@
+---
+status: accepted
+---
+
+# Integrate Asset Pipeline as an internal supporting context
+
+Accepted by the project owner on 2026-09-07. Requirements and delivery status:
+[#907](https://github.com/aigengame/godot-agent/issues/907),
+[gda-blender milestone](https://github.com/aigengame/godot-agent/milestone/14).
+This records an accepted target, not implemented commands or validated runtime behavior.
+
+## Context
+
+Blender-to-Godot work repeatedly requires proving what was exported, what Godot
+imported, and what a selected running instance uses. Project checks and preview
+recipes also need production and file-processing steps. Adding all of that to
+gda's Godot operation groups would give those groups unrelated reasons to change.
+
+The owner requires a single gda entry, a new supporting context at `libs/gda-assets`,
+and primarily additive changes to the existing gda topology. Panda Adventure's
+generic asset scripts can seed the new context once; the game is not a dependency
+or an ongoing migration target.
+
+## Decision
+
+1. **One product entry, two models.** Add the command group `gda asset-pipeline`.
+   The internal Python package is `gda_assets`, carried by `libs/gda-assets`.
+   It has no user-facing CLI, daemon, separate setup flow, or service deployment.
+   `gda-mcp` continues to derive its public tools from the same gda descriptors.
+2. **The supporting context supplies the pipeline service.** For this service
+   contract, gda-assets is upstream and gda's entry/integration is downstream.
+   gda-assets owns application orchestration from production through selected checks.
+   Subdomain importance, data-flow order, and runtime call direction do not change
+   this contract-specific relationship.
+3. **The host supplies Godot capabilities by injection.** gda-assets declares
+   narrow application-owned ports for the engine operations its use cases need.
+   A gda-side adapter implements them through typed, returning gda operations.
+   It translates engine results into the pipeline's required facts while preserving
+   measurement scope, omissions, failure reasons, and unsupported cases.
+   gda remains the authority for import/cache semantics and runtime observations.
+4. **Source imports stay acyclic.** gda integration imports the explicit
+   `gda_assets` API/port contracts and gda operations. gda-assets imports neither
+   gda internals nor its CLI, and never starts a nested gda process. No operation
+   adapter calls back into the asset-pipeline service. gda's composition constructs
+   the host adapter and injects it into the service.
+5. **Translation is local.** The gda integration translates public gda requests,
+   results, and registered errors at the service boundary. The same compact
+   integration module can hold the host-port adapter; two abstract frameworks are
+   unnecessary. Blender and image-generation anti-corruption layers live inside
+   gda-assets. Their vendor SDK types, errors, and transport semantics do not enter
+   the gda core or the pipeline Domain.
+6. **Core operations remain independently useful.** Resource import/inspection,
+   scene/property operations, session control, capture, diagnostics, and export
+   continue to work without a recipe, receipt, profile, or pipeline history.
+   Selected hashes and check results are optional workflow data, not a new core
+   precondition. New engine facts go in their existing owning group.
+
+## gda implementation seam
+
+The planned addition is a thin `commands/asset_pipeline.py` group and a compact
+`integrations/asset_pipeline.py` host adapter/factory. The group retains its gda
+params/result models, renderers, classifiers, descriptors, and dispatch. Its recipe
+delegates cross-tool application work to the supporting context. This extends
+ADR-0040 only at this group; it does not move other groups or rebuild the core.
+
+Composition remains rooted in `cli.py`. The integration module must not import
+that root to recover a service. Prefer returning operation functions; CLI dispatch
+tails emit output and can exit, so they are not host service methods.
+`HeadlessCommand.execute` is not a generic recipe executor. Extract a narrow
+returning operation only where the actual needed seam is absent.
+
+The first command slice must extend descriptor execution metadata truthfully for
+a composite asset-pipeline recipe. It must not label the entire workflow as one
+headless or live operation or add a generalized runner engine. The selected steps
+retain their own engine/platform/readiness checks; a file/import-only workflow
+does not acquire live-session requirements from an optional preview step.
+
+Canonical spelling is `asset-pipeline`, with planned `run`, `check`, and `preview`
+verbs introduced by their own slices. Each implemented verb must reach help,
+structured params, schema, generated MCP, human output, and shipped skill guidance
+together. This document does not advertise those commands as available today.
+
+## Packaging and lifecycle
+
+A normal gda installation must include a compatible gda-assets implementation with
+no separate user install. The first integration slice owns the packaging decision
+and proves it by installing built artifacts outside the checkout; a source-only
+path dependency is insufficient. Coordinate package compatibility and release
+ordering with the existing release authority before shipping that slice.
+ADR-0038's independent sibling-product release model does not automatically apply
+to this internal supporting library.
+
+Importing the public API, listing schema, and displaying help/version must not
+initialize vendor SDKs, discover/connect to Blender, read credentials, or contact a
+generation service. Producer configuration is checked only for a selected producer.
+External tools still require their normal installation and configuration.
+
+## Alternatives and consequences
+
+- An external script invoking gda would reuse the current surface with less initial
+  integration work, but would not satisfy the accepted single-entry support model.
+- Putting the workflow in gda command groups would avoid a package seam but couple
+  producer changes and project policy to Godot operations.
+- The selected package boundary adds a small supported internal API and explicit
+  translation tests. It does not require a public Python SDK, plugin registry,
+  message bus, persisted workflow engine, or separate product release promise.
+
+The supporting context owns its model and decisions in
+[ASSETS-CONTEXT.md](../../libs/gda-assets/ASSETS-CONTEXT.md) and its
+[architecture](../../libs/gda-assets/docs/ARCHITECTURE.md). Those documents reference
+this integration contract instead of redefining gda's core semantics.
+
+## Verification still required
+
+The design review supports the placement; real integration is not yet proven.
+AP-01 in the local architecture tracks clean-install discovery, one-way imports,
+public CLI/MCP parity, and an end-to-end file-to-import path. Engine-facing slices
+must retain their real-Godot cases. This documentation change does not satisfy them.

--- a/libs/gda-assets/AGENTS.md
+++ b/libs/gda-assets/AGENTS.md
@@ -1,0 +1,40 @@
+# Asset Pipeline context
+
+This subtree carries **Asset Pipeline**, gda's internal asset-workflow supporting
+context. It is not a sibling user-facing product. The accepted design is recorded;
+implementation is pending. Requirements and delivery status live in
+[#907](https://github.com/aigengame/godot-agent/issues/907).
+
+Inherit root `AGENTS.md`, `RULES.md`, issue tracker, and triage conventions except
+for domain-document routing. Local domain authority is:
+
+| Artifact | Owns |
+| --- | --- |
+| `ASSETS-CONTEXT.md` | Local language and responsibility boundaries |
+| `docs/ARCHITECTURE.md` | Target structure, workflow, validation gaps, and delivery mapping |
+| `docs/adr/NNNN-*.md` | Local asset decisions, cited as aADR-NNNN |
+
+For domain skills, map `CONTEXT.md` to `ASSETS-CONTEXT.md` and `docs/adr/` to this
+subtree's `docs/adr/`. The repo-root `CONTEXT-MAP.md` remains the routing authority.
+Read root ADR-0042 for integration with gda; root ADRs own gda transport and engine
+contracts. Write producer/project vocabulary here, not into the root glossary.
+
+## Implementation boundaries
+
+- Domain owns small asset rules and values. Application owns cross-tool use cases
+  and the ports they require. Outbound adapters translate external systems.
+- `gda_assets` must not import `gda`, call its CLI, or import game code. The gda host
+  injects implementations of the Godot ports. Only the explicit package API and
+  published port/result contracts are consumed across the package boundary.
+- Blender/image-generation SDKs belong behind local adapters. Load/configure them
+  when requested, not during public API import or gda discovery.
+- Project recipes own art direction, node expectations, collision/script/material
+  policies, and output paths. Do not embed Panda Adventure defaults in the framework.
+- Transplant useful Panda asset code once, then refactor here. Do not modify the
+  original game to consume this library or preserve its internal import API.
+- Add structures when a vertical slice needs them. Do not scaffold empty pattern
+  directories, a generic job system, a central asset registry, or an event bus.
+
+Implementation issues use the same GitHub tracker and milestone #14. Use
+`asset-pipeline:` for workflow titles; keep Godot primitive titles with their
+existing object group. A context boundary does not imply a separate release train.

--- a/libs/gda-assets/AGENTS.md
+++ b/libs/gda-assets/AGENTS.md
@@ -32,6 +32,9 @@ contracts. Write producer/project vocabulary here, not into the root glossary.
   policies, and output paths. Do not embed Panda Adventure defaults in the framework.
 - Transplant useful Panda asset code once, then refactor here. Do not modify the
   original game to consume this library or preserve its internal import API.
+- The `gda-blender-mcp` skill is optional reference material. Follow aADR-0001's
+  helper boundary: no installed-skill dependency and no substitution of helper
+  execution for a planned product feature or its acceptance.
 - Add structures when a vertical slice needs them. Do not scaffold empty pattern
   directories, a generic job system, a central asset registry, or an event bus.
 

--- a/libs/gda-assets/AGENTS.md
+++ b/libs/gda-assets/AGENTS.md
@@ -32,9 +32,6 @@ contracts. Write producer/project vocabulary here, not into the root glossary.
   policies, and output paths. Do not embed Panda Adventure defaults in the framework.
 - Transplant useful Panda asset code once, then refactor here. Do not modify the
   original game to consume this library or preserve its internal import API.
-- The `gda-blender-mcp` skill is optional reference material. Follow aADR-0001's
-  helper boundary: no installed-skill dependency and no substitution of helper
-  execution for a planned product feature or its acceptance.
 - Add structures when a vertical slice needs them. Do not scaffold empty pattern
   directories, a generic job system, a central asset registry, or an event bus.
 

--- a/libs/gda-assets/ASSETS-CONTEXT.md
+++ b/libs/gda-assets/ASSETS-CONTEXT.md
@@ -1,0 +1,85 @@
+# Asset Pipeline
+
+Asset Pipeline is a supporting subdomain implemented as the internal `gda_assets`
+package. It turns producer outputs into usable, checked Godot assets by coordinating
+production, file processing, installation, import, and selected acceptance steps.
+Users access it through `gda asset-pipeline`; they do not operate a second product.
+This is the accepted target vocabulary, with implementation tracked by
+[#907](https://github.com/aigengame/godot-agent/issues/907).
+
+## Boundary
+
+Asset Pipeline owns workflow order, project expectation evaluation, compatible
+report comparison, and producer adaptation. gda owns engine operations and the
+meaning of engine facts. A project owns its recipes and acceptance policy. Blender
+and image-generation systems own their native authoring/generation models.
+
+The context initially serves Blender and image-generation outputs. Aseprite is a
+later extension driven by a real use case; it does not set today's abstraction cost.
+Panda Adventure is a scaffold source, not the pipeline's domain model or client
+compatibility requirement.
+
+## Language
+
+**Asset recipe**: Project-owned input selecting a producer or existing files,
+output locations, applicable processing/import choices, and optional acceptance or
+preview settings. A small declarative input, not a programming language or workflow DAG.
+
+**Producer**: A boundary that supplies asset files from a native source or generation
+request. Its adapter owns vendor options and failure translation. A producer need
+not support modeling, source inspection, animation, or interactive sessions.
+
+**Produced files**: The files handed to the next stage, with roles, source mode, and
+available producer information. This is an ordinary result, not an immutable asset
+identity, version registry entry, or proof that the metadata is independently true.
+
+**Source mode**: The actual input used by a producer, such as a saved Blender file,
+an explicitly supported unsaved scene, or previously generated image files. A saved
+file and an unsaved interactive scene are not interchangeable fallback inputs.
+
+**Godot asset port**: A narrow application-owned contract for the Godot capabilities
+a workflow needs. Implemented by the gda host through existing or extended engine
+operations. Port result projection preserves engine fact scope and unavailable data.
+
+**Model facts**: Bounded observations of a selected resource or instance, including
+measurement basis, origin, locators, and omissions. A project expectation is not an
+engine fact. Blender base/evaluated/export meshes and Godot meshes need not have
+equal counts.
+
+**Asset expectations**: Project-authored conditions on compatible facts: required
+node paths/types, dimension/count ranges, material slots, or animation bindings.
+They do not define universal artistic quality or infer gameplay requirements.
+
+**Asset check result**: Per-condition observations and a verdict of pass, fail, or
+insufficient information. Invalid expectations are input errors. Omitted facts
+cannot prove a dependent condition passes or that a compared object was deleted.
+
+**Pipeline result**: The stages completed, produced/installed outputs, checks, and
+any failure or unsupported step. It describes the work that actually happened.
+It is not a persisted run aggregate or a promise of automatic resume.
+
+**Selected content receipt**: Optional workflow output that associates selected
+file/configuration/artifact hashes and their observation limits. Producer
+declarations remain labelled. It does not prove runtime instance freshness or full
+reproducibility. No core operation requires a receipt.
+
+**Preview recipe**: Project-local scene/settings plus a workflow that fixes the
+camera, lighting, renderer, pose, and observation conditions. It uses existing gda
+capture/diagnostic/performance operations. It is not a new renderer or profiler.
+
+**Package acceptance**: Evaluate the same expectations against facts obtained from
+the actual exported package in isolation. Package inspection and native executable
+render/input testing are separate results.
+
+## Naming and authority
+
+- Product command: `gda asset-pipeline` (singular `asset`).
+- Physical home: `libs/gda-assets`; Python package: `gda_assets`.
+- Avoid `gda-assets` as a user command, `assets-pipeline`, a generic `pipeline`
+  group, or an `asset` group duplicating resource/scene/game operations.
+- gda's Engine session, cache states, and capture-receipt terms retain their root
+  meanings. The host translates them; this context does not redefine them.
+
+See [the architecture](docs/ARCHITECTURE.md) for placement and validation, and
+[root ADR-0042](../../docs/adr/0042-asset-pipeline-supporting-context-integration.md)
+for the integration contract.

--- a/libs/gda-assets/ASSETS-CONTEXT.md
+++ b/libs/gda-assets/ASSETS-CONTEXT.md
@@ -2,16 +2,18 @@
 
 Asset Pipeline is a supporting subdomain implemented as the internal `gda_assets`
 package. It turns producer outputs into usable, checked Godot assets by coordinating
-production, file processing, installation, import, and selected acceptance steps.
+prompt/reference preparation, production, file processing, installation, import,
+and selected acceptance steps.
 Users access it through `gda asset-pipeline`; they do not operate a second product.
 This is the accepted target vocabulary, with implementation tracked by
 [#907](https://github.com/aigengame/godot-agent/issues/907).
 
 ## Boundary
 
-Asset Pipeline owns workflow order, project expectation evaluation, compatible
-report comparison, and producer adaptation. gda owns engine operations and the
-meaning of engine facts. A project owns its recipes and acceptance policy. Blender
+Asset Pipeline owns workflow order, prompt preservation and reference selection,
+project expectation evaluation, compatible report comparison, and producer
+adaptation. gda owns engine operations and the meaning of engine facts. A project
+owns its recipes and acceptance policy. Blender
 and image-generation systems own their native authoring/generation models.
 
 The context initially serves Blender and image-generation outputs. Aseprite is a
@@ -22,8 +24,23 @@ compatibility requirement.
 ## Language
 
 **Asset recipe**: Project-owned input selecting a producer or existing files,
-output locations, applicable processing/import choices, and optional acceptance or
-preview settings. A small declarative input, not a programming language or workflow DAG.
+output locations, applicable preparation/processing/import choices, and optional
+acceptance or preview settings. A small declarative input, not a programming
+language or workflow DAG.
+
+**Prompt record**: Project-local saved input for one generation attempt: authored
+text/template and inputs, resolved prompt, selected reference inputs, and requested
+producer options. Output files and reported details can be associated afterward.
+It supports inspect, explicit revision, and reuse; it is not a content receipt,
+provider-execution proof, or guarantee of reproducible output.
+
+**Concept reference**: An explicitly selected image-gen result used to guide new
+model or sprite authoring. Its role differs from a finished runtime asset. Project
+art direction determines suitable views, poses, and style.
+
+**Authoring handoff**: Selected usable concept files, their prompt-record links,
+intended use, and project instructions delivered to a tool or agent before authoring.
+It is a small prepared input, not a persisted workflow aggregate.
 
 **Producer**: A boundary that supplies asset files from a native source or generation
 request. Its adapter owns vendor options and failure translation. A producer need

--- a/libs/gda-assets/docs/ARCHITECTURE.md
+++ b/libs/gda-assets/docs/ARCHITECTURE.md
@@ -285,6 +285,22 @@ the new home. The equal-frame packer/SpriteFrames emitter is not complete Asepri
 support for trimmed regions, frame timing, or richer metadata. Do not change the
 original Panda codebase or mark it archived as part of this work.
 
+The `gda-blender-mcp` skill is another optional source of production lessons.
+[aADR-0001](adr/0001-domain-application-and-producer-adapters.md) owns its reuse
+boundary. Its `mcp_stdio_client.py` demonstrates protocol/result handling for a
+specific Blender MCP implementation; its SDK pin and agent-config defaults are not
+product requirements. Its `inspect_blender_asset.py` demonstrates selected-subtree
+inspection, derived-transform updates, visibility diagnostics, and explicit base
+geometry limitations. Those Blender observations do not replace gda's imported
+resource facts or the workflow's project-expectation evaluator.
+
+Transfer useful cases to tests owned by the relevant implementation slice. Run
+installed/public acceptance paths without the skill or its helper paths available,
+while retaining the selected external tools. A helper receipt or manually invoking
+the helper cannot close a product requirement. Reusable authoring recipes and
+examples delivered by #913 belong to the product/consumer example, and cannot
+require an installed helper to supply planned preparation or selection behavior.
+
 ## Evidence limits and validation gates
 
 [aADR-0002](adr/0002-minimum-results-and-optional-content-checks.md) owns the minimum

--- a/libs/gda-assets/docs/ARCHITECTURE.md
+++ b/libs/gda-assets/docs/ARCHITECTURE.md
@@ -1,0 +1,298 @@
+# Asset Pipeline architecture
+
+**Status:** accepted design, implementation pending. Accepted by the project owner
+on 2026-09-07 after review of the Blender-to-Godot workflow and milestone #14.
+Source baseline inspected: `cfcb8658e67df418a69694840a37a22a9cd3cbe0`.
+Acceptance and delivery status are owned by
+[#907](https://github.com/aigengame/godot-agent/issues/907)
+and its linked implementation issues. No command, package, or production validation
+is delivered merely by accepting this document.
+
+## Purpose and authority
+
+The repeated cost is establishing what a producer exported, what Godot loaded,
+and what the current scene uses. The pipeline coordinates those steps and reduces
+project-specific scripts for structure checks, import adjustments, preview, and
+package acceptance. It initially supports Blender and image-generation outputs.
+
+| Authority | Owns |
+| --- | --- |
+| Umbrella and child issues | User outcomes, acceptance criteria, blocking edges, completion |
+| Root CONTEXT-MAP and ADR-0042 | Context routing and integration with gda |
+| Local ASSETS-CONTEXT | Asset Pipeline vocabulary and ownership |
+| This document | Target module structure, complete workflow, delivery and validation mapping |
+| aADR-0001 / aADR-0002 | Internal decomposition and minimum-result decisions |
+| Project recipes and scenes | Art direction, output paths, gameplay expectations, authored overrides |
+| gda operation contracts | Engine facts, import/cache semantics, sessions, capture, export |
+
+The agreed drivers are: a single gda entry; additive integration into its existing
+topology; independent workflow ownership; Blender and image-generation variation;
+project/framework separation; and minimum sufficient mechanisms. No asset registry,
+general workflow platform, automatic topology/UV/rig repair, universal art-quality
+assessment, or hot swap is part of this design.
+
+## Context boundary and integration
+
+The binding gda integration contract is
+[ADR-0042](../../../docs/adr/0042-asset-pipeline-supporting-context-integration.md).
+This diagram shows runtime calls; source imports are described below it.
+
+```mermaid
+flowchart TD
+    User[Agent or user] --> Entry[gda entry and generated MCP surface]
+    Entry --> Core[Existing gda operation groups]
+    Entry --> Group[asset-pipeline command adapter]
+    Group --> API[gda-assets service API]
+    API --> App[Asset Pipeline application]
+    App --> Domain[Recipe and expectation rules]
+    App --> Producer[Producer ports and outbound ACLs]
+    Producer --> Blender[Blender]
+    Producer --> Image[Image generation or file handoff]
+    App --> Port[Godot asset ports]
+    Port --> Host[gda host adapter]
+    Host --> Core
+    Core --> Engine[Godot]
+    Compose[gda composition] -. injects .-> Host
+    Compose -. assembles .-> API
+```
+
+For the **pipeline service**, gda-assets is upstream; gda entry/integration consumes
+it downstream. The runtime callback into the Godot host port does not make
+gda-assets import gda. gda's engine model remains authoritative for engine facts.
+
+Source dependency rules:
+
+1. `gda.cli` composes the command group and host adapter; the integration never
+   imports `gda.cli` to retrieve a service.
+2. The group/integration consumes the package's explicit public API and port/result
+   contracts. The host adapter also imports returning gda operations one-way.
+3. `gda_assets.application` depends on its own Domain and ports; it imports no gda,
+   vendor SDK, game configuration module, or CLI dispatch.
+4. Producer adapters implement local contracts and depend on external systems.
+   Their composition is internal. Domain depends on neither adapters nor the host.
+
+| Boundary | Translation and owner |
+| --- | --- |
+| gda entry to pipeline service | gda integration maps CLI models/results/errors to the supported service API |
+| Pipeline Godot port to gda operations | gda host adapter preserves engine semantics while projecting required facts |
+| Blender to pipeline | Local Blender ACL maps source selection, export options, outputs, native errors |
+| Image system to pipeline | Local image-generation ACL maps callable-provider responses or explicit file handoff |
+
+These are small adapters at actual model boundaries. They do not justify duplicate
+import-state rules, two result registries, or an integration framework.
+
+## Responsibility and target structure
+
+| Capability | Owner |
+| --- | --- |
+| Godot 3D properties and loaded resource/instance facts | Existing gda groups and engine payloads |
+| Import metadata, option mutation, and actual engine work | gda resource operations |
+| Production, installation, check ordering, selected comparison | Asset Pipeline Application |
+| Expectation evaluation and comparison compatibility | Asset Pipeline Domain |
+| Producer-specific preprocessing/export and native structure analysis | Producer adapter, with project-selected native operations |
+| Raster normalization and format processing | Local processors; only for matching artifact kinds |
+| Required limbs, scale tolerances, style, collision/scripts/material overrides | Project recipe and authored project resources |
+| Session lifecycle, runtime sampling, captures, diagnostics, performance | gda; composed by preview/refresh workflows |
+| Package-only acceptance | Asset Pipeline flow/evaluator using gda export and engine observations |
+
+Create files with the slice that needs them, not empty layers in advance:
+
+```text
+src/gda/
+  cli.py                              # composition, existing role
+  commands/asset_pipeline.py           # gda transport slice and thin recipe
+  integrations/asset_pipeline.py       # service ACL, Godot adapter, factory
+  commands/resource.py, game.py, ...   # existing engine capability owners
+
+libs/gda-assets/
+  AGENTS.md
+  ASSETS-CONTEXT.md
+  docs/ARCHITECTURE.md
+  docs/adr/
+  pyproject.toml                      # added with installable first slice
+  src/gda_assets/
+    api.py                            # deliberately supported cross-package API
+    domain/
+      recipe.py
+      artifacts.py
+      expectations.py
+    application/
+      ports.py
+      integrate.py
+      produce.py
+      preview.py                      # when preview slice lands
+      package_check.py                # when package slice lands
+    adapters/outbound/
+      blender/
+      imagegen/
+      files.py
+      raster.py
+    bootstrap.py                      # producer composition, lazy setup
+  tests/
+```
+
+The tree is a placement guide, not a requirement for one class per file. The
+package API exports only supported service inputs/results and required ports;
+it is not a wholesale re-export of internal modules. There is no second CLI.
+
+## Tactical model and interfaces
+
+[aADR-0001](adr/0001-domain-application-and-producer-adapters.md) owns the DDD
+decomposition. Start with `AssetRecipe`, `ProducedFiles`, `AssetExpectations`,
+`AssetCheckResult`, and `PipelineResult` as ordinary data/value types. The current
+workflow has no demonstrated entity/aggregate/repository lifecycle requirement.
+
+The intended contract shape is small; these are design signatures, not a shipped
+Python API or frozen serialization schema:
+
+```python
+run_pipeline(request, *, producer, godot, files) -> PipelineResult
+AssetProducer.produce(request, workspace) -> ProducedFiles
+GodotAssetPort.import_assets(request) -> ImportOutcome
+GodotAssetPort.check_load(request) -> LoadObservation
+GodotAssetPort.inspect_model(request) -> ModelFacts
+```
+
+Application owns these required contracts. A producer returns files with roles,
+source mode, and available metadata. Its options stay in a producer-specific
+validated section; Blender fields are not mandatory image fields. Add optional
+source inspection only when used, and add runtime/package ports with their slices.
+Do not mirror every gda operation into a general Godot SDK.
+
+The first handoff slice needs only a bounded engine load observation for its PNG
+and GLB fixtures. The richer `inspect_model` contract arrives with [#886](https://github.com/aigengame/godot-agent/issues/886); the first
+Blender tracer can verify its selected dimensions without waiting for the full
+structure/material/animation report.
+
+Project recipe paths are resolved relative to the recipe's declared base; target
+`res://` paths use gda's resolved project. Do not let the current working directory
+silently choose between those two meanings. The implementation slice freezes and
+tests its concrete input/result schemas across CLI and generated MCP.
+
+## Complete execution and failure path
+
+1. Validate the recipe, selected producer/inputs, destination paths, and requested
+   capabilities. Validate project configuration without contacting unused providers.
+2. Obtain files from the selected producer or explicit existing-file handoff.
+   Blender native preprocessing/export belongs in its adapter; style/export choices
+   belong to the project. Report which saved source or supported live source was used.
+3. Apply matching file processors in a workspace. A 3D export does not pass through
+   Panda's raster-only `raw.png` assumptions. Unsupported transforms fail explicitly.
+4. Install outputs into the selected project and report affected files. If a
+   multi-file install is partial, stop before import and report remaining state.
+5. Invoke gda import, optionally applying supported import options through the
+   owning gda operation. Disclose actual project-wide work and preserve unselected
+   options and project-authored scenes/material overrides.
+6. Obtain engine facts and evaluate selected project expectations. Report exact
+   resource/node/surface locators, expected/actual values, and incomplete coverage.
+7. When requested, run preview, controlled session refresh, or package acceptance.
+   Each returns separate stage outcomes; unsupported runtime evidence cannot become
+   a verified result through a successful earlier stage.
+
+Default results report completed stages, outputs, and failure/unsupported state.
+Recovery reuses existing files/reports after checking inputs. A failed Godot import
+must not regenerate an image or rerun Blender implicitly. There is no transaction
+across a remote producer, filesystem writes, import, and a running engine. Cleanup
+is restricted to owned temporary files; useful outputs remain available.
+
+Pre/postprocessing does not grant permission to rewrite authored gameplay content.
+A project can use wrapper scenes, inherited scenes, or import scripts to retain
+collisions, scripts, and material overrides. gda exposes engine mechanisms; the
+workflow does not impose a universal project composition strategy.
+
+For image-generation tools available only to the agent runtime, the initial port
+is an explicit generated-file handoff. The result states that production occurred
+outside the Python command. A callable provider adapter can later automate that
+step without changing the host integration; no invented background tool access or
+automatic retry after an unknown provider outcome is assumed.
+
+## Existing seams and required additions
+
+| Seam | Treatment |
+| --- | --- |
+| Descriptor registration, structured params, schema and generated MCP | Reuse; new group and honest composite execution metadata |
+| Project resolution and structured gda failures | Reuse in gda; translate at the service boundary |
+| Returning resource import/export and other typed operations | Reuse; do not call CLI emit/exit dispatch from application code |
+| Headless/Godot runners | Keep Godot-specific; do not use as generic Blender process launchers |
+| Scene loading | Reuse PackedScene loading, including imported GLB; extend facts instead of claiming loading is absent |
+| Shared property projection/coercion | Extend through [#885](https://github.com/aigengame/godot-agent/issues/885), retaining engine/harness parity |
+| Import options and effective result verification | Extend resource operations through [#888](https://github.com/aigengame/godot-agent/issues/888); cached does not prove options applied |
+| Producer ports, local ACLs, workflow API, Godot host ports | New narrow seams in this design |
+| Optional content receipt / runtime content sampling | Add only scoped facts required by [#889](https://github.com/aigengame/godot-agent/issues/889)/[#890](https://github.com/aigengame/godot-agent/issues/890), with independent core operation use |
+| Preview and package acceptance | Compose existing capabilities plus the missing bounded probes; no generic renderer/export verifier |
+
+## Milestone delivery
+
+The umbrella issue owns scope and completion; child issues own detailed acceptance.
+The following is a delivery map, not a second editable acceptance checklist.
+
+| Slice | Primary owner and independently observable result | Blocked by |
+| --- | --- | --- |
+| [#908](https://github.com/aigengame/godot-agent/issues/908) | Unified entry: existing files / generated-image handoff through processing, installation, real Godot import/load; installable internal library | None |
+| [#909](https://github.com/aigengame/godot-agent/issues/909) | Saved Blender source, bounded source inspection, export-only scale preparation, same integration path, and Godot load/dimension check | [#908](https://github.com/aigengame/godot-agent/issues/908) |
+| [#885](https://github.com/aigengame/godot-agent/issues/885) | gda: structured Vector3 and Node3D local transform operations | None |
+| [#886](https://github.com/aigengame/godot-agent/issues/886) | gda: bounded imported model facts | None |
+| [#887](https://github.com/aigengame/godot-agent/issues/887) | Asset Pipeline: project expectations and compatible report comparison via `check` | [#886](https://github.com/aigengame/godot-agent/issues/886), [#908](https://github.com/aigengame/godot-agent/issues/908) |
+| [#888](https://github.com/aigengame/godot-agent/issues/888) | gda: supported importer options and effective reimport | None; coordinate [#741](https://github.com/aigengame/godot-agent/issues/741)/[#853](https://github.com/aigengame/godot-agent/issues/853) |
+| [#889](https://github.com/aigengame/godot-agent/issues/889) | Asset Pipeline: optional selected content receipt, using gda import facts | [#908](https://github.com/aigengame/godot-agent/issues/908) |
+| [#890](https://github.com/aigengame/godot-agent/issues/890) | gda runtime facts plus Asset Pipeline controlled restart and content comparison | [#886](https://github.com/aigengame/godot-agent/issues/886), [#908](https://github.com/aigengame/godot-agent/issues/908); [#889](https://github.com/aigengame/godot-agent/issues/889) is optional enrichment |
+| [#891](https://github.com/aigengame/godot-agent/issues/891) | Asset Pipeline preview fixture/flow, existing gda observations | [#886](https://github.com/aigengame/godot-agent/issues/886), [#908](https://github.com/aigengame/godot-agent/issues/908) |
+| [#892](https://github.com/aigengame/godot-agent/issues/892) | Asset Pipeline package-only checks using the same evaluator | [#887](https://github.com/aigengame/godot-agent/issues/887) |
+
+All implementation slices are AFK under the accepted direction. The umbrella is
+tracking/architecture, not one giant implementation task. Blocking edges express
+technical prerequisites, not a waterfall: [#885](https://github.com/aigengame/godot-agent/issues/885), [#886](https://github.com/aigengame/godot-agent/issues/886), [#888](https://github.com/aigengame/godot-agent/issues/888) and the first integration
+slice can progress independently. Producer integration does not wait for runtime
+refresh or delivery-package features.
+
+Panda extraction is part of the first applicable vertical slice: reuse acquisition
+boundaries, selected raster transforms, deterministic emitters, and isolation test
+ideas. Its raster-shaped orchestration and game manifest policy are redesigned in
+the new home. The equal-frame packer/SpriteFrames emitter is not complete Aseprite
+support for trimmed regions, frame timing, or richer metadata. Do not change the
+original Panda codebase or mark it archived as part of this work.
+
+## Evidence limits and validation gates
+
+[aADR-0002](adr/0002-minimum-results-and-optional-content-checks.md) owns the minimum
+result policy. The following stable claims are implementation validation items,
+not a product evidence/profile framework. All remain **open** at the target scope.
+The architecture was accepted; the mechanisms have not passed production tests.
+
+| Claim | Driver, owner, and available evidence | Disconfirming case and required validation |
+| --- | --- | --- |
+| AP-01 | Single entry and additive topology; root ADR-0042. Existing descriptor/recipe and returning-operation seams inspected | Clean built install needs checkout/PYTHONPATH, gda_assets imports gda, discovery starts a provider, or CLI/MCP disagree. Test install/discovery/import direction and real file-to-import path |
+| AP-02 | Producer variation; aADR-0001. Panda's reusable pieces and raster limitations inspected; Blender native behavior researched | Image handoff requires Blender-only fields, adding saved Blender changes core dispatch, or saved source hides unsaved edits. Run image and saved-Blender tracers with declared source/measurement scope |
+| AP-03 | Reliable option-only reimport; gda [#888](https://github.com/aigengame/godot-agent/issues/888). Current import fast path and engine docs inspected | Unchanged GLB plus changed root scale returns cached success with old dimensions. Real engine option-only, no-op, invalid, and failed cases |
+| AP-04 | Honest runtime freshness; [#890](https://github.com/aigengame/godot-agent/issues/890). Current session/capture semantics inspected | A/B share path, names, counts, bounds, material refs but differ in supported content and compare equal. Test selected-instance content, stale/wrong instance, runtime replacement, session and capture scope |
+| AP-05 | Minimum machinery with usable recovery; aADR-0002. Existing scripts offer reusable stages, no generic resume proof | Import failure or unknown producer outcome triggers regeneration or false completion. Inject stage failures, retain outputs, and explicitly retry remaining steps without production replay |
+
+The design's boundary review covers known owners and source cycles, but does not
+prove runtime conformance. Each slice must test its complete public path and real
+external boundary where relevant. Fakes can isolate local rules; they cannot be
+the sole evidence for Blender, Godot import, a runtime instance, or an exported
+package. No Godot/Blender runtime or new package-install tests were run for this
+documentation-only change.
+
+## Research basis and retained limits
+
+- DDD bounded contexts and local anti-corruption layers support model ownership;
+  they do not prescribe a service per context or aggregates for every workflow.
+  Reference: [DDD Reference, 2015 edition](https://www.domainlanguage.com/wp-content/uploads/2016/05/DDD_Reference_2015-03.pdf).
+- [Godot 4.6 import configuration](https://docs.godotengine.org/en/4.6/tutorials/assets_pipeline/importing_3d_scenes/import_configuration.html)
+  provides engine-native settings and project composition mechanisms. [#888](https://github.com/aigengame/godot-agent/issues/888) must
+  prove its selected mechanism, including option-only changes; this document does
+  not assume complete built-in importer metadata is dynamically script-discoverable.
+- [Godot 4.6 ResourceLoader](https://docs.godotengine.org/en/4.6/classes/class_resourceloader.html)
+  cache replacement does not establish arbitrary instantiated-scene refresh. This
+  design starts with explicit restart and bounded instance observations.
+- [Blender dependency-graph API](https://docs.blender.org/api/current/bpy.types.Depsgraph.html)
+  distinguishes original and evaluated geometry. The adapter must state which it
+  measured and pin its supported Blender version in the implementation tests.
+- [Aseprite CLI](https://www.aseprite.org/docs/cli/) is a future producer reference,
+  not a current adapter commitment. Do not generalize the model around all its
+  export variants before Blender and image paths work.
+
+External documentation is design provenance. Local issues and operation contracts
+define supported behavior; implementation must verify engine/vendor versions when
+choosing actual APIs.

--- a/libs/gda-assets/docs/ARCHITECTURE.md
+++ b/libs/gda-assets/docs/ARCHITECTURE.md
@@ -14,6 +14,9 @@ The repeated cost is establishing what a producer exported, what Godot loaded,
 and what the current scene uses. The pipeline coordinates those steps and reduces
 project-specific scripts for structure checks, import adjustments, preview, and
 package acceptance. It initially supports Blender and image-generation outputs.
+Preparation also preserves project prompts and supplies selected image-gen concept
+references before new model or sprite authoring. Existing-file and saved-source
+handoff remain independently usable.
 
 | Authority | Owns |
 | --- | --- |
@@ -21,8 +24,8 @@ package acceptance. It initially supports Blender and image-generation outputs.
 | Root CONTEXT-MAP and ADR-0042 | Context routing and integration with gda |
 | Local ASSETS-CONTEXT | Asset Pipeline vocabulary and ownership |
 | This document | Target module structure, complete workflow, delivery and validation mapping |
-| aADR-0001 / aADR-0002 | Internal decomposition and minimum-result decisions |
-| Project recipes and scenes | Art direction, output paths, gameplay expectations, authored overrides |
+| aADR-0001 / aADR-0002 / aADR-0003 | Internal decomposition, minimum results, and prompt/reference preparation |
+| Project recipes and scenes | Prompts, concept choices, art direction, output paths, gameplay expectations, authored overrides |
 | gda operation contracts | Engine facts, import/cache semantics, sessions, capture, export |
 
 The agreed drivers are: a single gda entry; additive integration into its existing
@@ -88,6 +91,7 @@ import-state rules, two result registries, or an integration framework.
 | Godot 3D properties and loaded resource/instance facts | Existing gda groups and engine payloads |
 | Import metadata, option mutation, and actual engine work | gda resource operations |
 | Production, installation, check ordering, selected comparison | Asset Pipeline Application |
+| Prompt preservation/reuse, candidate selection, authoring handoff | Asset Pipeline Application, using local Domain values/rules and file handling |
 | Expectation evaluation and comparison compatibility | Asset Pipeline Domain |
 | Producer-specific preprocessing/export and native structure analysis | Producer adapter, with project-selected native operations |
 | Raster normalization and format processing | Local processors; only for matching artifact kinds |
@@ -116,10 +120,12 @@ libs/gda-assets/
       recipe.py
       artifacts.py
       expectations.py
+      preparation.py                 # prompt/reference values when needed
     application/
       ports.py
       integrate.py
       produce.py
+      prepare.py                     # save inputs, register outputs, select references
       preview.py                      # when preview slice lands
       package_check.py                # when package slice lands
     adapters/outbound/
@@ -141,6 +147,14 @@ it is not a wholesale re-export of internal modules. There is no second CLI.
 decomposition. Start with `AssetRecipe`, `ProducedFiles`, `AssetExpectations`,
 `AssetCheckResult`, and `PipelineResult` as ordinary data/value types. The current
 workflow has no demonstrated entity/aggregate/repository lifecycle requirement.
+
+[aADR-0003](adr/0003-project-prompts-and-concept-references.md) adds `PromptRecord`
+and `AuthoringHandoff` as ordinary project-local data. The recipe selects reusable
+project art direction; a prompt record preserves the resolved input for one attempt.
+This saved input is not a second editable authority for the project's current style.
+Preparation precedes `AssetProducer.produce` and can finish with an explicit external
+handoff. A missing candidate is not a successful produced-file result. Do not enlarge
+every producer into a prompt manager or general authoring interface.
 
 The intended contract shape is small; these are design signatures, not a shipped
 Python API or frozen serialization schema:
@@ -173,6 +187,11 @@ tests its concrete input/result schemas across CLI and generated MCP.
 
 1. Validate the recipe, selected producer/inputs, destination paths, and requested
    capabilities. Validate project configuration without contacting unused providers.
+   For enabled generation, preserve the resolved prompt and selected inputs before
+   external work. For new model/sprite authoring, generate or explicitly reuse a
+   concept, select its references, and deliver them to the authoring consumer before
+   that consumer starts. Record preparation, generation, selection, and consumption
+   separately. Existing-file admission and saved-source export skip this preparation.
 2. Obtain files from the selected producer or explicit existing-file handoff.
    Blender native preprocessing/export belongs in its adapter; style/export choices
    belong to the project. Report which saved source or supported live source was used.
@@ -206,6 +225,12 @@ outside the Python command. A callable provider adapter can later automate that
 step without changing the host integration; no invented background tool access or
 automatic retry after an unknown provider outcome is assumed.
 
+The concept-reference slice extends that handoff with saved prompts, candidates,
+selection, and real authoring examples. It must prove usable reference delivery to
+Blender and a small sprite-sheet workflow. It does not make the saved-source export
+adapter a model generator or add full Aseprite support. Concept images have their
+own role and are not installed as runtime assets without explicit mapping.
+
 ## Existing seams and required additions
 
 | Seam | Treatment |
@@ -218,6 +243,7 @@ automatic retry after an unknown provider outcome is assumed.
 | Shared property projection/coercion | Extend through [#885](https://github.com/aigengame/godot-agent/issues/885), retaining engine/harness parity |
 | Import options and effective result verification | Extend resource operations through [#888](https://github.com/aigengame/godot-agent/issues/888); cached does not prove options applied |
 | Producer ports, local ACLs, workflow API, Godot host ports | New narrow seams in this design |
+| Prompt preparation and concept-reference handoff | Extend the local workflow API and file/producer adapters through #912/#913; no new Godot port or core prompt model |
 | Optional content receipt / runtime content sampling | Add only scoped facts required by [#889](https://github.com/aigengame/godot-agent/issues/889)/[#890](https://github.com/aigengame/godot-agent/issues/890), with independent core operation use |
 | Preview and package acceptance | Compose existing capabilities plus the missing bounded probes; no generic renderer/export verifier |
 
@@ -229,6 +255,8 @@ The following is a delivery map, not a second editable acceptance checklist.
 | Slice | Primary owner and independently observable result | Blocked by |
 | --- | --- | --- |
 | [#908](https://github.com/aigengame/godot-agent/issues/908) | Unified entry: existing files / generated-image handoff through processing, installation, real Godot import/load; installable internal library | None |
+| [#912](https://github.com/aigengame/godot-agent/issues/912) | Save, inspect, revise, and reuse project prompts before generation; register associated outputs | [#908](https://github.com/aigengame/godot-agent/issues/908) |
+| [#913](https://github.com/aigengame/godot-agent/issues/913) | Generate/select concept references and demonstrate their use before Blender and sprite authoring | [#912](https://github.com/aigengame/godot-agent/issues/912) |
 | [#909](https://github.com/aigengame/godot-agent/issues/909) | Saved Blender source, bounded source inspection, export-only scale preparation, same integration path, and Godot load/dimension check | [#908](https://github.com/aigengame/godot-agent/issues/908) |
 | [#885](https://github.com/aigengame/godot-agent/issues/885) | gda: structured Vector3 and Node3D local transform operations | None |
 | [#886](https://github.com/aigengame/godot-agent/issues/886) | gda: bounded imported model facts | None |
@@ -244,6 +272,11 @@ tracking/architecture, not one giant implementation task. Blocking edges express
 technical prerequisites, not a waterfall: [#885](https://github.com/aigengame/godot-agent/issues/885), [#886](https://github.com/aigengame/godot-agent/issues/886), [#888](https://github.com/aigengame/godot-agent/issues/888) and the first integration
 slice can progress independently. Producer integration does not wait for runtime
 refresh or delivery-package features.
+
+The new preparation branch is #908 → #912 → #913. The saved-source branch remains
+#908 → #909: exporting an already authored source does not require generating a
+new concept. For the new-authoring demonstration, #913 supplies the reference
+consumer workflow; it does not rely on #909 to provide a modeling capability.
 
 Panda extraction is part of the first applicable vertical slice: reuse acquisition
 boundaries, selected raster transforms, deterministic emitters, and isolation test
@@ -266,6 +299,7 @@ The architecture was accepted; the mechanisms have not passed production tests.
 | AP-03 | Reliable option-only reimport; gda [#888](https://github.com/aigengame/godot-agent/issues/888). Current import fast path and engine docs inspected | Unchanged GLB plus changed root scale returns cached success with old dimensions. Real engine option-only, no-op, invalid, and failed cases |
 | AP-04 | Honest runtime freshness; [#890](https://github.com/aigengame/godot-agent/issues/890). Current session/capture semantics inspected | A/B share path, names, counts, bounds, material refs but differ in supported content and compare equal. Test selected-instance content, stale/wrong instance, runtime replacement, session and capture scope |
 | AP-05 | Minimum machinery with usable recovery; aADR-0002. Existing scripts offer reusable stages, no generic resume proof | Import failure or unknown producer outcome triggers regeneration or false completion. Inject stage failures, retain outputs, and explicitly retry remaining steps without production replay |
+| AP-06 | Prompt preservation and usable concept references; aADR-0003, #912/#913. Panda prompt composition and post-acquisition manifest recording inspected; implementation evidence remains open | Editing style/reference inputs changes an earlier attempt, reuse regenerates silently, or an authoring consumer loads an unselected candidate. Test separate attempts, explicit reuse/revision, failure ordering, real image generation, and selected-reference consumption in Blender and sprite examples |
 
 The design's boundary review covers known owners and source cycles, but does not
 prove runtime conformance. Each slice must test its complete public path and real

--- a/libs/gda-assets/docs/ARCHITECTURE.md
+++ b/libs/gda-assets/docs/ARCHITECTURE.md
@@ -285,22 +285,6 @@ the new home. The equal-frame packer/SpriteFrames emitter is not complete Asepri
 support for trimmed regions, frame timing, or richer metadata. Do not change the
 original Panda codebase or mark it archived as part of this work.
 
-The `gda-blender-mcp` skill is another optional source of production lessons.
-[aADR-0001](adr/0001-domain-application-and-producer-adapters.md) owns its reuse
-boundary. Its `mcp_stdio_client.py` demonstrates protocol/result handling for a
-specific Blender MCP implementation; its SDK pin and agent-config defaults are not
-product requirements. Its `inspect_blender_asset.py` demonstrates selected-subtree
-inspection, derived-transform updates, visibility diagnostics, and explicit base
-geometry limitations. Those Blender observations do not replace gda's imported
-resource facts or the workflow's project-expectation evaluator.
-
-Transfer useful cases to tests owned by the relevant implementation slice. Run
-installed/public acceptance paths without the skill or its helper paths available,
-while retaining the selected external tools. A helper receipt or manually invoking
-the helper cannot close a product requirement. Reusable authoring recipes and
-examples delivered by #913 belong to the product/consumer example, and cannot
-require an installed helper to supply planned preparation or selection behavior.
-
 ## Evidence limits and validation gates
 
 [aADR-0002](adr/0002-minimum-results-and-optional-content-checks.md) owns the minimum

--- a/libs/gda-assets/docs/adr/0001-domain-application-and-producer-adapters.md
+++ b/libs/gda-assets/docs/adr/0001-domain-application-and-producer-adapters.md
@@ -42,21 +42,6 @@ universal asset superclass would preserve those assumptions under new names.
   Keep Panda style, dimensions, fonts, manifests, and game policy out of the new
   defaults. Do not update the game to become a library client or maintain its
   private import paths as compatibility APIs.
-- Treat the `gda-blender-mcp` skill and its bundled helpers as optional sources of
-  production experience and regression cases. Their presence does not satisfy,
-  defer, or reduce any planned product capability. Do not import or invoke scripts
-  from an installed skill, discover its installation path, or require it for product
-  execution, tests, or acceptance examples. Useful code may be adapted into the
-  owning product module with applicable attribution and tests; that module then
-  owns its implementation and maintenance. Product-owned scripts remain a valid
-  implementation form when they meet the public contract and distribution rules.
-  Choose required tool dependencies and configuration from the supported producer
-  contract; do not inherit a helper's SDK pin, agent configuration, receipt format,
-  or compatibility promise merely because the helper uses it. External tools and
-  the explicit agent-native generation handoff remain supported boundaries.
-  Validate each delivered path without the skill installed. Helper retirement or
-  shared-skill maintenance is separate work, not a prerequisite or compatibility
-  obligation for the product.
 
 The service and Godot-port integration is owned by
 [root ADR-0042](../../../../docs/adr/0042-asset-pipeline-supporting-context-integration.md).

--- a/libs/gda-assets/docs/adr/0001-domain-application-and-producer-adapters.md
+++ b/libs/gda-assets/docs/adr/0001-domain-application-and-producer-adapters.md
@@ -1,0 +1,61 @@
+---
+status: accepted
+---
+
+# aADR-0001: Separate workflow rules, application use cases, and producer adapters
+
+Accepted on 2026-09-07. The project owner approved a greenfield supporting context
+with DDD boundaries and limited initial complexity. This decision is not evidence
+that its implementation works.
+
+## Context
+
+Panda Adventure separated generic asset tooling from game configuration, but its
+main path assumed raster input/output and did not model Blender production. A
+universal asset superclass would preserve those assumptions under new names.
+
+## Decision
+
+- Use a compact Domain / Application / Adapters structure inside the context.
+  Domain holds recipe constraints, artifact roles, expectations, and compatible
+  comparison rules. Application sequences use cases and owns required outbound
+  ports. External adapters translate native data and failures.
+- Start with ordinary data/value types and explicit application functions.
+  There is no observed need for entity lifecycle, aggregate identity, Repository,
+  domain events, or a persisted PipelineRun. Do not introduce them for DDD symmetry.
+- Use one narrow producer boundary that returns produced files. Keep Blender
+  option validation and scene/export handling in its adapter, and image service
+  configuration/response interpretation in the image-generation adapter.
+  Source inspection is an optional, producer-specific capability, not a required
+  method on every producer. File and raster processing have their own small owners.
+- The first Blender path uses an explicit saved source and scene/root selection.
+  A future interactive or MCP transport must preserve its declared source mode;
+  it must not silently substitute a saved file for unsaved edits. No snapshot
+  manager is required for the first path.
+- The image-generation boundary can accept already generated local files. When
+  the agent's native generation tool cannot be called by the Python process,
+  report the required handoff instead of claiming the command generated an image.
+  A real callable provider may be added behind the same boundary when configured.
+  Uncertain external completion must not cause automatic regeneration.
+- Copy useful generic Panda code once into this context and refactor here.
+  Preserve source attribution and tests where their semantics still apply.
+  Keep Panda style, dimensions, fonts, manifests, and game policy out of the new
+  defaults. Do not update the game to become a library client or maintain its
+  private import paths as compatibility APIs.
+
+The service and Godot-port integration is owned by
+[root ADR-0042](../../../../docs/adr/0042-asset-pipeline-supporting-context-integration.md).
+Application imports neither gda nor vendor SDKs. The host implements and injects
+the Godot ports; outbound producer adapters stay local.
+
+## Consequences and alternatives
+
+Keeping the original Panda pipeline would minimize edits but leave a raster-shaped
+orchestrator and continued game coupling. A generic plugin/workflow framework would
+add configuration and lifecycle mechanisms before two concrete paths work. The
+selected design extracts only the useful pieces and proves existing-image and
+saved-Blender paths first. Aseprite adapters and broader capabilities wait for need.
+
+AP-01 and AP-02 in [the architecture](../ARCHITECTURE.md) remain open. Their tests
+must prove installation, engine integration, and producer substitution rather than
+only import isolation or fake adapters.

--- a/libs/gda-assets/docs/adr/0001-domain-application-and-producer-adapters.md
+++ b/libs/gda-assets/docs/adr/0001-domain-application-and-producer-adapters.md
@@ -42,6 +42,21 @@ universal asset superclass would preserve those assumptions under new names.
   Keep Panda style, dimensions, fonts, manifests, and game policy out of the new
   defaults. Do not update the game to become a library client or maintain its
   private import paths as compatibility APIs.
+- Treat the `gda-blender-mcp` skill and its bundled helpers as optional sources of
+  production experience and regression cases. Their presence does not satisfy,
+  defer, or reduce any planned product capability. Do not import or invoke scripts
+  from an installed skill, discover its installation path, or require it for product
+  execution, tests, or acceptance examples. Useful code may be adapted into the
+  owning product module with applicable attribution and tests; that module then
+  owns its implementation and maintenance. Product-owned scripts remain a valid
+  implementation form when they meet the public contract and distribution rules.
+  Choose required tool dependencies and configuration from the supported producer
+  contract; do not inherit a helper's SDK pin, agent configuration, receipt format,
+  or compatibility promise merely because the helper uses it. External tools and
+  the explicit agent-native generation handoff remain supported boundaries.
+  Validate each delivered path without the skill installed. Helper retirement or
+  shared-skill maintenance is separate work, not a prerequisite or compatibility
+  obligation for the product.
 
 The service and Godot-port integration is owned by
 [root ADR-0042](../../../../docs/adr/0042-asset-pipeline-supporting-context-integration.md).

--- a/libs/gda-assets/docs/adr/0001-domain-application-and-producer-adapters.md
+++ b/libs/gda-assets/docs/adr/0001-domain-application-and-producer-adapters.md
@@ -50,6 +50,12 @@ the Godot ports; outbound producer adapters stay local.
 
 ## Consequences and alternatives
 
+[aADR-0003](0003-project-prompts-and-concept-references.md) refines preparation:
+project prompts are preserved before generation, and selected image-gen concepts
+are delivered to new model/sprite authoring. Existing-file and saved-source paths
+retain their independent scope. This adds local application behavior, not a new
+context or reverse dependency on gda.
+
 Keeping the original Panda pipeline would minimize edits but leave a raster-shaped
 orchestrator and continued game coupling. A generic plugin/workflow framework would
 add configuration and lifecycle mechanisms before two concrete paths work. The

--- a/libs/gda-assets/docs/adr/0002-minimum-results-and-optional-content-checks.md
+++ b/libs/gda-assets/docs/adr/0002-minimum-results-and-optional-content-checks.md
@@ -1,0 +1,62 @@
+---
+status: accepted
+---
+
+# aADR-0002: Keep workflow results small and content checks optional
+
+Accepted on 2026-09-07. The project owner explicitly requires that identity,
+evidence, version, and profile mechanisms remain proportionate to current needs
+and do not become dependencies of gda's core operations.
+
+## Decision
+
+The default pipeline result contains completed stages, output locations, check
+results, and the failed or unsupported step with remaining state. Local results
+may be written for inspection/reuse; they do not require a persistent job engine.
+Resume initially means explicitly reusing available files or reports and rerunning
+the selected remaining work, with input checks. No implicit replay of generation,
+session restart, or other external effects is promised.
+
+Add only the observations needed by an enabled acceptance check:
+
+- Structural checks need bounded model facts, exact locators, origin, measurement
+  scope, and omissions. Missing observations produce insufficient information.
+- Selected content receipts may hash selected source/configuration/dependencies
+  and import artifacts. Distinguish producer declarations from observations,
+  disclose coverage, and reject an observed changing input rather than certify
+  mixed content. No hash is required for ordinary resource import or CRUD.
+- Runtime checks need a selected Engine session and instance plus content-sensitive
+  observations for a supported scope. Restart success, resource path/UID, summary
+  equality, or a screenshot cannot substitute for that comparison.
+- Package checks need facts from the actual package in isolation and its identity.
+  They do not prove a native release executable's rendering or input behavior.
+
+There is no default immutable handoff store, revision graph, whole-project hash,
+central asset registry, universal profile framework, domain-event log, automatic
+retry engine, or state-preserving hot swap. Do not make the absence of those
+mechanisms change gda's resource, scene, game, capture, or export behavior.
+
+## Failure and effect boundary
+
+Validate input and output targets before mutation. Produce/process files in a
+selected workspace before installing them. The workflow reports each installed
+file and stops before import if multi-file installation is incomplete. A set of
+file writes, engine import, and a remote producer is not one atomic transaction.
+Do not claim rollback of all effects; preserve usable outputs and report remaining
+state. Limit cleanup to workflow-owned temporary files.
+
+Timeouts and unknown external outcomes are distinct from a confirmed failure.
+Recovery starts from available artifacts after validation and never silently
+regenerates an image or discards an authored scene/material override. gda's own
+import and daemon outcomes remain authoritative at those boundaries.
+
+## Consequences
+
+This supports the current milestone without building a general provenance or
+workflow platform. It also limits claims: when a necessary observation is not yet
+implemented, the requested validation is unsupported/incomplete, not successful.
+Deferring machinery does not weaken the A/B and omission regressions in the issues.
+
+AP-03, AP-04, and AP-05 in [the architecture](../ARCHITECTURE.md) track the required
+option-change, runtime-content, and recovery checks. All remain open until the
+implementation slices provide the stated evidence.

--- a/libs/gda-assets/docs/adr/0002-minimum-results-and-optional-content-checks.md
+++ b/libs/gda-assets/docs/adr/0002-minimum-results-and-optional-content-checks.md
@@ -38,6 +38,11 @@ mechanisms change gda's resource, scene, game, capture, or export behavior.
 
 ## Failure and effect boundary
 
+[aADR-0003](0003-project-prompts-and-concept-references.md) adds required prompt
+records for enabled preparation/generation. These are reusable project inputs,
+not optional content receipts or a persistent job history. They add no prerequisite
+to existing-file import, saved-source export, or ordinary gda operations.
+
 Validate input and output targets before mutation. Produce/process files in a
 selected workspace before installing them. The workflow reports each installed
 file and stops before import if multi-file installation is incomplete. A set of

--- a/libs/gda-assets/docs/adr/0003-project-prompts-and-concept-references.md
+++ b/libs/gda-assets/docs/adr/0003-project-prompts-and-concept-references.md
@@ -1,0 +1,104 @@
+---
+status: accepted
+---
+
+# aADR-0003: Keep prompts and concept references as project-owned preparation inputs
+
+Recorded on 2026-09-07 from the project owner's added prompt-management and
+concept-reference requirements. This refines aADR-0001 and aADR-0002 for enabled
+generation workflows; it does not change the gda integration contract.
+
+## Context
+
+Panda composes a generation prompt and includes it in the manifest emitted after
+acquisition and postprocessing. That offers useful reuse, but does not establish
+generation-time preservation or explicit selection across attempts. A failed
+generation can lose its prepared input, and later style edits can change the next
+prompt without making that change visible.
+
+The previous design starts from completed images or a saved Blender source. It
+does not cover generating and selecting a concept before new model or sprite
+authoring. These are preparation needs inside Asset Pipeline, with project-owned
+art direction; they are not Godot engine facts or a new bounded context.
+
+## Decision
+
+### Prompt preparation
+
+Save a **prompt record** before invoking a generator or handing work to an
+external tool. It contains authored text or a simple template and explicit inputs,
+the resolved prompt, selected reference inputs, and requested non-secret producer
+options where available. The project chooses the content and storage location.
+The workflow preserves the text and reference files needed to reuse that attempt.
+
+Each attempt uses a separate ordinary file location. Inspect/reuse reads its saved
+inputs. Explicit revision creates another record and exposes the changed text or
+inputs; editing a style file must not silently change an earlier attempt. Record
+location is sufficient identity. Ordinary files and Git are sufficient management;
+there is no global prompt catalog, revision graph, or Repository requirement.
+
+Register output files after generation, retaining requested settings separately
+from provider-reported information. If a caller supplies different text actually
+submitted to an external tool, retain that text too. Unavailable execution details
+remain unknown. An associated local file does not independently prove what a
+provider executed, and identical prompts do not guarantee identical images.
+
+### Concept references before authoring
+
+New model or sprite production through this workflow first prepares an image-gen
+concept request, obtains candidate images, and explicitly selects references before
+authoring. Projects specify subject, style, and useful views/poses in a small brief.
+The caller can be an agent or a user; selection does not imply a new human approval
+gate. An already generated, explicitly selected concept can be reused.
+
+The **authoring handoff** contains usable selected image files, their prompt-record
+links, intended model/sprite use, and project instructions. Preserve the selected
+content for the receiving step; editing a candidate later must not silently replace
+it. The first implementation must demonstrate actual reference use in Blender and
+in a small sprite-sheet authoring path. A file-path field with no working consumer
+does not meet the requirement. Tool-specific reference loading belongs in a local
+adapter or reusable tool recipe, not Domain or the gda host.
+
+Concept references have a distinct file role from runtime assets. They are not
+automatically installed into Godot. This preparation does not require an Aseprite
+adapter, general procedural model generator, art-quality evaluator, or automatic
+repair loop. Artistic consistency is an aim supported by explicit reusable inputs,
+not a mechanically guaranteed result.
+
+### Application and integration
+
+Domain owns the small prompt/reference values and validity/selection rules.
+Application saves preparation before external effects, registers outputs, selects
+references, and returns the authoring handoff. Existing local file handling stores
+the records and selected files; producer ACLs translate generation and authoring
+tool options. No vendor types or project style policy enter the domain model.
+
+Add preparation and output-registration operations through the same
+`gda asset-pipeline` entry and package API. The implementation slices freeze their
+public names and schemas. No additional top-level command group or Godot port is
+needed for these producer-side operations. Existing gda integration translates the
+new service inputs/results without taking ownership of their workflow rules.
+
+When image gen is available only to an agent, preparation returns an explicit
+external handoff; registering the completed local output is a separate action.
+Python does not pretend to call a tool available only in the agent runtime.
+Missing references, no selection, and unknown generation completion stop dependent
+authoring. Failed import must not replay concept generation.
+
+## Scope and consequences
+
+Prompt records are required only for enabled preparation/generation. Existing-file
+admission, saved Blender export, and ordinary gda operations remain independently
+usable. These input records are separate from optional selected content receipts
+in aADR-0002: no import hashes, engine evidence, immutable store, or persistent
+PipelineRun is needed to keep a prompt. Provider credentials are not record fields.
+
+Two vertical issues separate prompt preservation/reuse from generated concepts and
+their authoring consumers. The latter depends on the former; both reuse the first
+installed workflow slice. Saved-source export remains its own complete path.
+Panda is only a one-time source of reusable composition ideas and tests.
+
+AP-06 in [the architecture](../ARCHITECTURE.md) remains open until two-attempt
+preservation, explicit reuse/selection, real concept generation, and actual
+reference consumption have been demonstrated. Recording this decision delivers
+none of those runtime capabilities.


### PR DESCRIPTION
Asset work in [gda-blender milestone 14](https://github.com/aigengame/godot-agent/milestone/14) needs a shared owner for production preparation and cross-tool workflows. This records the accepted Asset Pipeline supporting context behind the single `gda asset-pipeline` entry.

Engine operations and facts remain in gda. The internal library owns workflow rules, uses injected Godot ports, and keeps producer ACLs local. The PR adds the local context, architecture, and three local decisions; records root ADR-0042; and reconciles the context map and command-group/taxonomy ADRs. Optional content receipts remain bounded, and Panda Adventure is a one-time scaffold source.

The preparation amendment preserves project prompts before generation, separates attempts and explicit reuse, and requires selected image-generated concept references to reach real Blender and sprite authoring examples. It uses ordinary project files and the existing service boundary. Existing-file import and saved-source export remain independent; no core prompt model, new Godot port, registry, or persisted workflow engine is required.

Requirements and delivery are governed by #907. The twelve sub-issues are #885–#892, #908–#909, and #912–#913. Preparation follows #908 → #912 → #913, while saved-source export follows #908 → #909. This PR records design only; it implements no command or adapter and closes no requirement.

Validation: local Markdown link checks, `git diff --check`, independent Sol artifact and DDD/architecture reviews, and exact readback of synchronized issues and native sub-issue relationships. The preparation change contains no runtime implementation: no new Asset Pipeline runtime, image-generation, Blender, or clean-install validation was performed. AP-01 through AP-06 remain open implementation gates. CI for the updated commit is reported by this PR's checks; earlier-head CI is not evidence for the amendment.

Refs #907, #912, #913.
