### PR TITLE
feat(asset-pipeline): evaluate model expectations and compatible report differences

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@ names the file, and only `preflight` catches a first-frame failure.
 | Command | What it does |
 | ------- | ------------ |
 | `asset-pipeline run` | Export a saved Blender subtree or stage PNG/GLB files, then install, import and check the actual Godot-loaded result. |
+| `asset-pipeline check` | Evaluate project model expectations and compare compatible Godot inspection reports. Read the content verdict; completed checks exit 0. |
 
 Use explicit source-to-target mappings and an overwrite policy. Completed
 image-generation files use the same path with optional caller-declared metadata.

--- a/README.md
+++ b/README.md
@@ -591,7 +591,8 @@ project is trusted ([ADR-0009](docs/adr/0009-trust-boundary-trusted-project.md))
 - **Autoloads** start on every `--project` operation that boots the engine, read-only ones
   included (a cached `resource import` boots nothing).
 - **Scene scripts' `_init`** runs wherever a scene is instantiated: every mutating `node`
-  command, `node get`, and the GLB load check in `asset-pipeline run`;
+  command, `node get`, `resource inspect-model`, `asset-pipeline check --path`,
+  and the GLB load check in `asset-pipeline run`;
   `scene get` / `scene list` / `node list` read without instantiating.
 - **`script run`** executes the named script in full; **`scene preflight`** boots the scene
   and runs its `_ready`.

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=bb3de349a31d49df94362315c1b48bf4365bd29bc497611c0a0c9ab536f95aef -->
+<!-- gda-readme-i18n: source=README.md sha256=45a25a690000e9c729f1038676fb3bbd3f05c81ff42b4272eb5dfc9a0d203541 -->
 
 # gda — Automatización de Godot para agentes de IA
 
