### PR TITLE
feat(properties): support Vector3 and Node3D local transforms

### DIFF
--- a/docs/adr/0035-value-projection-compound-variants-to-structured-json.md
+++ b/docs/adr/0035-value-projection-compound-variants-to-structured-json.md
@@ -66,6 +66,22 @@ get-exports`, and the live `game get` read (and any future live value-returning 
 - **Both `.gd` files change byte-identically**; the mirror invariant and
   `tests/harness/test_harness_coercion_mirror.py` are preserved, not bypassed.
 
+## Vector3 and local Node3D components (2026-09-07, #885)
+
+The shared projection now includes `Vector3` as `[x, y, z]`, including recursive
+container and packed-array elements. Its write form uses the existing component
+parser with three comma-separated floats and the existing numeric-fidelity policy.
+Both engine payloads retain the byte-identical shared block and its drift guard.
+
+Node3D stores one `transform`, while its `position`, `rotation` and `scale` are
+derived, non-storage Vector3 properties. A narrow Node3D-only exception admits
+these local components through the existing node operations. Headless `node get`
+lists them; live `game get` reads them when explicitly named and retains the
+unfiltered storage listing. Both setters use Godot's own property setters, and
+the existing headless save and live frame-boundary/read-back semantics remain.
+Global properties and other compound transform types are not added. This extends
+the Godot property contract without any dependency on the supporting asset workflow.
+
 ## Considered options
 
 - **A `project get`-only compound renderer, leaving the shared `_jsonify` untouched** — **rejected.**

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -330,7 +330,8 @@ out-of-range indexes fail with `invalid_child_index` (exit 4), leaving the file 
 
 **Property reporting and value coercion** (established by #55): `gda node get` instantiates the
 scene and reports the addressed node's **storage** properties (the ones that serialize into the
-`.tscn`) as typed JSON — each a `{name, type, value}` triple where `type` is the property's
+`.tscn`), plus Node3D's local `position`, `rotation` and `scale`, as typed JSON — each a
+`{name, type, value}` triple where `type` is the property's
 declared Godot type name and `value` is its JSON projection. `gda node set` takes the property's
 declared type as the coercion target and converts the CLI `--value` **string** to it; the value
 the node ends up holding is reported back in the same JSON projection `node get` uses, so a `set`
@@ -353,6 +354,7 @@ mutation integrity boundary above. The supported target types and the string for
 | `Array` | a JSON array string (e.g. `["wine","key"]`) | a JSON array |
 | `Vector2` | two comma-separated floats: `x,y` (e.g. `10,20`) | `[x, y]` |
 | `Vector2i` | two comma-separated integers: `x,y` | `[x, y]` |
+| `Vector3` | three comma-separated floats: `x,y,z` (e.g. `1,2,3`) | `[x, y, z]` |
 | `Color` | `#rrggbb` / `#rrggbbaa`, or 3–4 comma-separated floats in 0..1 (`r,g,b[,a]`) | `[r, g, b, a]` |
 
 For `Dictionary` / `Array` JSON values, JSON integer literals stay Godot `int` and JSON float
