### PR TITLE
feat(asset-pipeline): preserve prompts and register external outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,12 @@ names the file, and only `preflight` catches a first-frame failure.
 | `asset-pipeline check` | Evaluate project model expectations and compare compatible Godot inspection reports. Read the content verdict; completed checks exit 0. |
 | `asset-pipeline preview` | Render three fixed views of a GLB in an isolated windowed project and collect bounded inspection, capture, diagnostic and scene-level performance results. |
 | `asset-pipeline check-package` | Apply the same model expectations to a resource loaded from an isolated exported PCK and check exact declared exclusions. |
+| `asset-pipeline prompt-prepare` / `prompt-inspect` | Save or reuse one attempt's prompt and PNG reference inputs before external generation. |
+| `asset-pipeline prompt-revise` / `prompt-register-output` | Create a separate revised attempt or preserve a completed local PNG with its declared/reported details. |
+
+The [prompt commands](libs/gda-assets/docs/prompts.md) work locally without Godot
+or a provider connection. Preparation returns an external handoff; it does not
+generate an image.
 
 Use explicit source-to-target mappings and an overwrite policy. Completed
 image-generation files use the same path with optional caller-declared metadata.

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=7589d50a4b80dcb257c9c6dff0f42968979eb4a0916286357e14308927c57176 -->
+<!-- gda-readme-i18n: source=README.md sha256=40e478a5d338ee83ba3ba811623d831ed075bd1af73499a68310544b2bb8e50e -->
 
 # gda — Automatización de Godot para agentes de IA
 
@@ -501,6 +501,10 @@ identifica el archivo y solo `preflight` detecta un fallo en el primer fotograma
 | `asset-pipeline check` | Evalúa el modelo según los requisitos del proyecto y compara informes compatibles de Godot. Una evaluación completada devuelve el código 0; el campo verdict indica si cumple los requisitos. |
 | `asset-pipeline preview` | Renderiza tres vistas fijas de un GLB en un proyecto aislado con ventana y recoge resultados acotados de inspección, captura, diagnóstico y rendimiento de la escena. |
 | `asset-pipeline check-package` | Aplica los mismos requisitos del modelo a un recurso cargado desde un PCK exportado y aislado, y comprueba las exclusiones declaradas mediante rutas exactas. |
+| `asset-pipeline prompt-prepare` / `prompt-inspect` | Guarda o reutiliza el prompt y las referencias PNG de un intento antes de la generación externa. |
+| `asset-pipeline prompt-revise` / `prompt-register-output` | Crea un intento revisado por separado o conserva un PNG local junto con los datos declarados y los comunicados por el proveedor. |
+
+Los [comandos de prompts](../libs/gda-assets/docs/prompts.md) funcionan localmente, sin Godot ni conexión con un proveedor. La preparación devuelve las entradas para la herramienta externa; no genera una imagen.
 
 Usa correspondencias explícitas entre origen y destino y define una política de sobrescritura.
 Los archivos que complete la generación de imágenes siguen el mismo flujo y pueden incluir metadatos

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=7589d50a4b80dcb257c9c6dff0f42968979eb4a0916286357e14308927c57176 -->
+<!-- gda-readme-i18n: source=README.md sha256=40e478a5d338ee83ba3ba811623d831ed075bd1af73499a68310544b2bb8e50e -->
 
 # gda — AI エージェント向け Godot オートメーション
 
@@ -497,6 +497,10 @@ Headless 検証はプロジェクトの実行準備を確認し、Live 操作は
 | `asset-pipeline check` | プロジェクトの条件に沿ってモデルを検証し、観測範囲が一致する Godot のレポートを比較します。検証が完了すると終了コードは 0 となり、合否は verdict に示されます。 |
 | `asset-pipeline preview` | 隔離されたウィンドウ表示プロジェクトで GLB を 3 つの固定視点からレンダリングし、範囲を限定した検査、キャプチャ、診断、シーン単位のパフォーマンス結果を収集します。 |
 | `asset-pipeline check-package` | 隔離されたエクスポート済み PCK からリソースを読み込み、同じモデル条件で検証するとともに、明示された除外対象を正確なパスで確認します。 |
+| `asset-pipeline prompt-prepare` / `prompt-inspect` | 外部ツールで生成する前に、1 回の試行で使うプロンプトと PNG 参照画像を保存し、保存済みの入力を再利用します。 |
+| `asset-pipeline prompt-revise` / `prompt-register-output` | 修正内容を別の試行として保存するか、生成済みのローカル PNG と、呼び出し側の申告・プロバイダーの報告を記録します。 |
+
+[プロンプト用コマンド](../libs/gda-assets/docs/prompts.md)はローカルで動作し、Godot や生成サービスへの接続は不要です。準備後は外部ツールに渡す入力を返します。画像の生成は行いません。
 
 ソースからターゲットへのマッピングと上書きポリシーを明示してください。生成が完了した画像ファイルも
 同じ手順で処理でき、呼び出し側が指定したメタデータを任意で付加できます。[アセットパイプラインガイド](../libs/gda-assets/README.md)では、

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=7589d50a4b80dcb257c9c6dff0f42968979eb4a0916286357e14308927c57176 -->
+<!-- gda-readme-i18n: source=README.md sha256=40e478a5d338ee83ba3ba811623d831ed075bd1af73499a68310544b2bb8e50e -->
 
 # gda — 面向 AI Agent 的 Godot 自动化
 
@@ -477,6 +477,10 @@ Headless 验证确认项目就绪状态；Live 操作返回用于验证实际行
 | `asset-pipeline check` | 按项目要求验收模型，并比较范围兼容的 Godot 检查报告。完成检查后退出码为 0，是否符合要求以结果中的 verdict 为准。 |
 | `asset-pipeline preview` | 在隔离的窗口化项目中渲染 GLB 的三个固定视角，并收集范围受限的检查、截图、诊断和场景级性能结果。 |
 | `asset-pipeline check-package` | 在隔离环境中从导出的 PCK 加载资源，按同一套模型要求验收，并检查明确声明的排除路径。 |
+| `asset-pipeline prompt-prepare` / `prompt-inspect` | 在调用外部生成工具前保存提示词和 PNG 参考图，并读取已保存的输入以供复用。 |
+| `asset-pipeline prompt-revise` / `prompt-register-output` | 将修订后的提示词保存为独立尝试，或登记已生成的本地 PNG 及调用者声明、工具报告的信息。 |
+
+[提示词命令](../libs/gda-assets/docs/prompts.md)在本地运行，无需 Godot 或连接生成服务。准备完成后返回交给外部工具的输入，不会生成图片。
 
 请使用明确的源文件到目标位置映射，并指定覆盖策略。图像生成完成后的文件沿用同一流程，
 也可以附带调用方声明的元数据。[资产管线指南](../libs/gda-assets/README.md)介绍了 Blender 导出、文件输入、引用、