@@ -608,7 +608,8 @@ proyecto es de confianza ([ADR-0009](adr/0009-trust-boundary-trusted-project.md)
 - **Los autoloads** arrancan en cada operación `--project` que inicia el motor, incluidas las de solo
   lectura (un `resource import` con la caché íntegra no arranca nada).
 - **El `_init` de los scripts de la escena** se ejecuta allí donde se instancia una escena: todo comando
-  `node` que modifica la escena, `node get` y la comprobación de carga de GLB de `asset-pipeline run`;
+  `node` que modifica la escena, `node get`, `resource inspect-model`,
+  `asset-pipeline check --path` y la comprobación de carga de GLB de `asset-pipeline run`;
   `scene get` / `scene list` / `node list` leen sin instanciar.
 - **`script run`** ejecuta íntegramente el script indicado; **`scene preflight`** arranca la escena y
   ejecuta su `_ready`.

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=e37039b783e1b1822c93cf395cf57a1bf7afdb777d15fce8c18206342b009e53 -->
+<!-- gda-readme-i18n: source=README.md sha256=bb3de349a31d49df94362315c1b48bf4365bd29bc497611c0a0c9ab536f95aef -->
 
 # gda — Automatización de Godot para agentes de IA
 
@@ -497,6 +497,7 @@ identifica el archivo y solo `preflight` detecta un fallo en el primer fotograma
 | Comando | Qué hace |
 | ------- | ------------ |
 | `asset-pipeline run` | Exporta un subárbol de un archivo de Blender guardado o prepara archivos PNG/GLB; después los instala e importa y comprueba el resultado que Godot carga realmente. |
+| `asset-pipeline check` | Evalúa el modelo según los requisitos del proyecto y compara informes compatibles de Godot. Una evaluación completada devuelve el código 0; el campo verdict indica si cumple los requisitos. |
 
 Usa correspondencias explícitas entre origen y destino y define una política de sobrescritura.
 Los archivos que complete la generación de imágenes siguen el mismo flujo y pueden incluir metadatos

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=e37039b783e1b1822c93cf395cf57a1bf7afdb777d15fce8c18206342b009e53 -->
+<!-- gda-readme-i18n: source=README.md sha256=bb3de349a31d49df94362315c1b48bf4365bd29bc497611c0a0c9ab536f95aef -->
 
 # gda — AI エージェント向け Godot オートメーション
 
@@ -493,6 +493,7 @@ Headless 検証はプロジェクトの実行準備を確認し、Live 操作は
 | コマンド | 機能 |
 | ------- | ------------ |
 | `asset-pipeline run` | 保存済みの Blender ファイルから選択したサブツリーをエクスポートするか、PNG/GLB ファイルを準備し、配置・インポート後に Godot の実際の読み込み結果を確認します。 |
+| `asset-pipeline check` | プロジェクトの条件に沿ってモデルを検証し、観測範囲が一致する Godot のレポートを比較します。検証が完了すると終了コードは 0 となり、合否は verdict に示されます。 |
 
 ソースからターゲットへのマッピングと上書きポリシーを明示してください。生成が完了した画像ファイルも
 同じ手順で処理でき、呼び出し側が指定したメタデータを任意で付加できます。[アセットパイプラインガイド](../libs/gda-assets/README.md)では、

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=bb3de349a31d49df94362315c1b48bf4365bd29bc497611c0a0c9ab536f95aef -->
+<!-- gda-readme-i18n: source=README.md sha256=45a25a690000e9c729f1038676fb3bbd3f05c81ff42b4272eb5dfc9a0d203541 -->
 
 # gda — AI エージェント向け Godot オートメーション
 
@@ -603,7 +603,8 @@ Blender からのエクスポート、ファイル入力、参照、部分的な
 - **オートロード**は、エンジンを起動するすべての `--project` 操作で実行されます。読み取り専用の操作も
   例外ではありません(キャッシュが完全な `resource import` は何も起動しません)。
 - **シーンスクリプトの `_init`** は、シーンをインスタンス化する操作では必ず実行されます。すべての変更系
-  `node` コマンド、`node get`、`asset-pipeline run` の GLB ロードチェックが該当し、
+  `node` コマンド、`node get`、`resource inspect-model`、`asset-pipeline check --path`、
+  `asset-pipeline run` の GLB ロードチェックが該当し、
   `scene get` / `scene list` / `node list` はインスタンス化せずに読み取ります。
 - **`script run`** は指定したスクリプトをすべて実行し、**`scene preflight`** はシーンを起動して `_ready` を実行します。
 - **`resource import`** はキャッシュ欠落時にエンジンのインポーター(およびプロジェクトのインポートプラグイン)を

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=e37039b783e1b1822c93cf395cf57a1bf7afdb777d15fce8c18206342b009e53 -->
+<!-- gda-readme-i18n: source=README.md sha256=bb3de349a31d49df94362315c1b48bf4365bd29bc497611c0a0c9ab536f95aef -->
 
 # gda — 面向 AI Agent 的 Godot 自动化
 
@@ -473,6 +473,7 @@ Headless 验证确认项目就绪状态；Live 操作返回用于验证实际行
 | 命令 | 作用 |
 | ------- | ------------ |
 | `asset-pipeline run` | 导出已保存的 Blender 资产子树，或暂存 PNG/GLB 文件，再安装、导入并检查 Godot 实际加载的结果。 |
+| `asset-pipeline check` | 按项目要求验收模型，并比较范围兼容的 Godot 检查报告。完成检查后退出码为 0，是否符合要求以结果中的 verdict 为准。 |
 
 请使用明确的源文件到目标位置映射，并指定覆盖策略。图像生成完成后的文件沿用同一流程，
 也可以附带调用方声明的元数据。[资产管线指南](../libs/gda-assets/README.md)介绍了 Blender 导出、文件输入、引用与

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=bb3de349a31d49df94362315c1b48bf4365bd29bc497611c0a0c9ab536f95aef -->
+<!-- gda-readme-i18n: source=README.md sha256=45a25a690000e9c729f1038676fb3bbd3f05c81ff42b4272eb5dfc9a0d203541 -->
 
 # gda — 面向 AI Agent 的 Godot 自动化
 
@@ -582,6 +582,7 @@ Headless 验证确认项目就绪状态；Live 操作返回用于验证实际行
 - **autoload** 在每个会启动引擎的 `--project` 操作中运行，只读操作也不例外（缓存完好的
   `resource import` 不启动任何东西）。
 - **场景脚本的 `_init`** 在场景被实例化的地方运行：每个改动状态的 `node` 命令、`node get`，
+  `resource inspect-model`、`asset-pipeline check --path`，
   以及 `asset-pipeline run` 中的 GLB 加载检查；`scene get` / `scene list` / `node list` 只读取、不实例化。
 - **`script run`** 会执行指定脚本的全部内容；**`scene preflight`** 启动场景并运行其 `_ready`。
 - **`resource import`** 在缓存缺失时运行引擎的导入器（以及项目的导入插件），不运行 autoload。

--- a/libs/gda-assets/AGENTS.md
+++ b/libs/gda-assets/AGENTS.md
@@ -1,8 +1,9 @@
 # Asset Pipeline context
 
 This subtree carries **Asset Pipeline**, gda's internal asset-workflow supporting
-context. It is not a sibling user-facing product. File handoff (#908) and saved
-Blender production (#909) are implemented; other workflows remain planned. Requirements and delivery status live in
+context. It is not a sibling user-facing product. File handoff (#908), saved
+Blender production (#909), and model expectation checks (#887) are implemented;
+other workflows remain planned. Requirements and delivery status live in
 [#907](https://github.com/aigengame/godot-agent/issues/907).
 
 Inherit root `AGENTS.md`, `RULES.md`, issue tracker, and triage conventions except

--- a/libs/gda-assets/README.md
+++ b/libs/gda-assets/README.md
@@ -7,6 +7,11 @@ source inspection and uniform scale preparation, see the
 [Blender production guide](docs/blender.md). Completed image-generation outputs
 use explicit file handoff; this command does not generate images.
 
+Use `gda asset-pipeline check` to evaluate project-owned model expectations against
+a current Godot inspection or a saved raw inspection report. See the
+[model checks guide](docs/checks.md) for the JSON format, seven supported check
+kinds, verdict semantics, partial coverage, and compatible baseline comparison.
+
 ```sh
 gda asset-pipeline run --project ./consumer --source-root ./production \
   --files '[{"source":"icon.png","target":"res://art/icon.png","resize":{"width":64,"height":64,"resampling":"nearest"}},{"source":"model.glb","target":"res://art/model.glb"}]' \
@@ -87,3 +92,17 @@ The script creates an isolated project, verifies PNG resize and a real GLB mesh
 load, exercises a structured no-op repeat and a pre-installation refusal, then
 cleans up its project. It also checks installed engine payload and guidance data.
 No game example is a runtime or test prerequisite.
+
+## Check model expectations
+
+Evaluate a model through Godot:
+
+```sh
+gda asset-pipeline check --expectations ./model.expectations.json \
+  --path res://art/model.glb --project ./consumer --json
+```
+
+Use `--report ./report.json` instead of `--path` to evaluate raw JSON previously
+saved from `gda resource inspect-model`. Add `--baseline ./older-report.json` for
+a separate compatible comparison. Completed `pass`, `fail`, and `insufficient`
+verdicts all exit 0; malformed input or workflow failure exits nonzero.

--- a/libs/gda-assets/docs/ARCHITECTURE.md
+++ b/libs/gda-assets/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # Asset Pipeline architecture
 
-**Status:** accepted design; file handoff (#908) and saved Blender production (#909)
-are implemented. Other
-workflows remain planned. Accepted by the project owner
+**Status:** accepted design; file handoff (#908), saved Blender production (#909),
+and model expectation checks (#887) are implemented. Other workflows remain
+planned. Accepted by the project owner
 on 2026-09-07 after review of the Blender-to-Godot workflow and milestone #14.
 Source baseline inspected: `cfcb8658e67df418a69694840a37a22a9cd3cbe0`.
 Acceptance and delivery status are owned by
@@ -150,6 +150,8 @@ selects the local adapter only when production is requested. The host transports
 generic options and injects the same Godot import/load port; native source
 inspection and export stay inside the Blender adapter and its bundled worker.
 The [Blender guide](blender.md) owns the supported execution and measurement policy.
+The [model checks guide](checks.md) owns the implemented expectation document,
+verdict, saved-report, and baseline-comparison user contract.
 
 ## Tactical model and interfaces
 
@@ -184,7 +186,7 @@ source inspection only when used, and add runtime/package ports with their slice
 Do not mirror every gda operation into a general Godot SDK.
 
 The first handoff slice needs only a bounded engine load observation for its PNG
-and GLB fixtures. The richer `inspect_model` contract arrives with [#886](https://github.com/aigengame/godot-agent/issues/886); the first
+and GLB fixtures. The richer `inspect_model` contract is implemented by [#886](https://github.com/aigengame/godot-agent/issues/886); the first
 Blender tracer can verify its selected dimensions without waiting for the full
 structure/material/animation report.
 
@@ -324,6 +326,10 @@ establish runtime refresh or package-only acceptance. #909 adds real saved-sourc
 Blender export through that same integration path, Godot-loaded dimension checks,
 and native export/import fault cases in `test_e2e_blender_producer.py`. The native
 result is bounded per invocation; it adds no persisted run or source identity model.
+[#887](https://github.com/aigengame/godot-agent/issues/887) adds project-owned
+expectations, native or supplied-report evaluation, bounded partial verdicts, and
+compatible baseline comparison. Its user contract is documented in
+[the model checks guide](checks.md); it adds no registry or run history.
 
 ## Research basis and retained limits
 

--- a/libs/gda-assets/docs/checks.md
+++ b/libs/gda-assets/docs/checks.md
@@ -1,0 +1,153 @@
+# Model checks
+
+`gda asset-pipeline check` evaluates project-owned expectations against the
+bounded facts from `gda resource inspect-model`. It can inspect a Godot resource
+now or consume a previously saved raw JSON report.
+
+Inspect a resource in the selected Godot project:
+
+```sh
+gda asset-pipeline check \
+  --expectations ./model.expectations.json \
+  --path res://models/character.glb \
+  --project ./game \
+  --json
+```
+
+To work offline, first save the native report without changing its JSON shape,
+then pass it to `--report`:
+
+```sh
+gda resource inspect-model res://models/character.glb \
+  --project ./game --json > ./reports/character.json
+gda asset-pipeline check \
+  --expectations ./model.expectations.json \
+  --report ./reports/character.json \
+  --json
+```
+
+Select exactly one of `--path` and `--report`. `--path` accepts the native
+inspection controls `--subtree`, `--max-nodes`, and `--max-items`. A supplied
+report already carries its scope and limits, so these controls cannot override it.
+
+The command schema describes CLI and structured inputs:
+
+```sh
+gda asset-pipeline check --schema
+```
+
+The expectation document format is described below. It is intentionally local
+JSON rather than a registry or saved workflow.
+
+## Expectation document
+
+The document contains 1 to 256 checks. Each check has a unique, nonempty `id`
+and one of seven `kind` values. The file must be at most 1 MiB.
+
+This small example checks a model like the fixture used by
+`tests/asset_pipeline/fixtures/model_check_fixture.gd`:
+
+```json
+{
+  "checks": [
+    {
+      "id": "left-arm",
+      "kind": "node",
+      "node": "Character/RootBone/Skeleton3D/Arm_L",
+      "type": "MeshInstance3D"
+    },
+    {
+      "id": "model-size",
+      "kind": "dimensions",
+      "min": [5.9, 3.9, 0.9],
+      "max": [6.1, 4.1, 1.1]
+    },
+    {
+      "id": "meshes",
+      "kind": "count",
+      "metric": "mesh_instance_count",
+      "min": 2,
+      "max": 2
+    }
+  ]
+}
+```
+
+Node locators are exact resource-relative paths. A short name such as `Arm_L`
+does not match the full path above. `.` means the resource root; selecting a subtree
+does not rebase node paths. Discover paths,
+surface indexes, binds, animations, tracks, and observed coverage with
+`gda resource inspect-model` before writing expectations.
+
+Range bounds are inclusive, finite, and nonnegative. Supply `min`, `max`, or both.
+`dimensions` uses three-axis vectors and checks resource-space static mesh AABB
+size. It does not infer posed or collision dimensions.
+
+Keep the expectation JSON in version control with the code that consumes the
+model. Change its conditions when project intent changes; do not silently relax
+conditions to accept a new export. Save a baseline report explicitly when a
+comparison is useful, and retain its engine and measurement scope. Neither file
+requires a registry or a persistent run history.
+
+## Check kinds
+
+| Kind | Required fields | Meaning |
+| --- | --- | --- |
+| `node` | `node`; optional `type` | Requires the exact node path and, when supplied, its exact Godot type. |
+| `count` | `metric`; `min` and/or `max` | Checks `node_count`, `mesh_instance_count`, or `unique_mesh_count` over the inspected subtree. |
+| `dimensions` | `min` and/or `max` | Checks the three inclusive resource-space size ranges. |
+| `material` | `node`, `surface`; optional `name`, `path` | Requires an effective material on the selected surface and optionally matches its name or resource path. |
+| `bone` | `node`, `name` | Requires the named bone on the selected `Skeleton3D`. |
+| `skin_bind` | `node`, `bind`, `skeleton`, `bone` | Requires an explicit resolved skin bind to the exact skeleton path and bone name. |
+| `animation_target` | `node`, `animation`, `track`, `target`; optional `bone` | Checks a statically resolved animation track target and optional bone. It does not prove successful playback. |
+
+Material presence and name can pass when the engine reports them. If an expected
+material path is unavailable, the result is `insufficient`, not an inferred match
+or mismatch. Missing detail in partial surface, bone, skin, or animation coverage
+is also `insufficient` when the report identifies that omission.
+
+## Verdicts and failures
+
+Every check returns its `id`, `location`, `expected`, `actual`, `reason`, and one
+of these verdicts:
+
+- `pass`: the observed facts satisfy the expectation.
+- `fail`: complete observed facts contradict the expectation.
+- `insufficient`: bounded coverage cannot decide the expectation.
+
+The overall verdict is `fail` if any check fails, otherwise `insufficient` if any
+check is insufficient, otherwise `pass`. All three are completed evaluations and
+exit with status 0. Read the structured `verdict`; do not use process status as the
+content verdict.
+
+Malformed expectations, invalid reports, missing projects, and native inspection
+failures exit nonzero. Their structured error preserves the native gda failure and
+includes the bounded partial result when available.
+
+A saved report is caller-provided evidence. `observation_source` is
+`supplied_report`; the command does not claim that the report is fresh or that its
+original inspection is reproducible. Reports are admitted as raw native
+`resource inspect-model` JSON and are limited to 16 MiB.
+
+## Baseline comparison
+
+Add `--baseline` to compare a saved native report with the selected current report:
+
+```sh
+gda asset-pipeline check \
+  --expectations ./model.expectations.json \
+  --report ./reports/current.json \
+  --baseline ./reports/baseline.json \
+  --json
+```
+
+The expectation `verdict` and `comparison` are separate results. A comparison is
+compatible only when engine major/minor, inspected subtree, and measurement basis
+match. Engine patch versions are ignored. The two resource paths may differ and
+are reported as `resources.before` and `resources.after`.
+
+Compatible complete reports list observed additions, removals, and changes.
+When either report has omitted or unavailable relevant facts, comparison status is `partial` and
+lists incomplete sections. It never interprets an absent item in partial coverage
+as a deletion. Incompatible reports return `non_comparable` with reasons rather
+than fabricated changes.

--- a/libs/gda-assets/src/gda_assets/adapters/expectations.py
+++ b/libs/gda-assets/src/gda_assets/adapters/expectations.py
@@ -1,0 +1,110 @@
+"""JSON syntax and shape for the small, project-owned expectation document."""
+
+import json
+from pathlib import Path
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+from gda_assets.application.ports import PortFailure
+from gda_assets.domain.expectations import Expectation, validate_conditions
+
+
+class ConditionInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+    id: str = Field(min_length=1, max_length=128)
+
+
+class NodeInput(ConditionInput):
+    kind: Literal["node"]
+    node: str
+    type: str | None = Field(default=None, min_length=1)
+
+
+class CountInput(ConditionInput):
+    kind: Literal["count"]
+    metric: Literal["node_count", "mesh_instance_count", "unique_mesh_count"]
+    min: int | None = Field(default=None, ge=0)
+    max: int | None = Field(default=None, ge=0)
+
+
+class DimensionsInput(ConditionInput):
+    kind: Literal["dimensions"]
+    min: list[float] | None = Field(default=None, min_length=3, max_length=3)
+    max: list[float] | None = Field(default=None, min_length=3, max_length=3)
+
+
+class MaterialInput(ConditionInput):
+    kind: Literal["material"]
+    node: str
+    surface: int = Field(ge=0)
+    name: str | None = Field(default=None, min_length=1)
+    path: str | None = Field(default=None, min_length=1)
+
+
+class BoneInput(ConditionInput):
+    kind: Literal["bone"]
+    node: str
+    name: str = Field(min_length=1)
+
+
+class SkinBindInput(ConditionInput):
+    kind: Literal["skin_bind"]
+    node: str
+    bind: int = Field(ge=0)
+    skeleton: str
+    bone: str = Field(min_length=1)
+
+
+class AnimationTargetInput(ConditionInput):
+    kind: Literal["animation_target"]
+    node: str
+    animation: str = Field(min_length=1)
+    track: int = Field(ge=0)
+    target: str
+    bone: str | None = Field(default=None, min_length=1)
+
+
+class ExpectationDocument(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+    checks: list[
+        Annotated[
+            NodeInput
+            | CountInput
+            | DimensionsInput
+            | MaterialInput
+            | BoneInput
+            | SkinBindInput
+            | AnimationTargetInput,
+            Field(discriminator="kind"),
+        ]
+    ] = Field(min_length=1, max_length=256)
+
+    @field_validator("checks")
+    @classmethod
+    def _unique_ids(cls, checks):
+        if len({check.id for check in checks}) != len(checks):
+            raise ValueError("check ids must be unique")
+        return checks
+
+
+def read_expectations(path: Path) -> tuple[Expectation, ...]:
+    try:
+        if path.stat().st_size > 1024 * 1024:
+            raise ValueError("expectation document exceeds 1 MiB")
+        document = ExpectationDocument.model_validate(
+            json.loads(path.read_text(encoding="utf-8"))
+        )
+        conditions = tuple(
+            Expectation(
+                item.id,
+                item.kind,
+                getattr(item, "node", None),
+                item.model_dump(exclude={"id", "kind", "node"}, exclude_none=True),
+            )
+            for item in document.checks
+        )
+        validate_conditions(conditions)
+        return conditions
+    except (OSError, ValueError, ValidationError) as exc:
+        raise PortFailure("invalid_expectations", str(exc)) from exc

--- a/libs/gda-assets/src/gda_assets/api.py
+++ b/libs/gda-assets/src/gda_assets/api.py
@@ -7,6 +7,7 @@ from gda_assets.application.ports import ModelInspectionPort
 from gda_assets.domain.model import (
     ModelFacts,
     ModelCheckResult,
+    ModelComparison,
     NodeFacts,
     MaterialFacts,
     SurfaceFacts,
@@ -43,6 +44,7 @@ __all__ = [
     "TrackFacts",
     "AnimationFacts",
     "ModelCheckResult",
+    "ModelComparison",
     "ModelInspectionPort",
     "AssetFile",
     "AssetRecipe",

--- a/libs/gda-assets/src/gda_assets/api.py
+++ b/libs/gda-assets/src/gda_assets/api.py
@@ -2,6 +2,20 @@
 
 from pathlib import Path
 
+from gda_assets.application.check import check_model as _check_model
+from gda_assets.application.ports import ModelInspectionPort
+from gda_assets.domain.model import (
+    ModelFacts,
+    ModelCheckResult,
+    NodeFacts,
+    MaterialFacts,
+    SurfaceFacts,
+    BoneFacts,
+    BindFacts,
+    TrackFacts,
+    AnimationFacts,
+)
+
 from gda_assets.application.integrate import run_pipeline as _run_pipeline
 from gda_assets.application.ports import (
     GodotAssetPort,
@@ -19,6 +33,17 @@ from gda_assets.domain.artifacts import (
 from gda_assets.domain.recipe import AssetFile, AssetRecipe, Resize
 
 __all__ = [
+    "check_model",
+    "ModelFacts",
+    "NodeFacts",
+    "MaterialFacts",
+    "SurfaceFacts",
+    "BoneFacts",
+    "BindFacts",
+    "TrackFacts",
+    "AnimationFacts",
+    "ModelCheckResult",
+    "ModelInspectionPort",
     "AssetFile",
     "AssetRecipe",
     "GodotAssetPort",
@@ -60,4 +85,36 @@ def run_pipeline(
         files=LocalFiles(),
         production=production,
         producer=producer,
+    )
+
+
+def check_model(
+    expectations: Path,
+    *,
+    path: str | None = None,
+    godot: ModelInspectionPort | None = None,
+    report: ModelFacts | None = None,
+    subtree: str = ".",
+    max_nodes: int = 256,
+    max_items: int = 1024,
+    baseline: ModelFacts | None = None,
+) -> ModelCheckResult:
+    """Read project expectations and evaluate injected or previously observed facts."""
+    from gda_assets.adapters.expectations import read_expectations
+
+    try:
+        conditions = read_expectations(expectations)
+    except PortFailure as exc:
+        return ModelCheckResult(
+            failure=PipelineFailure("validate", exc.code, str(exc), exc.cause)
+        )
+    return _check_model(
+        conditions,
+        path=path,
+        godot=godot,
+        report=report,
+        subtree=subtree,
+        max_nodes=max_nodes,
+        max_items=max_items,
+        baseline=baseline,
     )

--- a/libs/gda-assets/src/gda_assets/application/check.py
+++ b/libs/gda-assets/src/gda_assets/application/check.py
@@ -1,0 +1,61 @@
+"""Inspect or consume model facts, then evaluate project intent."""
+
+from gda_assets.application.ports import ModelInspectionPort, PortFailure
+from gda_assets.domain.artifacts import PipelineFailure
+from gda_assets.domain.expectations import Expectation, evaluate
+from gda_assets.domain.model import ModelCheckResult, ModelFacts
+
+
+def check_model(
+    conditions: tuple[Expectation, ...],
+    *,
+    path: str | None = None,
+    godot: ModelInspectionPort | None = None,
+    report: ModelFacts | None = None,
+    subtree: str = ".",
+    max_nodes: int = 256,
+    max_items: int = 1024,
+    baseline: ModelFacts | None = None,
+) -> ModelCheckResult:
+    result = ModelCheckResult(resource=path)
+    stage = "validate"
+    try:
+        if (path is None) == (report is None):
+            raise PortFailure("invalid_check", "Select exactly one of path or report")
+        if report is None and godot is None:
+            raise PortFailure(
+                "invalid_check", "A Godot port is required for inspection"
+            )
+        result.completed.append("validate")
+        stage = "inspect"
+        if report is None:
+            if path is None or godot is None:
+                raise PortFailure(
+                    "invalid_check",
+                    "A model path and Godot port are required for inspection",
+                )
+            report = godot.inspect_model(
+                path, subtree=subtree, max_nodes=max_nodes, max_items=max_items
+            )
+            result.observation_source = "godot"
+            result.completed.append("inspect")
+        else:
+            result.observation_source = "supplied_report"
+        result.resource = report.resource
+        result.checks = evaluate(conditions, report)
+        result.verdict = (
+            "fail"
+            if any(c.verdict == "fail" for c in result.checks)
+            else "insufficient"
+            if any(c.verdict == "insufficient" for c in result.checks)
+            else "pass"
+        )
+        result.completed.append("evaluate")
+        if baseline is not None:
+            from gda_assets.domain.model_diff import compare_models
+
+            result.comparison = compare_models(baseline, report)
+            result.completed.append("compare")
+    except PortFailure as exc:
+        result.failure = PipelineFailure(stage, exc.code, str(exc), exc.cause)
+    return result

--- a/libs/gda-assets/src/gda_assets/application/ports.py
+++ b/libs/gda-assets/src/gda_assets/application/ports.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from gda_assets.domain.artifacts import ImportOutcome, InstalledFile, LoadObservation
 from gda_assets.domain.recipe import AssetFile, AssetRecipe
+from gda_assets.domain.model import ModelFacts
 
 
 @dataclass(frozen=True)
@@ -73,3 +74,9 @@ class GodotAssetPort(Protocol):
     def import_assets(self, paths: list[str]) -> ImportOutcome: ...
 
     def check_load(self, path: str) -> LoadObservation: ...
+
+
+class ModelInspectionPort(Protocol):
+    def inspect_model(
+        self, path: str, *, subtree: str, max_nodes: int, max_items: int
+    ) -> "ModelFacts": ...

--- a/libs/gda-assets/src/gda_assets/domain/expectations.py
+++ b/libs/gda-assets/src/gda_assets/domain/expectations.py
@@ -1,0 +1,226 @@
+"""Project expectations and their interpretation over bounded model facts."""
+
+from dataclasses import asdict, dataclass
+import math
+from typing import Any
+
+from gda_assets.domain.model import CheckResult, ModelFacts, NodeFacts, Verdict
+
+
+@dataclass(frozen=True)
+class Expectation:
+    id: str
+    kind: str
+    node: str | None = None
+    options: dict[str, Any] | None = None
+
+
+def _in_range(value, options) -> bool:
+    return ("min" not in options or value >= options["min"]) and (
+        "max" not in options or value <= options["max"]
+    )
+
+
+def evaluate(
+    expectations: tuple[Expectation, ...], facts: ModelFacts
+) -> list[CheckResult]:
+    nodes = {node.path: node for node in facts.nodes}
+    results = []
+    for condition in expectations:
+        node = nodes.get(condition.node or "")
+        expected = condition.options or {}
+        location: dict[str, Any] = {"resource": facts.resource}
+        verdict: Verdict = "fail"
+        actual: Any = None
+        reason = "Required node and type"
+        if condition.kind in {"count", "dimensions"}:
+            location["subtree"] = facts.subtree
+            if condition.kind == "count":
+                actual = facts.counts[expected["metric"]]
+                passes = _in_range(actual, expected)
+                reason = "Count over the inspected subtree"
+            else:
+                actual = facts.bounds["size"] if facts.bounds else None
+                passes = actual is not None and all(
+                    _in_range(
+                        actual[i], {key: values[i] for key, values in expected.items()}
+                    )
+                    for i in range(3)
+                )
+                reason = (
+                    "Resource-space static mesh bounds; no pose or collision inference"
+                )
+            verdict = (
+                "insufficient"
+                if facts.incomplete("nodes")
+                else "pass"
+                if passes
+                else "fail"
+            )
+            if facts.incomplete("nodes"):
+                reason = "Node limit omitted part of the subtree; aggregate facts are partial"
+        else:
+            location["node"] = condition.node
+            if node is None:
+                if facts.incomplete("nodes") or not facts.includes(
+                    condition.node or "."
+                ):
+                    verdict = "insufficient"
+                    reason = "Required node is outside observed coverage"
+            elif condition.kind == "node":
+                actual = {"type": node.type}
+                verdict = "pass" if not expected or actual == expected else "fail"
+            else:
+                verdict, actual, reason = _check_detail(
+                    condition.kind, expected, node, facts
+                )
+            for key in ("surface", "bind", "animation", "track"):
+                if key in expected:
+                    location[key] = expected[key]
+        results.append(
+            CheckResult(condition.id, verdict, location, expected, actual, reason)
+        )
+    return results
+
+
+def validate_node_path(path: str) -> None:
+    if path != "." and (
+        not path
+        or any(part in {"", ".", ".."} for part in path.split("/"))
+        or ":" in path
+        or "\\" in path
+    ):
+        raise ValueError("node must be an exact resource-relative path, or .")
+
+
+def validate_conditions(conditions: tuple[Expectation, ...]) -> None:
+    for condition in conditions:
+        if condition.node is not None:
+            validate_node_path(condition.node)
+        options = condition.options or {}
+        for key in ("skeleton", "target"):
+            if key in options:
+                validate_node_path(options[key])
+        if condition.kind in {"count", "dimensions"}:
+            if "min" not in options and "max" not in options:
+                raise ValueError("range checks require min or max")
+            lower, upper = options.get("min"), options.get("max")
+            values = [v for v in (lower, upper) if v is not None]
+            if condition.kind == "dimensions":
+                values = [number for vector in values for number in vector]
+            if any(not math.isfinite(v) or v < 0 for v in values):
+                raise ValueError("range bounds must be finite and nonnegative")
+            if lower is not None and upper is not None:
+                if condition.kind == "dimensions":
+                    ordered = all(low <= high for low, high in zip(lower, upper))
+                else:
+                    ordered = lower <= upper
+                if not ordered:
+                    raise ValueError("min must not exceed max")
+
+
+def _missing(facts: ModelFacts, node: str, section: str, detail: str):
+    return (
+        "insufficient" if facts.incomplete(section, node) else "fail",
+        None,
+        f"Required {detail} was not observed"
+        + (
+            f"; {section} records were omitted"
+            if facts.incomplete(section, node)
+            else ""
+        ),
+    )
+
+
+def _check_detail(
+    kind: str, expected: dict[str, Any], node: NodeFacts, facts: ModelFacts
+) -> tuple[Verdict, Any, str]:
+    if kind == "material":
+        surface = next(
+            (s for s in node.surfaces if s.index == expected["surface"]), None
+        )
+        if surface is None:
+            return _missing(facts, node.path, "surfaces", "surface")
+        material = surface.material
+        if material is None:
+            return "fail", None, "Surface has no effective material"
+        actual = {"name": material.name, "path": material.path, "type": material.type}
+        if "name" in expected and expected["name"] != material.name:
+            return "fail", actual, "Material name differs"
+        if "path" in expected:
+            if material.path is None:
+                return "insufficient", actual, "Material resource path is unavailable"
+            if expected["path"] != material.path:
+                return "fail", actual, "Material path differs"
+        return (
+            "pass",
+            actual,
+            "Required effective material occupies the selected surface",
+        )
+    if kind == "bone":
+        bone = next((b for b in node.bones if b.name == expected["name"]), None)
+        if bone is None:
+            return _missing(facts, node.path, "bones", "bone")
+        return (
+            "pass",
+            {"index": bone.index, "name": bone.name},
+            "Required skeleton bone exists",
+        )
+    if kind == "skin_bind":
+        if node.skin_unavailable:
+            return "insufficient", None, node.skin_unavailable
+        if not node.skin_present:
+            return "fail", None, "Mesh has no explicit skin"
+        bind = next((b for b in node.binds if b.index == expected["bind"]), None)
+        if bind is None:
+            return _missing(facts, node.path, "skin_binds", "skin bind")
+        actual = {
+            "skeleton": node.skeleton,
+            "bone_index": bind.bone_index,
+            "reason": bind.reason,
+        }
+        if bind.reason or node.skeleton != expected["skeleton"]:
+            return (
+                "fail",
+                actual,
+                "Skin bind is unresolved or targets a different skeleton",
+            )
+        skeleton = next((n for n in facts.nodes if n.path == node.skeleton), None)
+        bone = (
+            next((b for b in skeleton.bones if b.index == bind.bone_index), None)
+            if skeleton
+            else None
+        )
+        if bone is None:
+            return (
+                "insufficient",
+                actual,
+                "Resolved bone name is outside observed skeleton detail",
+            )
+        actual["bone"] = bone.name
+        return (
+            ("pass" if bone.name == expected["bone"] else "fail"),
+            actual,
+            "Explicit skin bind target; no pose sampling",
+        )
+    animation = next(
+        (a for a in node.animations if a.name == expected["animation"]), None
+    )
+    if animation is None:
+        return _missing(facts, node.path, "animations", "animation")
+    track = next((t for t in animation.tracks if t.index == expected["track"]), None)
+    if track is None:
+        return _missing(facts, node.path, "animation_tracks", "animation track")
+    actual = asdict(track)
+    if track.status == "unavailable":
+        return "insufficient", actual, track.reason or "Track resolution unavailable"
+    matches = (
+        track.status == "resolved"
+        and track.target == expected["target"]
+        and ("bone" not in expected or track.bone == expected["bone"])
+    )
+    return (
+        ("pass" if matches else "fail"),
+        actual,
+        "Static animation target binding; successful playback is not established",
+    )

--- a/libs/gda-assets/src/gda_assets/domain/model.py
+++ b/libs/gda-assets/src/gda_assets/domain/model.py
@@ -1,0 +1,125 @@
+"""Project-facing model facts, independent of the engine's report representation."""
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from gda_assets.domain.artifacts import PipelineFailure
+
+Verdict = Literal["pass", "fail", "insufficient"]
+
+
+@dataclass(frozen=True)
+class MaterialFacts:
+    type: str
+    name: str
+    path: str | None
+    source: str
+    textures: tuple[tuple[str, str, str | None], ...] = ()
+    textures_available: bool = True
+
+
+@dataclass(frozen=True)
+class SurfaceFacts:
+    index: int
+    geometry: dict[str, Any]
+    material: MaterialFacts | None = None
+
+
+@dataclass(frozen=True)
+class BoneFacts:
+    index: int
+    name: str
+    parent: int
+    rest: tuple[float, ...]
+
+
+@dataclass(frozen=True)
+class BindFacts:
+    index: int
+    bone_index: int | None
+    reason: str | None
+
+
+@dataclass(frozen=True)
+class TrackFacts:
+    index: int
+    type: str
+    path: str
+    enabled: bool
+    target: str | None
+    bone: str | None
+    status: str
+    scope: str | None
+    reason: str | None
+
+
+@dataclass(frozen=True)
+class AnimationFacts:
+    name: str
+    length: float
+    loop_mode: int
+    track_count: int
+    tracks: tuple[TrackFacts, ...] = ()
+
+
+@dataclass(frozen=True)
+class NodeFacts:
+    path: str
+    type: str
+    transform: tuple[float, ...] | None = None
+    surface_count: int | None = None
+    surfaces: tuple[SurfaceFacts, ...] = ()
+    bone_count: int | None = None
+    bones: tuple[BoneFacts, ...] = ()
+    skin_present: bool = False
+    skin_unavailable: str | None = None
+    skeleton: str | None = None
+    bind_count: int | None = None
+    binds: tuple[BindFacts, ...] = ()
+    animation_count: int | None = None
+    animations: tuple[AnimationFacts, ...] = ()
+
+
+@dataclass(frozen=True)
+class ModelFacts:
+    resource: str
+    subtree: str
+    engine: tuple[int, int]
+    measurement: tuple[str, str]
+    nodes: tuple[NodeFacts, ...]
+    counts: dict[str, int]
+    bounds: dict[str, Any] | None
+    omissions: tuple[tuple[str, str], ...] = ()
+
+    def incomplete(self, section: str, node: str | None = None) -> bool:
+        return any(
+            s == section and (node is None or p == node) for p, s in self.omissions
+        )
+
+    def includes(self, node: str) -> bool:
+        return (
+            self.subtree == "."
+            or node == self.subtree
+            or node.startswith(self.subtree + "/")
+        )
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    id: str
+    verdict: Verdict
+    location: dict[str, Any]
+    expected: Any
+    actual: Any
+    reason: str
+
+
+@dataclass
+class ModelCheckResult:
+    completed: list[str] = field(default_factory=list)
+    resource: str | None = None
+    observation_source: str | None = None
+    verdict: Verdict | None = None
+    checks: list[CheckResult] = field(default_factory=list)
+    comparison: dict[str, Any] | None = None
+    failure: PipelineFailure | None = None

--- a/libs/gda-assets/src/gda_assets/domain/model.py
+++ b/libs/gda-assets/src/gda_assets/domain/model.py
@@ -114,6 +114,37 @@ class CheckResult:
     reason: str
 
 
+@dataclass(frozen=True)
+class ModelChange:
+    section: str
+    location: dict[str, Any]
+    kind: Literal["added", "removed", "changed"]
+    before: Any
+    after: Any
+
+
+@dataclass(frozen=True)
+class IncompleteSection:
+    section: str
+    reason: str
+    node: str
+
+
+@dataclass(frozen=True)
+class ComparedResources:
+    before: str
+    after: str
+
+
+@dataclass(frozen=True)
+class ModelComparison:
+    status: Literal["comparable", "partial", "non_comparable"]
+    reasons: list[str]
+    resources: ComparedResources
+    changes: list[ModelChange]
+    incomplete_sections: list[IncompleteSection]
+
+
 @dataclass
 class ModelCheckResult:
     completed: list[str] = field(default_factory=list)
@@ -121,5 +152,5 @@ class ModelCheckResult:
     observation_source: str | None = None
     verdict: Verdict | None = None
     checks: list[CheckResult] = field(default_factory=list)
-    comparison: dict[str, Any] | None = None
+    comparison: ModelComparison | None = None
     failure: PipelineFailure | None = None

--- a/libs/gda-assets/src/gda_assets/domain/model_diff.py
+++ b/libs/gda-assets/src/gda_assets/domain/model_diff.py
@@ -3,7 +3,16 @@
 from dataclasses import asdict
 from typing import Any, Iterable
 
-from gda_assets.domain.model import MaterialFacts, ModelFacts, NodeFacts, TrackFacts
+from gda_assets.domain.model import (
+    MaterialFacts,
+    ModelFacts,
+    NodeFacts,
+    TrackFacts,
+    ModelComparison,
+    ModelChange,
+    IncompleteSection,
+    ComparedResources,
+)
 
 
 def _change(
@@ -26,15 +35,11 @@ def _change(
 
 
 def _omissions(*facts: ModelFacts) -> list[dict[str, Any]]:
-    entries = {
-        (section, None if node == "." else node)
-        for fact in facts
-        for node, section in fact.omissions
-    }
+    entries = {(section, node) for fact in facts for node, section in fact.omissions}
     return [
         {
             "section": section,
-            **({"node": node} if node is not None else {}),
+            "node": node,
             "reason": "observation omitted",
         }
         for section, node in sorted(entries, key=lambda item: (item[0], item[1] or ""))
@@ -307,7 +312,7 @@ def _compare_animations(
             )
 
 
-def compare_models(before: ModelFacts, after: ModelFacts) -> dict[str, Any]:
+def compare_models(before: ModelFacts, after: ModelFacts) -> ModelComparison:
     """Compare like-for-like observations without treating omitted data as absence."""
     reasons = []
     if before.subtree != after.subtree:
@@ -330,7 +335,7 @@ def compare_models(before: ModelFacts, after: ModelFacts) -> dict[str, Any]:
         "incomplete_sections": incomplete,
     }
     if reasons:
-        return result
+        return _comparison_result(result)
 
     changes: list[dict[str, Any]] = result["changes"]
     old_nodes = {node.path: node for node in before.nodes}
@@ -442,7 +447,7 @@ def compare_models(before: ModelFacts, after: ModelFacts) -> dict[str, Any]:
         _compare_value(changes, "bounds", {}, before.bounds, after.bounds)
     if result["incomplete_sections"]:
         result["status"] = "partial"
-    return result
+    return _comparison_result(result)
 
 
 def _add_incomplete(
@@ -452,3 +457,15 @@ def _add_incomplete(
     if item not in incomplete:
         incomplete.append(item)
         incomplete.sort(key=lambda entry: (entry["section"], entry.get("node", "")))
+
+
+def _comparison_result(result: dict[str, Any]) -> ModelComparison:
+    return ModelComparison(
+        status=result["status"],
+        reasons=result["reasons"],
+        resources=ComparedResources(**result["resources"]),
+        changes=[ModelChange(**change) for change in result["changes"]],
+        incomplete_sections=[
+            IncompleteSection(**section) for section in result["incomplete_sections"]
+        ],
+    )

--- a/libs/gda-assets/src/gda_assets/domain/model_diff.py
+++ b/libs/gda-assets/src/gda_assets/domain/model_diff.py
@@ -1,0 +1,454 @@
+"""Compare bounded Godot observations, not artistic identity or equivalence."""
+
+from dataclasses import asdict
+from typing import Any, Iterable
+
+from gda_assets.domain.model import MaterialFacts, ModelFacts, NodeFacts, TrackFacts
+
+
+def _change(
+    changes: list[dict[str, Any]],
+    section: str,
+    location: dict[str, Any],
+    kind: str,
+    before: Any,
+    after: Any,
+) -> None:
+    changes.append(
+        {
+            "section": section,
+            "location": location,
+            "kind": kind,
+            "before": before,
+            "after": after,
+        }
+    )
+
+
+def _omissions(*facts: ModelFacts) -> list[dict[str, Any]]:
+    entries = {
+        (section, None if node == "." else node)
+        for fact in facts
+        for node, section in fact.omissions
+    }
+    return [
+        {
+            "section": section,
+            **({"node": node} if node is not None else {}),
+            "reason": "observation omitted",
+        }
+        for section, node in sorted(entries, key=lambda item: (item[0], item[1] or ""))
+    ]
+
+
+def _incomplete(facts: ModelFacts, section: str, node: str | None = None) -> bool:
+    return facts.incomplete(section, node)
+
+
+def _compare_value(
+    changes: list[dict[str, Any]],
+    section: str,
+    location: dict[str, Any],
+    before: Any,
+    after: Any,
+) -> None:
+    if before != after:
+        _change(changes, section, location, "changed", before, after)
+
+
+def _compare_material(
+    changes: list[dict[str, Any]],
+    incomplete: list[dict[str, Any]],
+    before_facts: ModelFacts,
+    after_facts: ModelFacts,
+    node: str,
+    surface: int,
+    before: MaterialFacts | None,
+    after: MaterialFacts | None,
+) -> None:
+    location = {"node": node, "surface": surface}
+    if before is None or after is None:
+        if before != after:
+            _change(
+                changes,
+                "materials",
+                location,
+                "added" if before is None else "removed",
+                asdict(before) if before else None,
+                asdict(after) if after else None,
+            )
+        return
+    before_material = (before.type, before.name, before.source)
+    after_material = (after.type, after.name, after.source)
+    _compare_value(changes, "materials", location, before_material, after_material)
+    if before.path is None or after.path is None:
+        _add_incomplete(incomplete, "materials", node, "material path unavailable")
+    elif before.path != after.path:
+        _change(changes, "materials", location, "changed", before.path, after.path)
+    if _incomplete(before_facts, "textures", node) or _incomplete(
+        after_facts, "textures", node
+    ):
+        return
+    if not before.textures_available or not after.textures_available:
+        _add_incomplete(incomplete, "textures", node, "texture details unavailable")
+        return
+    before_textures = {item[0]: item[1:] for item in before.textures}
+    after_textures = {item[0]: item[1:] for item in after.textures}
+    for role in sorted(before_textures.keys() | after_textures.keys()):
+        old = before_textures.get(role)
+        new = after_textures.get(role)
+        if old is not None and new is not None:
+            _compare_value(
+                changes,
+                "textures",
+                {**location, "texture": role},
+                old[0],
+                new[0],
+            )
+            if old[1] is None or new[1] is None:
+                _add_incomplete(
+                    incomplete, "textures", node, "texture path unavailable"
+                )
+            elif old[1] != new[1]:
+                _change(
+                    changes,
+                    "textures",
+                    {**location, "texture": role},
+                    "changed",
+                    old[1],
+                    new[1],
+                )
+        elif old != new:
+            _change(
+                changes,
+                "textures",
+                {**location, "texture": role},
+                "added" if old is None else "removed",
+                old,
+                new,
+            )
+
+
+def _compare_surfaces(
+    changes: list[dict[str, Any]],
+    incomplete: list[dict[str, Any]],
+    before: ModelFacts,
+    after: ModelFacts,
+    old: NodeFacts,
+    new: NodeFacts,
+) -> None:
+    if _incomplete(before, "surfaces", old.path) or _incomplete(
+        after, "surfaces", new.path
+    ):
+        return
+    _compare_value(
+        changes,
+        "surfaces",
+        {"node": old.path, "field": "count"},
+        old.surface_count,
+        new.surface_count,
+    )
+    old_items = {item.index: item for item in old.surfaces}
+    new_items = {item.index: item for item in new.surfaces}
+    for index in sorted(old_items.keys() | new_items.keys()):
+        left = old_items.get(index)
+        right = new_items.get(index)
+        location = {"node": old.path, "surface": index}
+        if left is None or right is None:
+            _change(
+                changes,
+                "surfaces",
+                location,
+                "added" if left is None else "removed",
+                asdict(left) if left else None,
+                asdict(right) if right else None,
+            )
+            continue
+        old_reason = left.geometry.get("counts_unavailable_reason")
+        new_reason = right.geometry.get("counts_unavailable_reason")
+        if old_reason or new_reason:
+            _add_incomplete(
+                incomplete,
+                "geometry",
+                old.path,
+                str(old_reason or new_reason),
+            )
+        old_geometry = {
+            key: value
+            for key, value in left.geometry.items()
+            if key != "counts_unavailable_reason"
+            and value is not None
+            and right.geometry.get(key) is not None
+        }
+        new_geometry = {key: right.geometry[key] for key in old_geometry}
+        _compare_value(changes, "surfaces", location, old_geometry, new_geometry)
+        _compare_material(
+            changes,
+            incomplete,
+            before,
+            after,
+            old.path,
+            index,
+            left.material,
+            right.material,
+        )
+
+
+def _compare_indexed(
+    changes: list[dict[str, Any]],
+    section: str,
+    node: str,
+    before: Iterable[Any],
+    after: Iterable[Any],
+    location_key: str,
+) -> None:
+    old_items = {item.index: item for item in before}
+    new_items = {item.index: item for item in after}
+    for index in sorted(old_items.keys() | new_items.keys()):
+        left = old_items.get(index)
+        right = new_items.get(index)
+        location = {"node": node, location_key: index}
+        if left != right:
+            _change(
+                changes,
+                section,
+                location,
+                "added" if left is None else "removed" if right is None else "changed",
+                asdict(left) if left else None,
+                asdict(right) if right else None,
+            )
+
+
+def _compare_tracks(
+    changes: list[dict[str, Any]],
+    incomplete: list[dict[str, Any]],
+    node: str,
+    name: str,
+    before: tuple[TrackFacts, ...],
+    after: tuple[TrackFacts, ...],
+) -> None:
+    old_items = {item.index: item for item in before}
+    new_items = {item.index: item for item in after}
+    for index in sorted(old_items.keys() | new_items.keys()):
+        left = old_items.get(index)
+        right = new_items.get(index)
+        if (
+            left is not None
+            and right is not None
+            and (left.status == "unavailable" or right.status == "unavailable")
+        ):
+            _add_incomplete(
+                incomplete,
+                "animation_tracks",
+                node,
+                left.reason or right.reason or "track details unavailable",
+            )
+            before_known = (left.type, left.path, left.enabled)
+            after_known = (right.type, right.path, right.enabled)
+            _compare_value(
+                changes,
+                "tracks",
+                {"node": node, "animation": name, "track": index},
+                before_known,
+                after_known,
+            )
+        elif left != right:
+            _change(
+                changes,
+                "tracks",
+                {"node": node, "animation": name, "track": index},
+                "added" if left is None else "removed" if right is None else "changed",
+                asdict(left) if left else None,
+                asdict(right) if right else None,
+            )
+
+
+def _compare_animations(
+    changes: list[dict[str, Any]],
+    incomplete: list[dict[str, Any]],
+    before: ModelFacts,
+    after: ModelFacts,
+    old: NodeFacts,
+    new: NodeFacts,
+) -> None:
+    if _incomplete(before, "animations", old.path) or _incomplete(
+        after, "animations", new.path
+    ):
+        return
+    old_items = {item.name: item for item in old.animations}
+    new_items = {item.name: item for item in new.animations}
+    for name in sorted(old_items.keys() | new_items.keys()):
+        left = old_items.get(name)
+        right = new_items.get(name)
+        location = {"node": old.path, "animation": name}
+        if left is None or right is None:
+            _change(
+                changes,
+                "animations",
+                location,
+                "added" if left is None else "removed",
+                asdict(left) if left else None,
+                asdict(right) if right else None,
+            )
+            continue
+        _compare_value(
+            changes,
+            "animations",
+            location,
+            (left.length, left.loop_mode, left.track_count),
+            (right.length, right.loop_mode, right.track_count),
+        )
+        if not (
+            _incomplete(before, "animation_tracks", old.path)
+            or _incomplete(after, "animation_tracks", new.path)
+        ):
+            _compare_tracks(
+                changes, incomplete, old.path, name, left.tracks, right.tracks
+            )
+
+
+def compare_models(before: ModelFacts, after: ModelFacts) -> dict[str, Any]:
+    """Compare like-for-like observations without treating omitted data as absence."""
+    reasons = []
+    if before.subtree != after.subtree:
+        reasons.append(f"subtree differs: {before.subtree} != {after.subtree}")
+    if before.measurement != after.measurement:
+        reasons.append(
+            f"measurement differs: {before.measurement} != {after.measurement}"
+        )
+    if before.engine[:2] != after.engine[:2]:
+        reasons.append(
+            f"engine major/minor differs: {'.'.join(map(str, before.engine[:2]))} != "
+            f"{'.'.join(map(str, after.engine[:2]))}"
+        )
+    incomplete = _omissions(before, after)
+    result: dict[str, Any] = {
+        "status": "non_comparable" if reasons else "comparable",
+        "reasons": reasons,
+        "resources": {"before": before.resource, "after": after.resource},
+        "changes": [],
+        "incomplete_sections": incomplete,
+    }
+    if reasons:
+        return result
+
+    changes: list[dict[str, Any]] = result["changes"]
+    old_nodes = {node.path: node for node in before.nodes}
+    new_nodes = {node.path: node for node in after.nodes}
+    common = sorted(old_nodes.keys() & new_nodes.keys())
+    for path in common:
+        old = old_nodes[path]
+        new = new_nodes[path]
+        _compare_value(
+            changes,
+            "nodes",
+            {"node": path},
+            {"type": old.type, "transform": old.transform},
+            {"type": new.type, "transform": new.transform},
+        )
+        _compare_surfaces(changes, incomplete, before, after, old, new)
+        if not (
+            _incomplete(before, "bones", path) or _incomplete(after, "bones", path)
+        ):
+            _compare_value(
+                changes,
+                "bones",
+                {"node": path, "field": "count"},
+                old.bone_count,
+                new.bone_count,
+            )
+            _compare_indexed(changes, "bones", path, old.bones, new.bones, "bone")
+        if old.skin_unavailable or new.skin_unavailable:
+            _add_incomplete(
+                incomplete,
+                "skin",
+                path,
+                old.skin_unavailable or new.skin_unavailable or "skin unavailable",
+            )
+        else:
+            _compare_value(
+                changes,
+                "skin",
+                {"node": path},
+                (old.skin_present, old.skin_unavailable, old.skeleton),
+                (new.skin_present, new.skin_unavailable, new.skeleton),
+            )
+        if not (
+            _incomplete(before, "skin_binds", path)
+            or _incomplete(after, "skin_binds", path)
+        ):
+            _compare_value(
+                changes,
+                "binds",
+                {"node": path, "field": "count"},
+                old.bind_count,
+                new.bind_count,
+            )
+            old_binds = {item.index: item for item in old.binds}
+            new_binds = {item.index: item for item in new.binds}
+            for index in sorted(old_binds.keys() | new_binds.keys()):
+                left = old_binds.get(index)
+                right = new_binds.get(index)
+                if (
+                    left is not None
+                    and right is not None
+                    and (left.bone_index is None or right.bone_index is None)
+                ):
+                    _add_incomplete(
+                        incomplete,
+                        "skin_binds",
+                        path,
+                        left.reason or right.reason or "bind target unavailable",
+                    )
+                elif left != right:
+                    _change(
+                        changes,
+                        "binds",
+                        {"node": path, "bind": index},
+                        "added"
+                        if left is None
+                        else "removed"
+                        if right is None
+                        else "changed",
+                        asdict(left) if left else None,
+                        asdict(right) if right else None,
+                    )
+        _compare_animations(changes, incomplete, before, after, old, new)
+
+    nodes_complete = not (_incomplete(before, "nodes") or _incomplete(after, "nodes"))
+    if nodes_complete:
+        for path in sorted(old_nodes.keys() - new_nodes.keys()):
+            _change(
+                changes,
+                "nodes",
+                {"node": path},
+                "removed",
+                asdict(old_nodes[path]),
+                None,
+            )
+        for path in sorted(new_nodes.keys() - old_nodes.keys()):
+            _change(
+                changes, "nodes", {"node": path}, "added", None, asdict(new_nodes[path])
+            )
+    if nodes_complete:
+        for name in sorted(before.counts.keys() | after.counts.keys()):
+            _compare_value(
+                changes,
+                "counts",
+                {"count": name},
+                before.counts.get(name),
+                after.counts.get(name),
+            )
+        _compare_value(changes, "bounds", {}, before.bounds, after.bounds)
+    if result["incomplete_sections"]:
+        result["status"] = "partial"
+    return result
+
+
+def _add_incomplete(
+    incomplete: list[dict[str, Any]], section: str, node: str, reason: str
+) -> None:
+    item = {"section": section, "node": node, "reason": reason}
+    if item not in incomplete:
+        incomplete.append(item)
+        incomplete.sort(key=lambda entry: (entry["section"], entry.get("node", "")))

--- a/libs/gda-assets/tests/test_model_diff.py
+++ b/libs/gda-assets/tests/test_model_diff.py
@@ -1,0 +1,353 @@
+from dataclasses import replace
+
+from gda_assets.domain.model import (
+    AnimationFacts,
+    BindFacts,
+    MaterialFacts,
+    ModelFacts,
+    NodeFacts,
+    SurfaceFacts,
+    TrackFacts,
+)
+from gda_assets.domain.model_diff import compare_models
+
+
+def _facts(*nodes: NodeFacts, omissions=(), resource="res://before.glb") -> ModelFacts:
+    mesh_count = sum(node.type == "MeshInstance3D" for node in nodes)
+    return ModelFacts(
+        resource=resource,
+        subtree=".",
+        engine=(4, 6),
+        measurement=("resource", "static_mesh_aabb"),
+        nodes=nodes,
+        counts={
+            "node_count": len(nodes),
+            "mesh_instance_count": mesh_count,
+            "unique_mesh_count": mesh_count,
+        },
+        bounds={"position": [0, 0, 0], "size": [2, 2, 2]},
+        omissions=omissions,
+    )
+
+
+def test_compare_models_reports_stable_relevant_changes() -> None:
+    material = MaterialFacts(
+        "StandardMaterial3D",
+        "Fur",
+        "res://fur.tres",
+        "mesh_surface",
+        (("albedo", "Texture2D", "res://old.png"),),
+    )
+    before = _facts(
+        NodeFacts(
+            "Body",
+            "MeshInstance3D",
+            transform=(1.0,) * 12,
+            surface_count=1,
+            surfaces=(SurfaceFacts(0, {"vertices": 8}, material),),
+            animation_count=1,
+            animations=(
+                AnimationFacts(
+                    "walk",
+                    1.0,
+                    0,
+                    1,
+                    (
+                        TrackFacts(
+                            0,
+                            "position_3d",
+                            "Arm:position",
+                            True,
+                            "Arm",
+                            None,
+                            "resolved",
+                            "node",
+                            None,
+                        ),
+                    ),
+                ),
+            ),
+        )
+    )
+    changed_material = replace(
+        material, textures=(("albedo", "Texture2D", "res://new.png"),)
+    )
+    after = _facts(
+        replace(
+            before.nodes[0],
+            transform=(2.0,) * 12,
+            surfaces=(SurfaceFacts(0, {"vertices": 12}, changed_material),),
+            animations=(
+                replace(
+                    before.nodes[0].animations[0],
+                    tracks=(
+                        replace(before.nodes[0].animations[0].tracks[0], target="Hand"),
+                    ),
+                ),
+            ),
+        ),
+        NodeFacts("Tail", "Node3D"),
+        resource="res://after.glb",
+    )
+
+    result = compare_models(before, after)
+
+    assert result["status"] == "comparable"
+    assert result["reasons"] == []
+    assert result["resources"] == {
+        "before": "res://before.glb",
+        "after": "res://after.glb",
+    }
+    assert [(c["section"], c["location"], c["kind"]) for c in result["changes"]] == [
+        ("nodes", {"node": "Body"}, "changed"),
+        ("surfaces", {"node": "Body", "surface": 0}, "changed"),
+        ("textures", {"node": "Body", "surface": 0, "texture": "albedo"}, "changed"),
+        ("tracks", {"node": "Body", "animation": "walk", "track": 0}, "changed"),
+        ("nodes", {"node": "Tail"}, "added"),
+        ("counts", {"count": "node_count"}, "changed"),
+    ]
+    assert result["incomplete_sections"] == []
+
+
+def test_compare_models_does_not_infer_removals_from_omitted_collections() -> None:
+    surface = SurfaceFacts(0, {"vertices": 8})
+    track = TrackFacts(
+        0, "position_3d", "Arm:position", True, "Arm", None, "resolved", "node", None
+    )
+    complete = _facts(
+        NodeFacts(
+            "Body",
+            "MeshInstance3D",
+            surface_count=1,
+            surfaces=(surface,),
+            bind_count=1,
+            binds=(BindFacts(0, 2, None),),
+        ),
+        NodeFacts(
+            "Anim",
+            "AnimationPlayer",
+            animation_count=1,
+            animations=(AnimationFacts("walk", 1, 0, 1, (track,)),),
+        ),
+        NodeFacts("Tail", "Node3D"),
+    )
+    partial = _facts(
+        NodeFacts("Body", "MeshInstance3D", surface_count=1, bind_count=1),
+        NodeFacts(
+            "Anim",
+            "AnimationPlayer",
+            animation_count=1,
+            animations=(AnimationFacts("walk", 1, 0, 1),),
+        ),
+        omissions=(
+            (".", "nodes"),
+            ("Body", "surfaces"),
+            ("Body", "skin_binds"),
+            ("Anim", "animation_tracks"),
+        ),
+        resource="res://partial.glb",
+    )
+
+    result = compare_models(complete, partial)
+
+    assert result["status"] == "partial"
+    assert not any(change["kind"] == "removed" for change in result["changes"])
+    assert result["incomplete_sections"] == [
+        {
+            "section": "animation_tracks",
+            "node": "Anim",
+            "reason": "observation omitted",
+        },
+        {"section": "nodes", "reason": "observation omitted"},
+        {"section": "skin_binds", "node": "Body", "reason": "observation omitted"},
+        {"section": "surfaces", "node": "Body", "reason": "observation omitted"},
+    ]
+
+
+def test_texture_omission_is_partial_without_false_removal_and_keeps_aggregates() -> (
+    None
+):
+    material = MaterialFacts(
+        "StandardMaterial3D",
+        "Fur",
+        "res://fur.tres",
+        "mesh_surface",
+        (("albedo", "Texture2D", "res://fur.png"),),
+    )
+    before = _facts(
+        NodeFacts(
+            "Body",
+            "MeshInstance3D",
+            surface_count=1,
+            surfaces=(SurfaceFacts(0, {"vertices": 8}, material),),
+        )
+    )
+    after = replace(
+        before,
+        resource="res://after.glb",
+        nodes=(
+            replace(
+                before.nodes[0],
+                surfaces=(
+                    SurfaceFacts(0, {"vertices": 8}, replace(material, textures=())),
+                ),
+            ),
+        ),
+        counts={
+            "node_count": 2,
+            "mesh_instance_count": 1,
+            "unique_mesh_count": 1,
+        },
+        bounds={"position": [0, 0, 0], "size": [3, 2, 2]},
+        omissions=(("Body", "textures"),),
+    )
+
+    result = compare_models(before, after)
+
+    assert result["status"] == "partial"
+    assert not any(change["section"] == "textures" for change in result["changes"])
+    assert [
+        (change["section"], change["location"]) for change in result["changes"]
+    ] == [
+        ("counts", {"count": "node_count"}),
+        ("bounds", {}),
+    ]
+    assert result["incomplete_sections"] == [
+        {"section": "textures", "node": "Body", "reason": "observation omitted"}
+    ]
+
+
+def test_unknown_material_path_is_incomplete_not_a_proved_change() -> None:
+    before_material = MaterialFacts("StandardMaterial3D", "Fur", None, "mesh_surface")
+    after_material = replace(before_material, path="res://fur.tres")
+    before = _facts(
+        NodeFacts(
+            "Body",
+            "MeshInstance3D",
+            surface_count=1,
+            surfaces=(SurfaceFacts(0, {}, before_material),),
+        )
+    )
+    after = replace(
+        before,
+        resource="res://after.glb",
+        nodes=(
+            replace(before.nodes[0], surfaces=(SurfaceFacts(0, {}, after_material),)),
+        ),
+    )
+
+    result = compare_models(before, after)
+
+    assert result["status"] == "partial"
+    assert not any(change["section"] == "materials" for change in result["changes"])
+    assert result["incomplete_sections"] == [
+        {"section": "materials", "node": "Body", "reason": "material path unavailable"}
+    ]
+
+
+def test_unavailable_textures_are_partial_without_an_omission_record() -> None:
+    material = MaterialFacts(
+        "ShaderMaterial",
+        "Fur",
+        "res://fur.tres",
+        "mesh_surface",
+        textures_available=False,
+    )
+    before = _facts(
+        NodeFacts(
+            "Body",
+            "MeshInstance3D",
+            surface_count=1,
+            surfaces=(SurfaceFacts(0, {}, material),),
+        )
+    )
+
+    result = compare_models(before, replace(before, resource="res://after.glb"))
+
+    assert result["status"] == "partial"
+    assert result["changes"] == []
+    assert result["incomplete_sections"] == [
+        {"section": "textures", "node": "Body", "reason": "texture details unavailable"}
+    ]
+
+
+def test_unknown_geometry_and_skin_are_explicitly_partial() -> None:
+    before = _facts(
+        NodeFacts(
+            "Body",
+            "MeshInstance3D",
+            surface_count=1,
+            surfaces=(
+                SurfaceFacts(
+                    0,
+                    {
+                        "primitive": None,
+                        "vertices": None,
+                        "counts_unavailable_reason": "non-ArrayMesh geometry",
+                    },
+                ),
+            ),
+            skin_present=False,
+            skin_unavailable="no explicit Skin resource",
+        )
+    )
+    after = replace(
+        before,
+        resource="res://after.glb",
+        nodes=(
+            replace(
+                before.nodes[0],
+                surfaces=(
+                    SurfaceFacts(
+                        0,
+                        {
+                            "primitive": "triangles",
+                            "vertices": 8,
+                            "counts_unavailable_reason": None,
+                        },
+                    ),
+                ),
+                skin_present=True,
+                skin_unavailable=None,
+                skeleton="Rig",
+            ),
+        ),
+    )
+
+    result = compare_models(before, after)
+
+    assert result["status"] == "partial"
+    assert not any(
+        change["section"] in {"surfaces", "skin"} for change in result["changes"]
+    )
+    assert result["incomplete_sections"] == [
+        {"section": "geometry", "node": "Body", "reason": "non-ArrayMesh geometry"},
+        {"section": "skin", "node": "Body", "reason": "no explicit Skin resource"},
+    ]
+
+
+def test_compare_models_refuses_incompatible_scope_measurement_or_engine() -> None:
+    before = _facts(NodeFacts("Body", "Node3D"))
+    after = replace(
+        before,
+        subtree="Body",
+        engine=(4, 7),
+        measurement=("world", "static_mesh_aabb"),
+    )
+
+    result = compare_models(before, after)
+
+    assert result["status"] == "non_comparable"
+    assert result["reasons"] == [
+        "subtree differs: . != Body",
+        "measurement differs: ('resource', 'static_mesh_aabb') != ('world', 'static_mesh_aabb')",
+        "engine major/minor differs: 4.6 != 4.7",
+    ]
+    assert result["changes"] == []
+
+
+def test_compare_models_treats_patch_build_difference_as_compatible() -> None:
+    before = replace(_facts(NodeFacts("Body", "Node3D")), engine=(4, 6, 2))  # type: ignore[arg-type]
+    after = replace(before, engine=(4, 6, 5), resource="res://after.glb")  # type: ignore[arg-type]
+
+    assert compare_models(before, after)["status"] == "comparable"

--- a/libs/gda-assets/tests/test_model_diff.py
+++ b/libs/gda-assets/tests/test_model_diff.py
@@ -1,4 +1,4 @@
-from dataclasses import replace
+from dataclasses import asdict, replace
 
 from gda_assets.domain.model import (
     AnimationFacts,
@@ -9,7 +9,11 @@ from gda_assets.domain.model import (
     SurfaceFacts,
     TrackFacts,
 )
-from gda_assets.domain.model_diff import compare_models
+from gda_assets.domain.model_diff import compare_models as _compare_models
+
+
+def compare_models(before: ModelFacts, after: ModelFacts) -> dict:
+    return asdict(_compare_models(before, after))
 
 
 def _facts(*nodes: NodeFacts, omissions=(), resource="res://before.glb") -> ModelFacts:
@@ -158,7 +162,7 @@ def test_compare_models_does_not_infer_removals_from_omitted_collections() -> No
             "node": "Anim",
             "reason": "observation omitted",
         },
-        {"section": "nodes", "reason": "observation omitted"},
+        {"section": "nodes", "node": ".", "reason": "observation omitted"},
         {"section": "skin_binds", "node": "Body", "reason": "observation omitted"},
         {"section": "surfaces", "node": "Body", "reason": "observation omitted"},
     ]

--- a/scripts/smoke_asset_pipeline.py
+++ b/scripts/smoke_asset_pipeline.py
@@ -53,7 +53,7 @@ def glb(path: Path) -> None:
                     "count": 3,
                     "type": "VEC3",
                     "min": [0, 0, 0],
-                    "max": [1, 1, 0],
+                    "max": [1, 1, 0.0001],
                 },
                 {"bufferView": 1, "componentType": 5123, "count": 3, "type": "SCALAR"},
             ],
@@ -135,6 +135,58 @@ def smoke(gda: Path, godot: str | None) -> None:
             observation["engine"]["major"] >= 4 for observation in first["observations"]
         )
         assert (source / "icon.png").read_bytes() == original
+        expectations = root / "model.expectations.json"
+        expectations.write_text(
+            json.dumps(
+                {
+                    "checks": [
+                        {
+                            "id": "mesh",
+                            "kind": "count",
+                            "metric": "mesh_instance_count",
+                            "min": 1,
+                            "max": 1,
+                        },
+                        {
+                            "id": "size",
+                            "kind": "dimensions",
+                            "min": [1, 1, 0],
+                            "max": [1, 1, 0.0001],
+                        },
+                    ]
+                }
+            )
+        )
+        checked = call(
+            "asset-pipeline",
+            "check",
+            "--expectations",
+            str(expectations),
+            "--path",
+            "res://art/model.glb",
+            *common,
+        )
+        assert checked["verdict"] == "pass", checked
+        report = root / "inspection.json"
+        report.write_text(
+            json.dumps(
+                call("resource", "inspect-model", "res://art/model.glb", *common)
+            )
+        )
+        offline = call(
+            "asset-pipeline",
+            "check",
+            "--expectations",
+            str(expectations),
+            "--report",
+            str(report),
+            "--baseline",
+            str(report),
+            "--json",
+        )
+        assert offline["verdict"] == "pass", offline
+        assert offline["comparison"]["changes"] == []
+        assert offline["observation_source"] == "supplied_report"
         repeat = call(
             "asset-pipeline",
             "run",
@@ -177,7 +229,7 @@ def smoke(gda: Path, godot: str | None) -> None:
         assert not (project / "not-installed.png").exists()
         assert not (project / "missing.png").exists()
     print(
-        "Installed asset pipeline smoke passed: PNG resize, GLB load, repeat, declarations, refusal, cleanup."
+        "Installed asset pipeline smoke passed: PNG resize, GLB load, model expectations, saved comparison, repeat, declarations, refusal, cleanup."
     )
 
 

--- a/src/gda/commands/asset_pipeline.py
+++ b/src/gda/commands/asset_pipeline.py
@@ -439,3 +439,192 @@ def asset_pipeline_run(
 
 def register(root: typer.Typer) -> None:
     root.add_typer(_app, name="asset-pipeline")
+
+
+class AssetPipelineCheckParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    expectations: Path = Field(
+        description="Project-owned expectation JSON file; relative paths use the caller's working directory."
+    )
+    path: str | None = Field(
+        default=None,
+        min_length=1,
+        description="Model resource to inspect now; select exactly one of path or report.",
+    )
+    report: Path | None = Field(
+        default=None,
+        description="Saved resource inspect-model JSON; evaluated without an engine call.",
+    )
+    baseline: Path | None = Field(
+        default=None,
+        description="Optional saved inspection report to compare with current facts.",
+    )
+    subtree: str = Field(
+        default=".",
+        description="Resource-relative inspection subtree; saved reports carry their own scope.",
+    )
+    max_nodes: int = Field(
+        default=256, ge=1, le=4096, description="Live inspection node limit."
+    )
+    max_items: int = Field(
+        default=1024, ge=1, le=16384, description="Live inspection detail limit."
+    )
+
+    @model_validator(mode="after")
+    def _one_source(self) -> "AssetPipelineCheckParams":
+        if (self.path is not None) == (self.report is not None):
+            raise ValueError("Select exactly one of path or report")
+        if self.report is not None and (
+            self.subtree != "." or self.max_nodes != 256 or self.max_items != 1024
+        ):
+            raise ValueError(
+                "subtree and inspection limits apply only to live path inspection"
+            )
+        return self
+
+
+class AssetConditionResult(BaseModel):
+    id: str
+    verdict: Literal["pass", "fail", "insufficient"]
+    location: dict[str, Any]
+    expected: Any
+    actual: Any
+    reason: str
+
+
+class AssetPipelineCheckResult(BaseModel):
+    completed: list[str]
+    resource: str | None
+    observation_source: Literal["godot", "supplied_report"] | None
+    verdict: Literal["pass", "fail", "insufficient"] | None = Field(
+        description="Content verdict. Every completed evaluation exits 0; invalid input or workflow failure exits nonzero."
+    )
+    checks: list[AssetConditionResult]
+    comparison: dict[str, Any] | None
+    failure: PipelineFailureResult | None
+
+
+def run_asset_check(
+    params: AssetPipelineCheckParams, *, project: Path | None, godot: str | None
+) -> AssetPipelineCheckResult | Failure:
+    from gda_assets.api import (
+        check_model,
+        ModelCheckResult,
+        PipelineFailure,
+        PortFailure,
+    )
+    from gda.integrations.model_reports import read_model_report
+
+    port = GdaGodotAssetPort(project, godot) if project is not None else None
+    native_failure = None
+    try:
+        if params.path is not None and port is None:
+            native_failure = invalid_project_failure(
+                "asset-pipeline check --path requires a Godot project; pass --project"
+            )
+            raise PortFailure(native_failure.error.code, native_failure.error.message)
+        report = read_model_report(params.report) if params.report else None
+        baseline = read_model_report(params.baseline) if params.baseline else None
+        result = check_model(
+            params.expectations,
+            path=params.path,
+            godot=port,
+            report=report,
+            subtree=params.subtree,
+            max_nodes=params.max_nodes,
+            max_items=params.max_items,
+            baseline=baseline,
+        )
+    except PortFailure as exc:
+        result = ModelCheckResult(
+            failure=PipelineFailure("validate", exc.code, str(exc), exc.cause)
+        )
+    typed = AssetPipelineCheckResult.model_validate(asdict(result))
+    if result.failure is None:
+        return typed
+    failure = native_failure or (port.last_failure if port else None)
+    message = (
+        f"asset pipeline failed during {result.failure.stage}: {result.failure.message}"
+    )
+    if failure is None:
+        failure = make_failure(
+            "invalid_params"
+            if result.failure.code
+            in {"invalid_expectations", "invalid_report", "invalid_check"}
+            else "operation_failed",
+            message,
+            "",
+        )
+    failure.error = failure.error.model_copy(
+        update={"message": message, "partial_result": typed.model_dump(mode="json")}
+    )
+    return failure
+
+
+def render_asset_check(result: AssetPipelineCheckResult) -> str:
+    lines = [f"asset check: {result.verdict} ({result.resource})"]
+    lines.extend(
+        f"  {item.verdict:>12}  {item.id}: {item.reason}" for item in result.checks
+    )
+    if result.comparison:
+        lines.append(f"  comparison: {result.comparison['status']}")
+    return "\n".join(lines)
+
+
+ASSET_PIPELINE_CHECK_COMMAND = HeadlessCommand(
+    operation="asset-pipeline-check",
+    input_model=AssetPipelineCheckParams,
+    output_model=AssetPipelineCheckResult,
+    render=render_asset_check,
+    kind=ExecutionKind.COMPOSITE,
+    recipe=run_asset_check,
+)
+
+
+@_app.command(name="check", cls=ASSET_PIPELINE_CHECK_COMMAND.command_class())
+def asset_pipeline_check(
+    expectations: Path = typer.Option(
+        ..., "--expectations", help="Project-owned expectation JSON file."
+    ),
+    path: Optional[str] = typer.Option(
+        None, "--path", help="Model resource to inspect through Godot."
+    ),
+    report: Optional[Path] = typer.Option(
+        None, "--report", help="Saved resource inspect-model JSON; no engine call."
+    ),
+    baseline: Optional[Path] = typer.Option(
+        None, "--baseline", help="Saved inspection report for compatible comparison."
+    ),
+    subtree: str = typer.Option(
+        ".", "--subtree", help="Full resource-relative subtree for live inspection."
+    ),
+    max_nodes: int = typer.Option(
+        256, "--max-nodes", min=1, max=4096, help="Live inspection node limit."
+    ),
+    max_items: int = typer.Option(
+        1024, "--max-items", min=1, max=16384, help="Live inspection detail limit."
+    ),
+    json_output: bool = json_option(),
+    schema: bool = ASSET_PIPELINE_CHECK_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+    godot: Optional[str] = godot_option(),
+    project: Optional[str] = project_option(),
+) -> None:
+    """Evaluate project intent and compare model facts. Read verdict; pass/fail/insufficient exit 0."""
+    params = params_or_bad_parameter(
+        AssetPipelineCheckParams,
+        expectations=expectations,
+        path=path,
+        report=report,
+        baseline=baseline,
+        subtree=subtree,
+        max_nodes=max_nodes,
+        max_items=max_items,
+    )
+    dispatch_recipe(
+        ASSET_PIPELINE_CHECK_COMMAND,
+        params,
+        json_output=json_output,
+        godot=godot,
+        project=project,
+    )

--- a/src/gda/commands/asset_pipeline.py
+++ b/src/gda/commands/asset_pipeline.py
@@ -12,6 +12,7 @@ from gda_assets.api import (
     AssetFile,
     AssetRecipe,
     PipelineResult,
+    ModelComparison,
     Resize,
     run_pipeline,
     ProductionRequest,
@@ -500,7 +501,7 @@ class AssetPipelineCheckResult(BaseModel):
         description="Content verdict. Every completed evaluation exits 0; invalid input or workflow failure exits nonzero."
     )
     checks: list[AssetConditionResult]
-    comparison: dict[str, Any] | None
+    comparison: ModelComparison | None
     failure: PipelineFailureResult | None
 
 
@@ -567,7 +568,7 @@ def render_asset_check(result: AssetPipelineCheckResult) -> str:
         f"  {item.verdict:>12}  {item.id}: {item.reason}" for item in result.checks
     )
     if result.comparison:
-        lines.append(f"  comparison: {result.comparison['status']}")
+        lines.append(f"  comparison: {result.comparison.status}")
     return "\n".join(lines)
 
 

--- a/src/gda/integrations/asset_pipeline.py
+++ b/src/gda/integrations/asset_pipeline.py
@@ -3,10 +3,12 @@
 from pathlib import Path
 from typing import NoReturn
 
-from gda_assets.api import ImportOutcome, LoadObservation, PortFailure
+from gda_assets.api import ImportOutcome, LoadObservation, PortFailure, ModelFacts
 
 from gda.commands.resource import (
     ResourceImportParams,
+    ResourceInspectModelParams,
+    run_resource_inspect_model_operation,
     run_resource_import_operation,
     run_resource_load_operation,
 )
@@ -72,3 +74,22 @@ class GdaGodotAssetPort:
             scene_node_count=outcome.scene_node_count,
             engine=outcome.engine_version.model_dump(mode="json"),
         )
+
+    def inspect_model(
+        self, path: str, *, subtree: str, max_nodes: int, max_items: int
+    ) -> ModelFacts:
+        from gda.integrations.model_reports import project_model_report
+
+        outcome = run_resource_inspect_model_operation(
+            self._project,
+            ResourceInspectModelParams(
+                path=path, subtree=subtree, max_nodes=max_nodes, max_items=max_items
+            ),
+            godot=self._godot,
+        )
+        if isinstance(outcome, Failure):
+            self._raise(outcome)
+        try:
+            return project_model_report(outcome)
+        except ValueError as exc:
+            raise PortFailure("invalid_observation", str(exc)) from exc

--- a/src/gda/integrations/model_report_validation.py
+++ b/src/gda/integrations/model_report_validation.py
@@ -1,0 +1,263 @@
+"""Semantic admission for bounded reports supplied to the asset pipeline."""
+
+import math
+from collections.abc import Iterable, Sequence
+
+from gda.commands.resource import ModelNode, ResourceInspectModelResult
+
+
+_DETAIL_COMPONENT = {
+    "surfaces": "mesh",
+    "textures": "mesh",
+    "bones": "skeleton",
+    "skin_binds": "skin",
+    "animations": "animation_player",
+    "animation_tracks": "animation_player",
+}
+
+
+def _require_finite(value: object) -> None:
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ValueError("model report numeric facts must be finite")
+    if isinstance(value, dict):
+        for item in value.values():
+            _require_finite(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            _require_finite(item)
+
+
+def _prefix_indices(items: Iterable[object], label: str) -> None:
+    indices = [getattr(item, "index") for item in items]
+    if indices != list(range(len(indices))):
+        raise ValueError(f"{label} indices must be an exact zero-based prefix")
+
+
+def _has_omission(
+    omissions: set[tuple[str, str, str]], node_path: str, section: str
+) -> bool:
+    return (node_path, section, "detail_limit") in omissions
+
+
+def _check_counted_prefix(
+    count: int,
+    items: Sequence[object],
+    *,
+    label: str,
+    omitted: bool,
+) -> None:
+    if count < 0:
+        raise ValueError(f"{label} count must be non-negative")
+    _prefix_indices(items, label)
+    if (
+        len(items) > count
+        or (omitted and len(items) >= count)
+        or (not omitted and len(items) != count)
+    ):
+        raise ValueError(
+            f"{label} records contradict declared count or omission coverage"
+        )
+
+
+def _component_present(node: ModelNode, section: str) -> bool:
+    component = _DETAIL_COMPONENT[section]
+    if component == "skin":
+        return node.mesh is not None and node.mesh.skin is not None
+    return getattr(node, component) is not None
+
+
+def _is_full_node_locator(path: str) -> bool:
+    if path == ".":
+        return True
+    return (
+        bool(path)
+        and not path.startswith("/")
+        and ":" not in path
+        and all(part not in ("", ".", "..") for part in path.split("/"))
+    )
+
+
+def validate_model_report(report: ResourceInspectModelResult) -> None:
+    """Reject contradictions that make expectation coverage ambiguous."""
+    raw = report.model_dump(mode="python")
+    _require_finite(raw)
+
+    paths = [node.path for node in report.nodes]
+    if (
+        not paths
+        or paths[0] != report.subtree
+        or not _is_full_node_locator(report.subtree)
+        or any(not _is_full_node_locator(path) for path in paths)
+        or len(paths) != len(set(paths))
+    ):
+        raise ValueError("model report node paths must be unique exact locators")
+    if report.subtree != "." and any(
+        path != report.subtree and not path.startswith(report.subtree + "/")
+        for path in paths
+    ):
+        raise ValueError("model report nodes must lie within the selected subtree")
+
+    summary = report.summary
+    if (
+        min(summary.node_count, summary.mesh_instance_count, summary.unique_mesh_count)
+        < 0
+    ):
+        raise ValueError("model report summary counts must be non-negative")
+    mesh_count = sum(node.mesh is not None for node in report.nodes)
+    if summary.node_count != len(report.nodes):
+        raise ValueError("model report summary node_count contradicts nodes")
+    if summary.mesh_instance_count != mesh_count:
+        raise ValueError("model report summary mesh_instance_count contradicts nodes")
+    if not 0 <= summary.unique_mesh_count <= mesh_count:
+        raise ValueError("model report unique_mesh_count contradicts mesh instances")
+    if (summary.unique_mesh_count == 0) != (mesh_count == 0):
+        raise ValueError("model report unique_mesh_count contradicts mesh instances")
+    if report.bounds is not None:
+        if any(size < 0 for size in report.bounds.size):
+            raise ValueError("model report bounds size must be non-negative")
+        if mesh_count == 0:
+            raise ValueError("model report bounds require a visited mesh instance")
+
+    omission_keys = [
+        (item.node_path, item.section, item.reason) for item in report.omissions
+    ]
+    omissions = set(omission_keys)
+    if report.truncated != bool(omissions):
+        raise ValueError("model report truncated flag contradicts omission coverage")
+    if len(omissions) != len(omission_keys):
+        raise ValueError("model report omission locators must be unique")
+    nodes = {node.path: node for node in report.nodes}
+    for omission in report.omissions:
+        if omission.section == "nodes":
+            if omission.reason != "node_limit" or omission.node_path != report.subtree:
+                raise ValueError("nodes omission must locate the selected subtree")
+            continue
+        if (
+            omission.section not in _DETAIL_COMPONENT
+            or omission.reason != "detail_limit"
+        ):
+            raise ValueError("model report contains an unrecognized omission")
+        node = nodes.get(omission.node_path)
+        if node is None or not _component_present(node, omission.section):
+            raise ValueError(
+                "model report omission does not locate a matching component"
+            )
+
+    for node in report.nodes:
+        if node.mesh is not None:
+            mesh = node.mesh
+            _check_counted_prefix(
+                mesh.surface_count,
+                mesh.surfaces,
+                label="surfaces",
+                omitted=_has_omission(omissions, node.path, "surfaces"),
+            )
+            if mesh.skin is not None:
+                skin = mesh.skin
+                if (skin.resolved_skeleton_path is None) == (
+                    skin.unresolved_reason is None
+                ):
+                    raise ValueError(
+                        "skin skeleton resolution facts contradict each other"
+                    )
+                _check_counted_prefix(
+                    skin.bind_count,
+                    skin.binds,
+                    label="skin binds",
+                    omitted=_has_omission(omissions, node.path, "skin_binds"),
+                )
+                for bind in skin.binds:
+                    if (bind.resolved_bone_index is None) == (
+                        bind.unresolved_reason is None
+                    ):
+                        raise ValueError(
+                            "skin bind resolution facts contradict each other"
+                        )
+                    if (
+                        bind.resolved_bone_index is not None
+                        and bind.resolved_bone_index < 0
+                    ):
+                        raise ValueError(
+                            "resolved skin bind index must be non-negative"
+                        )
+        if node.skeleton is not None:
+            _check_counted_prefix(
+                node.skeleton.bone_count,
+                node.skeleton.bones,
+                label="bones",
+                omitted=_has_omission(omissions, node.path, "bones"),
+            )
+        if node.animation_player is not None:
+            player = node.animation_player
+            if (player.resolved_root_path is None) == (
+                player.unresolved_reason is None
+            ):
+                raise ValueError(
+                    "animation root resolution facts contradict each other"
+                )
+            animations_omitted = _has_omission(omissions, node.path, "animations")
+            if (
+                player.animation_count < 0
+                or len(player.animations) > player.animation_count
+            ):
+                raise ValueError("animations contradict declared count")
+            if animations_omitted:
+                if len(player.animations) >= player.animation_count:
+                    raise ValueError(
+                        "animations omission requires a short emitted prefix"
+                    )
+            elif len(player.animations) != player.animation_count:
+                raise ValueError(
+                    "animations records contradict declared count or omission coverage"
+                )
+            names = [animation.name for animation in player.animations]
+            if len(names) != len(set(names)):
+                raise ValueError("animation names must be unique within a player")
+            tracks_omitted = _has_omission(omissions, node.path, "animation_tracks")
+            any_short = False
+            for animation in player.animations:
+                _prefix_indices(animation.tracks, "animation tracks")
+                if (
+                    animation.track_count < 0
+                    or len(animation.tracks) > animation.track_count
+                ):
+                    raise ValueError("animation tracks contradict declared count")
+                any_short |= len(animation.tracks) < animation.track_count
+                if (
+                    not tracks_omitted
+                    and len(animation.tracks) != animation.track_count
+                ):
+                    raise ValueError("animation tracks lack matching omission coverage")
+                if animation.length < 0 or animation.loop_mode not in (0, 1, 2):
+                    raise ValueError("animation timing facts are invalid")
+            if tracks_omitted and not any_short:
+                raise ValueError(
+                    "animation_tracks omission requires at least one short track prefix"
+                )
+
+    for node in report.nodes:
+        if node.mesh is not None:
+            for surface in node.mesh.surfaces:
+                for count in (
+                    surface.vertex_count,
+                    surface.index_count,
+                    surface.triangle_count,
+                ):
+                    if count is not None and count < 0:
+                        raise ValueError("surface counts must be non-negative")
+        if node.animation_player is not None:
+            for animation in node.animation_player.animations:
+                for track in animation.tracks:
+                    if track.status == "resolved":
+                        if (
+                            track.target_node_path is None
+                            or track.resolution_scope is None
+                            or track.reason is not None
+                        ):
+                            raise ValueError(
+                                "resolved animation track facts contradict their status"
+                            )
+                    elif track.resolution_scope is not None or not track.reason:
+                        raise ValueError(
+                            "unresolved animation track facts contradict their status"
+                        )

--- a/src/gda/integrations/model_reports.py
+++ b/src/gda/integrations/model_reports.py
@@ -1,0 +1,132 @@
+"""Translate Godot's imported-resource report into Asset Pipeline model facts."""
+
+from pathlib import Path
+
+from gda_assets.api import (
+    AnimationFacts,
+    BindFacts,
+    BoneFacts,
+    MaterialFacts,
+    ModelFacts,
+    NodeFacts,
+    PortFailure,
+    SurfaceFacts,
+    TrackFacts,
+)
+
+from gda.commands.resource import ModelTransform, ResourceInspectModelResult
+from gda.integrations.model_report_validation import validate_model_report
+
+
+def _transform(value: ModelTransform | None) -> tuple[float, ...] | None:
+    if value is None:
+        return None
+    return tuple(value.origin) + tuple(
+        component for column in value.basis for component in column
+    )
+
+
+def project_model_report(report: ResourceInspectModelResult) -> ModelFacts:
+    """Preserve fact scope and coverage while removing native model dependencies."""
+    validate_model_report(report)
+    nodes = []
+    for node in report.nodes:
+        mesh, skeleton, player = node.mesh, node.skeleton, node.animation_player
+        skin = mesh.skin if mesh else None
+        surfaces = []
+        for surface in mesh.surfaces if mesh else []:
+            material = surface.material
+            surfaces.append(
+                SurfaceFacts(
+                    surface.index,
+                    surface.model_dump(exclude={"index", "material"}),
+                    MaterialFacts(
+                        material.resource.type,
+                        material.resource.name,
+                        material.resource.path,
+                        material.source,
+                        tuple(
+                            (t.role, t.resource.type, t.resource.path)
+                            for t in material.textures
+                        ),
+                        material.textures_unavailable_reason is None,
+                    )
+                    if material
+                    else None,
+                )
+            )
+        nodes.append(
+            NodeFacts(
+                path=node.path,
+                type=node.type,
+                transform=_transform(node.resource_transform),
+                surface_count=mesh.surface_count if mesh else None,
+                surfaces=tuple(surfaces),
+                bone_count=skeleton.bone_count if skeleton else None,
+                bones=tuple(
+                    BoneFacts(b.index, b.name, b.parent, _transform(b.rest) or ())
+                    for b in skeleton.bones
+                )
+                if skeleton
+                else (),
+                skin_present=skin is not None,
+                skin_unavailable=mesh.skin_unavailable_reason if mesh else None,
+                skeleton=skin.resolved_skeleton_path if skin else None,
+                bind_count=skin.bind_count if skin else None,
+                binds=tuple(
+                    BindFacts(b.index, b.resolved_bone_index, b.unresolved_reason)
+                    for b in skin.binds
+                )
+                if skin
+                else (),
+                animation_count=player.animation_count if player else None,
+                animations=tuple(
+                    AnimationFacts(
+                        a.name,
+                        a.length,
+                        a.loop_mode,
+                        a.track_count,
+                        tuple(
+                            TrackFacts(
+                                t.index,
+                                t.type,
+                                t.path,
+                                t.enabled,
+                                t.target_node_path,
+                                t.bone_name,
+                                t.status,
+                                t.resolution_scope,
+                                t.reason,
+                            )
+                            for t in a.tracks
+                        ),
+                    )
+                    for a in player.animations
+                )
+                if player
+                else (),
+            )
+        )
+    return ModelFacts(
+        resource=report.path,
+        subtree=report.subtree,
+        engine=(report.engine_version.major, report.engine_version.minor),
+        measurement=(report.measurement.coordinate_space, report.measurement.geometry),
+        nodes=tuple(nodes),
+        counts=report.summary.model_dump(),
+        bounds=report.bounds.model_dump(mode="json") if report.bounds else None,
+        omissions=tuple((o.node_path, o.section) for o in report.omissions),
+    )
+
+
+def read_model_report(path: Path) -> ModelFacts:
+    """A saved report is caller-supplied data, not a fresh engine observation."""
+    try:
+        if path.stat().st_size > 16 * 1024 * 1024:
+            raise ValueError("model report exceeds 16 MiB")
+        raw = path.read_text(encoding="utf-8")
+        # Validate JSON types before Python tuples represent engine vectors.
+        report = ResourceInspectModelResult.model_validate_json(raw, strict=True)
+        return project_model_report(report)
+    except (OSError, ValueError) as exc:
+        raise PortFailure("invalid_report", f"{path}: {exc}") from exc

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -43,6 +43,20 @@ native inspect/prepare/export facts and `observations` for actual Godot loading.
 After import failure, use the installed GLB for an explicit import retry; repeating
 `--production` runs a new export. No concept/prompt record is required.
 
+Use `gda asset-pipeline check --expectations /project/art/model.expectations.json
+--path res://art/model.glb --json` for project acceptance. The JSON document contains
+`checks`, each with a unique `id` and a `kind`: `node`, `count`, `dimensions`,
+`material`, `bone`, `skin_bind`, or `animation_target`. For example,
+`{"checks":[{"id":"left-arm","kind":"node","node":"Rig/Arm_L","type":"MeshInstance3D"}]}`.
+Use full resource-relative node paths from `resource inspect-model`.
+Replace `--path` with `--report /reports/model.json` to evaluate a saved inspection;
+`--baseline /reports/previous.json` adds a compatible comparison. Valid content
+verdicts `pass`, `fail`, and `insufficient` all exit 0: always inspect `verdict`.
+Omitted facts cannot prove acceptance or deletion; a supplied report does not
+establish current engine state. Input and workflow failures exit nonzero and
+include `error.partial_result`. See `asset-pipeline check --schema` for input bindings
+and the [expectation format](https://github.com/aigengame/godot-agent/blob/main/libs/gda-assets/docs/checks.md).
+
 ## Setup
 
 - **Engine** — set `GDA_GODOT` to your Godot binary (or pass `--godot PATH`).
@@ -234,7 +248,7 @@ Every headless reply carries its floats at full binary64 precision, so a value r
 
 | Group | Commands |
 | --- | --- |
-| `asset-pipeline` | `run` (saved Blender export or PNG/GLB handoff, installation, import and actual engine load) |
+| `asset-pipeline` | `run`, `check` (production and handoff; project expectations and compatible report comparison) |
 
 ## Live operations (via the daemon; Godot 4.6+, macOS/Linux)
 

--- a/tests/asset_pipeline/fixtures/model_check_fixture.gd
+++ b/tests/asset_pipeline/fixtures/model_check_fixture.gd
@@ -1,0 +1,88 @@
+extends SceneTree
+
+# Generate a deterministic GLB with duplicate short names, a named material,
+# skeleton bindings, and an animation target. The fixture is built by Godot so
+# the check command is exercised against the real 3D import path.
+func _initialize() -> void:
+	var root := Node3D.new()
+	root.name = "Model"
+
+	var character := Node3D.new()
+	character.name = "Character"
+	root.add_child(character)
+	character.owner = root
+
+	var rig := Skeleton3D.new()
+	rig.name = "Rig"
+	character.add_child(rig)
+	rig.owner = root
+	rig.add_bone("RootBone")
+	rig.add_bone("HandBone")
+	rig.set_bone_parent(1, 0)
+	rig.set_bone_rest(1, Transform3D(Basis.IDENTITY, Vector3(0, 1, 0)))
+
+	var mesh := ArrayMesh.new()
+	var arrays := []
+	arrays.resize(Mesh.ARRAY_MAX)
+	arrays[Mesh.ARRAY_VERTEX] = PackedVector3Array([
+		Vector3(-1, -2, -0.5), Vector3(1, -2, -0.5), Vector3(-1, 2, 0.5),
+		Vector3(1, 2, 0.5),
+	])
+	arrays[Mesh.ARRAY_INDEX] = PackedInt32Array([0, 1, 2, 1, 3, 2])
+	arrays[Mesh.ARRAY_BONES] = PackedInt32Array([
+		1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0,
+	])
+	arrays[Mesh.ARRAY_WEIGHTS] = PackedFloat32Array([
+		1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0,
+	])
+	mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, arrays)
+	var material := StandardMaterial3D.new()
+	material.resource_name = "LimbMaterial"
+	mesh.surface_set_material(0, material)
+
+	var limb := MeshInstance3D.new()
+	limb.name = "Arm_L"
+	limb.mesh = mesh
+	limb.skeleton = NodePath("../Rig")
+	var skin := Skin.new()
+	skin.add_named_bind("HandBone", Transform3D.IDENTITY)
+	limb.skin = skin
+	character.add_child(limb)
+	limb.owner = root
+
+	var props := Node3D.new()
+	props.name = "Props"
+	root.add_child(props)
+	props.owner = root
+	var duplicate := MeshInstance3D.new()
+	duplicate.name = "Arm_L"
+	duplicate.mesh = mesh
+	duplicate.position = Vector3(4, 0, 0)
+	props.add_child(duplicate)
+	duplicate.owner = root
+
+	var player := AnimationPlayer.new()
+	player.name = "AnimationPlayer"
+	root.add_child(player)
+	player.owner = root
+	var animation := Animation.new()
+	animation.length = 1.0
+	var track := animation.add_track(Animation.TYPE_POSITION_3D)
+	animation.track_set_path(track, NodePath("Character/Rig:HandBone"))
+	animation.track_insert_key(track, 0.0, Vector3.ZERO)
+	animation.track_insert_key(track, 1.0, Vector3(0, 1, 0))
+	var library := AnimationLibrary.new()
+	library.add_animation("Wave", animation)
+	player.add_animation_library("", library)
+	# PackedScene preserves the duplicate short names. The GLB importer makes
+	# names globally unique, so this companion resource tests exact full paths.
+	var packed := PackedScene.new()
+	assert(packed.pack(root) == OK)
+	assert(ResourceSaver.save(packed, "res://duplicate_names.tscn") == OK)
+
+	var document := GLTFDocument.new()
+	var state := GLTFState.new()
+	assert(document.append_from_scene(root, state) == OK)
+	assert(document.write_to_filesystem(state, "res://model.glb") == OK)
+	root.free()
+	quit()

--- a/tests/asset_pipeline/test_discovery_boundary.py
+++ b/tests/asset_pipeline/test_discovery_boundary.py
@@ -19,7 +19,7 @@ import gda_assets.api
 from gda.cli import app
 from typer.testing import CliRunner
 runner = CliRunner()
-for argv in [['--help'], ['--version'], ['asset-pipeline', 'run', '--schema']]:
+for argv in [['--help'], ['--version'], ['asset-pipeline', 'run', '--schema'], ['asset-pipeline', 'check', '--schema']]:
     outcome = runner.invoke(app, argv)
     assert outcome.exit_code == 0, (argv, outcome.output, outcome.exception)
 assert 'gda_assets.adapters.blender' not in sys.modules

--- a/tests/asset_pipeline/test_e2e_model_check.py
+++ b/tests/asset_pipeline/test_e2e_model_check.py
@@ -1,0 +1,346 @@
+"""Project expectations evaluated against real Godot-imported model facts."""
+
+import json
+import struct
+from pathlib import Path
+
+import pytest
+
+from tests.support import Gda
+
+pytestmark = pytest.mark.e2e
+LIMB = "Character/RootBone/Skeleton3D/Arm_L"
+SKELETON = "Character/RootBone/Skeleton3D"
+
+
+def _mutate_glb(path: Path, mutation) -> None:
+    data = path.read_bytes()
+    json_length = struct.unpack_from("<I", data, 12)[0]
+    document = json.loads(data[20 : 20 + json_length])
+    mutation(document)
+    payload = json.dumps(document, separators=(",", ":")).encode()
+    payload += b" " * (-len(payload) % 4)
+    chunks = (
+        struct.pack("<I4s", len(payload), b"JSON") + payload + data[20 + json_length :]
+    )
+    path.write_bytes(struct.pack("<4sII", b"glTF", 2, 12 + len(chunks)) + chunks)
+
+
+@pytest.fixture
+def checked_model(godot_project):
+    generator = Path(__file__).parent / "fixtures" / "model_check_fixture.gd"
+    (godot_project / "create_model.gd").write_bytes(generator.read_bytes())
+    run = Gda(godot_project, json_output=True)
+    assert (
+        run.json("script", "run", "res://create_model.gd", "--strict")["exit_status"]
+        == 0
+    )
+
+    # GLTFDocument emits one mesh per instance. Sharing mesh 0 gives the
+    # imported fixture an independently known unique-mesh count.
+    model = godot_project / "model.glb"
+
+    def share_mesh(document):
+        for node in document["nodes"]:
+            if "mesh" in node:
+                node["mesh"] = 0
+
+    _mutate_glb(model, share_mesh)
+    run.json("resource", "import", "res://model.glb")
+    (godot_project / "baseline.json").write_text(
+        json.dumps(run.json("resource", "inspect-model", "res://model.glb"))
+    )
+    return godot_project
+
+
+def _expectations(project: Path, name: str, checks: list[dict]) -> Path:
+    path = project / name
+    path.write_text(json.dumps({"checks": checks}))
+    return path
+
+
+def _check(run: Gda, expectations: Path, *source: str) -> dict:
+    return run.json(
+        "asset-pipeline", "check", "--expectations", str(expectations), *source
+    )
+
+
+def _baseline_checks() -> list[dict]:
+    return [
+        {"id": "limb", "kind": "node", "node": LIMB, "type": "MeshInstance3D"},
+        {"id": "nodes", "kind": "count", "metric": "node_count", "min": 8, "max": 8},
+        {
+            "id": "meshes",
+            "kind": "count",
+            "metric": "mesh_instance_count",
+            "min": 2,
+            "max": 2,
+        },
+        {
+            "id": "shared",
+            "kind": "count",
+            "metric": "unique_mesh_count",
+            "min": 1,
+            "max": 1,
+        },
+        {"id": "size", "kind": "dimensions", "min": [6, 4, 1], "max": [6, 4, 1]},
+        {
+            "id": "material",
+            "kind": "material",
+            "node": LIMB,
+            "surface": 0,
+            "name": "LimbMaterial",
+        },
+        {"id": "bone", "kind": "bone", "node": SKELETON, "name": "HandBone"},
+        {
+            "id": "skin",
+            "kind": "skin_bind",
+            "node": LIMB,
+            "bind": 0,
+            "skeleton": SKELETON,
+            "bone": "HandBone",
+        },
+        {
+            "id": "animation",
+            "kind": "animation_target",
+            "node": "AnimationPlayer",
+            "animation": "Wave",
+            "track": 0,
+            "target": SKELETON,
+            "bone": "HandBone",
+        },
+    ]
+
+
+def test_imported_glb_satisfies_all_supported_expectation_kinds(checked_model):
+    project = checked_model
+    checks = _baseline_checks()
+    result = _check(
+        Gda(project, json_output=True),
+        _expectations(project, "baseline-expectations.json", checks),
+        "--path",
+        "res://model.glb",
+    )
+
+    assert result["completed"] == ["validate", "inspect", "evaluate"]
+    assert result["resource"] == "res://model.glb"
+    assert result["observation_source"] == "godot"
+    assert result["verdict"] == "pass"
+    assert {item["id"]: item["verdict"] for item in result["checks"]} == {
+        item["id"]: "pass" for item in checks
+    }
+
+
+def test_renamed_imported_limb_fails_fixed_path_but_preserves_mesh_count(checked_model):
+    project = checked_model
+    run = Gda(project, json_output=True)
+    expectations = _expectations(project, "rename.json", _baseline_checks()[:3])
+    _mutate_glb(
+        project / "model.glb",
+        lambda document: next(
+            node for node in document["nodes"] if node.get("name") == "Arm_L"
+        ).update(name="Arm_R"),
+    )
+    assert (
+        run.json("resource", "import", "res://model.glb")["assets"][0]["status"]
+        == "imported"
+    )
+
+    result = _check(
+        run,
+        expectations,
+        "--path",
+        "res://model.glb",
+        "--baseline",
+        str(project / "baseline.json"),
+    )
+    assert {item["id"]: item["verdict"] for item in result["checks"]} == {
+        "limb": "fail",
+        "nodes": "pass",
+        "meshes": "pass",
+    }
+    node_changes = [
+        (change["kind"], change["location"]["node"])
+        for change in result["comparison"]["changes"]
+        if change["section"] == "nodes"
+    ]
+    assert node_changes == [
+        ("removed", LIMB),
+        ("added", "Character/RootBone/Skeleton3D/Arm_R"),
+    ]
+
+
+def test_real_geometry_material_and_animation_mutations_fail_fixed_expectations(
+    checked_model,
+):
+    project = checked_model
+    run = Gda(project, json_output=True)
+    expectations = _expectations(project, "mutations.json", _baseline_checks())
+
+    def mutate(document):
+        other = next(
+            i
+            for i, node in enumerate(document["nodes"])
+            if node.get("name") == "Arm_L2"
+        )
+        # Godot normalizes transforms on a skinned mesh node. Scale the other
+        # imported mesh so the static resource-space bounds must change.
+        document["nodes"][other]["scale"] = [2, 1, 1]
+        document["meshes"][0]["primitives"][0].pop("material")
+        document["animations"][0]["channels"][0]["target"]["node"] = other
+
+    _mutate_glb(project / "model.glb", mutate)
+    assert (
+        run.json("resource", "import", "res://model.glb")["assets"][0]["status"]
+        == "imported"
+    )
+    result = _check(
+        run,
+        expectations,
+        "--path",
+        "res://model.glb",
+        "--baseline",
+        str(project / "baseline.json"),
+    )
+
+    assert result["verdict"] == "fail"
+    assert {item["id"]: item["verdict"] for item in result["checks"]} == {
+        "limb": "pass",
+        "nodes": "pass",
+        "meshes": "pass",
+        "shared": "pass",
+        "size": "fail",
+        "material": "fail",
+        "bone": "pass",
+        "skin": "pass",
+        "animation": "fail",
+    }
+    changes = result["comparison"]["changes"]
+    assert [change["section"] for change in changes] == [
+        "tracks",
+        "materials",
+        "nodes",
+        "materials",
+        "bounds",
+    ]
+    assert changes[0]["location"] == {
+        "node": "AnimationPlayer",
+        "animation": "Wave",
+        "track": 0,
+    }
+    assert changes[0]["kind"] == "changed"
+    assert changes[1]["location"] == {"node": LIMB, "surface": 0}
+    assert changes[1]["kind"] in {"changed", "removed"}
+    assert changes[-1]["after"]["size"] == [7, 4, 1]
+
+
+def test_node_truncation_makes_unobserved_requirements_insufficient(checked_model):
+    project = checked_model
+    expectations = _expectations(
+        project,
+        "partial-nodes.json",
+        [
+            {"id": "limb", "kind": "node", "node": LIMB},
+            {"id": "nodes", "kind": "count", "metric": "node_count", "min": 8},
+            {"id": "size", "kind": "dimensions", "min": [6, 4, 1]},
+        ],
+    )
+    result = _check(
+        Gda(project, json_output=True),
+        expectations,
+        "--path",
+        "res://model.glb",
+        "--max-nodes",
+        "1",
+    )
+    assert result["verdict"] == "insufficient"
+    assert {item["verdict"] for item in result["checks"]} == {"insufficient"}
+
+
+def test_duplicate_short_names_require_exact_full_paths(checked_model):
+    project = checked_model
+    expectations = _expectations(
+        project,
+        "duplicate-paths.json",
+        [
+            {"id": "character", "kind": "node", "node": "Character/Arm_L"},
+            {"id": "prop", "kind": "node", "node": "Props/Arm_L"},
+            {"id": "short", "kind": "node", "node": "Arm_L"},
+        ],
+    )
+    result = _check(
+        Gda(project, json_output=True),
+        expectations,
+        "--path",
+        "res://duplicate_names.tscn",
+    )
+
+    assert {item["id"]: item["verdict"] for item in result["checks"]} == {
+        "character": "pass",
+        "prop": "pass",
+        "short": "fail",
+    }
+
+
+def test_detail_truncation_is_insufficient_without_false_diff_removals(checked_model):
+    project = checked_model
+    expectations = _expectations(
+        project,
+        "partial-details.json",
+        [
+            {
+                "id": "material",
+                "kind": "material",
+                "node": LIMB,
+                "surface": 0,
+                "name": "LimbMaterial",
+            },
+            {
+                "id": "animation",
+                "kind": "animation_target",
+                "node": "AnimationPlayer",
+                "animation": "Wave",
+                "track": 0,
+                "target": SKELETON,
+                "bone": "HandBone",
+            },
+        ],
+    )
+    result = _check(
+        Gda(project, json_output=True),
+        expectations,
+        "--path",
+        "res://model.glb",
+        "--max-items",
+        "1",
+        "--baseline",
+        str(project / "baseline.json"),
+    )
+
+    assert result["verdict"] == "insufficient"
+    assert {item["verdict"] for item in result["checks"]} == {"insufficient"}
+    comparison = result["comparison"]
+    assert comparison["status"] == "partial"
+    assert comparison["incomplete_sections"]
+    assert not any(
+        change["section"] in {"tracks", "surfaces"} and change["kind"] == "removed"
+        for change in comparison["changes"]
+    )
+
+
+def test_raw_inspection_report_is_accepted_without_engine_reinspection(checked_model):
+    project = checked_model
+    expectations = _expectations(
+        project,
+        "report-expectations.json",
+        [{"id": "limb", "kind": "node", "node": LIMB}],
+    )
+    result = _check(
+        Gda(project, json_output=True),
+        expectations,
+        "--report",
+        str(project / "baseline.json"),
+    )
+    assert result["completed"] == ["validate", "evaluate"]
+    assert result["observation_source"] == "supplied_report"
+    assert result["verdict"] == "pass"

--- a/tests/asset_pipeline/test_model_checks.py
+++ b/tests/asset_pipeline/test_model_checks.py
@@ -375,3 +375,31 @@ def test_inspection_failure_keeps_native_code_details_and_workflow_stage(
     assert partial["completed"] == ["validate"]
     assert partial["failure"]["stage"] == "inspect"
     assert partial["failure"]["cause"]["code"] == "not_a_scene"
+
+
+def test_comparison_schema_publishes_fixed_contract_for_cli_and_mcp():
+    import json
+    from typer.testing import CliRunner
+    from gda.cli import app
+
+    result = CliRunner().invoke(app, ["asset-pipeline", "check", "--schema"])
+    schema = json.loads(result.stdout)["output"]
+    choices = schema["properties"]["comparison"]["anyOf"]
+    reference = next(choice["$ref"] for choice in choices if "$ref" in choice)
+    comparison = schema["$defs"][reference.rsplit("/", 1)[1]]
+    assert set(comparison["properties"]) == {
+        "status",
+        "reasons",
+        "resources",
+        "changes",
+        "incomplete_sections",
+    }
+    assert set(comparison["properties"]["status"]["enum"]) == {
+        "comparable",
+        "partial",
+        "non_comparable",
+    }
+    change_ref = comparison["properties"]["changes"]["items"]["$ref"]
+    change = schema["$defs"][change_ref.rsplit("/", 1)[1]]
+    assert set(change["required"]) == {"section", "location", "kind", "before", "after"}
+    assert set(change["properties"]["kind"]["enum"]) == {"added", "removed", "changed"}

--- a/tests/asset_pipeline/test_model_checks.py
+++ b/tests/asset_pipeline/test_model_checks.py
@@ -1,0 +1,377 @@
+"""Project expectations through the installed supporting-context API."""
+
+from gda_assets.api import check_model
+from gda_assets.application.ports import ModelInspectionPort
+from gda_assets.domain.model import ModelFacts, NodeFacts
+
+
+class ObservedModel:
+    def inspect_model(self, path, *, subtree, max_nodes, max_items):
+        return ModelFacts(
+            resource=path,
+            subtree=subtree,
+            engine=(4, 6),
+            measurement=("resource", "static_mesh_aabb"),
+            nodes=(NodeFacts(".", "Node3D"), NodeFacts("Arm_L", "MeshInstance3D")),
+            counts={"node_count": 2, "mesh_instance_count": 1, "unique_mesh_count": 1},
+            bounds=None,
+        )
+
+
+def test_required_full_path_fails_after_limb_rename_with_same_mesh_count(tmp_path):
+    expectations = tmp_path / "model.expectations.json"
+    expectations.write_text(
+        '{"checks":[{"id":"limb","kind":"node","node":"Arm_R","type":"MeshInstance3D"}]}'
+    )
+    port: ModelInspectionPort = ObservedModel()
+    result = check_model(expectations, path="res://model.glb", godot=port)
+    assert result.failure is None
+    assert result.verdict == "fail"
+    assert result.checks[0].id == "limb"
+    assert result.checks[0].location == {"resource": "res://model.glb", "node": "Arm_R"}
+    assert result.checks[0].actual is None
+    assert result.checks[0].expected == {"type": "MeshInstance3D"}
+
+
+def test_missing_node_in_partial_report_is_insufficient_but_present_node_passes(
+    tmp_path,
+):
+    from dataclasses import replace
+
+    class Partial(ObservedModel):
+        def inspect_model(self, path, **kwargs):
+            return replace(
+                super().inspect_model(path, **kwargs), omissions=((".", "nodes"),)
+            )
+
+    expectations = tmp_path / "expectations.json"
+    expectations.write_text(
+        '{"checks":[{"id":"known","kind":"node","node":"Arm_L"},{"id":"missing","kind":"node","node":"Arm_R"}]}'
+    )
+    result = check_model(expectations, path="res://model.glb", godot=Partial())
+    assert result.verdict == "insufficient"
+    assert [c.verdict for c in result.checks] == ["pass", "insufficient"]
+
+
+def test_invalid_expectations_are_input_failure_before_inspection(tmp_path):
+    expectations = tmp_path / "expectations.json"
+    expectations.write_text(
+        '{"checks":[{"id":"limb","kind":"node","node":"../Arm_L"}]}'
+    )
+    result = check_model(expectations, path="res://model.glb", godot=ObservedModel())
+    assert result.verdict is None
+    assert result.failure is not None
+    assert result.failure.code == "invalid_expectations"
+    assert result.failure.stage == "validate"
+    assert result.completed == []
+
+
+def test_count_and_dimensions_use_node_coverage_not_texture_coverage(tmp_path):
+    import json
+    from dataclasses import replace
+
+    facts = ObservedModel().inspect_model(
+        "res://model.glb", subtree=".", max_nodes=256, max_items=1024
+    )
+    facts = replace(
+        facts,
+        bounds={"position": [0, 0, 0], "size": [2, 4, 2]},
+        omissions=(("Arm_L", "textures"),),
+    )
+    expectations = tmp_path / "expectations.json"
+    expectations.write_text(
+        json.dumps(
+            {
+                "checks": [
+                    {
+                        "id": "meshes",
+                        "kind": "count",
+                        "metric": "mesh_instance_count",
+                        "min": 1,
+                        "max": 1,
+                    },
+                    {
+                        "id": "size",
+                        "kind": "dimensions",
+                        "min": [1, 1, 1],
+                        "max": [3, 3, 3],
+                    },
+                ]
+            }
+        )
+    )
+    result = check_model(expectations, report=facts)
+    assert result.verdict == "fail"
+    assert [c.verdict for c in result.checks] == ["pass", "fail"]
+    result = check_model(
+        expectations, report=replace(facts, omissions=((".", "nodes"),))
+    )
+    assert result.verdict == "insufficient"
+    assert [c.verdict for c in result.checks] == ["insufficient", "insufficient"]
+
+
+def test_material_bone_skin_and_animation_bindings_keep_exact_locations(tmp_path):
+    import json
+    from dataclasses import replace
+    from gda_assets.domain.model import (
+        AnimationFacts,
+        BindFacts,
+        BoneFacts,
+        MaterialFacts,
+        SurfaceFacts,
+        TrackFacts,
+    )
+
+    facts = ObservedModel().inspect_model(
+        "res://model.glb", subtree=".", max_nodes=256, max_items=1024
+    )
+    facts = replace(
+        facts,
+        nodes=(
+            NodeFacts(
+                "Rig",
+                "Skeleton3D",
+                bone_count=1,
+                bones=(BoneFacts(0, "Arm_L", -1, ()),),
+            ),
+            NodeFacts(
+                "Body",
+                "MeshInstance3D",
+                surface_count=1,
+                surfaces=(
+                    SurfaceFacts(
+                        0,
+                        {},
+                        MaterialFacts(
+                            "StandardMaterial3D", "Fur", None, "mesh_surface"
+                        ),
+                    ),
+                ),
+                skin_present=True,
+                skeleton="Rig",
+                bind_count=1,
+                binds=(BindFacts(0, 0, None),),
+            ),
+            NodeFacts(
+                "AnimationPlayer",
+                "AnimationPlayer",
+                animation_count=1,
+                animations=(
+                    AnimationFacts(
+                        "Walk",
+                        1,
+                        0,
+                        1,
+                        (
+                            TrackFacts(
+                                0,
+                                "position_3d",
+                                "Rig:Arm_L",
+                                True,
+                                "Rig",
+                                "Arm_L",
+                                "resolved",
+                                "bone",
+                                None,
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+    expectations = tmp_path / "expectations.json"
+    expectations.write_text(
+        json.dumps(
+            {
+                "checks": [
+                    {
+                        "id": "fur",
+                        "kind": "material",
+                        "node": "Body",
+                        "surface": 0,
+                        "name": "Fur",
+                    },
+                    {"id": "bone", "kind": "bone", "node": "Rig", "name": "Arm_L"},
+                    {
+                        "id": "bind",
+                        "kind": "skin_bind",
+                        "node": "Body",
+                        "bind": 0,
+                        "skeleton": "Rig",
+                        "bone": "Arm_L",
+                    },
+                    {
+                        "id": "walk",
+                        "kind": "animation_target",
+                        "node": "AnimationPlayer",
+                        "animation": "Walk",
+                        "track": 0,
+                        "target": "Rig",
+                        "bone": "Arm_L",
+                    },
+                ]
+            }
+        )
+    )
+    result = check_model(expectations, report=facts)
+    assert result.verdict == "pass", result
+    assert result.checks[0].location["surface"] == 0
+    assert result.checks[3].location == {
+        "resource": "res://model.glb",
+        "node": "AnimationPlayer",
+        "animation": "Walk",
+        "track": 0,
+    }
+    broken = replace(
+        facts,
+        nodes=(
+            facts.nodes[0],
+            replace(facts.nodes[1], surfaces=(SurfaceFacts(0, {}),)),
+            replace(
+                facts.nodes[2],
+                animations=(
+                    AnimationFacts(
+                        "Walk",
+                        1,
+                        0,
+                        1,
+                        (
+                            TrackFacts(
+                                0,
+                                "position_3d",
+                                "Rig:Missing",
+                                True,
+                                "Rig",
+                                "Missing",
+                                "unresolved",
+                                None,
+                                "bone not found",
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+    result = check_model(expectations, report=broken)
+    assert [c.verdict for c in result.checks] == ["fail", "pass", "pass", "fail"]
+
+
+def test_check_entry_schema_and_saved_report_fail_verdict_agree_on_both_input_paths(
+    tmp_path,
+    monkeypatch,
+):
+    import json
+    from typer.testing import CliRunner
+    from gda.cli import app
+    from tests.asset_pipeline.test_model_report_validation import _report
+
+    report = tmp_path / "report.json"
+    report.write_text(json.dumps(_report()))
+    expectations = tmp_path / "expectations.json"
+    expectations.write_text('{"checks":[{"id":"limb","kind":"node","node":"Missing"}]}')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("GDA_PROJECT", raising=False)
+    monkeypatch.setenv("GDA_GODOT", str(tmp_path / "absent-engine"))
+    runner = CliRunner()
+    schema_call = runner.invoke(app, ["asset-pipeline", "check", "--schema"])
+    assert schema_call.exit_code == 0, schema_call.output
+    schema = json.loads(schema_call.stdout)
+    assert schema["kind"] == "composite"
+    assert "verdict" in schema["output"]["properties"]
+    argv = runner.invoke(
+        app,
+        [
+            "asset-pipeline",
+            "check",
+            "--expectations",
+            str(expectations),
+            "--report",
+            str(report),
+            "--json",
+        ],
+    )
+    structured = runner.invoke(
+        app,
+        [
+            "asset-pipeline",
+            "check",
+            "--params-json",
+            json.dumps({"expectations": str(expectations), "report": str(report)}),
+            "--json",
+        ],
+    )
+    assert argv.exit_code == structured.exit_code == 0, (argv.output, structured.output)
+    assert json.loads(argv.stdout) == json.loads(structured.stdout)
+    assert json.loads(argv.stdout)["verdict"] == "fail"
+
+
+def test_invalid_document_is_nonzero_workflow_error_on_cli_and_structured_input(
+    tmp_path,
+):
+    import json
+    from typer.testing import CliRunner
+    from gda.cli import app
+    from tests.asset_pipeline.test_model_report_validation import _report
+
+    report = tmp_path / "report.json"
+    report.write_text(json.dumps(_report()))
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text('{"checks":[{"id":"size","kind":"dimensions","min":[NaN,0,0]}]}')
+    runner = CliRunner()
+    options = {"expectations": str(invalid), "report": str(report)}
+    argv = runner.invoke(
+        app,
+        [
+            "asset-pipeline",
+            "check",
+            "--expectations",
+            str(invalid),
+            "--report",
+            str(report),
+            "--json",
+        ],
+    )
+    structured = runner.invoke(
+        app, ["asset-pipeline", "check", "--params-json", json.dumps(options), "--json"]
+    )
+    assert argv.exit_code == structured.exit_code == 4
+    assert json.loads(argv.stdout) == json.loads(structured.stdout)
+    error = json.loads(argv.stdout)["error"]
+    assert error["code"] == "invalid_params"
+    assert error["partial_result"]["failure"]["code"] == "invalid_expectations"
+    assert error["partial_result"]["verdict"] is None
+
+
+def test_inspection_failure_keeps_native_code_details_and_workflow_stage(
+    monkeypatch, tmp_path
+):
+    from gda.commands.asset_pipeline import AssetPipelineCheckParams, run_asset_check
+    from gda.errors import Failure, make_failure
+    from tests.support import minimal_project
+
+    expectation = tmp_path / "checks.json"
+    expectation.write_text('{"checks":[{"id":"root","kind":"node","node":"."}]}')
+    failure = make_failure(
+        "not_a_scene",
+        "could not be loaded as PackedScene",
+        "Check the imported resource",
+    )
+    monkeypatch.setattr(
+        "gda.integrations.asset_pipeline.run_resource_inspect_model_operation",
+        lambda *a, **k: failure,
+    )
+    result = run_asset_check(
+        AssetPipelineCheckParams(expectations=expectation, path="res://broken.glb"),
+        project=minimal_project(tmp_path / "project"),
+        godot=None,
+    )
+    assert isinstance(result, Failure)
+    assert result.error.code == "not_a_scene"
+    assert "could not be loaded as PackedScene" in result.error.message
+    partial = result.error.partial_result
+    assert partial is not None
+    assert partial["completed"] == ["validate"]
+    assert partial["failure"]["stage"] == "inspect"
+    assert partial["failure"]["cause"]["code"] == "not_a_scene"

--- a/tests/asset_pipeline/test_model_report_validation.py
+++ b/tests/asset_pipeline/test_model_report_validation.py
@@ -1,0 +1,180 @@
+"""Semantic admission checks for caller-supplied inspect-model reports."""
+
+from copy import deepcopy
+
+import pytest
+
+from gda.commands.resource import ResourceInspectModelResult
+from gda.integrations.model_report_validation import validate_model_report
+
+
+def _report() -> dict:
+    identity = {
+        "origin": [0.0, 0.0, 0.0],
+        "basis": [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+    }
+    return {
+        "path": "res://model.glb",
+        "subtree": ".",
+        "engine_version": {
+            "major": 4,
+            "minor": 5,
+            "patch": 0,
+            "hex": 0x40500,
+            "status": "stable",
+            "build": "official",
+            "hash": "abc",
+            "string": "4.5.stable",
+            "timestamp": 0,
+        },
+        "measurement": {
+            "coordinate_space": "resource",
+            "geometry": "static_mesh_aabb",
+            "limitations": [],
+        },
+        "nodes": [
+            {
+                "path": ".",
+                "type": "Node3D",
+                "local_transform": identity,
+                "resource_transform": identity,
+                "mesh": None,
+                "skeleton": None,
+                "animation_player": None,
+            },
+            {
+                "path": "Body",
+                "type": "MeshInstance3D",
+                "local_transform": identity,
+                "resource_transform": identity,
+                "mesh": {
+                    "resource": {
+                        "type": "ArrayMesh",
+                        "name": "Body",
+                        "path": None,
+                        "unavailable_reason": "resource has no stored path",
+                    },
+                    "surface_count": 1,
+                    "surfaces": [
+                        {
+                            "index": 0,
+                            "primitive": "triangles",
+                            "vertex_count": 3,
+                            "index_count": 3,
+                            "triangle_count": 1,
+                            "triangle_count_basis": "index_slots",
+                            "counts_unavailable_reason": None,
+                            "material": None,
+                        }
+                    ],
+                    "skin": None,
+                    "skin_unavailable_reason": "no explicit Skin resource; runtime-generated bindings are not observed",
+                },
+                "skeleton": None,
+                "animation_player": None,
+            },
+        ],
+        "summary": {"node_count": 2, "mesh_instance_count": 1, "unique_mesh_count": 1},
+        "bounds": {"position": [0.0, 0.0, 0.0], "size": [1.0, 2.0, 3.0]},
+        "truncated": False,
+        "omissions": [],
+    }
+
+
+def _model(payload: dict) -> ResourceInspectModelResult:
+    return ResourceInspectModelResult.model_validate(payload)
+
+
+def test_accepts_a_complete_engine_shaped_report():
+    validate_model_report(_model(_report()))
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (lambda value: value["summary"].update(node_count=3), "node_count"),
+        (lambda value: value["nodes"].append(deepcopy(value["nodes"][1])), "node path"),
+        (lambda value: value["nodes"][1].update(path="../Body"), "node path"),
+        (lambda value: value["bounds"]["size"].__setitem__(0, float("nan")), "finite"),
+        (lambda value: value["bounds"]["size"].__setitem__(0, -1.0), "non-negative"),
+        (lambda value: value["nodes"][1]["mesh"].update(surface_count=2), "surfaces"),
+    ],
+)
+def test_rejects_semantically_contradictory_complete_reports(mutate, match):
+    payload = _report()
+    mutate(payload)
+    with pytest.raises(ValueError, match=match):
+        validate_model_report(_model(payload))
+
+
+def test_accepts_engine_prefixes_when_matching_omissions_locate_them():
+    payload = _report()
+    payload["nodes"][1]["mesh"].update(surface_count=2)
+    payload["truncated"] = True
+    payload["omissions"] = [
+        {"node_path": "Body", "section": "surfaces", "reason": "detail_limit"}
+    ]
+    validate_model_report(_model(payload))
+
+
+@pytest.mark.parametrize(
+    "omission",
+    [
+        {"node_path": ".", "section": "nodes", "reason": "detail_limit"},
+        {"node_path": "Missing", "section": "surfaces", "reason": "detail_limit"},
+        {"node_path": ".", "section": "bones", "reason": "detail_limit"},
+    ],
+)
+def test_rejects_unrecognized_or_unlocatable_omissions(omission):
+    payload = _report()
+    payload["truncated"] = True
+    payload["omissions"] = [omission]
+    with pytest.raises(ValueError, match="omission"):
+        validate_model_report(_model(payload))
+
+
+def test_rejects_truncation_flag_without_coverage_records():
+    payload = _report()
+    payload["truncated"] = True
+    with pytest.raises(ValueError, match="truncated"):
+        validate_model_report(_model(payload))
+
+
+def test_accepts_node_truncation_at_the_selected_subtree():
+    payload = _report()
+    payload["nodes"] = payload["nodes"][:1]
+    payload["summary"] = {
+        "node_count": 1,
+        "mesh_instance_count": 0,
+        "unique_mesh_count": 0,
+    }
+    payload["bounds"] = None
+    payload["truncated"] = True
+    payload["omissions"] = [
+        {"node_path": ".", "section": "nodes", "reason": "node_limit"}
+    ]
+    validate_model_report(_model(payload))
+
+
+def test_rejects_resolution_fields_that_contradict_their_status():
+    payload = _report()
+    payload["nodes"].append(
+        {
+            "path": "AnimationPlayer",
+            "type": "AnimationPlayer",
+            "local_transform": None,
+            "resource_transform": None,
+            "mesh": None,
+            "skeleton": None,
+            "animation_player": {
+                "root_path": "..",
+                "resolved_root_path": ".",
+                "unresolved_reason": "animation root not found",
+                "animation_count": 0,
+                "animations": [],
+            },
+        }
+    )
+    payload["summary"]["node_count"] = 3
+    with pytest.raises(ValueError, match="animation root resolution"):
+        validate_model_report(_model(payload))

--- a/tests/cli/test_command_descriptor_registry.py
+++ b/tests/cli/test_command_descriptor_registry.py
@@ -162,6 +162,7 @@ def test_no_renderer_is_orphaned():
 # an asserted INVARIANT over the descriptors, not a dispatch mechanism.
 _RECIPE_OPERATIONS = {
     "asset-pipeline-run",
+    "asset-pipeline-check",
     "export-run",
     # `script run` is the third execution shape (ADR-0031): a user-script passthrough
     # run, fulfilled by a CLI-side recipe (it emits no ADR-0002 sentinel) like export

--- a/tests/mcp/test_mcp_dispatch.py
+++ b/tests/mcp/test_mcp_dispatch.py
@@ -130,3 +130,42 @@ def test_asset_production_object_reaches_structured_dispatch_verbatim():
     assert args == ["asset-pipeline", "run", "--params-json", "-", "--json"]
     assert stdin is not None
     assert json.loads(stdin) == arguments
+
+
+def test_asset_check_content_verdict_is_relayed_as_success_with_explicit_verdict():
+    for verdict in ("pass", "fail", "insufficient"):
+        payload = {
+            "completed": ["validate", "evaluate"],
+            "resource": "res://model.glb",
+            "observation_source": "supplied_report",
+            "verdict": verdict,
+            "checks": [
+                {
+                    "id": "arm",
+                    "verdict": verdict,
+                    "location": {"resource": "res://model.glb", "node": "Arm"},
+                    "expected": {},
+                    "actual": None,
+                    "reason": "Required node",
+                }
+            ],
+            "comparison": None,
+            "failure": None,
+        }
+        runner = FakeGdaRunner(
+            schema_then(lambda args, stdin: gda_result(json.dumps(payload)))
+        )
+        result = call_tool(
+            build_server(runner),
+            "asset_pipeline_check",
+            {"expectations": "/art/checks.json", "report": "/art/report.json"},
+        )
+        assert result.is_error is False
+        assert result.structured_content == payload
+        args, stdin, _ = runner.calls[-1]
+        assert args == ["asset-pipeline", "check", "--params-json", "-", "--json"]
+        assert stdin is not None
+        assert json.loads(stdin) == {
+            "expectations": "/art/checks.json",
+            "report": "/art/report.json",
+        }

--- a/tests/mcp/test_mcp_dispatch.py
+++ b/tests/mcp/test_mcp_dispatch.py
@@ -149,7 +149,13 @@ def test_asset_check_content_verdict_is_relayed_as_success_with_explicit_verdict
                     "reason": "Required node",
                 }
             ],
-            "comparison": None,
+            "comparison": {
+                "status": "comparable",
+                "reasons": [],
+                "resources": {"before": "res://model.glb", "after": "res://model.glb"},
+                "changes": [],
+                "incomplete_sections": [],
+            },
             "failure": None,
         }
         runner = FakeGdaRunner(


### PR DESCRIPTION
## Behavior

A model edit can preserve mesh counts while breaking a gameplay node or animation binding. `gda asset-pipeline check` evaluates a small project-owned expectation file against actual Godot inspection facts, or against a saved native report. It reports exact locations and `pass`, `fail`, or `insufficient`; all completed content evaluations exit 0, while invalid input and workflow failures remain nonzero.

The supporting context owns seven expectation kinds, coverage interpretation, and compatible baseline comparison. The gda host injects inspection and admits native reports through an ACL. Truncated or unavailable facts cannot establish acceptance or inferred deletion. Existing Godot commands remain independent of expectation files or workflow state.

## Validation

- Fast suite at the final head: 2592 passed, 2 skipped; Ruff and Pyright pass.
- Real Godot 4.6.3: seven E2E cases cover an imported GLB baseline, actual node rename with unchanged mesh count, scale/material/animation mutations, exact duplicate short names, bounded detail, saved reports, and baseline differences.
- Built sdist/wheel and clean installed consumer: PNG/GLB handoff, model acceptance, saved-report comparison without a project, repeat and failure behavior pass.
- CLI, structured parameters, generated MCP verdicts, help/schema, and translated command guidance are covered.

Independent Sol Standards, Spec, and DDMA reviews pass at `6d6202e51eeaa23ab9f1ad2f48acaecfdafc1fb3`. The Standards review found an opaque comparison schema; the follow-up publishes the existing fixed result through small domain values reused directly by Pydantic. A discriminating schema test and non-null generated MCP result cover the fix. The seven native checks and installed-wheel smoke pass again after it.

[Full hosted CI at the reviewed head](https://github.com/aigengame/godot-agent/actions/runs/34185052203) passed, including real Godot tests, the installed workflow smoke, Panda compatibility and every member matrix job. Regular PR checks also passed. The earlier manual run was cancelled after this head superseded it.

## Integration

Refs #887. Part of umbrella #907 and [gda-blender milestone](https://github.com/aigengame/godot-agent/milestone/14).

This issue branch targets `codex/asset-pipeline-dev` only. Merging it does not merge the milestone into `main` or complete the remaining milestone work.