@@ -369,6 +371,25 @@ reported by `node get` — compound values arrive structured through the shared 
 projection or the `str()` fallback (see [`project`](#project)) — but `node set` cannot coerce to
 those remaining types yet and refuses with `uncoercible_value` unless a separate assignment contract
 below applies.
+
+**Node3D local transforms** (#885): `position`, `rotation` and `scale` are explicitly
+settable through `node set` and live `game set`. They use the node's local transform,
+relative to its parent; `rotation` uses Euler angles in **radians** and the node's
+`rotation_order`. For example, `node set res://main.tscn --node Model --property position
+--value 1,2,3` places the model at local `[1, 2, 3]`. The same `value` string is used in
+`--params-json` and generated MCP inputs; a JSON array or constructor literal is not
+the Vector3 write form. `node get` includes all three components; `game get` reads each
+when named with `--property`. The live unfiltered storage listing stays unchanged.
+
+Godot's setters update the selected component and preserve the other local components
+within engine precision. Headless writes save the resulting transform; live writes
+report the observed value and `verified` without saving. Vector3 uses the engine build's
+component precision (normally 32-bit), followed by gda's full-precision JSON transport.
+Godot can normalize Euler or scale representations when it reconstructs a basis;
+use nonzero, same-sign scale components for a stable decomposition, as described in
+the [Node3D scale contract](https://docs.godotengine.org/en/stable/classes/class_node3d.html#class-node3d-property-scale).
+Global-transform editing, Quaternion, Basis and Transform3D assignment are outside this
+slice. Shared Vector3 projection also applies inside containers and PackedVector3Array.
 
 **`Control.position` convenience assignment** (#464): `Control.position` is layout-derived from
 offsets rather than a normal serialized storage field, but it is a common authoring target. For a
@@ -410,7 +431,7 @@ as `node set` round-trips through `node get`; here `unknown_property` names a pr
 **resource** rather than a node. The live `gda game set` (#220) applies the same coercion table to a
 **running** node's runtime property (the gda harness carries a verbatim copy of the coercion helpers,
 kept in sync by a drift test). When a `game get` / `game set` property name is explicit, the harness
-checks storage properties first, then attached-script variables; unfiltered `game get` keeps the
+checks storage properties and Node3D local components first, then attached-script variables; unfiltered `game get` keeps the
 storage-property listing and does not dump plain script variables. Live set success results keep
 `value` as the observed read-back value and add `verified`: `true` when that read-back equals the
 coerced requested value, `false` when the set completed but the read-back differs. The harness does
@@ -1368,7 +1389,7 @@ re-derives every verdict from a running engine.
   properties — the live counterparts of headless `node get` / `node set`, applying the
   **same** value-coercion table and returning the observed read-back value plus
   `verified` to distinguish a matched read-back from a completed set whose value did not
-  stick. When a property is explicitly named, storage properties are preferred and plain
+  stick. When a property is explicitly named, storage properties and Node3D local components are preferred and plain
   attached-script variables are addressable as a fallback; unfiltered `game get` keeps the
   storage-property listing. `game get --texture-digest` (shipped, #666) opts a read into
   the content digest of each PATH-LESS `Texture2D` value's **texture projection**

--- a/src/gda/commands/game.py
+++ b/src/gda/commands/game.py
@@ -658,8 +658,9 @@ def game_get(
         None,
         "--property",
         help=(
-            "If set, read only this property: storage first, then an attached "
-            "script variable. Without it, list only the storage surface."
+            "If set, read only this property: storage and Node3D local components "
+            "first, then an attached script variable. Without it, list only the "
+            "storage surface."
         ),
     ),
     texture_digest: bool = typer.Option(
@@ -754,8 +755,8 @@ def game_set(
         ...,
         "--property",
         help=(
-            "The property to set (e.g. position, visible): storage first, then an "
-            "attached script variable."
+            "The property to set (e.g. position, visible): storage and Node3D local "
+            "components first, then an attached script variable."
         ),
     ),
     value: str = typer.Option(

--- a/src/gda/commands/game.py
+++ b/src/gda/commands/game.py
@@ -39,6 +39,7 @@ from gda.headless import (
 )
 from gda.live_numbers import LIVE_ENGINE_PRECISION, MAX_EXACT_JSON_INT
 from gda.models import (
+    NODE3D_LOCAL_TRANSFORM_DESC,
     RelayedLiveParams,
     NodeProperty,
     RUNTIME_NODE_DESC,
@@ -168,7 +169,7 @@ class GameGetParams(RelayedLiveParams):
     (absolute) node path rather than a ``.tscn`` file + root-relative node path:
     there is no file, only the live SceneTree of the engine session. ``property``
     optionally narrows the read to one property. When explicitly named, a plain
-    attached-script variable is addressable after storage properties are checked;
+    Node3D local component or attached-script variable is also addressable;
     unfiltered reads still list only the storage-property surface.
     """
 
@@ -177,8 +178,9 @@ class GameGetParams(RelayedLiveParams):
         default=None,
         description=(
             "If set, read only this one property. Explicit names first match the "
-            "storage surface, then attached-script variables; unset keeps the "
-            "default storage-property listing."
+            "storage surface and Node3D local components, then attached-script "
+            "variables; unset keeps the default storage-property listing. "
+            + NODE3D_LOCAL_TRANSFORM_DESC
         ),
     )
     texture_digest: bool = Field(
@@ -200,7 +202,7 @@ class GameGetResult(BaseModel):
     The live counterpart of :class:`NodeGetResult` (no ``scene_path`` — there is
     no file): echoes the addressed node (runtime ``path``/``name``/``type``) and
     its storage properties, each a typed :class:`NodeProperty`; an explicitly named
-    plain attached-script variable can also appear as the single returned property.
+    Node3D local component or plain attached-script variable can also appear alone.
     Each value goes through the same recursive value projection the headless reads
     use (ADR-0035): compound values arrive structured; a ``res://``-pathed Resource
     is a :class:`ReferenceProjection`, a path-less ``Texture2D`` a
@@ -269,7 +271,7 @@ class GameSetParams(RelayedLiveParams):
     string value, coerced to the property's declared or inferred target Godot type
     by the gda harness (the SAME coercion table headless ``node set`` uses) and
     applied at a frame boundary (ADR-0020). Explicit names first target storage
-    properties, then plain attached-script variables; script-variable mutations
+    properties and Node3D local components, then plain attached-script variables; mutations
     are bound to the session, not persisted.
     """
 
@@ -277,7 +279,8 @@ class GameSetParams(RelayedLiveParams):
     property: str = Field(
         description=(
             "The property to set (e.g. position, visible). Explicit names first "
-            "target storage properties, then attached-script variables."
+            "target storage properties and Node3D local components, then "
+            "attached-script variables. " + NODE3D_LOCAL_TRANSFORM_DESC
         )
     )
     value: str = Field(
@@ -684,6 +687,8 @@ def game_get(
     `live_unknown_property`. A named plain script variable on the node's attached
     script is addressable explicitly after storage properties are checked; unfiltered
     reads keep the storage-property listing and do not dump script variables.
+    Node3D position, rotation and scale are explicitly addressable local components;
+    rotation is in radians and Vector3 values read as [x, y, z].
     A path-less Texture2D value projects as a TextureProjection ({type, width,
     height, object_string, digest}, ADR-0035 amendment #666); `--texture-digest`
     opts into its content digest.
@@ -776,6 +781,8 @@ def game_set(
     The gda harness coerces `--value` to the property's declared or inferred target
     Godot type — the SAME coercion table `node set` uses — and applies it at a frame
     boundary (ADR-0020); the mutation is bound to the session, not persisted to disk.
+    Node3D position, rotation and scale use local parent space; rotation uses radians.
+    Vector3 input is three comma-separated numbers, such as `--value 1,2,3`.
     A named plain script variable on the node's attached script is settable explicitly
     after storage properties are checked. The success result includes `verified`:
     true when the observed read-back value equals the coerced requested value,

--- a/src/gda/commands/node.py
+++ b/src/gda/commands/node.py
@@ -30,6 +30,7 @@ from gda.headless import (
     project_option,
 )
 from gda.models import (
+    NODE3D_LOCAL_TRANSFORM_DESC,
     NodeProperty,
     NormalizedPath,
     OBJECT_SET_ECHO_DESC,
@@ -217,9 +218,9 @@ class NodeGetResult(BaseModel):
     """The result of ``gda node get``: a node's properties as typed JSON (issue #55).
 
     Echoes the addressed node (``path``/``name``/``type``) and its storage
-    properties — the ones that serialize into the ``.tscn`` — each as a typed
+    properties plus Node3D's local position, rotation and scale, each as a typed
     :class:`NodeProperty`, so an agent reads a node's state without parsing the
-    scene file and can feed any property straight back into ``node set``.
+    scene file and can edit supported types with ``node set``.
     """
 
     scene_path: str
@@ -228,7 +229,7 @@ class NodeGetResult(BaseModel):
     )
     name: str
     type: str = Field(description="The node's engine class (e.g. Sprite2D).")
-    properties: list[NodeProperty]
+    properties: list[NodeProperty] = Field(description=NODE3D_LOCAL_TRANSFORM_DESC)
 
 
 class NodeSetParams(BaseModel):
@@ -247,7 +248,10 @@ class NodeSetParams(BaseModel):
             "itself, 'Player/Arm' a nested node."
         )
     )
-    property: str = Field(description="The property to set (e.g. position, visible).")
+    property: str = Field(
+        description="The property to set (e.g. position, visible). "
+        + NODE3D_LOCAL_TRANSFORM_DESC
+    )
     value: str = Field(
         description=(
             "The value to set, as a string. The operation coerces it to the "
@@ -765,7 +769,11 @@ def get(
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
-    """Read a node's properties (by node path) as typed JSON."""
+    """Read storage properties and Node3D local position, rotation and scale.
+
+    Vector3 values are [x, y, z]. Local components use parent space; rotation
+    uses Euler radians under the node's rotation_order. This read does not save.
+    """
     dispatch_domain(
         NODE_GET_COMMAND,
         NodeGetParams(path=path, node=node),
@@ -794,7 +802,7 @@ def set_property(
         "--value",
         help=(
             "The value to set, as a string. Coerced to the property's declared "
-            "Godot type: Vector2/Vector2i/Color take comma-separated components "
+            "Godot type: Vector2/Vector2i/Vector3/Color take comma-separated components "
             '(e.g. "48,72", "0.2,0.6,1,1"), and a property expecting a Resource '
             "(sub)class takes a res:// path to an existing Resource of that class. "
             "An uncoercible value is a clean error."
@@ -806,7 +814,12 @@ def set_property(
     godot: Optional[str] = godot_option(),
     project: Optional[str] = project_option(),
 ) -> None:
-    """Set a node property, coercing the value to its declared Godot type."""
+    """Set a node property, coercing the value to its declared Godot type.
+
+    Node3D position, rotation and scale are local to the parent; rotation uses
+    Euler radians. Use three comma-separated numbers for Vector3, such as 1,2,3.
+    The resulting scene is saved; node get reads it back in a fresh engine.
+    """
     dispatch_domain(
         NODE_SET_COMMAND,
         NodeSetParams(path=path, node=node, property=property, value=value),

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -470,9 +470,10 @@ func _handle_game_get(params: Dictionary) -> String:
 	var has_filter := params.has("property") and not wanted.is_empty()
 	var properties: Array = []
 	for prop in node.get_property_list():
-		if not _is_storage_property(prop):
-			continue
 		var prop_name := String(prop.get("name", ""))
+		if not _is_storage_property(prop) \
+				and not (has_filter and _is_node3d_local_transform(node, prop_name)):
+			continue
 		if has_filter and prop_name != wanted:
 			continue
 		properties.append({
@@ -1955,24 +1956,32 @@ func gda_log(level: String, message: String, fields: Dictionary = {}) -> void:
 # one file. tests/harness/test_harness_coercion_mirror.py asserts the two blocks are
 # byte-identical (modulo leading tabs), so an edit here must be mirrored there.
 # Whether a property-list entry is a STORAGE property — the ones node get
-# reports and node set targets: the properties that serialize into the .tscn,
-# excluding the engine's category headers, group separators, and editor-only
+# ordinarily reports and node set targets: the properties that serialize into
+# the .tscn, excluding the engine's category headers, group separators, and editor-only
 # (non-storage) entries. This is the same usage flag the scene serializer keys
-# on, so node get reports exactly the surface a saved scene can carry.
+# on. Node3D local components have a separate, narrow exception below (#885).
 func _is_storage_property(prop: Dictionary) -> bool:
 	var usage := int(prop.get("usage", 0))
 	return (usage & PROPERTY_USAGE_STORAGE) != 0
 
 
 # The declared Godot type of a settable property on the node, or TYPE_NIL if the
-# node has no storage property by that name. node set keys coercion off this:
+# node has no supported property by that name. node set keys coercion off this:
 # the value's target type comes from the property the node actually declares,
 # never from guessing.
 func _property_type(node: Node, prop_name: String) -> int:
 	for prop in node.get_property_list():
-		if String(prop.get("name", "")) == prop_name and _is_storage_property(prop):
+		if String(prop.get("name", "")) == prop_name \
+				and (_is_storage_property(prop) or _is_node3d_local_transform(node, prop_name)):
 			return int(prop.get("type", TYPE_NIL))
 	return TYPE_NIL
+
+
+# Node3D serializes one Transform3D, but these three derived Vector3 properties
+# are the editable local components (#885). Keep the exception node-specific;
+# neither other non-storage properties nor global transform editing is admitted.
+func _is_node3d_local_transform(node: Node, prop_name: String) -> bool:
+	return node is Node3D and prop_name in ["position", "rotation", "scale"]
 
 
 # Read a string param defensively: a non-string value (the params arrive as
@@ -2014,8 +2023,8 @@ const JSONIFY_BOOKKEEPING_PROPS: Array[String] = [
 # The read-side Value projection (ADR-0035, grown from issue #55): render a
 # Godot Variant into the structured JSON a result's value field carries.
 # Scalars pass through; the fixed-shape value types node set supports become
-# flat number arrays so node get's output is exactly the projection node set
-# accepts back: Vector2 → [x, y], Vector2i likewise, Color → [r, g, b, a].
+# flat number arrays: Vector2 → [x, y], Vector2i likewise, Vector3 → [x, y, z],
+# Color → [r, g, b, a]. The write form uses comma-separated components.
 # A Dictionary projects to a JSON object (keys stringified), an Array and the
 # packed-array family to a JSON array, each value re-entering the projection;
 # an Object renders as a reference projection, an inline value projection, or
@@ -2031,6 +2040,8 @@ func _jsonify(value: Variant, depth: int = 0, texture_digest: bool = false) -> V
 			return [value.x, value.y]
 		TYPE_VECTOR2I:
 			return [value.x, value.y]
+		TYPE_VECTOR3:
+			return [value.x, value.y, value.z]
 		TYPE_COLOR:
 			return [value.r, value.g, value.b, value.a]
 		TYPE_DICTIONARY:
@@ -2054,8 +2065,8 @@ func _jsonify(value: Variant, depth: int = 0, texture_digest: bool = false) -> V
 				return str(value)
 			var items := []
 			# Element-wise re-entry: a PackedVector2Array element projects as
-			# [x, y]; an element type with no structured arm of its own (e.g.
-			# Vector3) stays str(), per the fixed-shape list above.
+			# [x, y], a PackedVector3Array element as [x, y, z]; types without
+			# their own structured arm keep the string fallback.
 			for element in value:
 				items.append(_jsonify(element, depth + 1, texture_digest))
 			return items
@@ -2161,6 +2172,9 @@ func _coerce_value(raw: String, type: int, current: Variant = null) -> Variant:
 		TYPE_VECTOR2I:
 			var parts: Variant = _coerce_int_list(raw, 2)
 			return Vector2i(parts[0], parts[1]) if parts != null else null
+		TYPE_VECTOR3:
+			var parts: Variant = _coerce_float_list(raw, 3)
+			return Vector3(parts[0], parts[1], parts[2]) if parts != null else null
 		TYPE_COLOR:
 			return _coerce_color(raw)
 		_:
@@ -2188,8 +2202,8 @@ func _coerce_int(raw: String) -> Variant:
 # --- Float fidelity: the WRITE side of the engine's number domain (#772, #805) ---
 #
 # The rule below is about a LITERAL, not about a property type, so it reaches every
-# float a write can spell: the scalar `--value` and the components of a Vector2 or a
-# Color, which `_coerce_float` parses one at a time, and the JSON numbers inside a
+# float a write can spell: the scalar `--value` and the components of a Vector2,
+# Vector3 or Color, which `_coerce_float` parses one at a time, and the JSON numbers inside a
 # Dictionary or an Array value, which no per-element step parses at all and which
 # `_destroyed_json_number` therefore reads from the raw text (#805). Until that was
 # added the container was the one path where a destroyed float still landed
@@ -2333,8 +2347,8 @@ func _destroyed_json_number(raw: String) -> String:
 # The literal whose destruction ACTUALLY refused this coercion, or "" when the
 # refusal was anything else. A note must never explain a failure it did not
 # diagnose, so this walks exactly what `_coerce_value` walks for `type`, in the
-# same order and behind the same gates: only TYPE_FLOAT, TYPE_VECTOR2, TYPE_COLOR
-# (through `_coerce_float`) and TYPE_DICTIONARY / TYPE_ARRAY (through the raw-text
+# same order and behind the same gates: TYPE_FLOAT, TYPE_VECTOR2, TYPE_VECTOR3,
+# TYPE_COLOR (through `_coerce_float`) and TYPE_DICTIONARY / TYPE_ARRAY (through the raw-text
 # scan) refuse on a destroyed literal at all — TYPE_INT, TYPE_VECTOR2I and the rest
 # refuse for reasons of their own and no float spelling would help them; a wrong
 # component count refuses on ARITY before a component is parsed; a Color in hex
@@ -2357,6 +2371,10 @@ func _destroyed_float_literal(raw: String, type: int) -> String:
 		TYPE_VECTOR2:
 			components = raw.split(",")
 			if components.size() != 2:
+				return ""
+		TYPE_VECTOR3:
+			components = raw.split(",")
+			if components.size() != 3:
 				return ""
 		TYPE_COLOR:
 			var trimmed := raw.strip_edges()

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -87,7 +87,7 @@ HARNESS_ADDONS_RES_PATH = f"res://{HARNESS_ADDONS_DIR}"
 # copy to it (#225). The installed copy declares its version in a leading header
 # (`# gda-harness-version: <N>`); a mismatch re-materializes via the content
 # compare. NOT the package version — the harness changes far less often.
-HARNESS_VERSION = "20"
+HARNESS_VERSION = "21"
 
 _VERSION_HEADER_PREFIX = "# gda-harness-version:"
 _AUTOLOAD_HEADER = "[autoload]"

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -763,7 +763,7 @@ class RelayedLiveParams(BaseModel):
 VALUE_PROJECTION_DESC = (
     "Rendered through the one recursive read-side value projection "
     "(ADR-0035): a scalar for a scalar type; a flat number list for a "
-    "fixed-shape type (Vector2 → [x, y], Color → [r, g, b, a]); a JSON "
+    "fixed-shape type (Vector2 → [x, y], Vector3 → [x, y, z], Color → [r, g, b, a]); a JSON "
     "object for a Dictionary (keys stringified); a JSON array for an Array "
     "or packed array (elements re-projected). An Object value renders as a "
     "ReferenceProjection ({type, resource_path}) for a Resource with a "
@@ -772,7 +772,15 @@ VALUE_PROJECTION_DESC = (
     "({type, …storage properties}) for a whitelisted path-less value Object "
     "(InputEvent subclasses), or its str() form for any other Object — "
     "branch on the presence of resource_path (reference) or object_string "
-    "(texture)."
+    "(texture). Vector components retain the engine build's native precision."
+)
+
+# Both authored and runtime node commands expose the same local components.
+NODE3D_LOCAL_TRANSFORM_DESC = (
+    "Node3D position, rotation and scale address local transform components "
+    "in parent space. Rotation uses Euler angles in radians and the node's "
+    "rotation_order. Vector3 input is three comma-separated numbers: x,y,z; "
+    "output is [x, y, z] at engine precision."
 )
 
 # The set-echo variant: the set commands echo the value they set through the

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -1784,9 +1784,9 @@ func _op_node_get(params: Dictionary) -> void:
 
 	var properties: Array = []
 	for prop in node.get_property_list():
-		if not _is_storage_property(prop):
-			continue
 		var prop_name := String(prop.get("name", ""))
+		if not _is_storage_property(prop) and not _is_node3d_local_transform(node, prop_name):
+			continue
 		properties.append({
 			"name": prop_name,
 			"type": _type_name(int(prop.get("type", TYPE_NIL))),
@@ -6596,24 +6596,32 @@ func _int_param(params: Dictionary, key: String) -> int:
 # one file. tests/harness/test_harness_coercion_mirror.py asserts the two blocks are
 # byte-identical (modulo leading tabs), so an edit here must be mirrored there.
 # Whether a property-list entry is a STORAGE property — the ones node get
-# reports and node set targets: the properties that serialize into the .tscn,
-# excluding the engine's category headers, group separators, and editor-only
+# ordinarily reports and node set targets: the properties that serialize into
+# the .tscn, excluding the engine's category headers, group separators, and editor-only
 # (non-storage) entries. This is the same usage flag the scene serializer keys
-# on, so node get reports exactly the surface a saved scene can carry.
+# on. Node3D local components have a separate, narrow exception below (#885).
 func _is_storage_property(prop: Dictionary) -> bool:
 	var usage := int(prop.get("usage", 0))
 	return (usage & PROPERTY_USAGE_STORAGE) != 0
 
 
 # The declared Godot type of a settable property on the node, or TYPE_NIL if the
-# node has no storage property by that name. node set keys coercion off this:
+# node has no supported property by that name. node set keys coercion off this:
 # the value's target type comes from the property the node actually declares,
 # never from guessing.
 func _property_type(node: Node, prop_name: String) -> int:
 	for prop in node.get_property_list():
-		if String(prop.get("name", "")) == prop_name and _is_storage_property(prop):
+		if String(prop.get("name", "")) == prop_name \
+				and (_is_storage_property(prop) or _is_node3d_local_transform(node, prop_name)):
 			return int(prop.get("type", TYPE_NIL))
 	return TYPE_NIL
+
+
+# Node3D serializes one Transform3D, but these three derived Vector3 properties
+# are the editable local components (#885). Keep the exception node-specific;
+# neither other non-storage properties nor global transform editing is admitted.
+func _is_node3d_local_transform(node: Node, prop_name: String) -> bool:
+	return node is Node3D and prop_name in ["position", "rotation", "scale"]
 
 
 # Read a string param defensively: a non-string value (the params arrive as
@@ -6655,8 +6663,8 @@ const JSONIFY_BOOKKEEPING_PROPS: Array[String] = [
 # The read-side Value projection (ADR-0035, grown from issue #55): render a
 # Godot Variant into the structured JSON a result's value field carries.
 # Scalars pass through; the fixed-shape value types node set supports become
-# flat number arrays so node get's output is exactly the projection node set
-# accepts back: Vector2 → [x, y], Vector2i likewise, Color → [r, g, b, a].
+# flat number arrays: Vector2 → [x, y], Vector2i likewise, Vector3 → [x, y, z],
+# Color → [r, g, b, a]. The write form uses comma-separated components.
 # A Dictionary projects to a JSON object (keys stringified), an Array and the
 # packed-array family to a JSON array, each value re-entering the projection;
 # an Object renders as a reference projection, an inline value projection, or
@@ -6672,6 +6680,8 @@ func _jsonify(value: Variant, depth: int = 0, texture_digest: bool = false) -> V
 			return [value.x, value.y]
 		TYPE_VECTOR2I:
 			return [value.x, value.y]
+		TYPE_VECTOR3:
+			return [value.x, value.y, value.z]
 		TYPE_COLOR:
 			return [value.r, value.g, value.b, value.a]
 		TYPE_DICTIONARY:
@@ -6695,8 +6705,8 @@ func _jsonify(value: Variant, depth: int = 0, texture_digest: bool = false) -> V
 				return str(value)
 			var items := []
 			# Element-wise re-entry: a PackedVector2Array element projects as
-			# [x, y]; an element type with no structured arm of its own (e.g.
-			# Vector3) stays str(), per the fixed-shape list above.
+			# [x, y], a PackedVector3Array element as [x, y, z]; types without
+			# their own structured arm keep the string fallback.
 			for element in value:
 				items.append(_jsonify(element, depth + 1, texture_digest))
 			return items
@@ -6802,6 +6812,9 @@ func _coerce_value(raw: String, type: int, current: Variant = null) -> Variant:
 		TYPE_VECTOR2I:
 			var parts: Variant = _coerce_int_list(raw, 2)
 			return Vector2i(parts[0], parts[1]) if parts != null else null
+		TYPE_VECTOR3:
+			var parts: Variant = _coerce_float_list(raw, 3)
+			return Vector3(parts[0], parts[1], parts[2]) if parts != null else null
 		TYPE_COLOR:
 			return _coerce_color(raw)
 		_:
@@ -6829,8 +6842,8 @@ func _coerce_int(raw: String) -> Variant:
 # --- Float fidelity: the WRITE side of the engine's number domain (#772, #805) ---
 #
 # The rule below is about a LITERAL, not about a property type, so it reaches every
-# float a write can spell: the scalar `--value` and the components of a Vector2 or a
-# Color, which `_coerce_float` parses one at a time, and the JSON numbers inside a
+# float a write can spell: the scalar `--value` and the components of a Vector2,
+# Vector3 or Color, which `_coerce_float` parses one at a time, and the JSON numbers inside a
 # Dictionary or an Array value, which no per-element step parses at all and which
 # `_destroyed_json_number` therefore reads from the raw text (#805). Until that was
 # added the container was the one path where a destroyed float still landed
@@ -6974,8 +6987,8 @@ func _destroyed_json_number(raw: String) -> String:
 # The literal whose destruction ACTUALLY refused this coercion, or "" when the
 # refusal was anything else. A note must never explain a failure it did not
 # diagnose, so this walks exactly what `_coerce_value` walks for `type`, in the
-# same order and behind the same gates: only TYPE_FLOAT, TYPE_VECTOR2, TYPE_COLOR
-# (through `_coerce_float`) and TYPE_DICTIONARY / TYPE_ARRAY (through the raw-text
+# same order and behind the same gates: TYPE_FLOAT, TYPE_VECTOR2, TYPE_VECTOR3,
+# TYPE_COLOR (through `_coerce_float`) and TYPE_DICTIONARY / TYPE_ARRAY (through the raw-text
 # scan) refuse on a destroyed literal at all — TYPE_INT, TYPE_VECTOR2I and the rest
 # refuse for reasons of their own and no float spelling would help them; a wrong
 # component count refuses on ARITY before a component is parsed; a Color in hex
@@ -6998,6 +7011,10 @@ func _destroyed_float_literal(raw: String, type: int) -> String:
 		TYPE_VECTOR2:
 			components = raw.split(",")
 			if components.size() != 2:
+				return ""
+		TYPE_VECTOR3:
+			components = raw.split(",")
+			if components.size() != 3:
 				return ""
 		TYPE_COLOR:
 			var trimmed := raw.strip_edges()

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -476,6 +476,8 @@ forms — several of which are not obvious from `--help`:
   (`"Vector2(48,72)"`) is **rejected** (`uncoercible_value`).
 - `Color` — `#rrggbb` / `#rrggbbaa`, or 3–4 **comma-separated** floats in 0..1:
   `--value "0.2,0.6,1,1"`.
+- `Vector3` — three **comma-separated** numbers: `--value "1,2,3"`; reads return
+  `[x, y, z]`. This also reaches nested Vector3 values through the shared projection.
 - `Dictionary` — a JSON object string: `--value '{"wine":2}'`. In Dictionary/Array
   JSON values, JSON integer literals stay int and JSON float literals stay float;
   typed containers assign entries through their declared container type. A JSON number
@@ -486,13 +488,21 @@ forms — several of which are not obvious from `--help`:
 - An **Object-typed** (Resource) property — a `res://….tres` path, as above.
 
 Whitespace is trimmed for the numeric forms — `bool`, `int` / `float`, the
-`Vector2` / `Vector2i` components, and `Color` (hex or list) — but **not** for
+`Vector2` / `Vector2i` / `Vector3` components, and `Color` (hex or list) — but **not** for
 `String` / `StringName` (taken verbatim) or the `res://` path (matched literally, so a
 leading space fails as `expected_resource_path`). The value-typed forms are shared by
 `node set`, `resource set`, `project set`, and live `game set`; the `res://` Resource
 assignment is headless-only (`node set` / `resource set`). For live `game get` /
 `game set`, an explicitly named attached-script variable is addressable after storage
 properties are checked; unfiltered `game get` still lists only storage properties.
+
+For Node3D, `node get` includes local `position`, `rotation` and `scale`. Both
+`node set` and `game set` can edit them; live reads name the component explicitly
+(`game get /root/Main/Model --property position`). These are local to the parent,
+with Euler rotation in radians under the node's `rotation_order`. Headless changes
+are saved, while live changes stay in the session and return observed `value` and
+`verified`. Vector components use native engine precision; the scene reload can
+normalize transform representations. See the command catalog's Node3D contract.
 Inspect live `game set --json` results' `verified` field: `true` means the observed
 read-back value equals the coerced requested value, while `false` means the set
 completed but the value read back differently. Treat `verified:false` as a diagnostic

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -494,7 +494,8 @@ leading space fails as `expected_resource_path`). The value-typed forms are shar
 `node set`, `resource set`, `project set`, and live `game set`; the `res://` Resource
 assignment is headless-only (`node set` / `resource set`). For live `game get` /
 `game set`, an explicitly named attached-script variable is addressable after storage
-properties are checked; unfiltered `game get` still lists only storage properties.
+properties and Node3D local components are checked; unfiltered `game get` still lists
+only storage properties.
 
 For Node3D, `node get` includes local `position`, `rotation` and `scale`. Both
 `node set` and `game set` can edit them; live reads name the component explicitly

--- a/tests/harness/test_harness_install.py
+++ b/tests/harness/test_harness_install.py
@@ -805,9 +805,9 @@ def test_ready_gates_on_template_feature_as_its_first_statement():
 #   1. edit gda_harness.gd;
 #   2. bump HARNESS_VERSION in src/gda/harness/install.py;
 #   3. update the current pins below (the failure carries the new hash).
-PINNED_HARNESS_VERSION = "20"
+PINNED_HARNESS_VERSION = "21"
 PINNED_HARNESS_SHA256 = (
-    "1074e1ecb10913b0e020e4ac99991631840cbd8966dce4c8f928c4e994b0ea18"
+    "524fab48fd8d1597cabd580462fc828aeee50662720aa5ce49edd1b418cdd497"
 )
 
 

--- a/tests/value_projection/test_e2e_vector3.py
+++ b/tests/value_projection/test_e2e_vector3.py
@@ -1,0 +1,235 @@
+"""Vector3 values and Node3D local transforms through the public CLI (#885)."""
+
+import json
+
+import pytest
+
+from tests.conftest import LIVE_PROJECT_GODOT
+from tests.support import Gda
+
+pytestmark = pytest.mark.e2e
+
+TRANSFORM_SCENE = """[gd_scene format=3]
+
+[node name="Main" type="Node3D"]
+transform = Transform3D(0, -1, 0, 1, 0, 0, 0, 0, 1, 10, 20, 30)
+
+[node name="Child" type="Node3D" parent="."]
+transform = Transform3D(0, -3, 0, 2, 0, 0, 0, 0, 4, 1, 2, 3)
+"""
+LOCAL_FIELDS = ("position", "rotation", "scale")
+
+
+def _local_values(run):
+    data = run.json("node", "get", "res://main.tscn", "--node", "Child")
+    properties = {p["name"]: p["value"] for p in data["properties"]}
+    return {name: properties[name] for name in LOCAL_FIELDS}
+
+
+def test_vector3_projects_recursively_from_a_project_setting(godot_project):
+    config = godot_project / "project.godot"
+    config.write_text(
+        config.read_text()
+        + "\n[vectors]\nvalue=Vector3(1.25, -2.5, 3.75)\n"
+        + 'nested={"array": [Vector3(4, 5, 6)], '
+        + '"packed": PackedVector3Array(7, 8, 9)}\n',
+        encoding="utf-8",
+    )
+    run = Gda(godot_project, json_output=True)
+    assert run.json("project", "get", "vectors/value")["value"] == [1.25, -2.5, 3.75]
+    assert run.json("project", "get", "vectors/nested")["value"] == {
+        "array": [[4, 5, 6]],
+        "packed": [[7, 8, 9]],
+    }
+
+
+def test_vector3_assignment_uses_three_components_and_preserves_small_values(
+    godot_project,
+):
+    config = godot_project / "project.godot"
+    config.write_text(
+        config.read_text() + "\n[vectors]\nvalue=Vector3(1, 2, 3)\n",
+        encoding="utf-8",
+    )
+    run = Gda(godot_project, json_output=True)
+    assigned = run.json("project", "set", "vectors/value", "--value", "1e-18,-2.5,3.75")
+    assert assigned["value"] == pytest.approx([1e-18, -2.5, 3.75], abs=1e-25)
+    assert run.json("project", "get", "vectors/value")["value"] == assigned["value"]
+    before = config.read_bytes()
+    for invalid in ("1,2", "1,2,3,4", "1,two,3", "1,2,", "[1,2,3]", "1e-320,2,3"):
+        error = run.error(
+            "project",
+            "set",
+            "vectors/value",
+            "--value",
+            invalid,
+            code="uncoercible_value",
+        )
+        if invalid.startswith("1e-320"):
+            assert "Godot's own float parser" in error["message"]
+        assert config.read_bytes() == before
+
+
+def test_node3d_local_writes_survive_reopen_and_preserve_other_components(
+    godot_project,
+):
+    scene = godot_project / "main.tscn"
+    scene.write_text(TRANSFORM_SCENE, encoding="utf-8")
+    run = Gda(godot_project, json_output=True)
+    before = _local_values(run)
+    assert before["position"] == [1, 2, 3]
+    assert before["scale"] == [2, 3, 4]
+    # The initial child and parent both rotate 90 degrees around Z; the local
+    # rotation is a quarter turn in radians, not the world-space half turn.
+    assert before["rotation"] == pytest.approx([0, 0, 1.5707963267948966])
+    for field, value in (
+        ("position", [9, 8, 7]),
+        ("rotation", [0.2, 0.3, 0.4]),
+        ("scale", [1.5, 2.5, 3.5]),
+    ):
+        written = run.json(
+            "node",
+            "set",
+            "res://main.tscn",
+            "--node",
+            "Child",
+            "--property",
+            field,
+            "--value",
+            ",".join(map(str, value)),
+        )
+        assert written["type"] == "Vector3"
+        assert written["value"] == pytest.approx(value, abs=1e-6)
+        reopened = _local_values(run)  # each command starts a fresh engine
+        assert reopened[field] == pytest.approx(value, abs=1e-6)
+        for other in LOCAL_FIELDS:
+            if other != field:
+                assert reopened[other] == pytest.approx(before[other], abs=1e-6)
+        before = reopened
+    saved = scene.read_bytes()
+    run.error(
+        "node",
+        "set",
+        "res://main.tscn",
+        "--node",
+        "Child",
+        "--property",
+        "rotation",
+        "--value",
+        "1,2",
+        code="uncoercible_value",
+    )
+    assert scene.read_bytes() == saved
+
+    # Global properties are outside the writable surface of this slice.
+    run.error(
+        "node",
+        "set",
+        "res://main.tscn",
+        "--node",
+        "Child",
+        "--property",
+        "global_position",
+        "--value",
+        "1,2,3",
+        code="unknown_property",
+    )
+    assert scene.read_bytes() == saved
+
+
+@pytest.mark.skipif("os.name != 'posix'")
+def test_live_local_transform_reads_after_writes_without_saving(
+    tmp_path, daemon_runtime_dir
+):
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    scene = tmp_path / "main.tscn"
+    scene.write_text(TRANSFORM_SCENE, encoding="utf-8")
+    run = Gda(tmp_path, json_output=True)
+
+    def read_local():
+        return {
+            field: run.json("game", "get", "/root/Main/Child", "--property", field)[
+                "properties"
+            ][0]["value"]
+            for field in LOCAL_FIELDS
+        }
+
+    try:
+        run.json("daemon", "start")
+        before = read_local()
+        assert before["position"] == [1, 2, 3]
+        unfiltered = run.json("game", "get", "/root/Main/Child")
+        assert not set(LOCAL_FIELDS) & {p["name"] for p in unfiltered["properties"]}
+        saved = scene.read_bytes()
+        for field, value in (
+            ("position", [9, 8, 7]),
+            ("rotation", [0.2, 0.3, 0.4]),
+            ("scale", [1.5, 2.5, 3.5]),
+        ):
+            written = run.json(
+                "game",
+                "set",
+                "--params-json",
+                json.dumps(
+                    {
+                        "node": "/root/Main/Child",
+                        "property": field,
+                        "value": ",".join(map(str, value)),
+                    }
+                ),
+            )
+            assert written["type"] == "Vector3"
+            assert written["verified"] is True
+            observed = read_local()
+            assert observed[field] == written["value"]
+            assert observed[field] == pytest.approx(value, abs=1e-6)
+            for other in LOCAL_FIELDS:
+                if other != field:
+                    assert observed[other] == pytest.approx(before[other], abs=1e-6)
+            before = observed
+        for invalid in ("1,2", "1,two,3", "1e-320,2,3"):
+            refused = run(
+                "game",
+                "set",
+                "/root/Main/Child",
+                "--property",
+                "position",
+                "--value",
+                invalid,
+            )
+            assert refused.returncode != 0
+            error = json.loads(refused.stdout)["error"]
+            assert error["category"] == "live"
+            assert error["code"] == "live_uncoercible_value"
+            assert read_local() == before
+        refused = run(
+            "game",
+            "set",
+            "/root/Main/Child",
+            "--property",
+            "global_position",
+            "--value",
+            "1,2,3",
+        )
+        assert refused.returncode != 0
+        assert json.loads(refused.stdout)["error"]["code"] == "live_unknown_property"
+        assert scene.read_bytes() == saved
+    finally:
+        run("daemon", "stop")
+
+
+def test_vector3_resource_assignment_with_structured_params_and_human_read(
+    godot_project,
+):
+    run = Gda(godot_project, json_output=True)
+    run.json("resource", "create", "res://box.tres", "--type", "BoxMesh")
+    params = {"path": "res://box.tres", "property": "size", "value": "2,3,4"}
+    assigned = run.json("resource", "set", "--params-json", json.dumps(params))
+    assert assigned["value"] == [2, 3, 4]
+    read = run.json("resource", "get", "res://box.tres")
+    size = next(p for p in read["properties"] if p["name"] == "size")
+    assert size["value"] == [2, 3, 4]
+    assert size["type"] == "Vector3"
+    human = Gda(godot_project)("resource", "get", "res://box.tres")
+    assert human.returncode == 0
+    assert "Vector3" in human.stdout and "size" in human.stdout

--- a/tests/value_projection/test_vector3_discovery.py
+++ b/tests/value_projection/test_vector3_discovery.py
@@ -7,6 +7,7 @@ from typer.testing import CliRunner
 from gda.cli import app
 from gda.mcp.server import build_server
 from tests.mcp_support import FakeGdaRunner, list_tools, schema_then
+from tests.support import panel_text
 
 
 def test_local_transform_contract_reaches_cli_schema_and_generated_mcp():
@@ -33,5 +34,5 @@ def test_local_transform_contract_reaches_cli_schema_and_generated_mcp():
             if group == "game":
                 help_result = CliRunner().invoke(app, [group, action, "--help"])
                 assert help_result.exit_code == 0
-                help_text = " ".join(help_result.stdout.replace("│", " ").split())
+                help_text = panel_text(help_result.stdout)
                 assert "storage and Node3D local components first" in help_text

--- a/tests/value_projection/test_vector3_discovery.py
+++ b/tests/value_projection/test_vector3_discovery.py
@@ -30,3 +30,8 @@ def test_local_transform_contract_reaches_cli_schema_and_generated_mcp():
             tool = tools[f"{group}_{action}"]
             assert tool.input_schema == schema["input"]
             assert tool.output_schema == schema["output"]
+            if group == "game":
+                help_result = CliRunner().invoke(app, [group, action, "--help"])
+                assert help_result.exit_code == 0
+                help_text = " ".join(help_result.stdout.replace("│", " ").split())
+                assert "storage and Node3D local components first" in help_text

--- a/tests/value_projection/test_vector3_discovery.py
+++ b/tests/value_projection/test_vector3_discovery.py
@@ -1,0 +1,32 @@
+"""The existing CLI and generated MCP advertise one Vector3 contract."""
+
+import json
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.mcp.server import build_server
+from tests.mcp_support import FakeGdaRunner, list_tools, schema_then
+
+
+def test_local_transform_contract_reaches_cli_schema_and_generated_mcp():
+    def no_dispatch(args, stdin):
+        raise AssertionError("schema discovery must not dispatch a Godot operation")
+
+    tools = {
+        tool.name: tool
+        for tool in list_tools(
+            build_server(FakeGdaRunner(schema_then(no_dispatch)))
+        ).tools
+    }
+    for group in ("node", "game"):
+        for action in ("get", "set"):
+            result = CliRunner().invoke(app, [group, action, "--schema"])
+            assert result.exit_code == 0
+            schema = json.loads(result.stdout)
+            text = json.dumps(schema, ensure_ascii=False)
+            assert "Vector3" in text and "[x, y, z]" in text
+            assert "parent space" in text and "radians" in text
+            tool = tools[f"{group}_{action}"]
+            assert tool.input_schema == schema["input"]
+            assert tool.output_schema == schema["output"]


### PR DESCRIPTION
Vector3 properties now read as `[x, y, z]` and accept three comma-separated components through the existing property commands. Node3D local `position`, `rotation` and `scale` can be edited and read back, including under a translated/rotated parent. Headless writes save the scene; live writes preserve the existing frame-boundary verification and do not save.

The change extends the shared mirrored Godot projection/coercion and admits only the three local Node3D components. It retains unfiltered live storage-property reads, existing numeric-fidelity failures, Vector2 and Resource assignment. Help, schemas, generated MCP descriptions, the command catalog and shipped guidance describe local coordinates, radians and native component precision. The harness version is advanced for automatic installation synchronization.

Validation:
- Full fast suite: 2537 passed, 2 skipped.
- New real-Godot paths, discovery and mirror checks: 9 passed.
- Existing primitive/Vector2/Control and Resource assignment real-Godot checks: 17 passed.
- Pyright, Ruff and diff checks passed.

## Standards

Sol found one stale help/guidance contract and verified it closed at `83a8e80fe7a9249e56c48d5b2d28f63497b86887`. The subsequent CI-only correction at `96997d20818de5fe16f1408d9e3e2a7385cb91ca` uses the existing Rich panel normalizer in that assertion; forced-color validation passed. Neither correction changes engine behavior. No Standards findings remain.

## Spec

Sol passed the implementation head `89f2219876d95a44ce58de4618adeb8c89ea18b4`, independently running 18 focused real-Godot, discovery, mirror and compatibility tests. No Spec findings remain.

## DDMA

Sol passed the same implementation head: Godot property ownership, mirrored policy authority, narrow derived-property admission and separate headless/live lifecycle remain intact. This axis was a source/architecture review, not a runtime test run. No DDMA findings remain.

All applicable CI checks passed at `96997d20818de5fe16f1408d9e3e2a7385cb91ca`.

This PR targets `codex/asset-pipeline-dev`; full integrated milestone E2E and HITL remain pending. Global-transform editing and other compound transform types are outside this slice. The PR workflow skips its scheduled/manual Godot job; local real-engine validation is reported separately above.

Refs #885, #907.
