### PR TITLE
docs(readme): remove redundant section dividers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@
 > `gda` is **pre-1.0**: every command works end to end today, but the command surface may
 > still change before 1.0.
 
----
-
 ## Contents
 
 - [Why `gda`?](#why-gda)
@@ -46,8 +44,6 @@
 - [Configuration](#configuration)
 - [Contributing](#contributing)
 - [License](#license)
-
----
 
 ## Why `gda`?
 
@@ -74,8 +70,6 @@ These capabilities were refined while
 [building a real game](https://aigengame.xyz/#showcase), with the work documented in a public
 [dogfooding record](https://github.com/aigengame/godot-agent/milestone/10).
 
----
-
 ## Capabilities at a glance
 
 | Goal | What `gda` provides | Start with |
@@ -85,8 +79,6 @@ These capabilities were refined while
 | Verify runtime behavior (Live) | Read runtime state, call declared methods, simulate input, capture frames, collect logs and errors, and sample performance | `gda daemon start`, then `game` / `input` / `screen` / `diag` / `logger` / `perf` |
 | Connect an AI coding agent | Use direct CLI execution, reusable Agent Skill guidance, or MCP tool discovery and calling | `gda` / `gda skill` / `gda-mcp` |
 | Run reliably in automation | Receive structured results, typed schemas and failures, bounded execution, isolated logs, and actionable diagnostics | `--json` / `--schema` / `--user-data-root` / timeouts |
-
----
 
 ## Installation
 
@@ -118,8 +110,6 @@ uv sync                  # create the environment + install dependencies
 uv run gda --help
 ```
 </details>
-
----
 
 ## Quick start
 
@@ -169,8 +159,6 @@ gda daemon stop
 
 (`gda screen capture` works live too, but needs a windowed session — start the daemon
 with `gda daemon start --windowed`.)
-
----
 
 ## Choose your integration
 
@@ -314,8 +302,6 @@ command — register via the JSON above or the Settings → MCP UI.
 > [registration recipes](docs/gda-mcp-registration.md).
 </details>
 
----
-
 ## How it works
 
 `gda` is one Godot automation toolchain with three components and two complementary
@@ -351,8 +337,6 @@ self-disables in the exported game — so a shipped game never *runs* anything d
 ¹ Headless is cross-platform by design (one-shot processes, no platform-specific
   dependency) — Windows keeps the full headless surface, though CI does not exercise it yet.
 ² Live operations use Unix domain sockets, so Windows is not supported yet.
-
----
 
 ## Command reference
 
@@ -555,8 +539,6 @@ Read injected mouse coordinates from `event.position` — in a daemon session
 | `--version` | Print the installed `gda` version. With `--json`, also where it came from — install kind (`wheel`, `editable`, or `unknown`) and, for an editable install, the source checkout's Git revision. |
 | `--help`    | Show usage for `gda` or any command.                                |
 
----
-
 ## Configuration
 
 `gda` finds the Godot binary from the **`--godot <path>`** flag, otherwise the
@@ -589,8 +571,6 @@ project is trusted ([ADR-0009](docs/adr/0009-trust-boundary-trusted-project.md))
   undeclared is ever called.
 
 </details>
-
----
 
 <details>
 <summary><strong>Under the hood</strong> — the structured-output contract & exit codes</summary>
@@ -690,8 +670,6 @@ CONTEXT.md          # the project's shared domain language
 one-shot headless process (`runner.py`) and talking to a running game via the daemon
 (`live_runner.py`). The e2e suite drives a real engine across both.
 </details>
-
----
 
 ## Contributing
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -34,8 +34,6 @@
 > `gda` está en **pre-1.0**: hoy cada comando funciona de extremo a extremo, pero la superficie de comandos
 > todavía puede cambiar antes de 1.0.
 
----
-
 ## Índice
 
 - [¿Por qué `gda`?](#why-gda)
@@ -48,8 +46,6 @@
 - [Configuración](#configuration)
 - [Contribuir](#contributing)
 - [Licencia](#license)
-
----
 
 <a id="why-gda"></a>
 ## ¿Por qué `gda`?
@@ -79,8 +75,6 @@ Estas capacidades se perfeccionaron mientras
 [se desarrollaba un juego real](https://aigengame.xyz/#showcase); el trabajo quedó documentado
 en un [registro público de dogfooding](https://github.com/aigengame/godot-agent/milestone/10).
 
----
-
 <a id="capabilities-at-a-glance"></a>
 ## Capacidades de un vistazo
 
@@ -91,8 +85,6 @@ en un [registro público de dogfooding](https://github.com/aigengame/godot-agent
 | Verificar el comportamiento en runtime (Live) | Leer el estado de runtime, llamar a métodos declarados, simular entradas, capturar frames, recopilar registros y errores, y medir el rendimiento | `gda daemon start`, luego `game` / `input` / `screen` / `diag` / `logger` / `perf` |
 | Conectar un agente de programación con IA | Usar la CLI directamente, la orientación reutilizable de Agent Skill o el descubrimiento y las llamadas de herramientas MCP | `gda` / `gda skill` / `gda-mcp` |
 | Ejecutar automatización de forma fiable | Recibir resultados estructurados, esquemas y fallos tipados, ejecución acotada, registros aislados y diagnósticos útiles | `--json` / `--schema` / `--user-data-root` / timeouts |
-
----
 
 <a id="installation"></a>
 ## Instalación
@@ -125,8 +117,6 @@ uv sync                  # create the environment + install dependencies
 uv run gda --help
 ```
 </details>
-
----
 
 <a id="quick-start"></a>
 ## Inicio rápido
@@ -178,8 +168,6 @@ gda daemon stop
 
 (`gda screen capture` también funciona en vivo, pero necesita una sesión con ventana — arranca el daemon
 con `gda daemon start --windowed`.)
-
----
 
 <a id="choose-your-integration"></a>
 ## Elige tu integración
@@ -326,8 +314,6 @@ funciona en el ámbito de proyecto; usa el ámbito de proyecto para varios proye
 > [recetas de registro](gda-mcp-registration.md).
 </details>
 
----
-
 <a id="how-it-works"></a>
 ## Cómo funciona
 
@@ -365,8 +351,6 @@ se autodeshabilita en el juego exportado — de modo que un juego publicado nunc
 ¹ Headless es multiplataforma por diseño (procesos de una sola pasada, sin dependencias específicas de
   plataforma) — Windows conserva toda la superficie headless, aunque la CI todavía no la ejercita.
 ² Las operaciones live usan sockets de dominio Unix, por lo que Windows todavía no es compatible.
-
----
 
 <a id="command-reference"></a>
 ## Referencia de comandos
@@ -570,8 +554,6 @@ Lee las coordenadas de ratón inyectadas desde `event.position` — en una sesi�
 | `--version` | Imprime la versión instalada de `gda`. Con `--json`, también de dónde viene: el tipo de instalación (`wheel`, `editable` o `unknown`) y, para una instalación editable, la revisión de Git del código fuente. |
 | `--help`    | Muestra el uso de `gda` o de cualquier comando.                     |
 
----
-
 <a id="configuration"></a>
 ## Configuración
 
@@ -605,8 +587,6 @@ proyecto es de confianza ([ADR-0009](adr/0009-trust-boundary-trusted-project.md)
   invoca nada que no esté declarado.
 
 </details>
-
----
 
 <details>
 <summary><strong>Bajo el capó</strong> — el contrato de salida estructurada y los códigos de salida</summary>
@@ -706,8 +686,6 @@ CONTEXT.md          # the project's shared domain language
 rápidas: lanzar un proceso headless de una sola pasada (`runner.py`) y comunicarse con un juego en ejecución
 a través del daemon (`live_runner.py`). La suite e2e maneja un motor real a través de ambas.
 </details>
-
----
 
 <a id="contributing"></a>
 ## Contribuir

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=150ed6831b06c9466fc94b1a74fc01750974b5285c215a4cbb7cd852cc5c1c4a -->
+<!-- gda-readme-i18n: source=README.md sha256=f5c8db9324ad6e438a7942a949c484d9d2db9a474c93f656664330b15baa420c -->
 
 # gda — Automatización de Godot para agentes de IA
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -34,8 +34,6 @@
 > `gda` は **pre-1.0** です。現時点ですべてのコマンドがエンドツーエンドで動作しますが、
 > コマンド体系は 1.0 までにまだ変わる可能性があります。
 
----
-
 ## 目次
 
 - [なぜ `gda`？](#why-gda)
@@ -48,8 +46,6 @@
 - [設定](#configuration)
 - [コントリビューション](#contributing)
 - [ライセンス](#license)
-
----
 
 <a id="why-gda"></a>
 ## なぜ `gda`？
@@ -75,8 +71,6 @@
 これらの機能は[実際のゲーム制作](https://aigengame.xyz/#showcase)を通じて磨かれ、その過程は
 公開されている[dogfooding の記録](https://github.com/aigengame/godot-agent/milestone/10)にまとめられています。
 
----
-
 <a id="capabilities-at-a-glance"></a>
 ## ひと目でわかる機能
 
@@ -87,8 +81,6 @@
 | ランタイム挙動を検証する（Live） | ランタイム状態の読み取り、宣言済みメソッドの呼び出し、入力シミュレーション、フレーム取得、ログとエラーの収集、パフォーマンス計測 | `gda daemon start`、その後 `game` / `input` / `screen` / `diag` / `logger` / `perf` |
 | AI コーディングエージェントを接続する | CLI の直接実行、Agent Skill の再利用可能なガイダンス、または MCP ツールの検出と呼び出し | `gda` / `gda skill` / `gda-mcp` |
 | 自動化環境で安定して実行する | 構造化結果、型付きのスキーマと失敗、範囲を制御した実行、分離されたログ、復旧に使える診断情報 | `--json` / `--schema` / `--user-data-root` / タイムアウト |
-
----
 
 <a id="installation"></a>
 ## インストール
@@ -121,8 +113,6 @@ uv sync                  # create the environment + install dependencies
 uv run gda --help
 ```
 </details>
-
----
 
 <a id="quick-start"></a>
 ## クイックスタート
@@ -175,8 +165,6 @@ gda daemon stop
 
 (`gda screen capture` も Live で動作しますが、ウィンドウ付きのセッションが必要です — `gda daemon
 start --windowed` でデーモンを起動してください。)
-
----
 
 <a id="choose-your-integration"></a>
 ## 統合方法を選ぶ
@@ -323,8 +311,6 @@ codex mcp add gda-mcp --env GDA_PROJECT=/absolute/path/to/your/godot/project -- 
 > ごとのプロジェクト固定 — は [登録レシピ](gda-mcp-registration.md) にあります。
 </details>
 
----
-
 <a id="how-it-works"></a>
 ## 仕組み
 
@@ -361,8 +347,6 @@ Headless 検証はプロジェクトの実行準備を確認し、Live 操作は
 ¹ Headless は設計上クロスプラットフォームです(ワンショットのプロセスで、プラットフォーム固有の
   依存がありません)— Windows でも Headless の全機能が使えますが、CI ではまだ検証されていません。
 ² Live 操作は Unix ドメインソケットを使うため、Windows はまだサポートされていません。
-
----
 
 <a id="command-reference"></a>
 ## コマンドリファレンス
@@ -566,8 +550,6 @@ Headless 検証はプロジェクトの実行準備を確認し、Live 操作は
 | `--version` | インストール済みの `gda` のバージョンを表示します。`--json` を付けると、その出どころも出力します — インストール種別(`wheel`・`editable`・`unknown`)と、editable インストールの場合はソースチェックアウトの Git リビジョンです。 |
 | `--help`    | `gda` または任意のコマンドの使い方を表示します。 |
 
----
-
 <a id="configuration"></a>
 ## 設定
 
@@ -601,8 +583,6 @@ Headless 検証はプロジェクトの実行準備を確認し、Live 操作は
   メソッドが呼ばれることはありません。
 
 </details>
-
----
 
 <details>
 <summary><strong>内部の仕組み</strong> — 構造化出力の契約と終了コード</summary>
@@ -701,8 +681,6 @@ CONTEXT.md          # the project's shared domain language
 ワンショットの Headless プロセスを起動すること(`runner.py`)と、デーモン経由で実行中ゲームと対話する
 こと(`live_runner.py`)です。e2e スイートは、その両方にわたって実際のエンジンを駆動します。
 </details>
-
----
 
 <a id="contributing"></a>
 ## コントリビューション

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=150ed6831b06c9466fc94b1a74fc01750974b5285c215a4cbb7cd852cc5c1c4a -->
+<!-- gda-readme-i18n: source=README.md sha256=f5c8db9324ad6e438a7942a949c484d9d2db9a474c93f656664330b15baa420c -->
 
 # gda — AI エージェント向け Godot オートメーション
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -33,8 +33,6 @@
 > `gda` 处于 **pre-1.0** 阶段：目前每条命令都能端到端跑通，但在 1.0 之前命令界面
 > 仍可能变化。
 
----
-
 ## 目录
 
 - [为什么选择 `gda`？](#why-gda)
@@ -47,8 +45,6 @@
 - [配置](#configuration)
 - [贡献](#contributing)
 - [许可证](#license)
-
----
 
 <a id="why-gda"></a>
 ## 为什么选择 `gda`？
@@ -70,8 +66,6 @@
 这些能力在[真实游戏制作](https://aigengame.xyz/zh/#showcase)中持续打磨，相关过程记录在
 公开的[dogfooding 记录](https://github.com/aigengame/godot-agent/milestone/10)中。
 
----
-
 <a id="capabilities-at-a-glance"></a>
 ## 能力速览
 
@@ -82,8 +76,6 @@
 | 验证运行时行为（Live） | 读取运行时状态、调用已声明的方法、模拟输入、捕获画面、收集日志和错误以及测量性能 | `gda daemon start`，然后使用 `game` / `input` / `screen` / `diag` / `logger` / `perf` |
 | 接入 Coding Agent | 使用 CLI 直接执行、Agent Skill 可复用指导，或 MCP 工具发现与调用 | `gda` / `gda skill` / `gda-mcp` |
 | 在自动化环境中可靠运行 | 获得结构化结果、带类型的 Schema 与失败信息、明确的执行边界、隔离日志和可直接处理的诊断信息 | `--json` / `--schema` / `--user-data-root` / 超时设置 |
-
----
 
 <a id="installation"></a>
 ## 安装
@@ -116,8 +108,6 @@ uv sync                  # create the environment + install dependencies
 uv run gda --help
 ```
 </details>
-
----
 
 <a id="quick-start"></a>
 ## 快速上手
@@ -167,8 +157,6 @@ gda daemon stop
 
 （`gda screen capture` 也能实时工作，但需要一个带窗口的会话——用
 `gda daemon start --windowed` 启动 daemon。）
-
----
 
 <a id="choose-your-integration"></a>
 ## 选择你的集成方式
@@ -307,8 +295,6 @@ Cursor 没有 `mcp add` 命令——请通过上面的 JSON 或 Settings → MCP
 > 用户级与项目级、各 agent 的项目固定方式——都在[注册配方](gda-mcp-registration.md)里。
 </details>
 
----
-
 <a id="how-it-works"></a>
 ## 工作原理
 
@@ -342,8 +328,6 @@ Headless 验证确认项目就绪状态；Live 操作返回用于验证实际行
 ¹ Headless 在设计上就是跨平台的（一次性进程，无平台相关依赖）——Windows 保留完整的
   headless 命令界面，尽管 CI 还没有对它做过验证。
 ² Live 操作使用 Unix 域套接字，所以暂不支持 Windows。
-
----
 
 <a id="command-reference"></a>
 ## 命令参考
@@ -546,8 +530,6 @@ Headless 验证确认项目就绪状态；Live 操作返回用于验证实际行
 | `--version` | 打印已安装的 `gda` 版本。加上 `--json` 时，同时给出它的来源——安装类型（`wheel`、`editable` 或 `unknown`），以及 editable 安装对应源码检出的 Git 版本号。 |
 | `--help`    | 显示 `gda` 或任意命令的用法。                                |
 
----
-
 <a id="configuration"></a>
 ## 配置
 
@@ -578,8 +560,6 @@ Headless 验证确认项目就绪状态；Live 操作返回用于验证实际行
 - **`game call`** 只运行节点 `GDA_CALLABLE` 声明中列出的那一个方法；未声明的绝不会被调用。
 
 </details>
-
----
 
 <details>
 <summary><strong>底层原理</strong> — 结构化输出契约与退出码</summary>
@@ -677,8 +657,6 @@ CONTEXT.md          # the project's shared domain language
 headless 进程（`runner.py`），以及通过 daemon 与正在运行的游戏对话（`live_runner.py`）。
 e2e 套件会驱动真实引擎覆盖这两条边界。
 </details>
-
----
 
 <a id="contributing"></a>
 ## 贡献

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=150ed6831b06c9466fc94b1a74fc01750974b5285c215a4cbb7cd852cc5c1c4a -->
+<!-- gda-readme-i18n: source=README.md sha256=f5c8db9324ad6e438a7942a949c484d9d2db9a474c93f656664330b15baa420c -->
 
 # gda — 面向 AI Agent 的 Godot 自动化
 


### PR DESCRIPTION
Removes the repeated full-width horizontal rules from the English, Chinese, Spanish, and Japanese README files. Section headings, anchors, content, links, and table separators remain unchanged. Validation: git diff --check passed, and no standalone horizontal rules remain in the four README files.