--- a/libs/gda-assets/AGENTS.md
+++ b/libs/gda-assets/AGENTS.md
@@ -4,7 +4,8 @@ This subtree carries **Asset Pipeline**, gda's internal asset-workflow supportin
 context. It is not a sibling user-facing product. File handoff (#908), saved
 Blender production (#909), model expectation checks (#887), optional content
 observations (#889), controlled runtime refresh (#890), preview (#891), and package
-acceptance (#892) are implemented. Prompt and concept workflows remain planned.
+acceptance (#892), and local prompt records (#912) are implemented. Concept
+selection and authoring consumers remain planned.
 Requirements, review, CI, and delivery status live in
 [#907](https://github.com/aigengame/godot-agent/issues/907).
 

--- a/libs/gda-assets/ASSETS-CONTEXT.md
+++ b/libs/gda-assets/ASSETS-CONTEXT.md
@@ -33,6 +33,8 @@ text/template and inputs, resolved prompt, selected reference inputs, and reques
 producer options. Output files and reported details can be associated afterward.
 It supports inspect, explicit revision, and reuse; it is not a content receipt,
 provider-execution proof, or guarantee of reproducible output.
+Its record directory is the local locator. Preparation and inspection return saved
+inputs for an external generator; explicit revision writes another directory.
 
 **Concept reference**: An explicitly selected image-gen result used to guide new
 model or sprite authoring. Its role differs from a finished runtime asset. Project

--- a/libs/gda-assets/README.md
+++ b/libs/gda-assets/README.md
@@ -7,6 +7,11 @@ source inspection and uniform scale preparation, see the
 [Blender production guide](docs/blender.md). Completed image-generation outputs
 use explicit file handoff; this command does not generate images.
 
+Use `gda asset-pipeline prompt-prepare` before external image generation to save
+the exact prompt and reference inputs. Inspect or revise those saved inputs, then
+register completed local output files. See the [prompt guide](docs/prompts.md)
+for the four local operations and their external-tool handoff.
+
 Use `gda asset-pipeline check` to evaluate project-owned model expectations against
 a current Godot inspection or a saved raw inspection report. See the
 [model checks guide](docs/checks.md) for the JSON format, seven supported check

--- a/libs/gda-assets/docs/ARCHITECTURE.md
+++ b/libs/gda-assets/docs/ARCHITECTURE.md
@@ -2,8 +2,9 @@
 
 **Status:** accepted design; file handoff (#908), saved Blender production (#909),
 model expectation checks (#887), optional content observations (#889), controlled
-runtime refresh (#890), preview (#891), and package acceptance (#892) are implemented.
-Prompt and concept workflows remain planned. Accepted by the project owner
+runtime refresh (#890), preview (#891), package acceptance (#892), and local prompt
+records (#912) are implemented. Concept selection and authoring consumers remain
+planned. Accepted by the project owner
 on 2026-09-07 after review of the Blender-to-Godot workflow and milestone #14.
 Source baseline inspected: `cfcb8658e67df418a69694840a37a22a9cd3cbe0`.
 Acceptance and delivery status are owned by
@@ -122,18 +123,20 @@ libs/gda-assets/
       recipe.py
       artifacts.py
       expectations.py
-      preparation.py                 # prompt/reference values when needed
+      prompt.py                       # prompt inputs, values, and composition rules
     application/
       ports.py
       integrate.py
       produce.py
-      prepare.py                     # save inputs, register outputs, select references
+      prompt.py                       # prepare, inspect, revise, register outputs
+      prompt_ports.py                 # required local file persistence
       preview.py                      # isolated model preview orchestration
       package.py                      # isolated package acceptance orchestration
     adapters/
       blender/
       imagegen/
       files.py
+      prompt_files.py                 # ordinary prompt snapshots and PNG copies
       raster.py
     bootstrap.py                      # producer composition, lazy setup
   tests/
@@ -153,6 +156,8 @@ inspection and export stay inside the Blender adapter and its bundled worker.
 The [Blender guide](blender.md) owns the supported execution and measurement policy.
 The [model checks guide](checks.md) owns the implemented expectation document,
 verdict, saved-report, and baseline-comparison user contract.
+The [prompt guide](prompts.md) owns local preparation, explicit reuse/revision,
+and completed-file registration. These use no Godot port or provider connection.
 The [runtime refresh guide](runtime-refresh.md) owns the implemented controlled
 restart, selected-instance comparison, and capture-association user contract.
 The root [static model content guide](../../../docs/model-content.md) owns the two
@@ -320,7 +325,7 @@ AP-06 remains open. Review, CI, and delivery status remain in the linked issues.
 | AP-03 | Reliable option-only reimport; gda [#888](https://github.com/aigengame/godot-agent/issues/888). Current import fast path and engine docs inspected | Unchanged GLB plus changed root scale returns cached success with old dimensions. Real engine option-only, no-op, invalid, and failed cases |
 | AP-04 | Honest runtime freshness; [#890](https://github.com/aigengame/godot-agent/issues/890). Current session/capture semantics inspected | A/B share path, names, counts, bounds, material refs but differ in supported content and compare equal. Test selected-instance content, stale/wrong instance, runtime replacement, session and capture scope |
 | AP-05 | Minimum machinery with usable recovery; aADR-0002. Existing scripts offer reusable stages, no generic resume proof | Import failure or unknown producer outcome triggers regeneration or false completion. Inject stage failures, retain outputs, and explicitly retry remaining steps without production replay |
-| AP-06 | Prompt preservation and usable concept references; aADR-0003, #912/#913. Panda prompt composition and post-acquisition manifest recording inspected; implementation evidence remains open | Editing style/reference inputs changes an earlier attempt, reuse regenerates silently, or an authoring consumer loads an unselected candidate. Test separate attempts, explicit reuse/revision, failure ordering, real image generation, and selected-reference consumption in Blender and sprite examples |
+| AP-06 | Prompt preservation and usable concept references; aADR-0003, #912/#913. Local prompt commands preserve and reuse separate attempts and register external outputs. Real concept generation and authoring-reference consumption remain open under #913 | Editing style/reference inputs changes an earlier attempt, reuse regenerates silently, or an authoring consumer loads an unselected candidate. Test separate attempts, explicit reuse/revision, failure ordering, real image generation, and selected-reference consumption in Blender and sprite examples |
 | AP-07 | Package-only acceptance; [#892](https://github.com/aigengame/godot-agent/issues/892) and aADR-0002. Real cold-export tests apply the same mesh, material, and animation rules to source and PCK facts, detect omitted models and included exclusions, and verify isolation, package hash, and cleanup | A warm source project masks an omitted packaged model, an exclusion scans outside selected exact paths, or an editor probe is reported as native release behavior. Unsupported-editor gating has separate runner tests; native executable behavior is outside this check |
 
 The design's boundary review covers known owners and source cycles, but does not

--- a/libs/gda-assets/docs/prompts.md
+++ b/libs/gda-assets/docs/prompts.md
@@ -1,0 +1,112 @@
+# Preserve prompts before generation
+
+The prompt commands save one attempt in an ordinary directory chosen by the
+caller. They require no Godot project, engine, provider credentials, or network
+connection. Use separate directories for separate attempts and manage them with
+your existing version control.
+
+Prepare a plain prompt before calling an external tool:
+
+```sh
+gda asset-pipeline prompt-prepare --record ./art/prompts/attempt-a \
+  --text 'A small blue robot with a round head, front and side views.' --json
+```
+
+Preparation returns an external generation handoff with the saved prompt and
+reference paths. Use these saved inputs when invoking the tool. The command does
+not invoke an image generator or claim that an image was generated. An external
+failure or unknown completion leaves the prepared inputs available.
+
+## Compose project inputs
+
+A template file uses Python's
+[simple template syntax](https://docs.python.org/3.13/library/string.html#template-strings)
+with `$name` or `${name}` placeholders. Supply string values
+in `--variables`; `$$` writes a literal dollar sign. Missing or unused variables
+and invalid placeholder syntax fail preparation. Plain `--text` is literal and
+does not substitute variables.
+
+An optional style file precedes the resolved main prompt, separated by a blank
+line. The attempt preserves its authored inputs, resolved text, and copies of the
+selected PNG reference files. Later source edits do not change those saved inputs.
+
+```sh
+gda asset-pipeline prompt-prepare --record ./art/prompts/attempt-b \
+  --template ./art/subject.txt --style ./art/style.txt \
+  --variables '{"subject":"blue robot"}' \
+  --reference ./art/palette.png --json
+```
+
+The template can contain `Three views of a $subject.`. Reference files must be
+valid PNG images; the initial path does not accept other reference formats.
+Preparation refuses an existing record destination.
+
+## Reuse and revise
+
+```sh
+gda asset-pipeline prompt-inspect --record ./art/prompts/attempt-a --json
+
+gda asset-pipeline prompt-revise --source-record ./art/prompts/attempt-b \
+  --record ./art/prompts/attempt-c \
+  --variables '{"subject":"orange robot"}' --json
+```
+
+Inspection returns the saved input without calling a producer. Internal file links
+resolve from the record directory, so inspection works in a new process or from
+another working directory. Command-line input paths resolve from the caller's
+working directory; pass an absolute record path when working elsewhere.
+
+Revision starts from the earlier saved inputs, applies explicit replacements, and
+writes a new record. Its result identifies the changed fields. It does not update
+the prior record or create a global revision history.
+
+## Register a completed output
+
+After an external tool returns a local PNG, associate it with the prepared attempt:
+
+```sh
+gda asset-pipeline prompt-register-output --record ./art/prompts/attempt-a \
+  --output ./generated/robot.png --name robot.png \
+  --caller-declarations '{"tool":"external image tool","generation_completed":true}' \
+  --submitted-prompt 'A small blue robot with a round head, front and side views.' --json
+```
+
+Registration validates and preserves the local output. It does not call or retry
+the producer. Missing or invalid output files fail without removing the prompt or
+earlier registered outputs. An existing output name is refused.
+
+Requested settings, caller declarations, and provider-reported details remain
+separate. Supply the exact actually submitted prompt when it differs from the
+prepared text; omitted dispatch information remains unknown. A registered local
+file does not independently prove provider execution, and identical prompts do
+not guarantee identical images. Do not place secrets in prompt text or metadata.
+
+`--requested-options` and `--reported-options` accept a JSON object with these
+selected keys: `aspect_ratio`, `background`, `model`, `output_format`, `quality`,
+`seed`, `size`, and `style`. Values are JSON scalars. These values are recorded;
+they do not configure or validate a remote provider. `--reported-provider` and
+`--reported-model` retain facts returned by the external tool. Use
+`--caller-declarations` for `tool`, `provider`, `model`, `request_id`, and
+`generation_completed` supplied by the caller. A completion declaration stays
+separate from the record's unknown independently verified generation status.
+
+Read `preparation.record` and `preparation.handoff` after prepare or inspect;
+`revision.preparation` and `revision.changed_fields` after revision; and
+`prompt_record.outputs` after registration. Output registration preserves a PNG
+copy and its own metadata without rewriting the saved preparation inputs.
+
+The initial limits are 16 reference images, 64 output registrations per record,
+64 variables, 1 MiB per text input/resolved prompt, and 4 MiB per JSON record or
+registration. Each PNG is limited to 256 MiB and 64 megapixels. Variable names
+are at most 128 characters and values at most 4,096 characters. Save another
+attempt when you need another group of outputs.
+
+Use each command's `--schema` for the supported input and result fields.
+The same input is available through `--params-json` and generated MCP. Successful
+local preparation, inspection, revision, or registration exits 0; invalid input or
+file operations fail with a structured error.
+
+Prompt records are optional for existing-file admission and saved Blender export.
+`gda asset-pipeline run` and ordinary resource, scene, and game operations keep
+their independent contracts. Concept selection and authoring-reference consumers
+are tracked separately by [#913](https://github.com/aigengame/godot-agent/issues/913).

--- a/libs/gda-assets/src/gda_assets/adapters/prompt_files.py
+++ b/libs/gda-assets/src/gda_assets/adapters/prompt_files.py
@@ -18,6 +18,7 @@ from gda_assets.domain.prompt import (
     PromptFile,
     PromptOutput,
     PromptOutputRequest,
+    PromptOptionKey,
     PromptRecord,
 )
 
@@ -33,6 +34,14 @@ _FILE = TypeAdapter(PromptFile)
 
 def _identity(item: os.stat_result) -> tuple[int, int, int, int, int]:
     return item.st_dev, item.st_ino, item.st_size, item.st_mtime_ns, item.st_ctime_ns
+
+
+def _validation_message(error: ValidationError) -> str:
+    details = []
+    for item in error.errors(include_input=False, include_url=False):
+        location = ".".join(str(part) for part in item["loc"])
+        details.append(f"{location}: {item['msg']}" if location else str(item["msg"]))
+    return "; ".join(details)
 
 
 def _safe_name(name: str) -> str:
@@ -144,7 +153,7 @@ class PromptFiles:
         resolved_prompt: str,
         references: tuple[Path, ...],
         producer: str | None,
-        requested_options: dict[str, JsonScalar],
+        requested_options: dict[PromptOptionKey, JsonScalar],
         revised_from: str | None = None,
     ) -> PromptRecord:
         root = record.absolute()
@@ -257,7 +266,12 @@ class PromptFiles:
             result = PromptRecord(**{**result.__dict__, "outputs": tuple(outputs)})
             self._verify(result)
             return result
-        except (OSError, ValidationError, TypeError, ValueError, PortFailure) as exc:
+        except ValidationError as exc:
+            raise PortFailure(
+                "invalid_prompt",
+                f"Invalid prompt record fields: {_validation_message(exc)}",
+            ) from exc
+        except (OSError, TypeError, ValueError, PortFailure) as exc:
             if isinstance(exc, PortFailure) and exc.code == "invalid_prompt":
                 raise
             raise PortFailure(

--- a/libs/gda-assets/src/gda_assets/adapters/prompt_files.py
+++ b/libs/gda-assets/src/gda_assets/adapters/prompt_files.py
@@ -1,0 +1,385 @@
+"""Ordinary local files for prompt records and registered PNG outputs."""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import stat
+from typing import Literal
+
+from pydantic import TypeAdapter, ValidationError
+
+from gda_assets.adapters.file_copy import copy_with_sha256
+from gda_assets.adapters.files import validate_format
+from gda_assets.application.ports import PortFailure
+from gda_assets.domain.prompt import (
+    JsonScalar,
+    PromptFile,
+    PromptOutput,
+    PromptOutputRequest,
+    PromptRecord,
+)
+
+
+_TEXT_LIMIT = 1024 * 1024
+_JSON_LIMIT = 4 * 1024 * 1024
+_PNG_LIMIT = 256 * 1024 * 1024
+_OUTPUT_LIMIT = 64
+_RECORD = TypeAdapter(PromptRecord)
+_OUTPUT = TypeAdapter(PromptOutput)
+_FILE = TypeAdapter(PromptFile)
+
+
+def _identity(item: os.stat_result) -> tuple[int, int, int, int, int]:
+    return item.st_dev, item.st_ino, item.st_size, item.st_mtime_ns, item.st_ctime_ns
+
+
+def _safe_name(name: str) -> str:
+    if (
+        not name
+        or name != Path(name).name
+        or Path(name).suffix.lower() != ".png"
+        or any(char in name for char in ("/", "\\", "\x00"))
+    ):
+        raise PortFailure("invalid_prompt", "Output name must be one PNG filename")
+    return name
+
+
+def _read_bounded(path: Path, limit: int) -> bytes:
+    try:
+        with path.open("rb") as stream:
+            before = os.fstat(stream.fileno())
+            if not stat.S_ISREG(before.st_mode) or before.st_size > limit:
+                raise ValueError("input is not a bounded regular file")
+            value = stream.read(limit + 1)
+            after = os.fstat(stream.fileno())
+        current = path.stat()
+        if (
+            len(value) > limit
+            or _identity(before) != _identity(after)
+            or _identity(after) != _identity(current)
+        ):
+            raise ValueError("input changed or exceeded its size limit")
+        return value
+    except (OSError, ValueError) as exc:
+        raise PortFailure(
+            "invalid_prompt", f"Invalid prompt input {path}: {exc}"
+        ) from exc
+
+
+def _png_facts(declared: Path, saved: Path) -> PromptFile:
+    try:
+        validate_format(saved)
+        from PIL import Image
+
+        with Image.open(saved) as image:
+            width, height = image.size
+        with saved.open("rb") as stream:
+            digest = hashlib.file_digest(stream, "sha256").hexdigest()
+        size = saved.stat().st_size
+        return PromptFile(str(declared), saved, digest, size, width, height)
+    except PortFailure as exc:
+        raise PortFailure("invalid_prompt", str(exc)) from exc
+
+
+def _relative_file(item: PromptFile | None, root: Path) -> dict | None:
+    if item is None:
+        return None
+    value = _FILE.dump_python(item, mode="json")
+    value["path"] = str(item.path.relative_to(root))
+    return value
+
+
+def _record_json(record: PromptRecord) -> bytes:
+    root = record.record
+    value = _RECORD.dump_python(record, mode="json")
+    value["record"] = "."
+    value["resolved_path"] = str(record.resolved_path.relative_to(root))
+    value["template"] = _relative_file(record.template, root)
+    value["style"] = _relative_file(record.style, root)
+    value["references"] = [_relative_file(item, root) for item in record.references]
+    value["outputs"] = []
+    return json.dumps(value, indent=2, sort_keys=True).encode()
+
+
+def _dump(record: PromptRecord, path: Path) -> None:
+    value = _record_json(record)
+    if len(value) > _JSON_LIMIT:
+        raise PortFailure("invalid_prompt", "Prompt record exceeds its JSON limit")
+    temporary = path.with_name(".record.json.tmp")
+    temporary.write_bytes(value + b"\n")
+    os.replace(temporary, path)
+
+
+class PromptFiles:
+    def read_text(self, path: Path) -> str:
+        try:
+            return _read_bounded(path.resolve(strict=True), _TEXT_LIMIT).decode("utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            raise PortFailure(
+                "invalid_prompt", f"Invalid prompt text {path}: {exc}"
+            ) from exc
+
+    def create(
+        self,
+        record: Path,
+        *,
+        mode: Literal["plain", "template"],
+        authored_text: str | None,
+        template: Path | None,
+        template_content: str | None,
+        style: Path | None,
+        style_content: str | None,
+        variables: dict[str, str],
+        resolved_prompt: str,
+        references: tuple[Path, ...],
+        producer: str | None,
+        requested_options: dict[str, JsonScalar],
+        revised_from: str | None = None,
+    ) -> PromptRecord:
+        root = record.absolute()
+        try:
+            root.mkdir(parents=True, exist_ok=False)
+        except OSError as exc:
+            raise PortFailure(
+                "destination_conflict",
+                f"Prompt record destination exists or cannot be created: {root}",
+            ) from exc
+        try:
+            inputs = root / "inputs"
+            inputs.mkdir()
+            resolved_path = root / "resolved-prompt.txt"
+            resolved_bytes = resolved_prompt.encode("utf-8")
+            resolved_path.write_bytes(resolved_bytes)
+            resolved_sha = hashlib.sha256(resolved_bytes).hexdigest()
+            template_fact = (
+                self._save_text(template, template_content, inputs / "template.txt")
+                if template
+                else None
+            )
+            style_fact = (
+                self._save_text(style, style_content, inputs / "style.txt")
+                if style
+                else None
+            )
+            reference_dir = inputs / "references"
+            reference_dir.mkdir()
+            reference_facts = []
+            for index, source in enumerate(references):
+                try:
+                    source = source.resolve(strict=True)
+                except OSError as exc:
+                    raise PortFailure(
+                        "invalid_prompt", f"Prompt reference is unavailable: {source}"
+                    ) from exc
+                if source.suffix.lower() != ".png":
+                    raise PortFailure(
+                        "invalid_prompt", "Prompt references must be PNG files"
+                    )
+                target = reference_dir / f"{index:03d}-{source.name}"
+                copy_with_sha256(source, target, max_bytes=_PNG_LIMIT)
+                reference_facts.append(_png_facts(source, target))
+            result = PromptRecord(
+                1,
+                root,
+                mode,
+                authored_text,
+                template_fact,
+                style_fact,
+                dict(variables),
+                resolved_prompt,
+                resolved_path,
+                resolved_sha,
+                tuple(reference_facts),
+                producer,
+                dict(requested_options),
+                revised_from=revised_from,
+            )
+            _dump(result, root / "record.json")
+            return result
+        except (OSError, PortFailure) as exc:
+            shutil.rmtree(root, ignore_errors=True)
+            if isinstance(exc, PortFailure):
+                raise
+            raise PortFailure(
+                "prompt_stage_failed", f"Could not prepare prompt record: {exc}"
+            ) from exc
+
+    def _save_text(
+        self, source: Path, content: str | None, destination: Path
+    ) -> PromptFile:
+        if content is None:
+            raise PortFailure("invalid_prompt", "Saved prompt text is unavailable")
+        encoded = content.encode()
+        if len(encoded) > _TEXT_LIMIT:
+            raise PortFailure(
+                "invalid_prompt", "Saved prompt text exceeds its size limit"
+            )
+        destination.write_bytes(encoded)
+        return PromptFile(
+            str(source), destination, hashlib.sha256(encoded).hexdigest(), len(encoded)
+        )
+
+    def read(self, record: Path) -> PromptRecord:
+        try:
+            root = record.resolve(strict=True)
+            result = _RECORD.validate_json(
+                _read_bounded(root / "record.json", _JSON_LIMIT), strict=True
+            )
+            result = self._rebase(result, root)
+            outputs = []
+            output_dir = root / "outputs"
+            if output_dir.exists():
+                if not output_dir.is_dir() or not output_dir.resolve().is_relative_to(
+                    root
+                ):
+                    raise ValueError("Prompt output directory is invalid")
+                registrations = sorted(output_dir.glob("*.json"))
+                if len(registrations) > _OUTPUT_LIMIT:
+                    raise ValueError("Prompt record has too many output registrations")
+                for registration in registrations:
+                    output = _OUTPUT.validate_json(
+                        _read_bounded(registration, _JSON_LIMIT), strict=True
+                    )
+                    file = self._rebase_file(output.file, root)
+                    assert file is not None
+                    outputs.append(PromptOutput(**{**output.__dict__, "file": file}))
+            result = PromptRecord(**{**result.__dict__, "outputs": tuple(outputs)})
+            self._verify(result)
+            return result
+        except (OSError, ValidationError, TypeError, ValueError, PortFailure) as exc:
+            if isinstance(exc, PortFailure) and exc.code == "invalid_prompt":
+                raise
+            raise PortFailure(
+                "invalid_prompt", f"Invalid prompt record {record}: {exc}"
+            ) from exc
+
+    @staticmethod
+    def _rebase_file(item: PromptFile | None, root: Path) -> PromptFile | None:
+        if item is None:
+            return None
+        path = item.path if item.path.is_absolute() else root / item.path
+        return PromptFile(**{**item.__dict__, "path": path})
+
+    def _rebase(self, record: PromptRecord, root: Path) -> PromptRecord:
+        resolved = (
+            record.resolved_path
+            if record.resolved_path.is_absolute()
+            else root / record.resolved_path
+        )
+        return PromptRecord(
+            **{
+                **record.__dict__,
+                "record": root,
+                "resolved_path": resolved,
+                "template": self._rebase_file(record.template, root),
+                "style": self._rebase_file(record.style, root),
+                "references": tuple(
+                    PromptFile(**{**item.__dict__, "path": root / item.path})
+                    if not item.path.is_absolute()
+                    else item
+                    for item in record.references
+                ),
+            }
+        )
+
+    def _verify(self, record: PromptRecord) -> None:
+        files = [item for item in (record.template, record.style) if item]
+        files.extend(record.references)
+        files.extend(output.file for output in record.outputs)
+        for item in files:
+            if (
+                not item.path.resolve().is_relative_to(record.record)
+                or not item.path.is_file()
+            ):
+                raise ValueError("Prompt record contains an unavailable saved file")
+            data = _read_bounded(
+                item.path, _PNG_LIMIT if item.width is not None else _TEXT_LIMIT
+            )
+            if (
+                len(data) != item.size_bytes
+                or hashlib.sha256(data).hexdigest() != item.sha256
+            ):
+                raise ValueError("Prompt record saved input or output changed")
+        if not record.resolved_path.resolve().is_relative_to(record.record):
+            raise ValueError("Prompt record resolved text escapes its directory")
+        resolved = _read_bounded(record.resolved_path, _TEXT_LIMIT)
+        if (
+            resolved.decode() != record.resolved_prompt
+            or hashlib.sha256(resolved).hexdigest() != record.resolved_sha256
+        ):
+            raise ValueError("Prompt record resolved text changed")
+
+    def add_output(
+        self, record: PromptRecord, request: PromptOutputRequest
+    ) -> PromptRecord:
+        if len(record.outputs) >= _OUTPUT_LIMIT:
+            raise PortFailure(
+                "invalid_prompt",
+                f"A prompt record supports at most {_OUTPUT_LIMIT} outputs",
+            )
+        name = _safe_name(request.name)
+        try:
+            source = request.output.resolve(strict=True)
+            if source.suffix.lower() != ".png":
+                raise PortFailure(
+                    "invalid_prompt", "Registered prompt outputs must be PNG files"
+                )
+            validate_format(source)
+        except (OSError, PortFailure) as exc:
+            raise PortFailure(
+                "invalid_prompt", f"Invalid prompt output {request.output}: {exc}"
+            ) from exc
+        output_dir = record.record / "outputs"
+        try:
+            output_dir.mkdir(exist_ok=True)
+            if not output_dir.resolve().is_relative_to(record.record):
+                raise ValueError("directory escapes its record")
+        except (OSError, ValueError) as exc:
+            raise PortFailure(
+                "invalid_prompt", f"Prompt output directory is invalid: {exc}"
+            ) from exc
+        target = output_dir / name
+        registration = output_dir / f"{name}.json"
+        if (
+            target.exists()
+            or registration.exists()
+            or any(item.name == name for item in record.outputs)
+        ):
+            raise PortFailure(
+                "destination_conflict", f"Prompt output already exists: {name}"
+            )
+        reserved = False
+        try:
+            registration.touch(exist_ok=False)
+            reserved = True
+            copy_with_sha256(source, target, max_bytes=_PNG_LIMIT)
+            fact = _png_facts(source, target)
+            output = PromptOutput(
+                name,
+                fact,
+                request.submitted_prompt,
+                dict(request.caller_declarations),
+                request.reported_provider,
+                request.reported_model,
+                dict(request.reported_options),
+            )
+            value = _OUTPUT.dump_python(output, mode="json")
+            value["file"]["path"] = str(fact.path.relative_to(record.record))
+            with registration.open("w", encoding="utf-8") as stream:
+                json.dump(value, stream, indent=2, sort_keys=True)
+                stream.write("\n")
+            updated = PromptRecord(
+                **{**record.__dict__, "outputs": (*record.outputs, output)}
+            )
+            return updated
+        except (OSError, PortFailure) as exc:
+            if reserved:
+                target.unlink(missing_ok=True)
+                registration.unlink(missing_ok=True)
+            if isinstance(exc, PortFailure):
+                raise
+            raise PortFailure(
+                "prompt_stage_failed", f"Could not register prompt output: {exc}"
+            ) from exc

--- a/libs/gda-assets/src/gda_assets/adapters/prompt_files.py
+++ b/libs/gda-assets/src/gda_assets/adapters/prompt_files.py
@@ -46,8 +46,16 @@ def _safe_name(name: str) -> str:
     return name
 
 
+def _regular_input(path: Path, limit: int) -> os.stat_result:
+    observed = path.stat()
+    if not stat.S_ISREG(observed.st_mode) or observed.st_size > limit:
+        raise ValueError("input is not a bounded regular file")
+    return observed
+
+
 def _read_bounded(path: Path, limit: int) -> bytes:
     try:
+        before_path = _regular_input(path, limit)
         with path.open("rb") as stream:
             before = os.fstat(stream.fileno())
             if not stat.S_ISREG(before.st_mode) or before.st_size > limit:
@@ -57,6 +65,7 @@ def _read_bounded(path: Path, limit: int) -> bytes:
         current = path.stat()
         if (
             len(value) > limit
+            or _identity(before_path) != _identity(before)
             or _identity(before) != _identity(after)
             or _identity(after) != _identity(current)
         ):
@@ -326,8 +335,9 @@ class PromptFiles:
                 raise PortFailure(
                     "invalid_prompt", "Registered prompt outputs must be PNG files"
                 )
+            _regular_input(source, _PNG_LIMIT)
             validate_format(source)
-        except (OSError, PortFailure) as exc:
+        except (OSError, ValueError, PortFailure) as exc:
             raise PortFailure(
                 "invalid_prompt", f"Invalid prompt output {request.output}: {exc}"
             ) from exc

--- a/libs/gda-assets/src/gda_assets/api.py
+++ b/libs/gda-assets/src/gda_assets/api.py
@@ -78,6 +78,8 @@ from gda_assets.domain.artifacts import (
 from gda_assets.domain.recipe import AssetFile, AssetRecipe, Resize
 from gda_assets.domain.prompt import (
     JsonScalar,
+    PromptOptionKey,
+    PromptDeclarationKey,
     PromptFile,
     PromptHandoff,
     PromptOutput,
@@ -157,6 +159,8 @@ __all__ = [
     "Resize",
     "run_pipeline",
     "JsonScalar",
+    "PromptOptionKey",
+    "PromptDeclarationKey",
     "PromptFile",
     "PromptHandoff",
     "PromptOutput",

--- a/libs/gda-assets/src/gda_assets/api.py
+++ b/libs/gda-assets/src/gda_assets/api.py
@@ -76,6 +76,18 @@ from gda_assets.domain.artifacts import (
     PipelineFailure,
 )
 from gda_assets.domain.recipe import AssetFile, AssetRecipe, Resize
+from gda_assets.domain.prompt import (
+    JsonScalar,
+    PromptFile,
+    PromptHandoff,
+    PromptOutput,
+    PromptOutputRequest,
+    PromptPreparation,
+    PromptPrepareRequest,
+    PromptRecord,
+    PromptRevision,
+    PromptRevisionRequest,
+)
 
 __all__ = [
     "check_package",
@@ -144,7 +156,55 @@ __all__ = [
     "ProductionOutput",
     "Resize",
     "run_pipeline",
+    "JsonScalar",
+    "PromptFile",
+    "PromptHandoff",
+    "PromptOutput",
+    "PromptOutputRequest",
+    "PromptPreparation",
+    "PromptPrepareRequest",
+    "PromptRecord",
+    "PromptRevision",
+    "PromptRevisionRequest",
+    "prepare_prompt",
+    "inspect_prompt",
+    "revise_prompt",
+    "register_prompt_output",
 ]
+
+
+def prepare_prompt(request: PromptPrepareRequest) -> PromptPreparation:
+    """Save one prompt record before an external generation attempt."""
+    from gda_assets.adapters.prompt_files import PromptFiles
+    from gda_assets.application.prompt import prepare_prompt as _prepare_prompt
+
+    return _prepare_prompt(request, files=PromptFiles())
+
+
+def inspect_prompt(record: Path) -> PromptPreparation:
+    """Inspect and reuse an existing prompt record from any working directory."""
+    from gda_assets.adapters.prompt_files import PromptFiles
+    from gda_assets.application.prompt import inspect_prompt as _inspect_prompt
+
+    return _inspect_prompt(record, files=PromptFiles())
+
+
+def revise_prompt(request: PromptRevisionRequest) -> PromptRevision:
+    """Create a separate prompt record from saved inputs plus explicit changes."""
+    from gda_assets.adapters.prompt_files import PromptFiles
+    from gda_assets.application.prompt import revise_prompt as _revise_prompt
+
+    return _revise_prompt(request, files=PromptFiles())
+
+
+def register_prompt_output(request: PromptOutputRequest) -> PromptRecord:
+    """Associate a validated local PNG without invoking a producer."""
+    from gda_assets.adapters.prompt_files import PromptFiles
+    from gda_assets.application.prompt import (
+        register_prompt_output as _register_prompt_output,
+    )
+
+    return _register_prompt_output(request, files=PromptFiles())
 
 
 def check_package(

--- a/libs/gda-assets/src/gda_assets/application/prompt.py
+++ b/libs/gda-assets/src/gda_assets/application/prompt.py
@@ -1,0 +1,141 @@
+"""Prepare, inspect, revise, and register project-owned prompt records."""
+
+from pathlib import Path
+
+from gda_assets.application.ports import PortFailure
+from gda_assets.application.prompt_ports import PromptFilesPort
+from gda_assets.domain.prompt import (
+    PromptOutputRequest,
+    PromptPreparation,
+    PromptPrepareRequest,
+    PromptRecord,
+    PromptRevision,
+    PromptRevisionRequest,
+    handoff,
+    resolve_prompt,
+    validate_output_request,
+    validate_prepare_request,
+)
+
+
+def _prepare(
+    request: PromptPrepareRequest,
+    files: PromptFilesPort,
+    *,
+    revised_from: str | None = None,
+) -> PromptPreparation:
+    try:
+        validate_prepare_request(request)
+        template_text = files.read_text(request.template) if request.template else None
+        style_text = files.read_text(request.style) if request.style else None
+        mode, resolved = resolve_prompt(
+            text=request.text,
+            template_text=template_text,
+            style_text=style_text,
+            variables=request.variables,
+        )
+        record = files.create(
+            request.record,
+            mode=mode,
+            authored_text=request.text,
+            template=request.template,
+            template_content=template_text,
+            style=request.style,
+            style_content=style_text,
+            variables=dict(request.variables),
+            resolved_prompt=resolved,
+            references=request.references,
+            producer=request.producer,
+            requested_options=dict(request.requested_options),
+            revised_from=revised_from,
+        )
+        return handoff(record)
+    except ValueError as exc:
+        raise PortFailure("invalid_prompt", str(exc)) from exc
+
+
+def prepare_prompt(
+    request: PromptPrepareRequest, *, files: PromptFilesPort
+) -> PromptPreparation:
+    return _prepare(request, files)
+
+
+def inspect_prompt(record: Path, *, files: PromptFilesPort) -> PromptPreparation:
+    return handoff(files.read(record))
+
+
+def revise_prompt(
+    request: PromptRevisionRequest, *, files: PromptFilesPort
+) -> PromptRevision:
+    saved = files.read(request.source_record)
+    changing_mode = request.text is not None or request.template is not None
+    text = request.text if changing_mode else saved.authored_text
+    template = (
+        request.template
+        if changing_mode
+        else (saved.template.path if saved.template else None)
+    )
+    style = (
+        None
+        if request.remove_style
+        else request.style or (saved.style.path if saved.style else None)
+    )
+    prepare_request = PromptPrepareRequest(
+        record=request.record,
+        text=text,
+        template=template,
+        style=style,
+        variables=request.variables
+        if request.variables is not None
+        else saved.variables,
+        references=(
+            request.references
+            if request.references is not None
+            else tuple(item.path for item in saved.references)
+        ),
+        producer=request.producer if request.producer is not None else saved.producer,
+        requested_options=(
+            request.requested_options
+            if request.requested_options is not None
+            else saved.requested_options
+        ),
+    )
+    prepared = _prepare(prepare_request, files, revised_from=str(saved.record))
+    changed = []
+    pairs = {
+        "mode": (saved.mode, prepared.record.mode),
+        "authored_text": (saved.authored_text, prepared.record.authored_text),
+        "template": (
+            saved.template.sha256 if saved.template else None,
+            prepared.record.template.sha256 if prepared.record.template else None,
+        ),
+        "style": (
+            saved.style.sha256 if saved.style else None,
+            prepared.record.style.sha256 if prepared.record.style else None,
+        ),
+        "variables": (saved.variables, prepared.record.variables),
+        "resolved_prompt": (saved.resolved_prompt, prepared.record.resolved_prompt),
+        "references": (
+            tuple(item.sha256 for item in saved.references),
+            tuple(item.sha256 for item in prepared.record.references),
+        ),
+        "producer": (saved.producer, prepared.record.producer),
+        "requested_options": (
+            saved.requested_options,
+            prepared.record.requested_options,
+        ),
+    }
+    for name, (before, after) in pairs.items():
+        if before != after:
+            changed.append(name)
+    return PromptRevision(prepared, tuple(changed))
+
+
+def register_prompt_output(
+    request: PromptOutputRequest, *, files: PromptFilesPort
+) -> PromptRecord:
+    try:
+        validate_output_request(request)
+    except ValueError as exc:
+        raise PortFailure("invalid_prompt", str(exc)) from exc
+    return files.add_output(files.read(request.record), request)

--- a/libs/gda-assets/src/gda_assets/application/prompt_ports.py
+++ b/libs/gda-assets/src/gda_assets/application/prompt_ports.py
@@ -1,0 +1,38 @@
+"""Local persistence required by prompt-record use cases."""
+
+from pathlib import Path
+from typing import Literal, Protocol
+
+from gda_assets.domain.prompt import (
+    JsonScalar,
+    PromptOutputRequest,
+    PromptRecord,
+)
+
+
+class PromptFilesPort(Protocol):
+    def read_text(self, path: Path) -> str: ...
+
+    def create(
+        self,
+        record: Path,
+        *,
+        mode: Literal["plain", "template"],
+        authored_text: str | None,
+        template: Path | None,
+        template_content: str | None,
+        style: Path | None,
+        style_content: str | None,
+        variables: dict[str, str],
+        resolved_prompt: str,
+        references: tuple[Path, ...],
+        producer: str | None,
+        requested_options: dict[str, JsonScalar],
+        revised_from: str | None = None,
+    ) -> PromptRecord: ...
+
+    def read(self, record: Path) -> PromptRecord: ...
+
+    def add_output(
+        self, record: PromptRecord, request: PromptOutputRequest
+    ) -> PromptRecord: ...

--- a/libs/gda-assets/src/gda_assets/application/prompt_ports.py
+++ b/libs/gda-assets/src/gda_assets/application/prompt_ports.py
@@ -6,6 +6,7 @@ from typing import Literal, Protocol
 from gda_assets.domain.prompt import (
     JsonScalar,
     PromptOutputRequest,
+    PromptOptionKey,
     PromptRecord,
 )
 
@@ -27,7 +28,7 @@ class PromptFilesPort(Protocol):
         resolved_prompt: str,
         references: tuple[Path, ...],
         producer: str | None,
-        requested_options: dict[str, JsonScalar],
+        requested_options: dict[PromptOptionKey, JsonScalar],
         revised_from: str | None = None,
     ) -> PromptRecord: ...
 

--- a/libs/gda-assets/src/gda_assets/domain/prompt.py
+++ b/libs/gda-assets/src/gda_assets/domain/prompt.py
@@ -3,26 +3,26 @@
 from dataclasses import dataclass, field
 from pathlib import Path
 from string import Template
-from typing import Literal, TypeAlias
+from typing import Literal, TypeAlias, get_args
 import math
 
 
 JsonScalar: TypeAlias = str | int | float | bool | None
-REQUESTED_OPTION_KEYS = frozenset(
-    {
-        "aspect_ratio",
-        "background",
-        "model",
-        "output_format",
-        "quality",
-        "seed",
-        "size",
-        "style",
-    }
-)
-DECLARATION_KEYS = frozenset(
-    {"generation_completed", "model", "provider", "request_id", "tool"}
-)
+PromptOptionKey: TypeAlias = Literal[
+    "aspect_ratio",
+    "background",
+    "model",
+    "output_format",
+    "quality",
+    "seed",
+    "size",
+    "style",
+]
+PromptDeclarationKey: TypeAlias = Literal[
+    "generation_completed", "model", "provider", "request_id", "tool"
+]
+REQUESTED_OPTION_KEYS = frozenset(get_args(PromptOptionKey))
+DECLARATION_KEYS = frozenset(get_args(PromptDeclarationKey))
 _TEXT_BYTES = 1024 * 1024
 
 

--- a/libs/gda-assets/src/gda_assets/domain/prompt.py
+++ b/libs/gda-assets/src/gda_assets/domain/prompt.py
@@ -1,0 +1,227 @@
+"""Project-owned prompt records and their explicit external-generation handoff."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from string import Template
+from typing import Literal, TypeAlias
+import math
+
+
+JsonScalar: TypeAlias = str | int | float | bool | None
+REQUESTED_OPTION_KEYS = frozenset(
+    {
+        "aspect_ratio",
+        "background",
+        "model",
+        "output_format",
+        "quality",
+        "seed",
+        "size",
+        "style",
+    }
+)
+DECLARATION_KEYS = frozenset(
+    {"generation_completed", "model", "provider", "request_id", "tool"}
+)
+_TEXT_BYTES = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class PromptPrepareRequest:
+    record: Path
+    text: str | None = None
+    template: Path | None = None
+    style: Path | None = None
+    variables: dict[str, str] = field(default_factory=dict)
+    references: tuple[Path, ...] = ()
+    producer: str | None = None
+    requested_options: dict[str, JsonScalar] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PromptRevisionRequest:
+    source_record: Path
+    record: Path
+    text: str | None = None
+    template: Path | None = None
+    style: Path | None = None
+    remove_style: bool = False
+    variables: dict[str, str] | None = None
+    references: tuple[Path, ...] | None = None
+    producer: str | None = None
+    requested_options: dict[str, JsonScalar] | None = None
+
+
+@dataclass(frozen=True)
+class PromptOutputRequest:
+    record: Path
+    output: Path
+    name: str
+    submitted_prompt: str | None = None
+    caller_declarations: dict[str, JsonScalar] = field(default_factory=dict)
+    reported_provider: str | None = None
+    reported_model: str | None = None
+    reported_options: dict[str, JsonScalar] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PromptFile:
+    declared_path: str
+    path: Path
+    sha256: str
+    size_bytes: int
+    width: int | None = None
+    height: int | None = None
+
+
+@dataclass(frozen=True)
+class PromptOutput:
+    name: str
+    file: PromptFile
+    submitted_prompt: str | None
+    caller_declarations: dict[str, JsonScalar]
+    reported_provider: str | None
+    reported_model: str | None
+    reported_options: dict[str, JsonScalar]
+
+
+@dataclass(frozen=True)
+class PromptRecord:
+    schema: Literal[1]
+    record: Path
+    mode: Literal["plain", "template"]
+    authored_text: str | None
+    template: PromptFile | None
+    style: PromptFile | None
+    variables: dict[str, str]
+    resolved_prompt: str
+    resolved_path: Path
+    resolved_sha256: str
+    references: tuple[PromptFile, ...]
+    producer: str | None
+    requested_options: dict[str, JsonScalar]
+    generation_status: Literal["unknown"] = "unknown"
+    outputs: tuple[PromptOutput, ...] = ()
+    revised_from: str | None = None
+
+
+@dataclass(frozen=True)
+class PromptHandoff:
+    action: Literal["external_generation_required"]
+    generation_status: Literal["unknown"]
+    record: Path
+    prompt: str
+    prompt_path: Path
+    references: tuple[Path, ...]
+    producer: str | None
+    requested_options: dict[str, JsonScalar]
+    registration_operation: Literal["prompt-register-output"] = "prompt-register-output"
+
+
+@dataclass(frozen=True)
+class PromptPreparation:
+    record: PromptRecord
+    handoff: PromptHandoff
+
+
+@dataclass(frozen=True)
+class PromptRevision:
+    preparation: PromptPreparation
+    changed_fields: tuple[str, ...]
+
+
+def validate_options(
+    values: dict[str, JsonScalar], *, declarations: bool = False
+) -> None:
+    allowed = DECLARATION_KEYS if declarations else REQUESTED_OPTION_KEYS
+    if len(values) > len(allowed) or any(key not in allowed for key in values):
+        raise ValueError("Prompt options contain unsupported keys")
+    for key, value in values.items():
+        if isinstance(value, str) and len(value) > 1024:
+            raise ValueError(f"Prompt option {key} is too long")
+        if isinstance(value, float) and not math.isfinite(value):
+            raise ValueError(f"Prompt option {key} must be finite")
+        if not isinstance(value, (str, int, float, bool, type(None))):
+            raise ValueError(f"Prompt option {key} must be a JSON scalar")
+
+
+def validate_prepare_request(request: PromptPrepareRequest) -> None:
+    if len(request.references) > 16:
+        raise ValueError("Select at most 16 prompt references")
+    if request.producer is not None and not 0 < len(request.producer) <= 256:
+        raise ValueError("Prompt producer must be a nonempty bounded string")
+    if len(request.variables) > 64 or any(
+        not isinstance(key, str)
+        or not isinstance(value, str)
+        or len(key) > 128
+        or len(value) > 4096
+        for key, value in request.variables.items()
+    ):
+        raise ValueError("Prompt variables must contain at most 64 bounded strings")
+    validate_options(request.requested_options)
+
+
+def validate_output_request(request: PromptOutputRequest) -> None:
+    validate_options(request.caller_declarations, declarations=True)
+    validate_options(request.reported_options)
+    completed = request.caller_declarations.get("generation_completed")
+    if completed is not None and type(completed) is not bool:
+        raise ValueError("Caller-declared generation_completed must be boolean")
+    for label, value in (
+        ("submitted prompt", request.submitted_prompt),
+        ("reported provider", request.reported_provider),
+        ("reported model", request.reported_model),
+    ):
+        if value is not None and (
+            not isinstance(value, str) or len(value.encode()) > _TEXT_BYTES
+        ):
+            raise ValueError(f"Prompt {label} must be a bounded string")
+
+
+def resolve_prompt(
+    *,
+    text: str | None,
+    template_text: str | None,
+    style_text: str | None,
+    variables: dict[str, str],
+) -> tuple[Literal["plain", "template"], str]:
+    if (text is None) == (template_text is None):
+        raise ValueError("Provide exactly one of prompt text or template")
+    if text is not None:
+        if variables:
+            raise ValueError("Plain prompt text does not accept template variables")
+        main = text
+        mode: Literal["plain", "template"] = "plain"
+    else:
+        template = Template(template_text or "")
+        if not template.is_valid():
+            raise ValueError("Prompt template syntax is invalid")
+        identifiers = set(template.get_identifiers())
+        if identifiers != set(variables):
+            raise ValueError(
+                "Prompt template variables must exactly match its placeholders"
+            )
+        main = template.substitute(variables)
+        mode = "template"
+    if not main.strip():
+        raise ValueError("Resolved prompt must not be empty")
+    resolved = f"{style_text.rstrip()}\n\n{main}" if style_text else main
+    if len(resolved.encode()) > _TEXT_BYTES:
+        raise ValueError("Resolved prompt exceeds its size limit")
+    return mode, resolved
+
+
+def handoff(record: PromptRecord) -> PromptPreparation:
+    return PromptPreparation(
+        record,
+        PromptHandoff(
+            "external_generation_required",
+            "unknown",
+            record.record,
+            record.resolved_prompt,
+            record.resolved_path,
+            tuple(item.path for item in record.references),
+            record.producer,
+            record.requested_options,
+        ),
+    )

--- a/libs/gda-assets/src/gda_assets/domain/prompt.py
+++ b/libs/gda-assets/src/gda_assets/domain/prompt.py
@@ -3,7 +3,8 @@
 from dataclasses import dataclass, field
 from pathlib import Path
 from string import Template
-from typing import Literal, TypeAlias, get_args
+from collections.abc import Mapping
+from typing import Literal, TypeAlias, TypeVar, get_args
 import math
 
 
@@ -24,6 +25,7 @@ PromptDeclarationKey: TypeAlias = Literal[
 REQUESTED_OPTION_KEYS = frozenset(get_args(PromptOptionKey))
 DECLARATION_KEYS = frozenset(get_args(PromptDeclarationKey))
 _TEXT_BYTES = 1024 * 1024
+_PromptKey = TypeVar("_PromptKey", PromptOptionKey, PromptDeclarationKey)
 
 
 @dataclass(frozen=True)
@@ -35,7 +37,7 @@ class PromptPrepareRequest:
     variables: dict[str, str] = field(default_factory=dict)
     references: tuple[Path, ...] = ()
     producer: str | None = None
-    requested_options: dict[str, JsonScalar] = field(default_factory=dict)
+    requested_options: dict[PromptOptionKey, JsonScalar] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -49,7 +51,7 @@ class PromptRevisionRequest:
     variables: dict[str, str] | None = None
     references: tuple[Path, ...] | None = None
     producer: str | None = None
-    requested_options: dict[str, JsonScalar] | None = None
+    requested_options: dict[PromptOptionKey, JsonScalar] | None = None
 
 
 @dataclass(frozen=True)
@@ -58,10 +60,12 @@ class PromptOutputRequest:
     output: Path
     name: str
     submitted_prompt: str | None = None
-    caller_declarations: dict[str, JsonScalar] = field(default_factory=dict)
+    caller_declarations: dict[PromptDeclarationKey, JsonScalar] = field(
+        default_factory=dict
+    )
     reported_provider: str | None = None
     reported_model: str | None = None
-    reported_options: dict[str, JsonScalar] = field(default_factory=dict)
+    reported_options: dict[PromptOptionKey, JsonScalar] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -79,10 +83,10 @@ class PromptOutput:
     name: str
     file: PromptFile
     submitted_prompt: str | None
-    caller_declarations: dict[str, JsonScalar]
+    caller_declarations: dict[PromptDeclarationKey, JsonScalar]
     reported_provider: str | None
     reported_model: str | None
-    reported_options: dict[str, JsonScalar]
+    reported_options: dict[PromptOptionKey, JsonScalar]
 
 
 @dataclass(frozen=True)
@@ -99,7 +103,7 @@ class PromptRecord:
     resolved_sha256: str
     references: tuple[PromptFile, ...]
     producer: str | None
-    requested_options: dict[str, JsonScalar]
+    requested_options: dict[PromptOptionKey, JsonScalar]
     generation_status: Literal["unknown"] = "unknown"
     outputs: tuple[PromptOutput, ...] = ()
     revised_from: str | None = None
@@ -114,7 +118,7 @@ class PromptHandoff:
     prompt_path: Path
     references: tuple[Path, ...]
     producer: str | None
-    requested_options: dict[str, JsonScalar]
+    requested_options: dict[PromptOptionKey, JsonScalar]
     registration_operation: Literal["prompt-register-output"] = "prompt-register-output"
 
 
@@ -131,7 +135,9 @@ class PromptRevision:
 
 
 def validate_options(
-    values: dict[str, JsonScalar], *, declarations: bool = False
+    values: Mapping[_PromptKey, JsonScalar],
+    *,
+    declarations: bool = False,
 ) -> None:
     allowed = DECLARATION_KEYS if declarations else REQUESTED_OPTION_KEYS
     if len(values) > len(allowed) or any(key not in allowed for key in values):

--- a/libs/gda-assets/tests/test_prompt_domain.py
+++ b/libs/gda-assets/tests/test_prompt_domain.py
@@ -34,7 +34,7 @@ def test_template_requires_exact_variables_and_supports_braced_names():
 
 def test_options_reject_unlisted_or_nonfinite_values():
     with pytest.raises(ValueError, match="unsupported"):
-        validate_options({"api_key": "secret"})
+        validate_options({"api_key": "secret"})  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="finite"):
         validate_options({"seed": float("nan")})
     with pytest.raises(ValueError, match="must be boolean"):
@@ -43,6 +43,6 @@ def test_options_reject_unlisted_or_nonfinite_values():
                 Path("record"),
                 Path("result.png"),
                 "result.png",
-                caller_declarations={"generation_completed": "yes"},
+                caller_declarations={"generation_completed": "yes"},  # type: ignore[dict-item]
             )
         )

--- a/libs/gda-assets/tests/test_prompt_domain.py
+++ b/libs/gda-assets/tests/test_prompt_domain.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+import pytest
+
+from gda_assets.domain.prompt import (
+    PromptOutputRequest,
+    resolve_prompt,
+    validate_options,
+    validate_output_request,
+)
+
+
+def test_plain_dollar_text_is_unchanged_and_style_is_ordered():
+    assert resolve_prompt(
+        text="cost is $5", template_text=None, style_text="ink style", variables={}
+    ) == ("plain", "ink style\n\ncost is $5")
+
+
+def test_template_requires_exact_variables_and_supports_braced_names():
+    assert resolve_prompt(
+        text=None,
+        template_text="A $subject in ${place}; $$ literal",
+        style_text=None,
+        variables={"subject": "fox", "place": "snow"},
+    ) == ("template", "A fox in snow; $ literal")
+    with pytest.raises(ValueError, match="exactly match"):
+        resolve_prompt(
+            text=None,
+            template_text="$subject",
+            style_text=None,
+            variables={"subject": "fox", "unused": "x"},
+        )
+
+
+def test_options_reject_unlisted_or_nonfinite_values():
+    with pytest.raises(ValueError, match="unsupported"):
+        validate_options({"api_key": "secret"})
+    with pytest.raises(ValueError, match="finite"):
+        validate_options({"seed": float("nan")})
+    with pytest.raises(ValueError, match="must be boolean"):
+        validate_output_request(
+            PromptOutputRequest(
+                Path("record"),
+                Path("result.png"),
+                "result.png",
+                caller_declarations={"generation_completed": "yes"},
+            )
+        )

--- a/libs/gda-assets/tests/test_prompt_files.py
+++ b/libs/gda-assets/tests/test_prompt_files.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 import os
 
 from PIL import Image
@@ -202,3 +203,38 @@ def test_invalid_output_directory_fails_without_modifying_existing_file(tmp_path
         register_prompt_output(PromptOutputRequest(record, image, "image.png"))
 
     assert (record / "outputs").read_bytes() == b"existing project file"
+
+
+def test_inspect_rejects_unknown_persisted_requested_option_concisely(tmp_path):
+    record = tmp_path / "attempt"
+    prepare_prompt(PromptPrepareRequest(record, text="prompt"))
+    path = record / "record.json"
+    value = json.loads(path.read_text())
+    value["requested_options"] = {"bogus": 1}
+    path.write_text(json.dumps(value))
+
+    with pytest.raises(PortFailure) as failure:
+        inspect_prompt(record)
+
+    assert failure.value.code == "invalid_prompt"
+    assert "requested_options.bogus" in str(failure.value)
+    assert "input_value" not in str(failure.value)
+    assert len(str(failure.value)) < 300
+
+
+def test_inspect_rejects_unknown_persisted_output_declaration(tmp_path):
+    record = tmp_path / "attempt"
+    image = tmp_path / "image.png"
+    prepare_prompt(PromptPrepareRequest(record, text="prompt"))
+    _png(image, "red")
+    register_prompt_output(PromptOutputRequest(record, image, "candidate.png"))
+    registration = record / "outputs" / "candidate.png.json"
+    value = json.loads(registration.read_text())
+    value["caller_declarations"] = {"bogus": True}
+    registration.write_text(json.dumps(value))
+
+    with pytest.raises(PortFailure) as failure:
+        inspect_prompt(record)
+
+    assert "caller_declarations.bogus" in str(failure.value)
+    assert "input_value" not in str(failure.value)

--- a/libs/gda-assets/tests/test_prompt_files.py
+++ b/libs/gda-assets/tests/test_prompt_files.py
@@ -1,0 +1,204 @@
+from pathlib import Path
+import os
+
+from PIL import Image
+import pytest
+
+from gda_assets.api import (
+    PromptOutputRequest,
+    PromptPrepareRequest,
+    PromptRevisionRequest,
+    inspect_prompt,
+    prepare_prompt,
+    register_prompt_output,
+    revise_prompt,
+)
+from gda_assets.application.ports import PortFailure
+
+
+def _png(path: Path, color: str) -> bytes:
+    Image.new("RGB", (3, 2), color).save(path)
+    return path.read_bytes()
+
+
+def test_prepare_snapshots_template_style_reference_and_inspects_from_other_cwd(
+    tmp_path,
+):
+    template = tmp_path / "template.txt"
+    style = tmp_path / "style.txt"
+    reference = tmp_path / "reference.png"
+    template.write_text("A $subject at ${place}")
+    style.write_text("watercolor")
+    original_png = _png(reference, "red")
+    record_path = tmp_path / "records" / "attempt-a"
+
+    prepared = prepare_prompt(
+        PromptPrepareRequest(
+            record_path,
+            template=template,
+            style=style,
+            variables={"subject": "fox", "place": "dawn"},
+            references=(reference,),
+            producer="native-image-tool",
+            requested_options={"size": "1024x1024", "quality": "high"},
+        )
+    )
+    template.write_text("changed $subject at $place")
+    style.write_text("changed")
+    _png(reference, "blue")
+    second = prepare_prompt(
+        PromptPrepareRequest(
+            tmp_path / "records" / "attempt-b",
+            template=template,
+            style=style,
+            variables={"subject": "owl", "place": "night"},
+            references=(reference,),
+        )
+    )
+    relocated = tmp_path / "relocated-attempt-a"
+    record_path.rename(relocated)
+    previous = Path.cwd()
+    os.chdir(tmp_path.parent)
+    try:
+        inspected = inspect_prompt(relocated)
+    finally:
+        os.chdir(previous)
+
+    assert prepared.handoff.action == "external_generation_required"
+    assert prepared.handoff.generation_status == "unknown"
+    assert inspected.record.resolved_prompt == "watercolor\n\nA fox at dawn"
+    assert inspected.record.references[0].path.read_bytes() == original_png
+    assert second.record.references[0].path.read_bytes() != original_png
+    assert second.record.resolved_prompt == "changed\n\nchanged owl at night"
+    assert inspected.handoff.references == (inspected.record.references[0].path,)
+    assert inspected.record.template is not None
+    assert not inspected.record.template.path.is_relative_to(Path.cwd())
+
+
+def test_destination_conflict_and_missing_inputs_fail_without_replacing_record(
+    tmp_path,
+):
+    record = tmp_path / "attempt"
+    prepare_prompt(PromptPrepareRequest(record, text="first"))
+
+    with pytest.raises(PortFailure) as conflict:
+        prepare_prompt(PromptPrepareRequest(record, text="second"))
+    assert conflict.value.code == "destination_conflict"
+    assert inspect_prompt(record).record.resolved_prompt == "first"
+
+    missing = tmp_path / "missing"
+    with pytest.raises(PortFailure) as invalid:
+        prepare_prompt(
+            PromptPrepareRequest(
+                missing, template=tmp_path / "absent.txt", variables={"x": "y"}
+            )
+        )
+    assert invalid.value.code == "invalid_prompt"
+    assert not missing.exists()
+
+
+def test_revision_uses_saved_inputs_and_reports_only_semantic_changes(tmp_path):
+    template = tmp_path / "template.txt"
+    style = tmp_path / "style.txt"
+    template.write_text("$subject")
+    style.write_text("graphite")
+    original = prepare_prompt(
+        PromptPrepareRequest(
+            tmp_path / "a",
+            template=template,
+            style=style,
+            variables={"subject": "fox"},
+        )
+    )
+    template.write_text("external drift")
+    style.write_text("external drift")
+
+    revision = revise_prompt(
+        PromptRevisionRequest(
+            original.record.record,
+            tmp_path / "b",
+            variables={"subject": "wolf"},
+        )
+    )
+
+    assert revision.preparation.record.resolved_prompt == "graphite\n\nwolf"
+    assert revision.changed_fields == ("variables", "resolved_prompt")
+    assert (
+        inspect_prompt(original.record.record).record.resolved_prompt
+        == "graphite\n\nfox"
+    )
+
+
+def test_registration_is_separate_local_association_and_preserves_base_record(tmp_path):
+    record_path = tmp_path / "attempt"
+    prepare_prompt(
+        PromptPrepareRequest(
+            record_path, text="prepared", requested_options={"seed": 7}
+        )
+    )
+    base_json = (record_path / "record.json").read_bytes()
+    output = tmp_path / "result.png"
+    output_bytes = _png(output, "green")
+
+    registered = register_prompt_output(
+        PromptOutputRequest(
+            record_path,
+            output,
+            "candidate.png",
+            submitted_prompt="actually submitted",
+            caller_declarations={"generation_completed": True, "tool": "imagegen"},
+            reported_provider="provider-a",
+            reported_model="model-b",
+            reported_options={"quality": "high"},
+        )
+    )
+
+    assert (record_path / "record.json").read_bytes() == base_json
+    assert registered.generation_status == "unknown"
+    assert registered.outputs[0].file.path.read_bytes() == output_bytes
+    assert registered.outputs[0].caller_declarations["generation_completed"] is True
+    assert registered.outputs[0].reported_provider == "provider-a"
+    assert registered.requested_options == {"seed": 7}
+    assert inspect_prompt(record_path).record.outputs == registered.outputs
+
+
+def test_invalid_registration_preserves_prompt_and_existing_outputs(tmp_path):
+    record = tmp_path / "attempt"
+    prepare_prompt(PromptPrepareRequest(record, text="prompt"))
+    invalid = tmp_path / "bad.png"
+    invalid.write_text("not png")
+
+    with pytest.raises(PortFailure) as failure:
+        register_prompt_output(PromptOutputRequest(record, invalid, "bad.png"))
+
+    assert failure.value.code == "invalid_prompt"
+    assert inspect_prompt(record).record.outputs == ()
+    assert not (record / "outputs" / "bad.png").exists()
+
+
+def test_registration_limit_refuses_next_output_and_keeps_record_readable(tmp_path):
+    record = tmp_path / "attempt"
+    prepare_prompt(PromptPrepareRequest(record, text="prompt"))
+    image = tmp_path / "image.png"
+    Image.new("RGB", (1, 1), "blue").save(image)
+    for index in range(64):
+        register_prompt_output(PromptOutputRequest(record, image, f"{index}.png"))
+
+    with pytest.raises(PortFailure, match="at most 64"):
+        register_prompt_output(PromptOutputRequest(record, image, "overflow.png"))
+
+    assert len(inspect_prompt(record).record.outputs) == 64
+    assert not (record / "outputs" / "overflow.png").exists()
+
+
+def test_invalid_output_directory_fails_without_modifying_existing_file(tmp_path):
+    record = tmp_path / "attempt"
+    prepare_prompt(PromptPrepareRequest(record, text="prompt"))
+    (record / "outputs").write_bytes(b"existing project file")
+    image = tmp_path / "image.png"
+    Image.new("RGB", (1, 1), "blue").save(image)
+
+    with pytest.raises(PortFailure, match="output directory"):
+        register_prompt_output(PromptOutputRequest(record, image, "image.png"))
+
+    assert (record / "outputs").read_bytes() == b"existing project file"

--- a/src/gda/commands/asset_pipeline.py
+++ b/src/gda/commands/asset_pipeline.py
@@ -29,6 +29,18 @@ from gda_assets.api import (
     PackageCheckRequest,
     PackageCheckResult,
     check_package,
+    JsonScalar,
+    PromptOutputRequest,
+    PromptPreparation,
+    PromptPrepareRequest,
+    PromptRecord,
+    PromptRevision,
+    PromptRevisionRequest,
+    prepare_prompt,
+    inspect_prompt,
+    register_prompt_output,
+    revise_prompt,
+    PortFailure,
 )
 
 from gda.dispatch import dispatch_recipe, params_or_bad_parameter
@@ -1207,5 +1219,470 @@ def asset_pipeline_check_package(
         ),
         json_output=json_output,
         godot=godot,
+        project=None,
+    )
+
+
+REQUESTED_OPTION_HELP = "Supported keys: aspect_ratio, background, model, output_format, quality, seed, size, style."
+DECLARATION_HELP = (
+    "Supported keys: generation_completed, model, provider, request_id, tool."
+)
+PromptVariableKey = Annotated[str, Field(max_length=128)]
+PromptVariableValue = Annotated[str, Field(max_length=4096)]
+
+
+class PromptPrepareParams(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+        allow_inf_nan=False,
+        json_schema_extra={
+            "oneOf": [
+                {"required": ["text"], "properties": {"template": {"type": "null"}}},
+                {"required": ["template"], "properties": {"text": {"type": "null"}}},
+            ]
+        },
+    )
+    record: Path = Field(description="New caller-visible prompt record directory.")
+    text: str | None = Field(
+        default=None,
+        description="Literal prompt text; select exactly one source. Resolved UTF-8 text is limited to 1 MiB.",
+    )
+    template: Path | None = Field(
+        default=None,
+        description="Template text file using $name or ${name}; select exactly one source.",
+    )
+    style: Path | None = Field(
+        default=None, description="Optional style text prepended before one blank line."
+    )
+    variables: dict[PromptVariableKey, PromptVariableValue] = Field(
+        default_factory=dict,
+        max_length=64,
+        description="At most 64 exact placeholders; keys at most 128 and values at most 4096 characters.",
+    )
+    references: tuple[Path, ...] = Field(
+        default=(),
+        max_length=16,
+        description="Up to 16 local reference files copied into the record.",
+    )
+    producer: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=256,
+        description="Optional caller-selected external producer name.",
+    )
+    requested_options: dict[str, JsonScalar] = Field(
+        default_factory=dict, description=REQUESTED_OPTION_HELP
+    )
+
+    @model_validator(mode="after")
+    def _one_prompt_source(self) -> "PromptPrepareParams":
+        if (self.text is None) == (self.template is None):
+            raise ValueError("Select exactly one of text or template")
+        return self
+
+
+class PromptInspectParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    record: Path = Field(description="Existing prompt record directory.")
+
+
+class PromptReviseParams(BaseModel):
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
+    source_record: Path = Field(
+        description="Existing record whose saved snapshots are reused."
+    )
+    record: Path = Field(description="New caller-visible revision record directory.")
+    text: str | None = Field(
+        default=None, description="Optional replacement literal prompt text."
+    )
+    template: Path | None = Field(
+        default=None, description="Optional replacement template file."
+    )
+    style: Path | None = Field(
+        default=None, description="Optional replacement style file."
+    )
+    remove_style: bool = Field(
+        default=False,
+        strict=True,
+        description="Explicitly remove the saved style snapshot.",
+    )
+    variables: dict[PromptVariableKey, PromptVariableValue] | None = Field(
+        default=None,
+        max_length=64,
+        description="Optional replacement of at most 64 bounded template variables.",
+    )
+    references: tuple[Path, ...] | None = Field(
+        default=None,
+        max_length=16,
+        description="Optional replacement set of up to 16 references.",
+    )
+    producer: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=256,
+        description="Optional replacement producer declaration.",
+    )
+    requested_options: dict[str, JsonScalar] | None = Field(
+        default=None, description=REQUESTED_OPTION_HELP
+    )
+
+
+class PromptRegisterOutputParams(BaseModel):
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
+    record: Path = Field(description="Existing prompt record directory.")
+    output: Path = Field(description="Existing completed local PNG file.")
+    name: str = Field(
+        min_length=1,
+        max_length=255,
+        description="Caller-chosen safe PNG filename for this record.",
+    )
+    submitted_prompt: str | None = Field(
+        default=None, description="Actual submitted prompt when explicitly known."
+    )
+    caller_declarations: dict[str, JsonScalar] = Field(
+        default_factory=dict, description=DECLARATION_HELP
+    )
+    reported_provider: str | None = Field(
+        default=None,
+        description="Provider identity reported after generation, if available.",
+    )
+    reported_model: str | None = Field(
+        default=None,
+        description="Model identity reported after generation, if available.",
+    )
+    reported_options: dict[str, JsonScalar] = Field(
+        default_factory=dict, description=REQUESTED_OPTION_HELP
+    )
+
+
+class PromptPreparationResult(BaseModel):
+    preparation: PromptPreparation
+
+
+class PromptRevisionResult(BaseModel):
+    revision: PromptRevision
+
+
+class PromptRecordResult(BaseModel):
+    prompt_record: PromptRecord
+
+
+def _prompt_failure(exc: PortFailure) -> Failure:
+    code = {
+        "destination_conflict": "already_exists",
+        "prompt_stage_failed": "operation_failed",
+    }.get(exc.code, "invalid_params")
+    return make_failure(code, str(exc), "")
+
+
+def run_prompt_prepare(
+    params: PromptPrepareParams, *, project: Path | None, godot: str | None
+) -> PromptPreparationResult | Failure:
+    del project, godot
+    try:
+        prepared = prepare_prompt(
+            PromptPrepareRequest(
+                params.record.resolve(),
+                params.text,
+                params.template.resolve() if params.template else None,
+                params.style.resolve() if params.style else None,
+                params.variables,
+                tuple(path.resolve() for path in params.references),
+                params.producer,
+                params.requested_options,
+            )
+        )
+        return PromptPreparationResult(preparation=prepared)
+    except PortFailure as exc:
+        return _prompt_failure(exc)
+
+
+def run_prompt_inspect(
+    params: PromptInspectParams, *, project: Path | None, godot: str | None
+) -> PromptPreparationResult | Failure:
+    del project, godot
+    try:
+        return PromptPreparationResult(
+            preparation=inspect_prompt(params.record.resolve())
+        )
+    except PortFailure as exc:
+        return _prompt_failure(exc)
+
+
+def run_prompt_revise(
+    params: PromptReviseParams, *, project: Path | None, godot: str | None
+) -> PromptRevisionResult | Failure:
+    del project, godot
+    try:
+        revised = revise_prompt(
+            PromptRevisionRequest(
+                source_record=params.source_record.resolve(),
+                record=params.record.resolve(),
+                text=params.text,
+                template=params.template.resolve() if params.template else None,
+                style=params.style.resolve() if params.style else None,
+                remove_style=params.remove_style,
+                variables=params.variables,
+                references=tuple(path.resolve() for path in params.references)
+                if params.references is not None
+                else None,
+                producer=params.producer,
+                requested_options=params.requested_options,
+            )
+        )
+        return PromptRevisionResult(revision=revised)
+    except PortFailure as exc:
+        return _prompt_failure(exc)
+
+
+def run_prompt_register_output(
+    params: PromptRegisterOutputParams, *, project: Path | None, godot: str | None
+) -> PromptRecordResult | Failure:
+    del project, godot
+    try:
+        record = register_prompt_output(
+            PromptOutputRequest(
+                params.record.resolve(),
+                params.output.resolve(),
+                params.name,
+                params.submitted_prompt,
+                params.caller_declarations,
+                params.reported_provider,
+                params.reported_model,
+                params.reported_options,
+            )
+        )
+        return PromptRecordResult(prompt_record=record)
+    except PortFailure as exc:
+        return _prompt_failure(exc)
+
+
+def render_prompt_preparation(result: PromptPreparationResult) -> str:
+    record, handoff = result.preparation.record, result.preparation.handoff
+    return (
+        f"prompt saved: {record.record}\n  mode: {record.mode}; generation: {record.generation_status}"
+        f"\n  inputs: {record.resolved_path}; {len(record.references)} reference(s)"
+        f"\n  handoff: {handoff.action}; register with {handoff.registration_operation}"
+        f"\n  outputs: {', '.join(item.name for item in record.outputs) or 'none'}"
+    )
+
+
+def render_prompt_revision(result: PromptRevisionResult) -> str:
+    prepared = PromptPreparationResult(preparation=result.revision.preparation)
+    return (
+        render_prompt_preparation(prepared)
+        + f"\n  changed: {', '.join(result.revision.changed_fields) or 'none'}"
+    )
+
+
+def render_prompt_record(result: PromptRecordResult) -> str:
+    record = result.prompt_record
+    return (
+        f"prompt record: {record.record}\n  generation: {record.generation_status}"
+        f"; registered outputs: {', '.join(item.name for item in record.outputs) or 'none'}"
+    )
+
+
+def _prompt_command(
+    operation, input_model, output_model, render, recipe
+) -> HeadlessCommand:
+    return HeadlessCommand(
+        operation=operation,
+        input_model=input_model,
+        output_model=output_model,
+        render=render,
+        kind=ExecutionKind.COMPOSITE,
+        recipe=recipe,
+        inherits_project=False,
+    )
+
+
+PROMPT_PREPARE_COMMAND = _prompt_command(
+    "asset-pipeline-prompt-prepare",
+    PromptPrepareParams,
+    PromptPreparationResult,
+    render_prompt_preparation,
+    run_prompt_prepare,
+)
+PROMPT_INSPECT_COMMAND = _prompt_command(
+    "asset-pipeline-prompt-inspect",
+    PromptInspectParams,
+    PromptPreparationResult,
+    render_prompt_preparation,
+    run_prompt_inspect,
+)
+PROMPT_REVISE_COMMAND = _prompt_command(
+    "asset-pipeline-prompt-revise",
+    PromptReviseParams,
+    PromptRevisionResult,
+    render_prompt_revision,
+    run_prompt_revise,
+)
+PROMPT_REGISTER_OUTPUT_COMMAND = _prompt_command(
+    "asset-pipeline-prompt-register-output",
+    PromptRegisterOutputParams,
+    PromptRecordResult,
+    render_prompt_record,
+    run_prompt_register_output,
+)
+
+
+def _json_map(value: str | None, label: str) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(f"invalid {label} JSON: {exc.msg}") from exc
+    if not isinstance(decoded, dict):
+        raise typer.BadParameter(f"{label} must be a JSON object")
+    return decoded
+
+
+@_app.command(name="prompt-prepare", cls=PROMPT_PREPARE_COMMAND.command_class())
+def prompt_prepare(
+    record: Path = typer.Option(..., "--record", help="New prompt record directory."),
+    text: Optional[str] = typer.Option(None, "--text", help="Literal prompt text."),
+    template: Optional[Path] = typer.Option(
+        None, "--template", help="Template file using $name placeholders."
+    ),
+    style: Optional[Path] = typer.Option(
+        None, "--style", help="Optional prepended style text file."
+    ),
+    variables: str = typer.Option(
+        "{}", "--variables", help="JSON object of exact string template variables."
+    ),
+    references: Optional[list[Path]] = typer.Option(
+        None, "--reference", help="Local reference file; repeat up to 16."
+    ),
+    producer: Optional[str] = typer.Option(
+        None, "--producer", help="Caller-selected external producer."
+    ),
+    requested_options: str = typer.Option(
+        "{}", "--requested-options", help=REQUESTED_OPTION_HELP
+    ),
+    json_output: bool = json_option(),
+    schema: bool = PROMPT_PREPARE_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+) -> None:
+    """Save prepared prompt inputs and return an external handoff."""
+    dispatch_recipe(
+        PROMPT_PREPARE_COMMAND,
+        params_or_bad_parameter(
+            PromptPrepareParams,
+            record=record,
+            text=text,
+            template=template,
+            style=style,
+            variables=_json_map(variables, "variables"),
+            references=references or (),
+            producer=producer,
+            requested_options=_json_map(requested_options, "requested-options"),
+        ),
+        json_output=json_output,
+        godot=None,
+        project=None,
+    )
+
+
+@_app.command(name="prompt-inspect", cls=PROMPT_INSPECT_COMMAND.command_class())
+def prompt_inspect(
+    record: Path = typer.Option(
+        ..., "--record", help="Existing prompt record directory."
+    ),
+    json_output: bool = json_option(),
+    schema: bool = PROMPT_INSPECT_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+) -> None:
+    """Inspect saved prompt inputs, outputs, and external handoff."""
+    dispatch_recipe(
+        PROMPT_INSPECT_COMMAND,
+        PromptInspectParams(record=record),
+        json_output=json_output,
+        godot=None,
+        project=None,
+    )
+
+
+@_app.command(name="prompt-revise", cls=PROMPT_REVISE_COMMAND.command_class())
+def prompt_revise(
+    source_record: Path = typer.Option(..., "--source-record"),
+    record: Path = typer.Option(..., "--record"),
+    text: Optional[str] = typer.Option(None, "--text"),
+    template: Optional[Path] = typer.Option(None, "--template"),
+    style: Optional[Path] = typer.Option(None, "--style"),
+    remove_style: bool = typer.Option(False, "--remove-style"),
+    variables: Optional[str] = typer.Option(
+        None, "--variables", help="Replacement JSON string map."
+    ),
+    references: Optional[list[Path]] = typer.Option(
+        None, "--reference", help="Replacement reference set; repeat."
+    ),
+    producer: Optional[str] = typer.Option(None, "--producer"),
+    requested_options: Optional[str] = typer.Option(
+        None, "--requested-options", help=REQUESTED_OPTION_HELP
+    ),
+    json_output: bool = json_option(),
+    schema: bool = PROMPT_REVISE_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+) -> None:
+    """Create a separate prompt record with explicit changes."""
+    dispatch_recipe(
+        PROMPT_REVISE_COMMAND,
+        params_or_bad_parameter(
+            PromptReviseParams,
+            source_record=source_record,
+            record=record,
+            text=text,
+            template=template,
+            style=style,
+            remove_style=remove_style,
+            variables=_json_map(variables, "variables"),
+            references=references,
+            producer=producer,
+            requested_options=_json_map(requested_options, "requested-options"),
+        ),
+        json_output=json_output,
+        godot=None,
+        project=None,
+    )
+
+
+@_app.command(
+    name="prompt-register-output", cls=PROMPT_REGISTER_OUTPUT_COMMAND.command_class()
+)
+def prompt_register_output(
+    record: Path = typer.Option(..., "--record"),
+    output: Path = typer.Option(..., "--output"),
+    name: str = typer.Option(..., "--name", help="Caller-chosen safe PNG filename."),
+    submitted_prompt: Optional[str] = typer.Option(None, "--submitted-prompt"),
+    caller_declarations: str = typer.Option(
+        "{}", "--caller-declarations", help=DECLARATION_HELP
+    ),
+    reported_provider: Optional[str] = typer.Option(None, "--reported-provider"),
+    reported_model: Optional[str] = typer.Option(None, "--reported-model"),
+    reported_options: str = typer.Option(
+        "{}", "--reported-options", help=REQUESTED_OPTION_HELP
+    ),
+    json_output: bool = json_option(),
+    schema: bool = PROMPT_REGISTER_OUTPUT_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+) -> None:
+    """Register an existing completed PNG without invoking a producer."""
+    dispatch_recipe(
+        PROMPT_REGISTER_OUTPUT_COMMAND,
+        params_or_bad_parameter(
+            PromptRegisterOutputParams,
+            record=record,
+            output=output,
+            name=name,
+            submitted_prompt=submitted_prompt,
+            caller_declarations=_json_map(caller_declarations, "caller-declarations"),
+            reported_provider=reported_provider,
+            reported_model=reported_model,
+            reported_options=_json_map(reported_options, "reported-options"),
+        ),
+        json_output=json_output,
+        godot=None,
         project=None,
     )

--- a/src/gda/commands/asset_pipeline.py
+++ b/src/gda/commands/asset_pipeline.py
@@ -3,7 +3,7 @@
 import json
 from dataclasses import asdict
 from pathlib import Path
-from typing import Annotated, Any, Literal, Optional
+from typing import Annotated, Any, Literal, Optional, get_args
 
 import typer
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
@@ -41,6 +41,8 @@ from gda_assets.api import (
     register_prompt_output,
     revise_prompt,
     PortFailure,
+    PromptDeclarationKey,
+    PromptOptionKey,
 )
 
 from gda.dispatch import dispatch_recipe, params_or_bad_parameter
@@ -1223,10 +1225,8 @@ def asset_pipeline_check_package(
     )
 
 
-REQUESTED_OPTION_HELP = "Supported keys: aspect_ratio, background, model, output_format, quality, seed, size, style."
-DECLARATION_HELP = (
-    "Supported keys: generation_completed, model, provider, request_id, tool."
-)
+REQUESTED_OPTION_HELP = f"Supported keys: {', '.join(get_args(PromptOptionKey))}."
+DECLARATION_HELP = f"Supported keys: {', '.join(get_args(PromptDeclarationKey))}."
 PromptVariableKey = Annotated[str, Field(max_length=128)]
 PromptVariableValue = Annotated[str, Field(max_length=4096)]
 
@@ -1237,8 +1237,20 @@ class PromptPrepareParams(BaseModel):
         allow_inf_nan=False,
         json_schema_extra={
             "oneOf": [
-                {"required": ["text"], "properties": {"template": {"type": "null"}}},
-                {"required": ["template"], "properties": {"text": {"type": "null"}}},
+                {
+                    "required": ["text"],
+                    "properties": {
+                        "text": {"type": "string"},
+                        "template": {"type": "null"},
+                    },
+                },
+                {
+                    "required": ["template"],
+                    "properties": {
+                        "template": {"type": "string"},
+                        "text": {"type": "null"},
+                    },
+                },
             ]
         },
     )
@@ -1270,7 +1282,7 @@ class PromptPrepareParams(BaseModel):
         max_length=256,
         description="Optional caller-selected external producer name.",
     )
-    requested_options: dict[str, JsonScalar] = Field(
+    requested_options: dict[PromptOptionKey, JsonScalar] = Field(
         default_factory=dict, description=REQUESTED_OPTION_HELP
     )
 
@@ -1322,7 +1334,7 @@ class PromptReviseParams(BaseModel):
         max_length=256,
         description="Optional replacement producer declaration.",
     )
-    requested_options: dict[str, JsonScalar] | None = Field(
+    requested_options: dict[PromptOptionKey, JsonScalar] | None = Field(
         default=None, description=REQUESTED_OPTION_HELP
     )
 
@@ -1339,8 +1351,16 @@ class PromptRegisterOutputParams(BaseModel):
     submitted_prompt: str | None = Field(
         default=None, description="Actual submitted prompt when explicitly known."
     )
-    caller_declarations: dict[str, JsonScalar] = Field(
-        default_factory=dict, description=DECLARATION_HELP
+    caller_declarations: dict[PromptDeclarationKey, JsonScalar] = Field(
+        default_factory=dict,
+        description=DECLARATION_HELP,
+        json_schema_extra={
+            "properties": {
+                "generation_completed": {
+                    "anyOf": [{"type": "boolean"}, {"type": "null"}]
+                }
+            }
+        },
     )
     reported_provider: str | None = Field(
         default=None,
@@ -1350,7 +1370,7 @@ class PromptRegisterOutputParams(BaseModel):
         default=None,
         description="Model identity reported after generation, if available.",
     )
-    reported_options: dict[str, JsonScalar] = Field(
+    reported_options: dict[PromptOptionKey, JsonScalar] = Field(
         default_factory=dict, description=REQUESTED_OPTION_HELP
     )
 
@@ -1389,7 +1409,7 @@ def run_prompt_prepare(
                 params.variables,
                 tuple(path.resolve() for path in params.references),
                 params.producer,
-                params.requested_options,
+                {str(key): value for key, value in params.requested_options.items()},
             )
         )
         return PromptPreparationResult(preparation=prepared)
@@ -1427,7 +1447,11 @@ def run_prompt_revise(
                 if params.references is not None
                 else None,
                 producer=params.producer,
-                requested_options=params.requested_options,
+                requested_options=(
+                    {str(key): value for key, value in params.requested_options.items()}
+                    if params.requested_options is not None
+                    else None
+                ),
             )
         )
         return PromptRevisionResult(revision=revised)
@@ -1446,10 +1470,10 @@ def run_prompt_register_output(
                 params.output.resolve(),
                 params.name,
                 params.submitted_prompt,
-                params.caller_declarations,
+                {str(key): value for key, value in params.caller_declarations.items()},
                 params.reported_provider,
                 params.reported_model,
-                params.reported_options,
+                {str(key): value for key, value in params.reported_options.items()},
             )
         )
         return PromptRecordResult(prompt_record=record)

--- a/src/gda/commands/asset_pipeline.py
+++ b/src/gda/commands/asset_pipeline.py
@@ -1409,7 +1409,7 @@ def run_prompt_prepare(
                 params.variables,
                 tuple(path.resolve() for path in params.references),
                 params.producer,
-                {str(key): value for key, value in params.requested_options.items()},
+                params.requested_options,
             )
         )
         return PromptPreparationResult(preparation=prepared)
@@ -1448,7 +1448,7 @@ def run_prompt_revise(
                 else None,
                 producer=params.producer,
                 requested_options=(
-                    {str(key): value for key, value in params.requested_options.items()}
+                    params.requested_options
                     if params.requested_options is not None
                     else None
                 ),
@@ -1470,10 +1470,10 @@ def run_prompt_register_output(
                 params.output.resolve(),
                 params.name,
                 params.submitted_prompt,
-                {str(key): value for key, value in params.caller_declarations.items()},
+                params.caller_declarations,
                 params.reported_provider,
                 params.reported_model,
-                {str(key): value for key, value in params.reported_options.items()},
+                params.reported_options,
             )
         )
         return PromptRecordResult(prompt_record=record)

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -92,6 +92,18 @@ the [asset pipeline guide](https://github.com/aigengame/godot-agent/blob/main/li
 for the source check, cold pack export, exact exclusions, identity and cleanup
 contract, bounds, and supported engine path.
 
+Before external image generation, use `gda asset-pipeline prompt-prepare --record
+/project/art/attempt-a --text 'Project prompt' --json`. Use the returned saved
+prompt and reference paths for the external tool call. Preparation is an external
+handoff, not generated success. `prompt-inspect --record` reuses saved inputs;
+`prompt-revise --source-record OLD --record NEW` preserves a separate attempt.
+After generation, `prompt-register-output --record OLD --output /generated/image.png
+--name image.png` preserves a local PNG without invoking or retrying a producer.
+Requested options, caller declarations, reported facts, and actually submitted
+text stay separate; unavailable execution facts remain unknown. These local
+commands need no Godot project or engine. See each command's `--schema` and the
+[prompt guide](https://github.com/aigengame/godot-agent/blob/main/libs/gda-assets/docs/prompts.md).
+
 ## Setup
 
 - **Engine** — set `GDA_GODOT` to your Godot binary (or pass `--godot PATH`).
@@ -283,7 +295,7 @@ Every headless reply carries its floats at full binary64 precision, so a value r
 
 | Group | Commands |
 | --- | --- |
-| `asset-pipeline` | `run`, `check`, `preview`, `check-package` (production and handoff; project expectations and compatible report comparison; isolated windowed model preview; exported-package acceptance) |
+| `asset-pipeline` | `run`, `check`, `preview`, `check-package`, `prompt-prepare`, `prompt-inspect`, `prompt-revise`, `prompt-register-output` (production and handoff; project expectations; model preview; package acceptance; local prompt preservation and external output registration) |
 
 Use `gda asset-pipeline preview --path /production/model.glb --output-dir
 /reports/model-preview --settings /project/preview-settings.json --frames 60

--- a/tests/asset_pipeline/test_prompt_cli.py
+++ b/tests/asset_pipeline/test_prompt_cli.py
@@ -2,11 +2,14 @@
 
 import json
 
+import jsonschema
 import pytest
 from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.mcp.server import build_server
+from gda_assets.api import PromptDeclarationKey, PromptOptionKey
+from typing import get_args
 from tests.mcp_support import FakeGdaRunner, gda_result, list_tools, schema_then
 
 
@@ -37,6 +40,49 @@ def test_prompt_prepare_is_a_projectless_typed_composite_command():
     tool = next(item for item in tools if item.name == "asset_pipeline_prompt_prepare")
     assert tool.input_schema == schema["input"]
     assert tool.output_schema == schema["output"]
+
+
+def test_prompt_map_keys_and_prompt_source_are_enforced_by_cli_and_mcp_schema():
+    runner = CliRunner()
+    prepare = json.loads(
+        runner.invoke(app, ["asset-pipeline", "prompt-prepare", "--schema"]).stdout
+    )
+    register = json.loads(
+        runner.invoke(
+            app, ["asset-pipeline", "prompt-register-output", "--schema"]
+        ).stdout
+    )
+    option_keys = set(get_args(PromptOptionKey))
+    declaration_keys = set(get_args(PromptDeclarationKey))
+    assert (
+        set(
+            prepare["input"]["properties"]["requested_options"]["propertyNames"]["enum"]
+        )
+        == option_keys
+    )
+    assert (
+        set(
+            register["input"]["properties"]["caller_declarations"]["propertyNames"][
+                "enum"
+            ]
+        )
+        == declaration_keys
+    )
+    validator = jsonschema.Draft202012Validator(prepare["input"])
+    valid = {"record": "/tmp/record", "text": "hello"}
+    assert not list(validator.iter_errors(valid))
+    for invalid in (
+        {"record": "/tmp/record"},
+        {"record": "/tmp/record", "text": None},
+        {**valid, "requested_options": {"unknown": "value"}},
+    ):
+        assert list(validator.iter_errors(invalid))
+
+    tools = list_tools(
+        build_server(FakeGdaRunner(schema_then(lambda *_: gda_result())))
+    ).tools
+    tool = next(item for item in tools if item.name == "asset_pipeline_prompt_prepare")
+    assert tool.input_schema == prepare["input"]
 
 
 def test_prompt_prepare_and_inspect_public_json_do_not_claim_generation(tmp_path):

--- a/tests/asset_pipeline/test_prompt_cli.py
+++ b/tests/asset_pipeline/test_prompt_cli.py
@@ -1,0 +1,105 @@
+"""Prompt records share the typed asset-pipeline CLI and MCP surface."""
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.mcp.server import build_server
+from tests.mcp_support import FakeGdaRunner, gda_result, list_tools, schema_then
+
+
+def test_prompt_prepare_is_a_projectless_typed_composite_command():
+    result = CliRunner().invoke(app, ["asset-pipeline", "prompt-prepare", "--schema"])
+
+    assert result.exit_code == 0, result.output
+    schema = json.loads(result.stdout)
+    assert schema["kind"] == "composite"
+    assert schema["input"]["additionalProperties"] is False
+    assert set(schema["input"]["properties"]) == {
+        "record",
+        "text",
+        "template",
+        "style",
+        "variables",
+        "references",
+        "producer",
+        "requested_options",
+    }
+    assert "PromptPreparation" in schema["output"]["$defs"]
+    reference = next(item for item in schema["argv"] if item["option"] == "--reference")
+    assert reference["input_property"] == "references"
+    assert reference["multiple"] is True
+    tools = list_tools(
+        build_server(FakeGdaRunner(schema_then(lambda *_: gda_result())))
+    ).tools
+    tool = next(item for item in tools if item.name == "asset_pipeline_prompt_prepare")
+    assert tool.input_schema == schema["input"]
+    assert tool.output_schema == schema["output"]
+
+
+def test_prompt_prepare_and_inspect_public_json_do_not_claim_generation(tmp_path):
+    record = tmp_path / "attempt"
+    runner = CliRunner()
+    prepared = runner.invoke(
+        app,
+        [
+            "asset-pipeline",
+            "prompt-prepare",
+            "--record",
+            str(record),
+            "--text",
+            "A mossy stone arch",
+            "--producer",
+            "external-tool",
+            "--requested-options",
+            '{"size":"1024x1024"}',
+            "--json",
+        ],
+    )
+    inspected = runner.invoke(
+        app,
+        [
+            "asset-pipeline",
+            "prompt-inspect",
+            "--params-json",
+            json.dumps({"record": str(record)}),
+            "--json",
+        ],
+    )
+
+    assert prepared.exit_code == inspected.exit_code == 0
+    first, second = json.loads(prepared.stdout), json.loads(inspected.stdout)
+    assert first == second
+    assert first["preparation"]["record"]["generation_status"] == "unknown"
+    assert first["preparation"]["handoff"]["action"] == "external_generation_required"
+    assert first["preparation"]["record"]["requested_options"] == {"size": "1024x1024"}
+
+
+@pytest.mark.parametrize(
+    ("command", "tool_name", "definition"),
+    [
+        ("prompt-inspect", "asset_pipeline_prompt_inspect", "PromptPreparation"),
+        ("prompt-revise", "asset_pipeline_prompt_revise", "PromptRevision"),
+        (
+            "prompt-register-output",
+            "asset_pipeline_prompt_register_output",
+            "PromptRecord",
+        ),
+    ],
+)
+def test_each_prompt_command_has_matching_cli_and_mcp_result_schema(
+    command, tool_name, definition
+):
+    result = CliRunner().invoke(app, ["asset-pipeline", command, "--schema"])
+    assert result.exit_code == 0, result.output
+    schema = json.loads(result.stdout)
+    assert schema["kind"] == "composite"
+    assert definition in schema["output"]["$defs"]
+    tools = list_tools(
+        build_server(FakeGdaRunner(schema_then(lambda *_: gda_result())))
+    ).tools
+    tool = next(item for item in tools if item.name == tool_name)
+    assert tool.input_schema == schema["input"]
+    assert tool.output_schema == schema["output"]

--- a/tests/asset_pipeline/test_prompt_cli.py
+++ b/tests/asset_pipeline/test_prompt_cli.py
@@ -68,6 +68,24 @@ def test_prompt_map_keys_and_prompt_source_are_enforced_by_cli_and_mcp_schema():
         )
         == declaration_keys
     )
+    prepare_defs = prepare["output"]["$defs"]
+    for definition in ("PromptRecord", "PromptHandoff"):
+        assert (
+            set(
+                prepare_defs[definition]["properties"]["requested_options"][
+                    "propertyNames"
+                ]["enum"]
+            )
+            == option_keys
+        )
+    prompt_output = prepare_defs["PromptOutput"]["properties"]
+    assert (
+        set(prompt_output["caller_declarations"]["propertyNames"]["enum"])
+        == declaration_keys
+    )
+    assert (
+        set(prompt_output["reported_options"]["propertyNames"]["enum"]) == option_keys
+    )
     validator = jsonschema.Draft202012Validator(prepare["input"])
     valid = {"record": "/tmp/record", "text": "hello"}
     assert not list(validator.iter_errors(valid))
@@ -83,6 +101,7 @@ def test_prompt_map_keys_and_prompt_source_are_enforced_by_cli_and_mcp_schema():
     ).tools
     tool = next(item for item in tools if item.name == "asset_pipeline_prompt_prepare")
     assert tool.input_schema == prepare["input"]
+    assert tool.output_schema == prepare["output"]
 
 
 def test_prompt_prepare_and_inspect_public_json_do_not_claim_generation(tmp_path):

--- a/tests/asset_pipeline/test_prompt_consumer.py
+++ b/tests/asset_pipeline/test_prompt_consumer.py
@@ -1,0 +1,273 @@
+"""Standalone public prompt records survive processes, cwd changes, and failure."""
+
+import hashlib
+import json
+import shutil
+import struct
+import subprocess
+import zlib
+from pathlib import Path
+
+from tests.support import Gda
+
+
+def _png(path: Path, rgba: tuple[int, int, int, int]) -> None:
+    def chunk(kind: bytes, data: bytes) -> bytes:
+        body = kind + data
+        return struct.pack(">I", len(data)) + body + struct.pack(">I", zlib.crc32(body))
+
+    path.write_bytes(
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", 2, 1, 8, 6, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(b"\0" + bytes(rgba) * 2))
+        + chunk(b"IEND", b"")
+    )
+
+
+def _tree(root: Path) -> dict[Path, bytes]:
+    return {
+        path.relative_to(root): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+def _run(cwd: Path) -> Gda:
+    return Gda(None, godot=None, json_output=True, cwd=cwd)
+
+
+def _record(preparation: dict) -> dict:
+    return preparation["preparation"]["record"]
+
+
+def test_prompt_records_are_portable_explicit_attempts_across_processes_and_cwds(
+    tmp_path,
+):
+    project = tmp_path / "git-project"
+    author = project / "authoring"
+    consumer = project / "consumer"
+    records = project / "records"
+    author.mkdir(parents=True)
+    consumer.mkdir()
+    records.mkdir()
+    subprocess.run(
+        ["git", "init", "--quiet", str(project)], check=True, capture_output=True
+    )
+    template = author / "prompt.txt"
+    style = author / "style.txt"
+    reference = author / "reference.png"
+    template.write_text("A ${subject} beside a $$ sign")
+    style.write_text("Soft watercolor, no text.\n")
+    _png(reference, (220, 40, 30, 255))
+    original_reference = reference.read_bytes()
+    secret = "must-not-enter-record"
+
+    prepared_a = _run(author).json(
+        "asset-pipeline",
+        "prompt-prepare",
+        "--record",
+        "../records/a",
+        "--template",
+        "prompt.txt",
+        "--style",
+        "style.txt",
+        "--variables",
+        json.dumps({"subject": "red fox"}),
+        "--reference",
+        "reference.png",
+        "--producer",
+        "external-image-tool",
+        "--requested-options",
+        json.dumps({"model": "requested-model", "size": "1024x1024", "seed": 7}),
+        extra_env={"PROMPT_TEST_SECRET": secret},
+    )
+    record_a = _record(prepared_a)
+    assert record_a["mode"] == "template"
+    assert record_a["resolved_prompt"] == (
+        "Soft watercolor, no text.\n\nA red fox beside a $ sign"
+    )
+    assert record_a["generation_status"] == "unknown"
+    assert record_a["outputs"] == []
+    assert prepared_a["preparation"]["handoff"]["action"] == (
+        "external_generation_required"
+    )
+    assert prepared_a["preparation"]["handoff"]["registration_operation"] == (
+        "prompt-register-output"
+    )
+    assert secret not in json.dumps(prepared_a)
+
+    template.write_text("A ${subject} under moonlight")
+    style.write_text("Sharp ink drawing.\n")
+    _png(reference, (20, 40, 230, 255))
+    prepared_b = _run(consumer).json(
+        "asset-pipeline",
+        "prompt-prepare",
+        "--record",
+        "../records/b",
+        "--template",
+        "../authoring/prompt.txt",
+        "--style",
+        "../authoring/style.txt",
+        "--variables",
+        json.dumps({"subject": "blue heron"}),
+        "--reference",
+        "../authoring/reference.png",
+    )
+    assert _record(prepared_b)["resolved_prompt"] == (
+        "Sharp ink drawing.\n\nA blue heron under moonlight"
+    )
+
+    moved_a = records / "moved-a"
+    shutil.copytree(records / "a", moved_a)
+    shutil.rmtree(records / "a")
+    inspected_a = _run(consumer).json(
+        "asset-pipeline", "prompt-inspect", "--record", "../records/moved-a"
+    )
+    frozen = _record(inspected_a)
+    assert frozen["record"] == str(moved_a.resolve())
+    assert frozen["resolved_prompt"] == record_a["resolved_prompt"]
+    assert Path(frozen["resolved_path"]).read_text() == frozen["resolved_prompt"]
+    assert Path(frozen["references"][0]["path"]).read_bytes() == original_reference
+    assert (
+        frozen["references"][0]["sha256"]
+        == hashlib.sha256(original_reference).hexdigest()
+    )
+    assert Path(inspected_a["preparation"]["handoff"]["prompt_path"]).is_relative_to(
+        moved_a
+    )
+    assert all(
+        Path(path).is_relative_to(moved_a)
+        for path in inspected_a["preparation"]["handoff"]["references"]
+    )
+
+    revised = _run(author).json(
+        "asset-pipeline",
+        "prompt-revise",
+        "--source-record",
+        "../records/moved-a",
+        "--record",
+        "../records/revision",
+        "--text",
+        "A charcoal fox portrait",
+        "--remove-style",
+        "--variables",
+        "{}",
+        "--reference",
+        "reference.png",
+        "--requested-options",
+        json.dumps({"quality": "high"}),
+    )["revision"]
+    revised_record = revised["preparation"]["record"]
+    assert revised_record["mode"] == "plain"
+    assert revised_record["resolved_prompt"] == "A charcoal fox portrait"
+    assert revised_record["revised_from"] == str(moved_a.resolve())
+    assert set(revised["changed_fields"]) >= {
+        "mode",
+        "resolved_prompt",
+        "style",
+        "references",
+        "requested_options",
+    }
+    assert (
+        _record(
+            _run(consumer).json(
+                "asset-pipeline", "prompt-inspect", "--record", "../records/moved-a"
+            )
+        )["resolved_prompt"]
+        == frozen["resolved_prompt"]
+    )
+
+    before_failures = _tree(moved_a)
+    missing = _run(consumer).error(
+        "asset-pipeline",
+        "prompt-register-output",
+        "--record",
+        "../records/moved-a",
+        "--output",
+        "missing.png",
+        "--name",
+        "result.png",
+        code="invalid_params",
+    )
+    assert (
+        "unavailable" in missing["message"].lower()
+        or "invalid" in missing["message"].lower()
+    )
+    assert _tree(moved_a) == before_failures
+    corrupt = consumer / "corrupt.png"
+    corrupt.write_bytes(b"not png")
+    _run(consumer).error(
+        "asset-pipeline",
+        "prompt-register-output",
+        "--record",
+        "../records/moved-a",
+        "--output",
+        "corrupt.png",
+        "--name",
+        "result.png",
+        code="invalid_params",
+    )
+    assert _tree(moved_a) == before_failures
+
+    output = consumer / "generated.png"
+    _png(output, (40, 180, 70, 255))
+    submitted = frozen["resolved_prompt"] + ", brighter lighting"
+    registered = _run(consumer).json(
+        "asset-pipeline",
+        "prompt-register-output",
+        "--record",
+        "../records/moved-a",
+        "--output",
+        "generated.png",
+        "--name",
+        "result.png",
+        "--submitted-prompt",
+        submitted,
+        "--caller-declarations",
+        json.dumps({"tool": "native-agent-tool", "request_id": "unknown"}),
+    )["prompt_record"]
+    assert registered["generation_status"] == "unknown"
+    assert len(registered["outputs"]) == 1
+    saved_output = registered["outputs"][0]
+    assert saved_output["submitted_prompt"] == submitted
+    assert saved_output["submitted_prompt"] != registered["resolved_prompt"]
+    assert saved_output["caller_declarations"] == {
+        "tool": "native-agent-tool",
+        "request_id": "unknown",
+    }
+    assert saved_output["reported_provider"] is None
+    assert saved_output["reported_model"] is None
+    assert saved_output["reported_options"] == {}
+    assert Path(saved_output["file"]["path"]).read_bytes() == output.read_bytes()
+    assert (
+        saved_output["file"]["sha256"]
+        == hashlib.sha256(output.read_bytes()).hexdigest()
+    )
+
+    registered_before_conflict = _tree(moved_a)
+    _run(author).error(
+        "asset-pipeline",
+        "prompt-register-output",
+        "--record",
+        "../records/moved-a",
+        "--output",
+        "../consumer/generated.png",
+        "--name",
+        "result.png",
+        code="already_exists",
+    )
+    assert _tree(moved_a) == registered_before_conflict
+    conflict = records / "conflict"
+    conflict.mkdir()
+    marker = conflict / "keep.txt"
+    marker.write_text("caller owned\n")
+    _run(author).error(
+        "asset-pipeline",
+        "prompt-prepare",
+        "--record",
+        "../records/conflict",
+        "--text",
+        "must not overwrite",
+        code="already_exists",
+    )
+    assert marker.read_text() == "caller owned\n"

--- a/tests/asset_pipeline/test_prompt_file_admission.py
+++ b/tests/asset_pipeline/test_prompt_file_admission.py
@@ -1,0 +1,45 @@
+"""Prompt file admission refuses non-regular inputs before opening them."""
+
+import os
+
+import pytest
+
+from tests.support import Gda
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="Named pipes require POSIX")
+@pytest.mark.parametrize("operation", ["prepare", "register"])
+def test_named_pipe_input_is_refused_without_waiting_for_a_writer(tmp_path, operation):
+    pipe = tmp_path / "input.png"
+    os.mkfifo(pipe)
+    record = tmp_path / "attempt"
+    gda = Gda(None, godot=None, json_output=True, timeout=3)
+    if operation == "prepare":
+        args = ("prompt-prepare", "--record", str(record), "--template", str(pipe))
+    else:
+        gda.json(
+            "asset-pipeline",
+            "prompt-prepare",
+            "--record",
+            str(record),
+            "--text",
+            "A robot.",
+        )
+        args = (
+            "prompt-register-output",
+            "--record",
+            str(record),
+            "--output",
+            str(pipe),
+            "--name",
+            "image.png",
+        )
+
+    error = gda.error("asset-pipeline", *args, code="invalid_params")
+
+    assert "regular file" in error["message"]
+    if operation == "prepare":
+        assert not record.exists()
+    else:
+        result = gda.json("asset-pipeline", "prompt-inspect", "--record", str(record))
+        assert result["preparation"]["record"]["outputs"] == []

--- a/tests/cli/test_command_descriptor_registry.py
+++ b/tests/cli/test_command_descriptor_registry.py
@@ -165,6 +165,10 @@ _RECIPE_OPERATIONS = {
     "asset-pipeline-check",
     "asset-pipeline-preview",
     "asset-pipeline-check-package",
+    "asset-pipeline-prompt-prepare",
+    "asset-pipeline-prompt-inspect",
+    "asset-pipeline-prompt-revise",
+    "asset-pipeline-prompt-register-output",
     "export-run",
     # `script run` is the third execution shape (ADR-0031): a user-script passthrough
     # run, fulfilled by a CLI-side recipe (it emits no ADR-0002 sentinel) like export


### PR DESCRIPTION
## Change

A generation attempt can lose its prompt when a tool fails, and later style/reference edits can change the inputs used for a retry. Add four local `gda asset-pipeline` commands to prepare, inspect, explicitly revise, and register completed outputs. Each caller-selected record directory preserves its text and PNG references; revisions use new directories, and registrations preserve separate output files and metadata. Saved inputs remain usable after source edits or moving the record.

Requested settings, caller declarations, provider-reported facts, and the actually submitted prompt remain separate. Preparation returns an external handoff; local file registration does not invoke a provider or prove generation. These commands need no Godot project, engine, provider connection, or optional helper skill. The supporting context owns the rules, use cases and local file adapter; the gda command group translates its explicit API.

Refs #912; umbrella #907 in [gda-blender milestone #14](https://github.com/aigengame/godot-agent/milestone/14).

## Validation

- 2,831 fast tests passed, 2 skipped; Ruff and Pyright passed.
- Public subprocess coverage: two attempts, source changes, record relocation, different working directories/processes, explicit revision, output registration, unknown dispatch facts, and failure/conflict preservation.
- Regression coverage refuses a 65th registration before it makes the record unreadable and preserves an existing file that occupies the output directory.
- Wheel/sdist build and clean installed-wheel consumer passed all four command paths outside the checkout, with invalid inherited Godot/project settings.
- Real image generation, concept selection, and authoring-reference consumption belong to #913 and are not claimed here.

Independent Sol Standards, Spec and DDMA reviews and final-head rechecks passed at `fe7e865878a39d92c1ed59ba7d22a41717e86061`. The metadata-key schema finding is closed across input, output and persisted records; named-pipe inputs are refused before opening. [Final-head CI](https://github.com/aigengame/godot-agent/actions/runs/34209392522) passed. The normal PR workflow skipped Godot E2E for this local-only slice. This PR targets `codex/asset-pipeline-dev`; no main merge or milestone completion is implied.
