### PR TITLE
feat(asset-pipeline): select concept references before authoring

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -9,8 +9,8 @@ override rules are declared in its own `AGENTS.md`.
 - [gda-balancing](libs/gda-balancing/BALANCING-CONTEXT.md) — the standalone numeric design & balancing toolkit.
 - [Asset Pipeline](libs/gda-assets/ASSETS-CONTEXT.md) — the internal supporting
   context, physically carried by `libs/gda-assets` and exposed through
-  `gda asset-pipeline`. The `run` file-handoff slice is implemented by #908;
-  other planned workflows are tracked by #907.
+  `gda asset-pipeline`. Workflow requirements and delivery status are tracked by
+  [#907](https://github.com/aigengame/godot-agent/issues/907).
 
 ## Asset Pipeline integration
 

--- a/README.md
+++ b/README.md
@@ -488,10 +488,12 @@ names the file, and only `preflight` catches a first-frame failure.
 | `asset-pipeline check-package` | Apply the same model expectations to a resource loaded from an isolated exported PCK and check exact declared exclusions. |
 | `asset-pipeline prompt-prepare` / `prompt-inspect` | Save or reuse one attempt's prompt and PNG reference inputs before external generation. |
 | `asset-pipeline prompt-revise` / `prompt-register-output` | Create a separate revised attempt or preserve a completed local PNG with its declared/reported details. |
+| `asset-pipeline concept-prepare` / `concept-select` / `concept-author` | Preserve a model or sprite brief, select registered PNG references, and run a bounded reference-use example. |
 
 The [prompt commands](libs/gda-assets/docs/prompts.md) work locally without Godot
 or a provider connection. Preparation returns an external handoff; it does not
-generate an image.
+generate an image. The [concept workflow](libs/gda-assets/docs/concepts.md) likewise
+uses explicit external generation and does not install references into Godot.
 
 Use explicit source-to-target mappings and an overwrite policy. Completed
 image-generation files use the same path with optional caller-declared metadata.

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=40e478a5d338ee83ba3ba811623d831ed075bd1af73499a68310544b2bb8e50e -->
+<!-- gda-readme-i18n: source=README.md sha256=d5809235a582579160cb9b6183987697a7703eeaf5280f3e074a124989b2b95b -->
 
 # gda — Automatización de Godot para agentes de IA
 
@@ -503,8 +503,9 @@ identifica el archivo y solo `preflight` detecta un fallo en el primer fotograma
 | `asset-pipeline check-package` | Aplica los mismos requisitos del modelo a un recurso cargado desde un PCK exportado y aislado, y comprueba las exclusiones declaradas mediante rutas exactas. |
 | `asset-pipeline prompt-prepare` / `prompt-inspect` | Guarda o reutiliza el prompt y las referencias PNG de un intento antes de la generación externa. |
 | `asset-pipeline prompt-revise` / `prompt-register-output` | Crea un intento revisado por separado o conserva un PNG local junto con los datos declarados y los comunicados por el proveedor. |
+| `asset-pipeline concept-prepare` / `concept-select` / `concept-author` | Conserva el brief de un modelo o sprite, selecciona referencias PNG registradas y ejecuta un ejemplo acotado de uso de esas referencias. |
 
-Los [comandos de prompts](../libs/gda-assets/docs/prompts.md) funcionan localmente, sin Godot ni conexión con un proveedor. La preparación devuelve las entradas para la herramienta externa; no genera una imagen.
+Los [comandos de prompts](../libs/gda-assets/docs/prompts.md) funcionan localmente, sin Godot ni conexión con un proveedor. La preparación devuelve las entradas para la herramienta externa; no genera una imagen. El [flujo de referencias conceptuales](../libs/gda-assets/docs/concepts.md) también deja la generación en manos de una herramienta externa y no instala las referencias en Godot.
 
 Usa correspondencias explícitas entre origen y destino y define una política de sobrescritura.
 Los archivos que complete la generación de imágenes siguen el mismo flujo y pueden incluir metadatos

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=40e478a5d338ee83ba3ba811623d831ed075bd1af73499a68310544b2bb8e50e -->
+<!-- gda-readme-i18n: source=README.md sha256=d5809235a582579160cb9b6183987697a7703eeaf5280f3e074a124989b2b95b -->
 
 # gda — AI エージェント向け Godot オートメーション
 
@@ -499,8 +499,9 @@ Headless 検証はプロジェクトの実行準備を確認し、Live 操作は
 | `asset-pipeline check-package` | 隔離されたエクスポート済み PCK からリソースを読み込み、同じモデル条件で検証するとともに、明示された除外対象を正確なパスで確認します。 |
 | `asset-pipeline prompt-prepare` / `prompt-inspect` | 外部ツールで生成する前に、1 回の試行で使うプロンプトと PNG 参照画像を保存し、保存済みの入力を再利用します。 |
 | `asset-pipeline prompt-revise` / `prompt-register-output` | 修正内容を別の試行として保存するか、生成済みのローカル PNG と、呼び出し側の申告・プロバイダーの報告を記録します。 |
+| `asset-pipeline concept-prepare` / `concept-select` / `concept-author` | モデルまたはスプライトの概要を保存し、登録済み PNG 参照画像を選択して、用途を限定した参照利用例を実行します。 |
 
-[プロンプト用コマンド](../libs/gda-assets/docs/prompts.md)はローカルで動作し、Godot や生成サービスへの接続は不要です。準備後は外部ツールに渡す入力を返します。画像の生成は行いません。
+[プロンプト用コマンド](../libs/gda-assets/docs/prompts.md)はローカルで動作し、Godot や生成サービスへの接続は不要です。準備後は外部ツールに渡す入力を返します。画像の生成は行いません。[コンセプト参照画像のワークフロー](../libs/gda-assets/docs/concepts.md)でも生成は明示的に外部ツールへ委ね、参照画像を Godot にインストールしません。
 
 ソースからターゲットへのマッピングと上書きポリシーを明示してください。生成が完了した画像ファイルも
 同じ手順で処理でき、呼び出し側が指定したメタデータを任意で付加できます。[アセットパイプラインガイド](../libs/gda-assets/README.md)では、

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- gda-readme-i18n: source=README.md sha256=40e478a5d338ee83ba3ba811623d831ed075bd1af73499a68310544b2bb8e50e -->
+<!-- gda-readme-i18n: source=README.md sha256=d5809235a582579160cb9b6183987697a7703eeaf5280f3e074a124989b2b95b -->
 
 # gda — 面向 AI Agent 的 Godot 自动化
 
@@ -479,8 +479,9 @@ Headless 验证确认项目就绪状态；Live 操作返回用于验证实际行
 | `asset-pipeline check-package` | 在隔离环境中从导出的 PCK 加载资源，按同一套模型要求验收，并检查明确声明的排除路径。 |
 | `asset-pipeline prompt-prepare` / `prompt-inspect` | 在调用外部生成工具前保存提示词和 PNG 参考图，并读取已保存的输入以供复用。 |
 | `asset-pipeline prompt-revise` / `prompt-register-output` | 将修订后的提示词保存为独立尝试，或登记已生成的本地 PNG 及调用者声明、工具报告的信息。 |
+| `asset-pipeline concept-prepare` / `concept-select` / `concept-author` | 保存模型或精灵简报，选择已登记的 PNG 参考图，并运行范围明确的参考图使用示例。 |
 
-[提示词命令](../libs/gda-assets/docs/prompts.md)在本地运行，无需 Godot 或连接生成服务。准备完成后返回交给外部工具的输入，不会生成图片。
+[提示词命令](../libs/gda-assets/docs/prompts.md)在本地运行，无需 Godot 或连接生成服务。准备完成后返回交给外部工具的输入，不会生成图片。[概念参考图流程](../libs/gda-assets/docs/concepts.md)同样由外部工具明确完成生成，也不会把参考图安装到 Godot。
 
 请使用明确的源文件到目标位置映射，并指定覆盖策略。图像生成完成后的文件沿用同一流程，
 也可以附带调用方声明的元数据。[资产管线指南](../libs/gda-assets/README.md)介绍了 Blender 导出、文件输入、引用、

--- a/libs/gda-assets/AGENTS.md
+++ b/libs/gda-assets/AGENTS.md
@@ -5,7 +5,8 @@ context. It is not a sibling user-facing product. File handoff (#908), saved
 Blender production (#909), model expectation checks (#887), optional content
 observations (#889), controlled runtime refresh (#890), preview (#891), and package
 acceptance (#892), and local prompt records (#912) are implemented. Concept
-selection and authoring consumers remain planned.
+selection and both bounded authoring consumers (#913) are implemented and observed;
+final independent review, CI, and delivery status remain issue-owned.
 Requirements, review, CI, and delivery status live in
 [#907](https://github.com/aigengame/godot-agent/issues/907).
 

--- a/libs/gda-assets/ASSETS-CONTEXT.md
+++ b/libs/gda-assets/ASSETS-CONTEXT.md
@@ -42,7 +42,10 @@ art direction determines suitable views, poses, and style.
 
 **Authoring handoff**: Selected usable concept files, their prompt-record links,
 intended use, and project instructions delivered to a tool or agent before authoring.
-It is a small prepared input, not a persisted workflow aggregate.
+It is a small prepared input, not a persisted workflow aggregate. The initial
+examples each consume exactly one selected PNG: a Blender reference blockout records
+pixel-derived material influence, and a sprite example records reference-derived
+frames. They do not claim general authoring, similarity, or production quality.
 
 **Producer**: A boundary that supplies asset files from a native source or generation
 request. Its adapter owns vendor options and failure translation. A producer need

--- a/libs/gda-assets/README.md
+++ b/libs/gda-assets/README.md
@@ -12,6 +12,10 @@ the exact prompt and reference inputs. Inspect or revise those saved inputs, the
 register completed local output files. See the [prompt guide](docs/prompts.md)
 for the four local operations and their external-tool handoff.
 
+Use the concept workflow to preserve a model/sprite brief, select registered PNG
+references, and run a bounded Blender blockout or sprite-sheet reference example.
+See the [concept reference guide](docs/concepts.md).
+
 Use `gda asset-pipeline check` to evaluate project-owned model expectations against
 a current Godot inspection or a saved raw inspection report. See the
 [model checks guide](docs/checks.md) for the JSON format, seven supported check

--- a/libs/gda-assets/docs/ARCHITECTURE.md
+++ b/libs/gda-assets/docs/ARCHITECTURE.md
@@ -3,8 +3,9 @@
 **Status:** accepted design; file handoff (#908), saved Blender production (#909),
 model expectation checks (#887), optional content observations (#889), controlled
 runtime refresh (#890), preview (#891), package acceptance (#892), and local prompt
-records (#912) are implemented. Concept selection and authoring consumers remain
-planned. Accepted by the project owner
+records (#912) are implemented. Concept selection and authoring consumers (#913)
+have real external-generation, Blender, and sprite observations; final independent
+review, CI, and delivery status remain issue-owned. Accepted by the project owner
 on 2026-09-07 after review of the Blender-to-Godot workflow and milestone #14.
 Source baseline inspected: `cfcb8658e67df418a69694840a37a22a9cd3cbe0`.
 Acceptance and delivery status are owned by
@@ -124,12 +125,15 @@ libs/gda-assets/
       artifacts.py
       expectations.py
       prompt.py                       # prompt inputs, values, and composition rules
+      concept.py                      # brief, selection, and authoring values
     application/
       ports.py
       integrate.py
       produce.py
       prompt.py                       # prepare, inspect, revise, register outputs
       prompt_ports.py                 # required local file persistence
+      concept.py                      # prepare, select, and author workflows
+      concept_ports.py                # local handoff and bounded consumer ports
       preview.py                      # isolated model preview orchestration
       package.py                      # isolated package acceptance orchestration
     adapters/
@@ -137,6 +141,7 @@ libs/gda-assets/
       imagegen/
       files.py
       prompt_files.py                 # ordinary prompt snapshots and PNG copies
+      concept_files.py                # movable selected-reference handoffs
       raster.py
     bootstrap.py                      # producer composition, lazy setup
   tests/
@@ -250,11 +255,13 @@ outside the Python command. A callable provider adapter can later automate that
 step without changing the host integration; no invented background tool access or
 automatic retry after an unknown provider outcome is assumed.
 
-The concept-reference slice extends that handoff with saved prompts, candidates,
-selection, and real authoring examples. It must prove usable reference delivery to
-Blender and a small sprite-sheet workflow. It does not make the saved-source export
-adapter a model generator or add full Aseprite support. Concept images have their
-own role and are not installed as runtime assets without explicit mapping.
+The concept-reference slice extends that handoff with saved briefs, registered PNG
+candidates, explicit selection, and two bounded authoring examples. Blender consumes
+one selected image before geometry and records pixel-derived material influence; the
+sprite example consumes one before deriving and checking a fixed sheet. These are
+observable reference-use examples, not general authoring, image-similarity or quality
+claims. They do not make the saved-source exporter a model generator or add Aseprite
+support. Concept images are not installed as runtime assets without explicit mapping.
 
 ## Existing seams and required additions
 
@@ -281,7 +288,7 @@ The following is a delivery map, not a second editable acceptance checklist.
 | --- | --- | --- |
 | [#908](https://github.com/aigengame/godot-agent/issues/908) | Unified entry: existing files / generated-image handoff through processing, installation, real Godot import/load; installable internal library | None |
 | [#912](https://github.com/aigengame/godot-agent/issues/912) | Save, inspect, revise, and reuse project prompts before generation; register associated outputs | [#908](https://github.com/aigengame/godot-agent/issues/908) |
-| [#913](https://github.com/aigengame/godot-agent/issues/913) | Generate/select concept references and demonstrate their use before Blender and sprite authoring | [#912](https://github.com/aigengame/godot-agent/issues/912) |
+| [#913](https://github.com/aigengame/godot-agent/issues/913) | Preserve a concept brief, select registered PNG references, and demonstrate one-reference Blender blockout and sprite-sheet use | [#912](https://github.com/aigengame/godot-agent/issues/912) |
 | [#909](https://github.com/aigengame/godot-agent/issues/909) | Saved Blender source, bounded source inspection, export-only scale preparation, same integration path, and Godot load/dimension check | [#908](https://github.com/aigengame/godot-agent/issues/908) |
 | [#885](https://github.com/aigengame/godot-agent/issues/885) | gda: structured Vector3 and Node3D local transform operations | None |
 | [#886](https://github.com/aigengame/godot-agent/issues/886) | gda: bounded imported model facts | None |
@@ -314,9 +321,9 @@ original Panda codebase or mark it archived as part of this work.
 
 [aADR-0002](adr/0002-minimum-results-and-optional-content-checks.md) owns the minimum
 result policy. The following stable claims are implementation validation items,
-not a product evidence/profile framework. Evidence is recorded per slice: completed
-slices below have implementation and native coverage in their owning tests, while
-AP-06 remains open. Review, CI, and delivery status remain in the linked issues.
+not a product evidence/profile framework. Evidence is recorded per slice in its
+owning tests and validation reports. Review, CI, and delivery status remain in the
+linked issues.
 
 | Claim | Driver, owner, and available evidence | Disconfirming case and required validation |
 | --- | --- | --- |
@@ -325,7 +332,7 @@ AP-06 remains open. Review, CI, and delivery status remain in the linked issues.
 | AP-03 | Reliable option-only reimport; gda [#888](https://github.com/aigengame/godot-agent/issues/888). Current import fast path and engine docs inspected | Unchanged GLB plus changed root scale returns cached success with old dimensions. Real engine option-only, no-op, invalid, and failed cases |
 | AP-04 | Honest runtime freshness; [#890](https://github.com/aigengame/godot-agent/issues/890). Current session/capture semantics inspected | A/B share path, names, counts, bounds, material refs but differ in supported content and compare equal. Test selected-instance content, stale/wrong instance, runtime replacement, session and capture scope |
 | AP-05 | Minimum machinery with usable recovery; aADR-0002. Existing scripts offer reusable stages, no generic resume proof | Import failure or unknown producer outcome triggers regeneration or false completion. Inject stage failures, retain outputs, and explicitly retry remaining steps without production replay |
-| AP-06 | Prompt preservation and usable concept references; aADR-0003, #912/#913. Local prompt commands preserve and reuse separate attempts and register external outputs. Real concept generation and authoring-reference consumption remain open under #913 | Editing style/reference inputs changes an earlier attempt, reuse regenerates silently, or an authoring consumer loads an unselected candidate. Test separate attempts, explicit reuse/revision, failure ordering, real image generation, and selected-reference consumption in Blender and sprite examples |
+| AP-06 | Prompt preservation and usable concept references; aADR-0003, #912/#913. One saved prompt produced a registered agent-native PNG; without another provider call, its selected bytes were consumed first by Blender 5.2.1 to write a one-cube material-influenced `.blend`/GLB and separately to write a checked four-frame sprite sheet. Final tests and independent review remain issue-owned | Editing style/reference inputs changes an earlier attempt, reuse regenerates silently, or an authoring consumer loads an unselected candidate. Retain separate-attempt, explicit reuse/reselection, failure-ordering, and selected-versus-unselected regressions |
 | AP-07 | Package-only acceptance; [#892](https://github.com/aigengame/godot-agent/issues/892) and aADR-0002. Real cold-export tests apply the same mesh, material, and animation rules to source and PCK facts, detect omitted models and included exclusions, and verify isolation, package hash, and cleanup | A warm source project masks an omitted packaged model, an exclusion scans outside selected exact paths, or an editor probe is reported as native release behavior. Unsupported-editor gating has separate runner tests; native executable behavior is outside this check |
 
 The design's boundary review covers known owners and source cycles, but does not

--- a/libs/gda-assets/docs/concepts.md
+++ b/libs/gda-assets/docs/concepts.md
@@ -19,6 +19,9 @@ Create a brief such as `concept.json`:
 }
 ```
 
+`use`, `subject`, and `style` are required. Supply at least one view or pose;
+the unused list and `instructions` can be omitted. Unknown fields are rejected.
+
 Then prepare one exclusive prompt-record directory:
 
 ```sh

--- a/libs/gda-assets/docs/concepts.md
+++ b/libs/gda-assets/docs/concepts.md
@@ -1,0 +1,107 @@
+# Concept references
+
+Use the concept workflow before authoring a new model or sprite sheet. It preserves
+the project brief and prompt, accepts explicitly registered local PNG candidates,
+copies the selected references into a movable handoff, and runs one of two bounded
+reference-use examples. It does not call an image provider or install anything into
+Godot.
+
+Create a brief such as `concept.json`:
+
+```json
+{
+  "use": "model",
+  "subject": "A squat brass maintenance robot",
+  "style": "Readable low-poly shapes with a warm industrial palette",
+  "views": ["front", "three-quarter"],
+  "poses": ["neutral"],
+  "instructions": "Keep the silhouette clear at gameplay camera distance."
+}
+```
+
+Then prepare one exclusive prompt-record directory:
+
+```sh
+gda asset-pipeline concept-prepare --brief ./concept.json \
+  --record ./concept-attempt-a --json
+```
+
+Optional `--producer` and JSON-object `--requested-options` record the requested
+external tool settings. The `preparation` result includes the saved brief and the existing prompt preparation with
+`action: external_generation_required` and `generation_status: unknown`. Submit the
+saved prompt to the external image tool yourself. Preparation alone is not image
+generation. After the tool returns a local PNG, register it with the existing
+operation:
+
+```sh
+gda asset-pipeline prompt-register-output --record ./concept-attempt-a \
+  --output ./generated/robot.png --name robot.png \
+  --caller-declarations '{"generation_completed":true}' --json
+gda asset-pipeline prompt-inspect --record ./concept-attempt-a --json
+```
+
+`generation_completed` is the caller's declaration, not proof from the provider.
+The prompt record keeps requested options, declarations, reported facts, and saved
+file facts separate. Create another record for another attempt; previous attempts
+are not overwritten.
+
+Select one to eight ordered candidates into a new handoff directory:
+
+```sh
+gda asset-pipeline concept-select --brief-record ./concept-attempt-a \
+  --handoff ./robot-references \
+  --candidates '[{"record":"./concept-attempt-a","output":"robot.png"}]' \
+  --json
+```
+
+Selection requires the exact registered output, a true caller completion
+declaration, and PNG bytes that still match their saved facts. It copies selected
+files and relative record/output links without changing candidates. Moving the
+complete handoff directory preserves those internal links. Reusing it never calls a
+provider. Read the result under `selection`.
+
+Use exactly one selected reference with a supported demonstration consumer:
+
+```sh
+gda asset-pipeline concept-author --handoff ./robot-references \
+  --consumer blender-reference-blockout --output ./robot-blockout \
+  --reference-index 0 --json
+```
+
+The Blender example loads the selected PNG as a reference before geometry, derives
+a simple material color from its pixels, and writes one `.blend` plus one `.glb`.
+It demonstrates reference loading and observable pixel influence, not shape
+inference, finished modeling, image similarity, or the saved-source export workflow.
+
+For a sprite brief, use the other bounded consumer:
+
+```sh
+gda asset-pipeline concept-author --handoff ./sprite-references \
+  --consumer sprite-sheet-reference --output ./sprite-example \
+  --reference-index 0 \
+  --sprite-layout '{"width":256,"height":64,"cell_width":64,"cell_height":64,"frames":4}' \
+  --json
+```
+
+This example reads the selected PNG before deriving frame pixels, then verifies the
+declared sheet dimensions, cell grid, and frame count. It is not an animation-quality
+check, Aseprite support, or a declaration that the output is runtime-ready.
+
+Both authoring results identify the consumed handoff file and digest,
+`reference_loaded`, the bounded influence, artifacts, and limitations. Missing,
+changed, corrupt, unselected, or completion-unknown references stop before authoring.
+Unsupported consumers also fail explicitly. Destination record, handoff, and output
+directories must be new. No command silently retries generation, changes prompt
+status, or maps a concept image into a Godot project.
+
+All three concept commands are projectless and support `--json`, `--params-json`,
+and `--schema`. `concept-author` returns its result under `authoring`; pass
+`--blender-executable` only when selecting the Blender consumer.
+
+The bounded native workflow has been observed with one registered 1,254×1,254
+agent-generated PNG. The same selected SHA-256 was loaded first by Blender 5.2.1,
+which wrote a one-cube material-influenced `.blend` and GLB, and separately by the
+sprite consumer, which wrote and checked a 256×256 sheet containing four 128×128
+cells. Reuse made no new provider call. This evidence establishes the declared
+reference-use mechanics within the limits above; final independent review and CI
+remain tracked by the implementation issue.

--- a/libs/gda-assets/src/gda_assets/adapters/_concept_blender_worker.py
+++ b/libs/gda-assets/src/gda_assets/adapters/_concept_blender_worker.py
@@ -1,0 +1,123 @@
+"""Bounded Blender reference blockout worker, executed in a separate process."""
+
+import hashlib
+import json
+from pathlib import Path
+import sys
+
+import bpy  # pyright: ignore[reportMissingImports]
+
+
+def _sample_color(image) -> list[float]:
+    """Return an alpha-weighted color from at most 64 decoded image pixels."""
+    width, height = image.size
+    columns = min(8, width)
+    rows = min(8, height)
+    coordinates = [
+        (
+            0 if columns == 1 else round(x * (width - 1) / (columns - 1)),
+            0 if rows == 1 else round(y * (height - 1) / (rows - 1)),
+        )
+        for y in range(rows)
+        for x in range(columns)
+    ]
+    pixels = image.pixels
+    values = []
+    for x, y in coordinates:
+        offset = (y * width + x) * 4
+        values.append(tuple(float(pixels[offset + channel]) for channel in range(4)))
+    alpha = sum(value[3] for value in values)
+    if alpha > 0:
+        rgb = [
+            sum(value[channel] * value[3] for value in values) / alpha
+            for channel in range(3)
+        ]
+    else:
+        rgb = [
+            sum(value[channel] for value in values) / len(values)
+            for channel in range(3)
+        ]
+    return [*rgb, sum(value[3] for value in values) / len(values)]
+
+
+def main() -> None:
+    request = json.loads(Path(sys.argv[sys.argv.index("--") + 1]).read_text())
+    reference = Path(request["reference"])
+    output = Path(request["output"])
+    result_path = Path(request["result"])
+    result = {"stage": "read_reference", "completed": []}
+    try:
+        raw = reference.read_bytes()
+        digest = hashlib.sha256(raw).hexdigest()
+        result["completed"].append("read_reference")
+        result["stage"] = "decode_reference"
+        image = bpy.data.images.load(str(reference), check_existing=False)
+        color = _sample_color(image)
+        width, height = (int(value) for value in image.size)
+        if not image.has_data or width < 1 or height < 1:
+            raise ValueError("Selected concept did not decode to a nonempty image")
+        result["completed"].append("decode_reference")
+
+        result["stage"] = "create_reference"
+        bpy.ops.object.select_all(action="SELECT")
+        bpy.ops.object.delete(use_global=False)
+        reference_object = bpy.data.objects.new("SelectedConceptReference", None)
+        reference_object.empty_display_type = "IMAGE"
+        reference_object.data = image
+        bpy.context.scene.collection.objects.link(reference_object)
+        result["completed"].append("create_reference")
+
+        result["stage"] = "create_blockout"
+        bpy.ops.object.select_all(action="DESELECT")
+        bpy.ops.mesh.primitive_cube_add()
+        blockout = bpy.context.object
+        blockout.name = "ReferenceBlockout"
+        material = bpy.data.materials.new("ReferenceColor")
+        material.diffuse_color = color
+        material.use_nodes = True
+        principled = material.node_tree.nodes.get("Principled BSDF")
+        if principled is None or "Base Color" not in principled.inputs:
+            raise ValueError("Blender lacks the required Principled Base Color input")
+        principled.inputs["Base Color"].default_value = color
+        blockout.data.materials.append(material)
+        result["completed"].append("create_blockout")
+
+        result["stage"] = "save"
+        blend = output / "reference-blockout.blend"
+        glb = output / "reference-blockout.glb"
+        bpy.ops.wm.save_as_mainfile(filepath=str(blend))
+        result["completed"].append("save_blend")
+        result["stage"] = "export"
+        if bpy.ops.export_scene.gltf(
+            filepath=str(glb),
+            export_format="GLB",
+            use_selection=True,
+            export_materials="EXPORT",
+            export_animations=False,
+            export_cameras=False,
+            export_lights=False,
+        ) != {"FINISHED"}:
+            raise ValueError("Blender GLB export did not finish")
+        result["completed"].append("export_glb")
+        result.update(
+            {
+                "stage": "complete",
+                "reference_sha256": digest,
+                "reference_width": width,
+                "reference_height": height,
+                "reference_object": reference_object.name,
+                "reference_loaded": reference_object.data == image,
+                "material_color": color,
+                "scene_objects": sorted(obj.name for obj in bpy.context.scene.objects),
+                "blend": str(blend),
+                "glb": str(glb),
+                "blender_version": bpy.app.version_string,
+            }
+        )
+    except Exception as exc:
+        result["failure"] = str(exc)[:4096]
+    result_path.write_text(json.dumps(result, allow_nan=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/gda-assets/src/gda_assets/adapters/concept_authoring.py
+++ b/libs/gda-assets/src/gda_assets/adapters/concept_authoring.py
@@ -1,0 +1,326 @@
+"""Bounded consumers proving selected concept bytes reach authoring tools."""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+from tempfile import TemporaryFile
+from typing import Literal
+
+from gda_assets.adapters.files import validate_format
+from gda_assets.application.ports import PortFailure
+from gda_assets.domain.concept import (
+    AuthoringArtifact,
+    ConceptAuthoringResult,
+    ConceptAuthorRequest,
+    ConceptSelection,
+    ConsumedConcept,
+    SpriteSheetObservation,
+)
+
+
+def _digest(path: Path) -> tuple[str, int]:
+    with path.open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").hexdigest(), path.stat().st_size
+
+
+def _selected(request: ConceptAuthorRequest, selection: ConceptSelection):
+    if request.reference_index < 0 or request.reference_index >= len(
+        selection.selected
+    ):
+        raise PortFailure(
+            "invalid_concept", "Selected concept reference index is out of range"
+        )
+    selected = selection.selected[request.reference_index]
+    path = selected.path.resolve()
+    try:
+        validate_format(path)
+        digest, size = _digest(path)
+    except (OSError, PortFailure) as exc:
+        raise PortFailure(
+            "invalid_concept_handoff", f"Cannot read selected concept: {path}"
+        ) from exc
+    if digest != selected.sha256 or size != selected.size_bytes:
+        raise PortFailure(
+            "invalid_concept_handoff", "Selected concept bytes changed after handoff"
+        )
+    return selected, path, digest
+
+
+def _artifact(
+    role: Literal["blend_source", "godot_glb", "sprite_sheet"],
+    path: Path,
+    *,
+    width=None,
+    height=None,
+) -> AuthoringArtifact:
+    digest, size = _digest(path)
+    return AuthoringArtifact(role, path, digest, size, width, height)
+
+
+def _tail(stream) -> str:
+    stream.seek(0, os.SEEK_END)
+    stream.seek(max(0, stream.tell() - 16384))
+    return stream.read().decode("utf-8", errors="replace")
+
+
+def _create_output(path: Path) -> None:
+    try:
+        path.mkdir(parents=True, exist_ok=False)
+    except FileExistsError as exc:
+        raise PortFailure(
+            "destination_conflict", f"Authoring output already exists: {path}"
+        ) from exc
+    except OSError as exc:
+        raise PortFailure(
+            "concept_author_failed", f"Cannot create authoring output: {path}"
+        ) from exc
+
+
+class BlenderReferenceBlockoutAuthor:
+    """Load one selected PNG as a Blender image reference before blockout creation."""
+
+    def author(
+        self, request: ConceptAuthorRequest, selection: ConceptSelection
+    ) -> ConceptAuthoringResult:
+        if (
+            request.consumer != "blender-reference-blockout"
+            or request.sprite_layout is not None
+        ):
+            raise PortFailure(
+                "invalid_concept", "Blender blockout does not accept a sprite layout"
+            )
+        selected, reference, digest = _selected(request, selection)
+        configured = (
+            request.blender_executable
+            or os.environ.get("GDA_BLENDER")
+            or shutil.which("blender")
+        )
+        binary = None if configured is None else Path(configured).expanduser()
+        if binary is not None and not binary.is_absolute():
+            found = shutil.which(str(binary))
+            binary = None if found is None else Path(found)
+        if binary is None or not binary.is_file() or not os.access(binary, os.X_OK):
+            raise PortFailure(
+                "unsupported_concept_consumer", "Blender executable is unavailable"
+            )
+        _create_output(request.output)
+        result_path = request.output / "blender-result.json"
+        request_path = request.output / "blender-request.json"
+        try:
+            request_path.write_text(
+                json.dumps(
+                    {
+                        "reference": str(reference),
+                        "output": str(request.output),
+                        "result": str(result_path),
+                    }
+                )
+            )
+        except OSError as exc:
+            raise PortFailure(
+                "concept_author_failed", "Cannot write Blender authoring request"
+            ) from exc
+        worker = Path(__file__).with_name("_concept_blender_worker.py")
+        argv = [
+            str(binary),
+            "--background",
+            "--factory-startup",
+            "--disable-autoexec",
+            "--python-exit-code",
+            "1",
+            "--python",
+            str(worker),
+            "--",
+            str(request_path),
+        ]
+        with TemporaryFile() as stdout, TemporaryFile() as stderr:
+            try:
+                process = subprocess.run(
+                    argv, stdout=stdout, stderr=stderr, timeout=180
+                )
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                raise PortFailure(
+                    "concept_author_failed",
+                    f"Blender reference authoring could not complete: {exc}",
+                ) from exc
+            diagnostics = {
+                "exit_code": process.returncode,
+                "stdout_tail": _tail(stdout),
+                "stderr_tail": _tail(stderr),
+            }
+        if not result_path.is_file() or result_path.stat().st_size > 131072:
+            raise PortFailure(
+                "concept_author_failed",
+                "Blender returned no bounded authoring result",
+                cause=diagnostics,
+            )
+        try:
+            native = json.loads(result_path.read_text())
+        except (OSError, ValueError) as exc:
+            raise PortFailure(
+                "concept_author_failed",
+                "Blender returned no valid authoring result",
+                cause=diagnostics,
+            ) from exc
+        if not isinstance(native, dict):
+            raise PortFailure(
+                "concept_author_failed",
+                "Blender returned no valid authoring result",
+                cause=diagnostics,
+            )
+        expected_steps = [
+            "read_reference",
+            "decode_reference",
+            "create_reference",
+            "create_blockout",
+            "save_blend",
+            "export_glb",
+        ]
+        if (
+            process.returncode != 0
+            or native.get("failure")
+            or native.get("completed") != expected_steps
+        ):
+            raise PortFailure(
+                "concept_author_failed",
+                f"Blender {native.get('stage', 'execution')}: {native.get('failure', 'incomplete result')}",
+                cause={**diagnostics, **native},
+            )
+        if (
+            native.get("reference_sha256") != digest
+            or native.get("reference_width") != selected.width
+            or native.get("reference_height") != selected.height
+            or native.get("reference_loaded") is not True
+        ):
+            raise PortFailure(
+                "concept_author_failed",
+                "Blender did not load the selected concept bytes",
+                cause=native,
+            )
+        blend, glb = (
+            request.output / "reference-blockout.blend",
+            request.output / "reference-blockout.glb",
+        )
+        if not blend.is_file() or not glb.is_file():
+            raise PortFailure(
+                "concept_author_failed",
+                "Blender authoring artifacts are missing",
+                cause=native,
+            )
+        color_values = native.get("material_color")
+        if not isinstance(color_values, list) or len(color_values) != 4:
+            raise PortFailure(
+                "concept_author_failed",
+                "Blender returned no valid material color",
+                cause=native,
+            )
+        color = (
+            float(color_values[0]),
+            float(color_values[1]),
+            float(color_values[2]),
+            float(color_values[3]),
+        )
+        consumed = ConsumedConcept(
+            request.reference_index, reference, digest, selected.width, selected.height
+        )
+        return ConceptAuthoringResult(
+            request.consumer,
+            selection.handoff,
+            consumed,
+            True,
+            "material_color_from_reference_pixels",
+            (_artifact("blend_source", blend), _artifact("godot_glb", glb)),
+            color,
+            None,
+            (
+                "Creates one static cube blockout; it does not infer shape or establish artistic similarity.",
+            ),
+        )
+
+
+class SpriteSheetReferenceAuthor:
+    """Decode one selected PNG before deriving a bounded sprite sheet from its pixels."""
+
+    def author(
+        self, request: ConceptAuthorRequest, selection: ConceptSelection
+    ) -> ConceptAuthoringResult:
+        if (
+            request.consumer != "sprite-sheet-reference"
+            or request.sprite_layout is None
+        ):
+            raise PortFailure(
+                "invalid_concept", "Sprite authoring requires a sprite sheet layout"
+            )
+        selected, reference, digest = _selected(request, selection)
+        layout = request.sprite_layout
+        from PIL import Image, ImageEnhance, ImageOps  # pyright: ignore[reportMissingImports]
+
+        _create_output(request.output)
+        try:
+            with Image.open(reference) as opened:
+                opened.load()
+                decoded = opened.convert("RGBA")
+            if decoded.size != (selected.width, selected.height):
+                raise ValueError("selected concept dimensions differ from its handoff")
+            frame = decoded.resize(
+                (layout.cell_width, layout.cell_height), Image.Resampling.NEAREST
+            )
+            transforms = (
+                lambda value: value,
+                ImageOps.mirror,
+                ImageOps.flip,
+                lambda value: ImageEnhance.Brightness(value).enhance(0.65),
+            )
+            sheet = Image.new("RGBA", (layout.width, layout.height))
+            columns = layout.width // layout.cell_width
+            for index in range(layout.frames):
+                produced = transforms[index % len(transforms)](frame)
+                sheet.paste(
+                    produced,
+                    (
+                        (index % columns) * layout.cell_width,
+                        (index // columns) * layout.cell_height,
+                    ),
+                )
+            output = request.output / "reference-sprite-sheet.png"
+            sheet.save(output, format="PNG")
+            with Image.open(output) as verified:
+                verified.load()
+                if verified.size != (layout.width, layout.height):
+                    raise ValueError(
+                        "written sprite sheet dimensions differ from its layout"
+                    )
+        except (OSError, ValueError) as exc:
+            raise PortFailure(
+                "concept_author_failed", f"Sprite reference authoring failed: {exc}"
+            ) from exc
+        consumed = ConsumedConcept(
+            request.reference_index, reference, digest, selected.width, selected.height
+        )
+        observation = SpriteSheetObservation(
+            layout.width,
+            layout.height,
+            layout.cell_width,
+            layout.cell_height,
+            layout.frames,
+        )
+        return ConceptAuthoringResult(
+            request.consumer,
+            selection.handoff,
+            consumed,
+            True,
+            "frames_from_reference_pixels",
+            (
+                _artifact(
+                    "sprite_sheet", output, width=layout.width, height=layout.height
+                ),
+            ),
+            None,
+            observation,
+            (
+                "Creates bounded pixel-derived example frames; it does not establish animation quality or runtime installation.",
+            ),
+        )

--- a/libs/gda-assets/src/gda_assets/adapters/concept_files.py
+++ b/libs/gda-assets/src/gda_assets/adapters/concept_files.py
@@ -1,0 +1,287 @@
+"""Bounded local brief and selected-reference handoff files."""
+
+import hashlib
+import json
+from dataclasses import fields
+from pathlib import Path
+import shutil
+
+from pydantic import TypeAdapter, ValidationError
+
+from gda_assets.adapters.file_copy import copy_with_sha256
+from gda_assets.adapters.files import validate_format
+from gda_assets.adapters.prompt_files import read_bounded_file
+from gda_assets.application.ports import PortFailure
+from gda_assets.domain.concept import (
+    ConceptBrief,
+    ConceptBriefSnapshot,
+    ConceptSelectRequest,
+    ConceptSelection,
+    SelectedConcept,
+    ValidatedConceptCandidate,
+    validate_brief,
+)
+
+
+_BRIEF_LIMIT = 1024 * 1024
+_HANDOFF_LIMIT = 4 * 1024 * 1024
+_PNG_LIMIT = 256 * 1024 * 1024
+_BRIEF = TypeAdapter(ConceptBrief)
+_SELECTION = TypeAdapter(ConceptSelection)
+
+
+def _validation_message(error: ValidationError) -> str:
+    return "; ".join(
+        f"{'.'.join(str(part) for part in item['loc'])}: {item['msg']}"
+        for item in error.errors(include_input=False, include_url=False)
+    )
+
+
+def _brief_bytes(brief: ConceptBrief) -> bytes:
+    value = _BRIEF.dump_json(brief, indent=2) + b"\n"
+    if len(value) > _BRIEF_LIMIT:
+        raise PortFailure("invalid_concept", "Concept brief exceeds 1 MiB")
+    return value
+
+
+def _snapshot(path: Path) -> ConceptBriefSnapshot:
+    value = read_bounded_file(path, _BRIEF_LIMIT)
+    return ConceptBriefSnapshot(path, hashlib.sha256(value).hexdigest(), len(value))
+
+
+class ConceptFiles:
+    def read_brief(self, path: Path) -> ConceptBrief:
+        try:
+            content = read_bounded_file(path.resolve(strict=True), _BRIEF_LIMIT)
+            raw = json.loads(content)
+            expected = {item.name for item in fields(ConceptBrief)}
+            if not isinstance(raw, dict) or set(raw) != expected:
+                raise ValueError(
+                    "Concept brief must contain exactly its documented fields"
+                )
+            brief = _BRIEF.validate_json(content, strict=True)
+            validate_brief(brief)
+            return brief
+        except ValidationError as exc:
+            raise PortFailure(
+                "invalid_concept",
+                f"Invalid concept brief fields: {_validation_message(exc)}",
+            ) from exc
+        except (OSError, ValueError, PortFailure) as exc:
+            if isinstance(exc, PortFailure) and exc.code == "invalid_concept":
+                raise
+            raise PortFailure(
+                "invalid_concept", f"Invalid concept brief: {exc}"
+            ) from exc
+
+    def save_brief(self, record: Path, brief: ConceptBrief) -> ConceptBriefSnapshot:
+        path = record / "concept-brief.json"
+        try:
+            with path.open("xb") as stream:
+                stream.write(_brief_bytes(brief))
+            return _snapshot(path)
+        except PortFailure:
+            raise
+        except OSError as exc:
+            raise PortFailure(
+                "concept_select_failed", f"Could not save concept brief: {exc}"
+            ) from exc
+
+    def load_brief(self, record: Path) -> tuple[ConceptBrief, ConceptBriefSnapshot]:
+        try:
+            root = record.resolve(strict=True)
+            path = root / "concept-brief.json"
+            return self.read_brief(path), _snapshot(path)
+        except PortFailure as exc:
+            raise PortFailure(
+                "invalid_concept", f"Invalid saved concept brief: {exc}"
+            ) from exc
+        except OSError as exc:
+            raise PortFailure(
+                "invalid_concept", f"Concept record is unavailable: {exc}"
+            ) from exc
+
+    def create_handoff(
+        self,
+        request: ConceptSelectRequest,
+        brief: ConceptBrief,
+        brief_snapshot: ConceptBriefSnapshot,
+        candidates: tuple[ValidatedConceptCandidate, ...],
+    ) -> ConceptSelection:
+        root = request.handoff.absolute()
+        try:
+            root.mkdir(parents=True, exist_ok=False)
+        except OSError as exc:
+            raise PortFailure(
+                "destination_conflict", f"Concept handoff destination exists: {root}"
+            ) from exc
+        try:
+            brief_bytes = _brief_bytes(brief)
+            if (
+                len(brief_bytes) != brief_snapshot.size_bytes
+                or hashlib.sha256(brief_bytes).hexdigest() != brief_snapshot.sha256
+            ):
+                raise PortFailure(
+                    "invalid_concept", "Saved concept brief changed before selection"
+                )
+            brief_path = root / "concept-brief.json"
+            brief_path.write_bytes(brief_bytes)
+            references = root / "references"
+            references.mkdir()
+            selected = []
+            for index, item in enumerate(candidates):
+                source = item.output.file.path
+                target = references / f"{index:03d}-{source.name}"
+                try:
+                    digest, size = copy_with_sha256(
+                        source, target, max_bytes=_PNG_LIMIT
+                    )
+                    validate_format(target)
+                    from PIL import Image
+
+                    with Image.open(target) as image:
+                        width, height = image.size
+                except (OSError, PortFailure) as exc:
+                    raise PortFailure(
+                        "invalid_concept_candidate",
+                        f"Candidate PNG is unavailable or invalid: {source}",
+                    ) from exc
+                if (
+                    digest != item.output.file.sha256
+                    or size != item.output.file.size_bytes
+                ):
+                    raise PortFailure(
+                        "invalid_concept_candidate",
+                        "Candidate bytes differ from their registered facts",
+                    )
+                if item.output.file.width is None or item.output.file.height is None:
+                    raise PortFailure(
+                        "invalid_concept_candidate",
+                        "Candidate PNG dimensions are unavailable",
+                    )
+                if (width, height) != (
+                    item.output.file.width,
+                    item.output.file.height,
+                ):
+                    raise PortFailure(
+                        "invalid_concept_candidate",
+                        "Candidate PNG dimensions differ from registered facts",
+                    )
+                selected.append(
+                    SelectedConcept(
+                        index,
+                        str(item.candidate.record),
+                        item.candidate.output,
+                        item.resolved_prompt_sha256,
+                        target,
+                        digest,
+                        size,
+                        item.output.file.width,
+                        item.output.file.height,
+                        True,
+                    )
+                )
+            selection = ConceptSelection(
+                1,
+                root,
+                brief,
+                ConceptBriefSnapshot(
+                    brief_path,
+                    hashlib.sha256(brief_path.read_bytes()).hexdigest(),
+                    brief_path.stat().st_size,
+                ),
+                tuple(selected),
+            )
+            self._write_handoff(selection)
+            return selection
+        except (OSError, PortFailure) as exc:
+            shutil.rmtree(root, ignore_errors=True)
+            if isinstance(exc, PortFailure):
+                raise
+            raise PortFailure(
+                "concept_select_failed", f"Could not create concept handoff: {exc}"
+            ) from exc
+
+    def _write_handoff(self, selection: ConceptSelection) -> None:
+        value = _SELECTION.dump_python(selection, mode="json")
+        value["handoff"] = "."
+        value["brief_snapshot"]["path"] = "concept-brief.json"
+        for raw, selected in zip(value["selected"], selection.selected):
+            raw["path"] = str(selected.path.relative_to(selection.handoff))
+        encoded = json.dumps(value, indent=2, sort_keys=True).encode() + b"\n"
+        if len(encoded) > _HANDOFF_LIMIT:
+            raise PortFailure("invalid_concept", "Concept handoff exceeds 4 MiB")
+        (selection.handoff / "handoff.json").write_bytes(encoded)
+
+    def load_handoff(self, path: Path) -> ConceptSelection:
+        try:
+            root = path.resolve(strict=True)
+            selection = _SELECTION.validate_json(
+                read_bounded_file(root / "handoff.json", _HANDOFF_LIMIT), strict=True
+            )
+            brief_path = root / selection.brief_snapshot.path
+            selected = tuple(
+                SelectedConcept(**{**item.__dict__, "path": root / item.path})
+                for item in selection.selected
+            )
+            selection = ConceptSelection(
+                **{
+                    **selection.__dict__,
+                    "handoff": root,
+                    "brief_snapshot": ConceptBriefSnapshot(
+                        brief_path,
+                        selection.brief_snapshot.sha256,
+                        selection.brief_snapshot.size_bytes,
+                    ),
+                    "selected": selected,
+                }
+            )
+            self._verify(selection)
+            return selection
+        except ValidationError as exc:
+            raise PortFailure(
+                "invalid_concept_handoff",
+                f"Invalid concept handoff fields: {_validation_message(exc)}",
+            ) from exc
+        except (OSError, ValueError, PortFailure) as exc:
+            if isinstance(exc, PortFailure) and exc.code == "invalid_concept_handoff":
+                raise
+            raise PortFailure(
+                "invalid_concept_handoff", f"Invalid concept handoff: {exc}"
+            ) from exc
+
+    def _verify(self, selection: ConceptSelection) -> None:
+        if not selection.selected or len(selection.selected) > 8:
+            raise ValueError("Concept handoff selection count is invalid")
+        if not selection.brief_snapshot.path.resolve().is_relative_to(
+            selection.handoff
+        ):
+            raise ValueError("Concept brief snapshot escapes its handoff")
+        brief = read_bounded_file(selection.brief_snapshot.path, _BRIEF_LIMIT)
+        if (
+            hashlib.sha256(brief).hexdigest() != selection.brief_snapshot.sha256
+            or len(brief) != selection.brief_snapshot.size_bytes
+        ):
+            raise ValueError("Concept brief changed")
+        validate_brief(selection.brief)
+        if _BRIEF.validate_json(brief, strict=True) != selection.brief:
+            raise ValueError("Concept brief facts differ")
+        for index, item in enumerate(selection.selected):
+            if (
+                item.index != index
+                or item.generation_completed_by_caller is not True
+                or not item.path.resolve().is_relative_to(selection.handoff)
+            ):
+                raise ValueError("Concept selected reference metadata is invalid")
+            data = read_bounded_file(item.path, _PNG_LIMIT)
+            validate_format(item.path)
+            from PIL import Image
+
+            with Image.open(item.path) as image:
+                dimensions = image.size
+            if (
+                len(data) != item.size_bytes
+                or hashlib.sha256(data).hexdigest() != item.sha256
+                or dimensions != (item.width, item.height)
+            ):
+                raise ValueError("Concept selected reference changed")

--- a/libs/gda-assets/src/gda_assets/adapters/concept_files.py
+++ b/libs/gda-assets/src/gda_assets/adapters/concept_files.py
@@ -55,9 +55,9 @@ class ConceptFiles:
             content = read_bounded_file(path.resolve(strict=True), _BRIEF_LIMIT)
             raw = json.loads(content)
             expected = {item.name for item in fields(ConceptBrief)}
-            if not isinstance(raw, dict) or set(raw) != expected:
+            if not isinstance(raw, dict) or set(raw) - expected:
                 raise ValueError(
-                    "Concept brief must contain exactly its documented fields"
+                    "Concept brief must be an object with only documented fields"
                 )
             brief = _BRIEF.validate_json(content, strict=True)
             validate_brief(brief)

--- a/libs/gda-assets/src/gda_assets/adapters/prompt_files.py
+++ b/libs/gda-assets/src/gda_assets/adapters/prompt_files.py
@@ -62,7 +62,7 @@ def _regular_input(path: Path, limit: int) -> os.stat_result:
     return observed
 
 
-def _read_bounded(path: Path, limit: int) -> bytes:
+def read_bounded_file(path: Path, limit: int) -> bytes:
     try:
         before_path = _regular_input(path, limit)
         with path.open("rb") as stream:
@@ -133,7 +133,9 @@ def _dump(record: PromptRecord, path: Path) -> None:
 class PromptFiles:
     def read_text(self, path: Path) -> str:
         try:
-            return _read_bounded(path.resolve(strict=True), _TEXT_LIMIT).decode("utf-8")
+            return read_bounded_file(path.resolve(strict=True), _TEXT_LIMIT).decode(
+                "utf-8"
+            )
         except (OSError, UnicodeDecodeError) as exc:
             raise PortFailure(
                 "invalid_prompt", f"Invalid prompt text {path}: {exc}"
@@ -243,7 +245,7 @@ class PromptFiles:
         try:
             root = record.resolve(strict=True)
             result = _RECORD.validate_json(
-                _read_bounded(root / "record.json", _JSON_LIMIT), strict=True
+                read_bounded_file(root / "record.json", _JSON_LIMIT), strict=True
             )
             result = self._rebase(result, root)
             outputs = []
@@ -258,7 +260,7 @@ class PromptFiles:
                     raise ValueError("Prompt record has too many output registrations")
                 for registration in registrations:
                     output = _OUTPUT.validate_json(
-                        _read_bounded(registration, _JSON_LIMIT), strict=True
+                        read_bounded_file(registration, _JSON_LIMIT), strict=True
                     )
                     file = self._rebase_file(output.file, root)
                     assert file is not None
@@ -317,7 +319,7 @@ class PromptFiles:
                 or not item.path.is_file()
             ):
                 raise ValueError("Prompt record contains an unavailable saved file")
-            data = _read_bounded(
+            data = read_bounded_file(
                 item.path, _PNG_LIMIT if item.width is not None else _TEXT_LIMIT
             )
             if (
@@ -327,7 +329,7 @@ class PromptFiles:
                 raise ValueError("Prompt record saved input or output changed")
         if not record.resolved_path.resolve().is_relative_to(record.record):
             raise ValueError("Prompt record resolved text escapes its directory")
-        resolved = _read_bounded(record.resolved_path, _TEXT_LIMIT)
+        resolved = read_bounded_file(record.resolved_path, _TEXT_LIMIT)
         if (
             resolved.decode() != record.resolved_prompt
             or hashlib.sha256(resolved).hexdigest() != record.resolved_sha256

--- a/libs/gda-assets/src/gda_assets/api.py
+++ b/libs/gda-assets/src/gda_assets/api.py
@@ -90,6 +90,24 @@ from gda_assets.domain.prompt import (
     PromptRevision,
     PromptRevisionRequest,
 )
+from gda_assets.domain.concept import (
+    AuthoringArtifact,
+    ConceptAuthoringResult,
+    ConceptAuthorRequest,
+    ConceptBrief,
+    ConceptBriefSnapshot,
+    ConceptCandidate,
+    ConceptConsumer,
+    ConceptPreparation,
+    ConceptPrepareRequest,
+    ConceptSelection,
+    ConceptSelectRequest,
+    ConceptUse,
+    ConsumedConcept,
+    SelectedConcept,
+    SpriteSheetLayout,
+    SpriteSheetObservation,
+)
 
 __all__ = [
     "check_package",
@@ -174,7 +192,65 @@ __all__ = [
     "inspect_prompt",
     "revise_prompt",
     "register_prompt_output",
+    "AuthoringArtifact",
+    "ConceptAuthoringResult",
+    "ConceptAuthorRequest",
+    "ConceptBrief",
+    "ConceptBriefSnapshot",
+    "ConceptCandidate",
+    "ConceptConsumer",
+    "ConceptPreparation",
+    "ConceptPrepareRequest",
+    "ConceptSelection",
+    "ConceptSelectRequest",
+    "ConceptUse",
+    "ConsumedConcept",
+    "SelectedConcept",
+    "SpriteSheetLayout",
+    "SpriteSheetObservation",
+    "prepare_concept",
+    "select_concept",
+    "author_concept",
 ]
+
+
+def prepare_concept(request: ConceptPrepareRequest) -> ConceptPreparation:
+    """Preserve a concept brief and its external generation handoff."""
+    from gda_assets.adapters.concept_files import ConceptFiles
+    from gda_assets.adapters.prompt_files import PromptFiles
+    from gda_assets.application.concept import prepare_concept as _prepare_concept
+
+    return _prepare_concept(request, files=ConceptFiles(), prompts=PromptFiles())
+
+
+def select_concept(request: ConceptSelectRequest) -> ConceptSelection:
+    """Pin explicitly completed, registered candidates into one handoff."""
+    from gda_assets.adapters.concept_files import ConceptFiles
+    from gda_assets.adapters.prompt_files import PromptFiles
+    from gda_assets.application.concept import select_concept as _select_concept
+
+    return _select_concept(request, files=ConceptFiles(), prompts=PromptFiles())
+
+
+def author_concept(request: ConceptAuthorRequest) -> ConceptAuthoringResult:
+    """Run one of the two bounded selected-reference authoring examples."""
+    from gda_assets.adapters.concept_authoring import (
+        BlenderReferenceBlockoutAuthor,
+        SpriteSheetReferenceAuthor,
+    )
+    from gda_assets.adapters.concept_files import ConceptFiles
+    from gda_assets.application.concept import author_concept as _author_concept
+
+    if request.consumer == "blender-reference-blockout":
+        author = BlenderReferenceBlockoutAuthor()
+    elif request.consumer == "sprite-sheet-reference":
+        author = SpriteSheetReferenceAuthor()
+    else:
+        raise PortFailure(
+            "unsupported_concept_consumer",
+            f"Unsupported concept consumer: {request.consumer}",
+        )
+    return _author_concept(request, files=ConceptFiles(), author=author)
 
 
 def prepare_prompt(request: PromptPrepareRequest) -> PromptPreparation:

--- a/libs/gda-assets/src/gda_assets/application/concept.py
+++ b/libs/gda-assets/src/gda_assets/application/concept.py
@@ -1,0 +1,153 @@
+"""Prepare, select, and author from project-owned concept references."""
+
+from gda_assets.application.concept_ports import (
+    ConceptAuthoringPort,
+    ConceptFilesPort,
+)
+from gda_assets.application.ports import PortFailure
+from gda_assets.application.prompt import inspect_prompt, prepare_prompt
+from gda_assets.application.prompt_ports import PromptFilesPort
+from gda_assets.domain.concept import (
+    ConceptAuthoringResult,
+    ConceptAuthorRequest,
+    ConceptCandidate,
+    ConceptPreparation,
+    ConceptPrepareRequest,
+    ConceptSelection,
+    ConceptSelectRequest,
+    ValidatedConceptCandidate,
+    concept_prompt,
+    validate_brief,
+    validate_layout,
+)
+from gda_assets.domain.prompt import PromptPrepareRequest
+
+
+def prepare_concept(
+    request: ConceptPrepareRequest,
+    *,
+    files: ConceptFilesPort,
+    prompts: PromptFilesPort,
+) -> ConceptPreparation:
+    brief = files.read_brief(request.brief)
+    try:
+        validate_brief(brief)
+        prompt = prepare_prompt(
+            PromptPrepareRequest(
+                record=request.record,
+                text=concept_prompt(brief),
+                producer=request.producer,
+                requested_options=request.requested_options,
+            ),
+            files=prompts,
+        )
+    except ValueError as exc:
+        raise PortFailure("invalid_concept", str(exc)) from exc
+    try:
+        snapshot = files.save_brief(prompt.record.record, brief)
+    except PortFailure as exc:
+        raise PortFailure(
+            "concept_prepare_failed",
+            f"Prompt was preserved but its concept brief was not: {exc}",
+            cause={"prepared_record": str(prompt.record.record)},
+        ) from exc
+    return ConceptPreparation(brief, snapshot, prompt)
+
+
+def select_concept(
+    request: ConceptSelectRequest,
+    *,
+    files: ConceptFilesPort,
+    prompts: PromptFilesPort,
+) -> ConceptSelection:
+    if not 1 <= len(request.candidates) <= 8:
+        raise PortFailure("invalid_concept", "Select between 1 and 8 candidates")
+    pairs = tuple((str(item.record), item.output) for item in request.candidates)
+    if len(set(pairs)) != len(pairs):
+        raise PortFailure("invalid_concept", "Concept candidates must be unique")
+    brief, snapshot = files.load_brief(request.brief_record)
+    selected = []
+    for candidate in request.candidates:
+        try:
+            record = inspect_prompt(candidate.record, files=prompts).record
+        except PortFailure as exc:
+            raise PortFailure(
+                "invalid_concept_candidate",
+                f"Invalid candidate prompt record {candidate.record}: {exc}",
+            ) from exc
+        output = next(
+            (item for item in record.outputs if item.name == candidate.output), None
+        )
+        if output is None:
+            raise PortFailure(
+                "concept_candidate_incomplete",
+                f"Candidate output is not registered: {candidate.output}",
+            )
+        if output.caller_declarations.get("generation_completed") is not True:
+            raise PortFailure(
+                "concept_candidate_incomplete",
+                "Candidate requires caller-declared generation_completed=true; this is not provider proof",
+            )
+        if (
+            output.file.width is None
+            or output.file.height is None
+            or output.file.width <= 0
+            or output.file.height <= 0
+        ):
+            raise PortFailure(
+                "invalid_concept_candidate",
+                "Candidate PNG dimensions are unavailable",
+            )
+        selected.append(
+            ValidatedConceptCandidate(
+                ConceptCandidate(record.record, candidate.output),
+                output,
+                record.resolved_sha256,
+            )
+        )
+    return files.create_handoff(request, brief, snapshot, tuple(selected))
+
+
+def author_concept(
+    request: ConceptAuthorRequest,
+    *,
+    files: ConceptFilesPort,
+    author: ConceptAuthoringPort,
+) -> ConceptAuthoringResult:
+    selection = files.load_handoff(request.handoff)
+    if not 0 <= request.reference_index < len(selection.selected):
+        raise PortFailure("invalid_concept", "Selected reference index is out of range")
+    expected_consumer = (
+        "blender-reference-blockout"
+        if selection.brief.use == "model"
+        else "sprite-sheet-reference"
+    )
+    if request.consumer != expected_consumer:
+        raise PortFailure(
+            "invalid_concept",
+            f"Concept use {selection.brief.use} requires {expected_consumer}",
+        )
+    if request.consumer == "sprite-sheet-reference":
+        if request.sprite_layout is None:
+            raise PortFailure(
+                "invalid_concept", "Sprite authoring requires a sheet layout"
+            )
+        try:
+            validate_layout(request.sprite_layout)
+        except ValueError as exc:
+            raise PortFailure("invalid_concept", str(exc)) from exc
+        if request.blender_executable is not None:
+            raise PortFailure(
+                "invalid_concept", "Sprite authoring does not use Blender"
+            )
+    elif request.consumer == "blender-reference-blockout":
+        if request.sprite_layout is not None:
+            raise PortFailure(
+                "invalid_concept", "Blender authoring does not use a sprite layout"
+            )
+    else:
+        raise PortFailure(
+            "unsupported_concept_consumer",
+            f"Unsupported concept consumer: {request.consumer}",
+        )
+    return author.author(request, selection)

--- a/libs/gda-assets/src/gda_assets/application/concept_ports.py
+++ b/libs/gda-assets/src/gda_assets/application/concept_ports.py
@@ -1,0 +1,38 @@
+"""Local file and authoring capabilities required by concept workflows."""
+
+from pathlib import Path
+from typing import Protocol
+
+from gda_assets.domain.concept import (
+    ConceptAuthoringResult,
+    ConceptAuthorRequest,
+    ConceptBrief,
+    ConceptBriefSnapshot,
+    ConceptSelectRequest,
+    ConceptSelection,
+    ValidatedConceptCandidate,
+)
+
+
+class ConceptFilesPort(Protocol):
+    def read_brief(self, path: Path) -> ConceptBrief: ...
+
+    def save_brief(self, record: Path, brief: ConceptBrief) -> ConceptBriefSnapshot: ...
+
+    def load_brief(self, record: Path) -> tuple[ConceptBrief, ConceptBriefSnapshot]: ...
+
+    def create_handoff(
+        self,
+        request: ConceptSelectRequest,
+        brief: ConceptBrief,
+        brief_snapshot: ConceptBriefSnapshot,
+        candidates: tuple[ValidatedConceptCandidate, ...],
+    ) -> ConceptSelection: ...
+
+    def load_handoff(self, path: Path) -> ConceptSelection: ...
+
+
+class ConceptAuthoringPort(Protocol):
+    def author(
+        self, request: ConceptAuthorRequest, selection: ConceptSelection
+    ) -> ConceptAuthoringResult: ...

--- a/libs/gda-assets/src/gda_assets/domain/concept.py
+++ b/libs/gda-assets/src/gda_assets/domain/concept.py
@@ -1,0 +1,212 @@
+"""Concept briefs, selected references, and bounded authoring observations."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal, TypeAlias
+
+from gda_assets.domain.prompt import (
+    JsonScalar,
+    PromptOptionKey,
+    PromptOutput,
+    PromptPreparation,
+)
+
+
+ConceptUse: TypeAlias = Literal["model", "sprite"]
+ConceptConsumer: TypeAlias = Literal[
+    "blender-reference-blockout", "sprite-sheet-reference"
+]
+
+
+@dataclass(frozen=True)
+class ConceptBrief:
+    use: ConceptUse
+    subject: str
+    style: str
+    views: tuple[str, ...] = ()
+    poses: tuple[str, ...] = ()
+    instructions: str = ""
+
+
+@dataclass(frozen=True)
+class ConceptBriefSnapshot:
+    path: Path
+    sha256: str
+    size_bytes: int
+
+
+@dataclass(frozen=True)
+class ConceptPrepareRequest:
+    brief: Path
+    record: Path
+    producer: str | None = None
+    requested_options: dict[PromptOptionKey, JsonScalar] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ConceptPreparation:
+    brief: ConceptBrief
+    brief_snapshot: ConceptBriefSnapshot
+    prompt: PromptPreparation
+
+
+@dataclass(frozen=True)
+class ConceptCandidate:
+    record: Path
+    output: str
+
+
+@dataclass(frozen=True)
+class ValidatedConceptCandidate:
+    candidate: ConceptCandidate
+    output: PromptOutput
+    resolved_prompt_sha256: str
+
+
+@dataclass(frozen=True)
+class ConceptSelectRequest:
+    brief_record: Path
+    handoff: Path
+    candidates: tuple[ConceptCandidate, ...]
+
+
+@dataclass(frozen=True)
+class SelectedConcept:
+    index: int
+    prompt_record: str
+    output: str
+    resolved_prompt_sha256: str
+    path: Path
+    sha256: str
+    size_bytes: int
+    width: int
+    height: int
+    generation_completed_by_caller: Literal[True]
+
+
+@dataclass(frozen=True)
+class ConceptSelection:
+    schema: Literal[1]
+    handoff: Path
+    brief: ConceptBrief
+    brief_snapshot: ConceptBriefSnapshot
+    selected: tuple[SelectedConcept, ...]
+    authoring_status: Literal["ready"] = "ready"
+    limitations: tuple[str, ...] = (
+        "Selected image copies are self-contained; prepared and submitted prompt fields remain in originating prompt records and become unavailable if those records are deleted.",
+        "Caller-declared generation completion is not verified provider execution.",
+    )
+
+
+@dataclass(frozen=True)
+class SpriteSheetLayout:
+    width: int
+    height: int
+    cell_width: int
+    cell_height: int
+    frames: int
+
+
+@dataclass(frozen=True)
+class ConceptAuthorRequest:
+    handoff: Path
+    consumer: ConceptConsumer
+    output: Path
+    reference_index: int = 0
+    blender_executable: Path | None = None
+    sprite_layout: SpriteSheetLayout | None = None
+
+
+@dataclass(frozen=True)
+class ConsumedConcept:
+    index: int
+    path: Path
+    sha256: str
+    width: int
+    height: int
+
+
+@dataclass(frozen=True)
+class AuthoringArtifact:
+    role: Literal["blend_source", "godot_glb", "sprite_sheet"]
+    path: Path
+    sha256: str
+    size_bytes: int
+    width: int | None = None
+    height: int | None = None
+
+
+@dataclass(frozen=True)
+class SpriteSheetObservation:
+    width: int
+    height: int
+    cell_width: int
+    cell_height: int
+    frames: int
+
+
+@dataclass(frozen=True)
+class ConceptAuthoringResult:
+    consumer: ConceptConsumer
+    handoff: Path
+    consumed: ConsumedConcept
+    reference_loaded: Literal[True]
+    influence: Literal[
+        "material_color_from_reference_pixels", "frames_from_reference_pixels"
+    ]
+    artifacts: tuple[AuthoringArtifact, ...]
+    material_color: tuple[float, float, float, float] | None = None
+    sprite_sheet: SpriteSheetObservation | None = None
+    limitations: tuple[str, ...] = ()
+
+
+def validate_brief(brief: ConceptBrief) -> None:
+    if brief.use not in ("model", "sprite"):
+        raise ValueError("Concept use must be model or sprite")
+    for label, value, limit in (
+        ("subject", brief.subject, 4096),
+        ("style", brief.style, 4096),
+        ("instructions", brief.instructions, 16384),
+    ):
+        if (
+            not isinstance(value, str)
+            or len(value) > limit
+            or (label != "instructions" and not value.strip())
+        ):
+            raise ValueError(f"Concept {label} is invalid")
+    if not brief.views and not brief.poses:
+        raise ValueError("Concept brief requires at least one view or pose")
+    for label, values in (("views", brief.views), ("poses", brief.poses)):
+        if (
+            len(values) > 8
+            or len(set(values)) != len(values)
+            or any(not value.strip() or len(value) > 128 for value in values)
+        ):
+            raise ValueError(f"Concept {label} must be unique bounded strings")
+
+
+def concept_prompt(brief: ConceptBrief) -> str:
+    validate_brief(brief)
+    lines = [
+        f"Intended use: {brief.use}",
+        f"Subject: {brief.subject}",
+        f"Style: {brief.style}",
+    ]
+    if brief.views:
+        lines.append(f"Requested views: {', '.join(brief.views)}")
+    if brief.poses:
+        lines.append(f"Requested poses: {', '.join(brief.poses)}")
+    if brief.instructions:
+        lines.append(f"Project instructions: {brief.instructions}")
+    return "\n".join(lines)
+
+
+def validate_layout(layout: SpriteSheetLayout) -> None:
+    values = (layout.width, layout.height, layout.cell_width, layout.cell_height)
+    if any(type(value) is not int or not 1 <= value <= 2048 for value in values):
+        raise ValueError("Sprite sheet dimensions must be integers in 1..2048")
+    if layout.width % layout.cell_width or layout.height % layout.cell_height:
+        raise ValueError("Sprite sheet cell dimensions must divide the sheet")
+    cells = (layout.width // layout.cell_width) * (layout.height // layout.cell_height)
+    if type(layout.frames) is not int or not 1 <= layout.frames <= min(64, cells):
+        raise ValueError("Sprite sheet frame count exceeds its bounded cell grid")

--- a/libs/gda-assets/tests/test_concept_authoring_adapter.py
+++ b/libs/gda-assets/tests/test_concept_authoring_adapter.py
@@ -1,0 +1,79 @@
+"""Native-result admission for the bounded Blender concept consumer."""
+
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+
+from PIL import Image
+import pytest
+
+from gda_assets.adapters.concept_authoring import BlenderReferenceBlockoutAuthor
+from gda_assets.application.ports import PortFailure
+from gda_assets.domain.concept import (
+    ConceptAuthorRequest,
+    ConceptBrief,
+    ConceptBriefSnapshot,
+    ConceptSelection,
+    SelectedConcept,
+)
+
+
+def _selection(root: Path) -> ConceptSelection:
+    root.mkdir()
+    image = root / "selected.png"
+    Image.new("RGBA", (2, 2), (255, 0, 0, 255)).save(image)
+    digest = hashlib.sha256(image.read_bytes()).hexdigest()
+    return ConceptSelection(
+        1,
+        root,
+        ConceptBrief("model", "block", "flat", views=("front",)),
+        ConceptBriefSnapshot(root / "concept-brief.json", "brief", 1),
+        (
+            SelectedConcept(
+                0,
+                "../attempt/prompt.json",
+                "selected.png",
+                "prompt-sha256",
+                image,
+                digest,
+                image.stat().st_size,
+                2,
+                2,
+                True,
+            ),
+        ),
+    )
+
+
+@pytest.mark.parametrize("native_result", ["null", "[]", "oversized"])
+def test_blender_refuses_non_object_or_oversized_native_result(
+    tmp_path, monkeypatch, native_result
+):
+    selection = _selection(tmp_path / "handoff")
+    executable = tmp_path / "blender"
+    executable.write_text("fake")
+    executable.chmod(0o755)
+
+    def fake_run(argv, **_kwargs):
+        request = json.loads(Path(argv[-1]).read_text())
+        result = Path(request["result"])
+        result.write_text(
+            "x" * 131073 if native_result == "oversized" else native_result
+        )
+        return subprocess.CompletedProcess(argv, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(PortFailure) as raised:
+        BlenderReferenceBlockoutAuthor().author(
+            ConceptAuthorRequest(
+                selection.handoff,
+                "blender-reference-blockout",
+                tmp_path / "output",
+                blender_executable=executable,
+            ),
+            selection,
+        )
+
+    assert raised.value.code == "concept_author_failed"
+    assert "authoring result" in str(raised.value)

--- a/libs/gda-assets/tests/test_concept_domain.py
+++ b/libs/gda-assets/tests/test_concept_domain.py
@@ -1,0 +1,46 @@
+from dataclasses import replace
+
+import pytest
+
+from gda_assets.domain.concept import (
+    ConceptBrief,
+    SpriteSheetLayout,
+    concept_prompt,
+    validate_brief,
+    validate_layout,
+)
+
+
+def test_brief_builds_one_deterministic_plain_prompt():
+    brief = ConceptBrief(
+        "model",
+        "red fox courier",
+        "ink wash",
+        views=("front", "side"),
+        poses=("standing",),
+        instructions="Readable silhouette.",
+    )
+    assert concept_prompt(brief) == (
+        "Intended use: model\n"
+        "Subject: red fox courier\n"
+        "Style: ink wash\n"
+        "Requested views: front, side\n"
+        "Requested poses: standing\n"
+        "Project instructions: Readable silhouette."
+    )
+
+
+def test_brief_rejects_missing_direction_and_duplicate_views():
+    brief = ConceptBrief("sprite", "fox", "pixels")
+    with pytest.raises(ValueError, match="view or pose"):
+        validate_brief(brief)
+    with pytest.raises(ValueError, match="unique"):
+        validate_brief(replace(brief, views=("front", "front")))
+
+
+def test_sprite_layout_requires_a_bounded_complete_cell_grid():
+    validate_layout(SpriteSheetLayout(64, 32, 16, 16, 8))
+    with pytest.raises(ValueError, match="divide"):
+        validate_layout(SpriteSheetLayout(65, 32, 16, 16, 8))
+    with pytest.raises(ValueError, match="frame count"):
+        validate_layout(SpriteSheetLayout(32, 32, 16, 16, 5))

--- a/libs/gda-assets/tests/test_concept_workflow.py
+++ b/libs/gda-assets/tests/test_concept_workflow.py
@@ -1,0 +1,196 @@
+from pathlib import Path
+import json
+import shutil
+
+from PIL import Image
+import pytest
+
+from gda_assets.adapters.concept_files import ConceptFiles
+from gda_assets.api import (
+    ConceptAuthorRequest,
+    ConceptCandidate,
+    ConceptPrepareRequest,
+    ConceptSelectRequest,
+    PromptOutputRequest,
+    prepare_concept,
+    register_prompt_output,
+    select_concept,
+)
+from gda_assets.application.concept import author_concept
+from gda_assets.application.ports import PortFailure
+
+
+def _brief(path: Path, *, use: str = "model") -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "use": use,
+                "subject": "fox courier",
+                "style": "ink wash",
+                "views": ["front", "side"],
+                "poses": [],
+                "instructions": "Keep the silhouette clear.",
+            }
+        )
+    )
+
+
+def _png(path: Path, color: str) -> bytes:
+    Image.new("RGB", (4, 3), color).save(path)
+    return path.read_bytes()
+
+
+def _candidate(
+    tmp_path: Path, name: str, color: str, *, completed: bool, use: str = "model"
+):
+    brief = tmp_path / f"{name}-brief.json"
+    record = tmp_path / f"{name}-record"
+    image = tmp_path / f"{name}.png"
+    _brief(brief, use=use)
+    prepare_concept(ConceptPrepareRequest(brief, record, producer="imagegen"))
+    _png(image, color)
+    register_prompt_output(
+        PromptOutputRequest(
+            record,
+            image,
+            f"{name}.png",
+            caller_declarations={"generation_completed": completed},
+        )
+    )
+    return record, image
+
+
+def test_prepare_saves_brief_and_keeps_generation_unknown(tmp_path):
+    brief = tmp_path / "brief.json"
+    record = tmp_path / "attempt"
+    _brief(brief)
+
+    result = prepare_concept(
+        ConceptPrepareRequest(
+            brief, record, producer="imagegen", requested_options={"size": "1024x1024"}
+        )
+    )
+
+    assert result.prompt.handoff.action == "external_generation_required"
+    assert result.prompt.record.generation_status == "unknown"
+    assert result.brief_snapshot.path == record / "concept-brief.json"
+    assert result.brief_snapshot.path.is_file()
+    assert "Subject: fox courier" in result.prompt.record.resolved_prompt
+
+
+def test_brief_unknown_field_is_rejected_before_prompt_record_creation(tmp_path):
+    brief = tmp_path / "brief.json"
+    record = tmp_path / "attempt"
+    _brief(brief)
+    value = json.loads(brief.read_text())
+    value["instruction"] = "Keep red eyes"
+    brief.write_text(json.dumps(value))
+
+    with pytest.raises(PortFailure) as failure:
+        prepare_concept(ConceptPrepareRequest(brief, record))
+
+    assert failure.value.code == "invalid_concept"
+    assert not record.exists()
+
+
+def test_select_pins_only_ordered_completed_candidates_and_survives_move(tmp_path):
+    red_record, red_source = _candidate(tmp_path, "red", "red", completed=True)
+    blue_record, _ = _candidate(tmp_path, "blue", "blue", completed=True)
+    handoff = tmp_path / "handoff"
+
+    selection = select_concept(
+        ConceptSelectRequest(
+            red_record,
+            handoff,
+            (ConceptCandidate(blue_record, "blue.png"),),
+        )
+    )
+    selected_bytes = selection.selected[0].path.read_bytes()
+    _png(red_source, "green")
+    shutil.rmtree(red_record)
+    shutil.rmtree(blue_record)
+    moved = tmp_path / "moved-handoff"
+    handoff.rename(moved)
+
+    loaded = ConceptFiles().load_handoff(moved)
+
+    assert loaded.selected[0].output == "blue.png"
+    assert loaded.selected[0].path.read_bytes() == selected_bytes
+    assert len(loaded.selected[0].resolved_prompt_sha256) == 64
+    assert loaded.authoring_status == "ready"
+    assert "self-contained" in loaded.limitations[0]
+
+
+def test_unknown_completion_stops_before_handoff_creation(tmp_path):
+    record, _ = _candidate(tmp_path, "unknown", "red", completed=False)
+    handoff = tmp_path / "handoff"
+
+    with pytest.raises(PortFailure) as failure:
+        select_concept(
+            ConceptSelectRequest(
+                record,
+                handoff,
+                (ConceptCandidate(record, "unknown.png"),),
+            )
+        )
+
+    assert failure.value.code == "concept_candidate_incomplete"
+    assert "caller-declared" in str(failure.value)
+    assert not handoff.exists()
+
+
+class _AuthorSpy:
+    def __init__(self):
+        self.called = False
+
+    def author(self, request, selection):
+        self.called = True
+        raise AssertionError("test spy has no authoring result")
+
+
+def test_invalid_author_request_stops_before_consumer(tmp_path):
+    record, _ = _candidate(tmp_path, "ready", "red", completed=True, use="sprite")
+    handoff = tmp_path / "handoff"
+    select_concept(
+        ConceptSelectRequest(record, handoff, (ConceptCandidate(record, "ready.png"),))
+    )
+    spy = _AuthorSpy()
+
+    with pytest.raises(PortFailure, match="requires a sheet layout"):
+        author_concept(
+            ConceptAuthorRequest(
+                handoff, "sprite-sheet-reference", tmp_path / "output"
+            ),
+            files=ConceptFiles(),
+            author=spy,
+        )
+
+    assert spy.called is False
+    assert not (tmp_path / "output").exists()
+
+
+def test_tampered_completion_or_selected_bytes_invalidates_handoff(tmp_path):
+    record, _ = _candidate(tmp_path, "ready", "red", completed=True)
+    handoff = tmp_path / "handoff"
+    selection = select_concept(
+        ConceptSelectRequest(record, handoff, (ConceptCandidate(record, "ready.png"),))
+    )
+    data = json.loads((handoff / "handoff.json").read_text())
+    data["selected"][0]["generation_completed_by_caller"] = False
+    (handoff / "handoff.json").write_text(json.dumps(data))
+    with pytest.raises(PortFailure) as failure:
+        ConceptFiles().load_handoff(handoff)
+    assert failure.value.code == "invalid_concept_handoff"
+
+    data["selected"][0]["generation_completed_by_caller"] = True
+    original_width = data["selected"][0]["width"]
+    data["selected"][0]["width"] = original_width + 1
+    (handoff / "handoff.json").write_text(json.dumps(data))
+    with pytest.raises(PortFailure, match="changed"):
+        ConceptFiles().load_handoff(handoff)
+
+    data["selected"][0]["width"] = original_width
+    (handoff / "handoff.json").write_text(json.dumps(data))
+    selection.selected[0].path.write_bytes(b"changed")
+    with pytest.raises(PortFailure):
+        ConceptFiles().load_handoff(handoff)

--- a/libs/gda-assets/tests/test_e2e_concept_authoring.py
+++ b/libs/gda-assets/tests/test_e2e_concept_authoring.py
@@ -1,0 +1,148 @@
+"""Real selected-reference consumption by the two bounded #913 examples."""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import struct
+
+from PIL import Image
+import pytest
+
+from gda_assets.adapters.concept_authoring import (
+    BlenderReferenceBlockoutAuthor,
+    SpriteSheetReferenceAuthor,
+)
+from gda_assets.domain.concept import (
+    ConceptAuthorRequest,
+    ConceptBrief,
+    ConceptBriefSnapshot,
+    ConceptSelection,
+    SelectedConcept,
+    SpriteSheetLayout,
+)
+
+
+pytestmark = pytest.mark.e2e
+
+
+def _digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _glb_base_color(path: Path):
+    payload = path.read_bytes()
+    json_size = struct.unpack_from("<I", payload, 12)[0]
+    document = json.loads(payload[20 : 20 + json_size])
+    return document["materials"][0]["pbrMetallicRoughness"]["baseColorFactor"]
+
+
+def _selection(root: Path, name: str, color: tuple[int, int, int, int]):
+    root.mkdir()
+    image = root / name
+    Image.new("RGBA", (4, 2), color).save(image)
+    selected = SelectedConcept(
+        0,
+        "../attempt/prompt.json",
+        name,
+        "resolved-prompt-sha256",
+        image,
+        _digest(image),
+        image.stat().st_size,
+        4,
+        2,
+        True,
+    )
+    return ConceptSelection(
+        1,
+        root,
+        ConceptBrief("model", "colored block", "flat", views=("front",)),
+        ConceptBriefSnapshot(root / "concept-brief.json", "brief", 1),
+        (selected,),
+    )
+
+
+def test_blender_uses_the_selected_png_bytes_for_exported_material(tmp_path):
+    blender = Path(
+        os.environ.get(
+            "GDA_BLENDER", "/Applications/Blender.app/Contents/MacOS/Blender"
+        )
+    )
+    assert blender.is_file(), "real Blender is required for the concept authoring E2E"
+    red = _selection(tmp_path / "red-handoff", "red.png", (255, 0, 0, 255))
+    blue = _selection(tmp_path / "blue-handoff", "blue.png", (0, 0, 255, 255))
+    red_output, blue_output = tmp_path / "red-output", tmp_path / "blue-output"
+    author = BlenderReferenceBlockoutAuthor()
+
+    red_result = author.author(
+        ConceptAuthorRequest(
+            red.handoff,
+            "blender-reference-blockout",
+            red_output,
+            blender_executable=blender,
+        ),
+        red,
+    )
+    blue_result = author.author(
+        ConceptAuthorRequest(
+            blue.handoff,
+            "blender-reference-blockout",
+            blue_output,
+            blender_executable=blender,
+        ),
+        blue,
+    )
+
+    assert red_result.reference_loaded and blue_result.reference_loaded
+    assert red_result.consumed.sha256 == red.selected[0].sha256
+    assert blue_result.consumed.sha256 == blue.selected[0].sha256
+    assert red_result.material_color == pytest.approx((1, 0, 0, 1))
+    assert blue_result.material_color == pytest.approx((0, 0, 1, 1))
+    assert [item.role for item in red_result.artifacts] == ["blend_source", "godot_glb"]
+    assert all(
+        item.path.is_file() and item.size_bytes > 0 for item in red_result.artifacts
+    )
+    assert _glb_base_color(red_result.artifacts[1].path) == pytest.approx((1, 0, 0, 1))
+    assert _glb_base_color(blue_result.artifacts[1].path) == pytest.approx((0, 0, 1, 1))
+    native = json.loads((red_output / "blender-result.json").read_text())
+    assert native["completed"][:3] == [
+        "read_reference",
+        "decode_reference",
+        "create_reference",
+    ]
+    assert native["scene_objects"] == ["ReferenceBlockout", "SelectedConceptReference"]
+
+
+def test_sprite_sheet_pixels_and_digest_follow_the_selected_png(tmp_path):
+    red = _selection(tmp_path / "red-handoff", "red.png", (255, 0, 0, 255))
+    blue = _selection(tmp_path / "blue-handoff", "blue.png", (0, 0, 255, 255))
+    layout = SpriteSheetLayout(16, 16, 8, 8, 4)
+    author = SpriteSheetReferenceAuthor()
+    results = []
+    for name, selection in (("red", red), ("blue", blue)):
+        output = tmp_path / f"{name}-output"
+        results.append(
+            author.author(
+                ConceptAuthorRequest(
+                    selection.handoff,
+                    "sprite-sheet-reference",
+                    output,
+                    sprite_layout=layout,
+                ),
+                selection,
+            )
+        )
+
+    red_result, blue_result = results
+    assert red_result.consumed.sha256 == red.selected[0].sha256
+    assert blue_result.consumed.sha256 == blue.selected[0].sha256
+    assert red_result.artifacts[0].sha256 != blue_result.artifacts[0].sha256
+    assert red_result.sprite_sheet is not None
+    assert red_result.sprite_sheet.frames == 4
+    with Image.open(red_result.artifacts[0].path) as sheet:
+        sheet.load()
+        assert sheet.size == (16, 16)
+        assert sheet.getpixel((0, 0)) == (255, 0, 0, 255)
+    with Image.open(blue_result.artifacts[0].path) as sheet:
+        sheet.load()
+        assert sheet.getpixel((0, 0)) == (0, 0, 255, 255)

--- a/src/gda/commands/asset_pipeline.py
+++ b/src/gda/commands/asset_pipeline.py
@@ -1519,7 +1519,7 @@ def render_prompt_record(result: PromptRecordResult) -> str:
     )
 
 
-def _prompt_command(
+def _projectless_asset_command(
     operation, input_model, output_model, render, recipe
 ) -> HeadlessCommand:
     return HeadlessCommand(
@@ -1533,28 +1533,28 @@ def _prompt_command(
     )
 
 
-PROMPT_PREPARE_COMMAND = _prompt_command(
+PROMPT_PREPARE_COMMAND = _projectless_asset_command(
     "asset-pipeline-prompt-prepare",
     PromptPrepareParams,
     PromptPreparationResult,
     render_prompt_preparation,
     run_prompt_prepare,
 )
-PROMPT_INSPECT_COMMAND = _prompt_command(
+PROMPT_INSPECT_COMMAND = _projectless_asset_command(
     "asset-pipeline-prompt-inspect",
     PromptInspectParams,
     PromptPreparationResult,
     render_prompt_preparation,
     run_prompt_inspect,
 )
-PROMPT_REVISE_COMMAND = _prompt_command(
+PROMPT_REVISE_COMMAND = _projectless_asset_command(
     "asset-pipeline-prompt-revise",
     PromptReviseParams,
     PromptRevisionResult,
     render_prompt_revision,
     run_prompt_revise,
 )
-PROMPT_REGISTER_OUTPUT_COMMAND = _prompt_command(
+PROMPT_REGISTER_OUTPUT_COMMAND = _projectless_asset_command(
     "asset-pipeline-prompt-register-output",
     PromptRegisterOutputParams,
     PromptRecordResult,
@@ -1923,21 +1923,21 @@ def render_concept_authoring(result: ConceptAuthorResult) -> str:
     )
 
 
-CONCEPT_PREPARE_COMMAND = _prompt_command(
+CONCEPT_PREPARE_COMMAND = _projectless_asset_command(
     "asset-pipeline-concept-prepare",
     ConceptPrepareParams,
     ConceptPreparationResult,
     render_concept_preparation,
     run_concept_prepare,
 )
-CONCEPT_SELECT_COMMAND = _prompt_command(
+CONCEPT_SELECT_COMMAND = _projectless_asset_command(
     "asset-pipeline-concept-select",
     ConceptSelectParams,
     ConceptSelectionResult,
     render_concept_selection,
     run_concept_select,
 )
-CONCEPT_AUTHOR_COMMAND = _prompt_command(
+CONCEPT_AUTHOR_COMMAND = _projectless_asset_command(
     "asset-pipeline-concept-author",
     ConceptAuthorParams,
     ConceptAuthorResult,

--- a/src/gda/commands/asset_pipeline.py
+++ b/src/gda/commands/asset_pipeline.py
@@ -43,6 +43,18 @@ from gda_assets.api import (
     PortFailure,
     PromptDeclarationKey,
     PromptOptionKey,
+    ConceptAuthoringResult,
+    ConceptAuthorRequest,
+    ConceptCandidate,
+    ConceptConsumer,
+    ConceptPreparation,
+    ConceptPrepareRequest,
+    ConceptSelection,
+    ConceptSelectRequest,
+    SpriteSheetLayout,
+    author_concept,
+    prepare_concept,
+    select_concept,
 )
 
 from gda.dispatch import dispatch_recipe, params_or_bad_parameter
@@ -1563,6 +1575,13 @@ def _json_map(value: str | None, label: str) -> dict[str, Any] | None:
     return decoded
 
 
+def _json_document(value: str, label: str) -> Any:
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(f"invalid {label} JSON: {exc.msg}") from exc
+
+
 @_app.command(name="prompt-prepare", cls=PROMPT_PREPARE_COMMAND.command_class())
 def prompt_prepare(
     record: Path = typer.Option(..., "--record", help="New prompt record directory."),
@@ -1705,6 +1724,309 @@ def prompt_register_output(
             reported_provider=reported_provider,
             reported_model=reported_model,
             reported_options=_json_map(reported_options, "reported-options"),
+        ),
+        json_output=json_output,
+        godot=None,
+        project=None,
+    )
+
+
+class ConceptPrepareParams(BaseModel):
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
+    brief: Path = Field(
+        description="Caller-authored concept brief JSON file (at most 1 MiB)."
+    )
+    record: Path = Field(
+        description="New exclusive concept and prompt record directory."
+    )
+    producer: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=256,
+        description="Optional caller-selected external producer name.",
+    )
+    requested_options: dict[PromptOptionKey, JsonScalar] = Field(
+        default_factory=dict, description=REQUESTED_OPTION_HELP
+    )
+
+
+class ConceptCandidateInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    record: Path = Field(description="Existing registered prompt record directory.")
+    output: str = Field(
+        min_length=1,
+        max_length=255,
+        description="Exact registered PNG output slot filename.",
+    )
+
+
+class ConceptSelectParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    brief_record: Path = Field(description="Record created by concept-prepare.")
+    handoff: Path = Field(
+        description="New exclusive selected-reference handoff directory."
+    )
+    candidates: tuple[ConceptCandidateInput, ...] = Field(
+        min_length=1,
+        max_length=8,
+        description="Ordered list of 1 to 8 registered prompt output candidates.",
+    )
+
+
+class SpriteSheetLayoutInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    width: int = Field(strict=True, ge=1, le=2048)
+    height: int = Field(strict=True, ge=1, le=2048)
+    cell_width: int = Field(strict=True, ge=1, le=2048)
+    cell_height: int = Field(strict=True, ge=1, le=2048)
+    frames: int = Field(strict=True, ge=1, le=64)
+
+
+class ConceptAuthorParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    handoff: Path = Field(description="Existing selected-reference handoff directory.")
+    consumer: ConceptConsumer = Field(description="Bounded example authoring consumer.")
+    output: Path = Field(description="New exclusive authoring output directory.")
+    reference_index: int = Field(
+        default=0,
+        strict=True,
+        ge=0,
+        le=7,
+        description="Zero-based selected reference to consume.",
+    )
+    blender_executable: Path | None = Field(
+        default=None,
+        description="Optional Blender executable for the blockout consumer.",
+    )
+    sprite_layout: SpriteSheetLayoutInput | None = Field(
+        default=None, description="Required layout for the sprite-sheet consumer."
+    )
+
+
+class ConceptPreparationResult(BaseModel):
+    preparation: ConceptPreparation
+
+
+class ConceptSelectionResult(BaseModel):
+    selection: ConceptSelection
+
+
+class ConceptAuthorResult(BaseModel):
+    authoring: ConceptAuthoringResult
+
+
+def _concept_failure(exc: PortFailure) -> Failure:
+    if exc.code == "destination_conflict":
+        code = "already_exists"
+    elif exc.code in {
+        "concept_prepare_failed",
+        "concept_select_failed",
+        "concept_author_failed",
+    }:
+        code = "operation_failed"
+    else:
+        code = "invalid_params"
+    return make_failure(code, str(exc), "")
+
+
+def run_concept_prepare(
+    params: ConceptPrepareParams, *, project: Path | None, godot: str | None
+) -> ConceptPreparationResult | Failure:
+    del project, godot
+    try:
+        return ConceptPreparationResult(
+            preparation=prepare_concept(
+                ConceptPrepareRequest(
+                    brief=params.brief.resolve(),
+                    record=params.record.resolve(),
+                    producer=params.producer,
+                    requested_options=params.requested_options,
+                )
+            )
+        )
+    except PortFailure as exc:
+        return _concept_failure(exc)
+
+
+def run_concept_select(
+    params: ConceptSelectParams, *, project: Path | None, godot: str | None
+) -> ConceptSelectionResult | Failure:
+    del project, godot
+    try:
+        return ConceptSelectionResult(
+            selection=select_concept(
+                ConceptSelectRequest(
+                    brief_record=params.brief_record.resolve(),
+                    handoff=params.handoff.resolve(),
+                    candidates=tuple(
+                        ConceptCandidate(item.record.resolve(), item.output)
+                        for item in params.candidates
+                    ),
+                )
+            )
+        )
+    except PortFailure as exc:
+        return _concept_failure(exc)
+
+
+def run_concept_author(
+    params: ConceptAuthorParams, *, project: Path | None, godot: str | None
+) -> ConceptAuthorResult | Failure:
+    del project, godot
+    layout = params.sprite_layout
+    try:
+        return ConceptAuthorResult(
+            authoring=author_concept(
+                ConceptAuthorRequest(
+                    handoff=params.handoff.resolve(),
+                    consumer=params.consumer,
+                    output=params.output.resolve(),
+                    reference_index=params.reference_index,
+                    blender_executable=params.blender_executable.resolve()
+                    if params.blender_executable
+                    else None,
+                    sprite_layout=SpriteSheetLayout(**layout.model_dump())
+                    if layout
+                    else None,
+                )
+            )
+        )
+    except PortFailure as exc:
+        return _concept_failure(exc)
+
+
+def render_concept_preparation(result: ConceptPreparationResult) -> str:
+    value = result.preparation
+    return (
+        f"concept prepared: {value.brief_snapshot.path}\n"
+        f"  use: {value.brief.use}; prompt record: {value.prompt.record.record}\n"
+        f"  handoff: {value.prompt.handoff.action}"
+    )
+
+
+def render_concept_selection(result: ConceptSelectionResult) -> str:
+    value = result.selection
+    return (
+        f"concept references selected: {value.handoff}\n"
+        f"  use: {value.brief.use}; selected: {len(value.selected)}\n"
+        f"  authoring: {value.authoring_status}"
+    )
+
+
+def render_concept_authoring(result: ConceptAuthorResult) -> str:
+    value = result.authoring
+    return (
+        f"concept authored: {value.consumer}\n"
+        f"  consumed: {value.consumed.path}; reference loaded: {value.reference_loaded}\n"
+        f"  influence: {value.influence}; artifacts: "
+        + (", ".join(str(item.path) for item in value.artifacts) or "none")
+    )
+
+
+CONCEPT_PREPARE_COMMAND = _prompt_command(
+    "asset-pipeline-concept-prepare",
+    ConceptPrepareParams,
+    ConceptPreparationResult,
+    render_concept_preparation,
+    run_concept_prepare,
+)
+CONCEPT_SELECT_COMMAND = _prompt_command(
+    "asset-pipeline-concept-select",
+    ConceptSelectParams,
+    ConceptSelectionResult,
+    render_concept_selection,
+    run_concept_select,
+)
+CONCEPT_AUTHOR_COMMAND = _prompt_command(
+    "asset-pipeline-concept-author",
+    ConceptAuthorParams,
+    ConceptAuthorResult,
+    render_concept_authoring,
+    run_concept_author,
+)
+
+
+@_app.command(name="concept-prepare", cls=CONCEPT_PREPARE_COMMAND.command_class())
+def concept_prepare(
+    brief: Path = typer.Option(..., "--brief"),
+    record: Path = typer.Option(..., "--record"),
+    producer: Optional[str] = typer.Option(None, "--producer"),
+    requested_options: str = typer.Option(
+        "{}", "--requested-options", help=REQUESTED_OPTION_HELP
+    ),
+    json_output: bool = json_option(),
+    schema: bool = CONCEPT_PREPARE_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+) -> None:
+    """Preserve a concept brief and return an external prompt handoff."""
+    dispatch_recipe(
+        CONCEPT_PREPARE_COMMAND,
+        params_or_bad_parameter(
+            ConceptPrepareParams,
+            brief=brief,
+            record=record,
+            producer=producer,
+            requested_options=_json_map(requested_options, "requested-options"),
+        ),
+        json_output=json_output,
+        godot=None,
+        project=None,
+    )
+
+
+@_app.command(name="concept-select", cls=CONCEPT_SELECT_COMMAND.command_class())
+def concept_select(
+    brief_record: Path = typer.Option(..., "--brief-record"),
+    handoff: Path = typer.Option(..., "--handoff"),
+    candidates: str = typer.Option(
+        ..., "--candidates", help="JSON array of 1 to 8 record/output objects."
+    ),
+    json_output: bool = json_option(),
+    schema: bool = CONCEPT_SELECT_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+) -> None:
+    """Pin completed registered PNG candidates into a reusable handoff."""
+    dispatch_recipe(
+        CONCEPT_SELECT_COMMAND,
+        params_or_bad_parameter(
+            ConceptSelectParams,
+            brief_record=brief_record,
+            handoff=handoff,
+            candidates=_json_document(candidates, "candidates"),
+        ),
+        json_output=json_output,
+        godot=None,
+        project=None,
+    )
+
+
+@_app.command(name="concept-author", cls=CONCEPT_AUTHOR_COMMAND.command_class())
+def concept_author(
+    handoff: Path = typer.Option(..., "--handoff"),
+    consumer: ConceptConsumer = typer.Option(..., "--consumer"),
+    output: Path = typer.Option(..., "--output"),
+    reference_index: int = typer.Option(0, "--reference-index", min=0, max=7),
+    blender_executable: Optional[Path] = typer.Option(None, "--blender-executable"),
+    sprite_layout: Optional[str] = typer.Option(
+        None, "--sprite-layout", help="JSON sprite sheet layout object."
+    ),
+    json_output: bool = json_option(),
+    schema: bool = CONCEPT_AUTHOR_COMMAND.schema_option(),
+    params_json: Optional[str] = params_json_option(),
+) -> None:
+    """Author one bounded example from a selected concept reference."""
+    dispatch_recipe(
+        CONCEPT_AUTHOR_COMMAND,
+        params_or_bad_parameter(
+            ConceptAuthorParams,
+            handoff=handoff,
+            consumer=consumer,
+            output=output,
+            reference_index=reference_index,
+            blender_executable=blender_executable,
+            sprite_layout=_json_document(sprite_layout, "sprite-layout")
+            if sprite_layout is not None
+            else None,
         ),
         json_output=json_output,
         godot=None,

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -104,6 +104,17 @@ text stay separate; unavailable execution facts remain unknown. These local
 commands need no Godot project or engine. See each command's `--schema` and the
 [prompt guide](https://github.com/aigengame/godot-agent/blob/main/libs/gda-assets/docs/prompts.md).
 
+For new model or sprite authoring, use `concept-prepare` with a brief file and new
+record, complete generation externally, and register each local PNG with
+`prompt-register-output`. Then use `concept-select` to create a new handoff from
+explicit record/output pairs and `concept-author` with either
+`blender-reference-blockout` or `sprite-sheet-reference`. These bounded examples
+each consume one selected PNG and report its digest and observable influence; they
+do not prove provider execution, general authoring, similarity, or production
+quality, and they do not install output into Godot. See the
+[concept reference guide](https://github.com/aigengame/godot-agent/blob/main/libs/gda-assets/docs/concepts.md)
+for runnable JSON and commands, reuse and failure behavior.
+
 ## Setup
 
 - **Engine** — set `GDA_GODOT` to your Godot binary (or pass `--godot PATH`).
@@ -295,7 +306,7 @@ Every headless reply carries its floats at full binary64 precision, so a value r
 
 | Group | Commands |
 | --- | --- |
-| `asset-pipeline` | `run`, `check`, `preview`, `check-package`, `prompt-prepare`, `prompt-inspect`, `prompt-revise`, `prompt-register-output` (production and handoff; project expectations; model preview; package acceptance; local prompt preservation and external output registration) |
+| `asset-pipeline` | `run`, `check`, `preview`, `check-package`, `prompt-prepare`, `prompt-inspect`, `prompt-revise`, `prompt-register-output`, `concept-prepare`, `concept-select`, `concept-author` (production and handoff; project expectations; model preview; package acceptance; prompt and concept-reference workflows) |
 
 Use `gda asset-pipeline preview --path /production/model.glb --output-dir
 /reports/model-preview --settings /project/preview-settings.json --frames 60

--- a/tests/asset_pipeline/test_concept_cli.py
+++ b/tests/asset_pipeline/test_concept_cli.py
@@ -13,6 +13,55 @@ from gda_assets.api import ConceptConsumer, PromptOptionKey
 from tests.mcp_support import FakeGdaRunner, gda_result, list_tools, schema_then
 
 
+@pytest.mark.parametrize("direction", ["views", "poses"])
+def test_concept_brief_defaults_work_and_unknown_fields_fail(tmp_path, direction):
+    brief = tmp_path / "brief.json"
+    value = {
+        "use": "model",
+        "subject": "Robot",
+        "style": "Low poly",
+        direction: ["front"],
+    }
+    brief.write_text(json.dumps(value))
+    record = tmp_path / "attempt"
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "asset-pipeline",
+            "concept-prepare",
+            "--brief",
+            str(brief),
+            "--record",
+            str(record),
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    saved = json.loads(result.stdout)["preparation"]["brief"]
+    assert saved[direction] == ["front"]
+    assert saved["poses" if direction == "views" else "views"] == []
+    assert saved["instructions"] == ""
+
+    brief.write_text(json.dumps({**value, "instruction": "Keep red eyes"}))
+    refused = tmp_path / "refused"
+    result = runner.invoke(
+        app,
+        [
+            "asset-pipeline",
+            "concept-prepare",
+            "--brief",
+            str(brief),
+            "--record",
+            str(refused),
+            "--json",
+        ],
+    )
+    assert result.exit_code != 0
+    assert json.loads(result.stdout)["error"]["code"] == "invalid_params"
+    assert not refused.exists()
+
+
 @pytest.mark.parametrize(
     ("command", "tool_name", "definition"),
     [

--- a/tests/asset_pipeline/test_concept_cli.py
+++ b/tests/asset_pipeline/test_concept_cli.py
@@ -1,0 +1,165 @@
+"""Concept-reference workflows use the typed asset-pipeline surface."""
+
+import json
+from typing import get_args
+
+import jsonschema
+import pytest
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.mcp.server import build_server
+from gda_assets.api import ConceptConsumer, PromptOptionKey
+from tests.mcp_support import FakeGdaRunner, gda_result, list_tools, schema_then
+
+
+@pytest.mark.parametrize(
+    ("command", "tool_name", "definition"),
+    [
+        ("concept-prepare", "asset_pipeline_concept_prepare", "ConceptPreparation"),
+        ("concept-select", "asset_pipeline_concept_select", "ConceptSelection"),
+        ("concept-author", "asset_pipeline_concept_author", "ConceptAuthoringResult"),
+    ],
+)
+def test_concept_commands_publish_matching_projectless_composite_schemas(
+    command, tool_name, definition
+):
+    result = CliRunner().invoke(app, ["asset-pipeline", command, "--schema"])
+    assert result.exit_code == 0, result.output
+    schema = json.loads(result.stdout)
+    assert schema["kind"] == "composite"
+    assert schema["input"]["additionalProperties"] is False
+    assert definition in schema["output"]["$defs"]
+
+    tools = list_tools(
+        build_server(FakeGdaRunner(schema_then(lambda *_: gda_result())))
+    ).tools
+    tool = next(item for item in tools if item.name == tool_name)
+    assert tool.input_schema == schema["input"]
+    assert tool.output_schema == schema["output"]
+
+
+def test_concept_nested_inputs_publish_real_bounds_and_literals():
+    runner = CliRunner()
+    prepare = json.loads(
+        runner.invoke(app, ["asset-pipeline", "concept-prepare", "--schema"]).stdout
+    )
+    select = json.loads(
+        runner.invoke(app, ["asset-pipeline", "concept-select", "--schema"]).stdout
+    )
+    author = json.loads(
+        runner.invoke(app, ["asset-pipeline", "concept-author", "--schema"]).stdout
+    )
+
+    assert set(
+        prepare["input"]["properties"]["requested_options"]["propertyNames"]["enum"]
+    ) == set(get_args(PromptOptionKey))
+    assert select["input"]["properties"]["candidates"]["maxItems"] == 8
+    consumer = author["input"]["properties"]["consumer"]
+    assert set(consumer["enum"]) == set(get_args(ConceptConsumer))
+    layout = author["input"]["$defs"]["SpriteSheetLayoutInput"]
+    assert layout["additionalProperties"] is False
+    assert layout["properties"]["frames"]["maximum"] == 64
+
+    validator = jsonschema.Draft202012Validator(select["input"])
+    base = {"brief_record": "/tmp/record", "handoff": "/tmp/handoff"}
+    assert list(validator.iter_errors({**base, "candidates": []}))
+    assert list(
+        validator.iter_errors(
+            {
+                **base,
+                "candidates": [
+                    {"record": f"/tmp/r{i}", "output": "image.png"} for i in range(9)
+                ],
+            }
+        )
+    )
+
+
+def test_concept_prepare_argv_and_structured_params_preserve_plain_handoff(tmp_path):
+    brief = tmp_path / "brief.json"
+    brief.write_text(
+        json.dumps(
+            {
+                "use": "model",
+                "subject": "Mossy stone arch",
+                "style": "painted low poly",
+                "views": ["front", "side"],
+                "poses": [],
+                "instructions": "Readable at game camera distance.",
+            }
+        )
+    )
+    runner = CliRunner()
+    first = runner.invoke(
+        app,
+        [
+            "asset-pipeline",
+            "concept-prepare",
+            "--brief",
+            str(brief),
+            "--record",
+            str(tmp_path / "attempt-a"),
+            "--producer",
+            "external-tool",
+            "--requested-options",
+            '{"size":"1024x1024"}',
+            "--json",
+        ],
+    )
+    second = runner.invoke(
+        app,
+        [
+            "asset-pipeline",
+            "concept-prepare",
+            "--params-json",
+            json.dumps(
+                {
+                    "brief": str(brief),
+                    "record": str(tmp_path / "attempt-b"),
+                    "producer": "external-tool",
+                    "requested_options": {"size": "1024x1024"},
+                }
+            ),
+            "--json",
+        ],
+    )
+
+    assert first.exit_code == second.exit_code == 0, first.output + second.output
+    left, right = (
+        json.loads(first.stdout)["preparation"],
+        json.loads(second.stdout)["preparation"],
+    )
+    assert left["brief"] == right["brief"]
+    assert (
+        left["prompt"]["record"]["resolved_prompt"]
+        == right["prompt"]["record"]["resolved_prompt"]
+    )
+    assert left["prompt"]["record"]["generation_status"] == "unknown"
+    assert left["prompt"]["handoff"]["action"] == "external_generation_required"
+
+
+def test_concept_failure_is_structured_and_does_not_require_a_project(tmp_path):
+    result = CliRunner().invoke(
+        app,
+        [
+            "asset-pipeline",
+            "concept-author",
+            "--handoff",
+            str(tmp_path / "missing"),
+            "--consumer",
+            "sprite-sheet-reference",
+            "--output",
+            str(tmp_path / "out"),
+            "--sprite-layout",
+            '{"width":64,"height":64,"cell_width":32,"cell_height":32,"frames":4}',
+            "--json",
+        ],
+    )
+
+    assert result.exit_code != 0
+    error = json.loads(result.stdout)["error"]
+    assert error["category"] == "operation"
+    assert error["code"] == "invalid_params"
+    assert "handoff" in error["message"].lower()
+    assert not (tmp_path / "out").exists()

--- a/tests/asset_pipeline/test_concept_consumer.py
+++ b/tests/asset_pipeline/test_concept_consumer.py
@@ -1,0 +1,316 @@
+"""Public concept records pin caller-selected pixels for standalone consumers."""
+
+import hashlib
+import json
+import shutil
+import struct
+import subprocess
+import zlib
+from pathlib import Path
+
+from PIL import Image
+
+from tests.support import Gda
+
+
+def _png(path: Path, rgba: tuple[int, int, int, int]) -> None:
+    def chunk(kind: bytes, data: bytes) -> bytes:
+        body = kind + data
+        return struct.pack(">I", len(data)) + body + struct.pack(">I", zlib.crc32(body))
+
+    path.write_bytes(
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", 2, 1, 8, 6, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(b"\0" + bytes(rgba) * 2))
+        + chunk(b"IEND", b"")
+    )
+
+
+def _gda(cwd: Path) -> Gda:
+    return Gda(None, godot=None, json_output=True, cwd=cwd)
+
+
+def _register(cwd: Path, record: str, source: str, name: str) -> dict:
+    return _gda(cwd).json(
+        "asset-pipeline",
+        "prompt-register-output",
+        "--record",
+        record,
+        "--output",
+        source,
+        "--name",
+        name,
+        "--caller-declarations",
+        json.dumps({"generation_completed": True, "tool": "external-agent"}),
+    )["prompt_record"]
+
+
+def _author_sprite(cwd: Path, handoff: str, output: str) -> dict:
+    return _gda(cwd).json(
+        "asset-pipeline",
+        "concept-author",
+        "--handoff",
+        handoff,
+        "--consumer",
+        "sprite-sheet-reference",
+        "--output",
+        output,
+        "--sprite-layout",
+        json.dumps(
+            {
+                "width": 4,
+                "height": 2,
+                "cell_width": 2,
+                "cell_height": 1,
+                "frames": 4,
+            }
+        ),
+    )["authoring"]
+
+
+def test_saved_selection_drives_actual_sprite_pixels_after_move_and_mutation(tmp_path):
+    project = tmp_path / "caller-project"
+    author = project / "author"
+    consumer = project / "consumer"
+    records = project / "records"
+    author.mkdir(parents=True)
+    consumer.mkdir()
+    records.mkdir()
+    subprocess.run(["git", "init", "--quiet", str(project)], check=True)
+
+    brief_path = author / "brief.json"
+    brief_path.write_text(
+        json.dumps(
+            {
+                "use": "sprite",
+                "subject": "tiny asymmetric courier",
+                "style": "flat readable pixels",
+                "views": ["side"],
+                "poses": ["idle"],
+                "instructions": "Keep the silhouette inside each cell.",
+            }
+        )
+    )
+    prepared = _gda(author).json(
+        "asset-pipeline",
+        "concept-prepare",
+        "--brief",
+        "brief.json",
+        "--record",
+        "../records/red-attempt",
+        "--producer",
+        "external-image-tool",
+    )["preparation"]
+    assert prepared["brief"]["subject"] == "tiny asymmetric courier"
+    assert prepared["prompt"]["record"]["generation_status"] == "unknown"
+    assert prepared["prompt"]["handoff"]["action"] == "external_generation_required"
+
+    _gda(consumer).json(
+        "asset-pipeline",
+        "prompt-revise",
+        "--source-record",
+        "../records/red-attempt",
+        "--record",
+        "../records/blue-attempt",
+    )
+    red_source = author / "red.png"
+    blue_source = author / "blue.png"
+    _png(red_source, (230, 20, 30, 255))
+    _png(blue_source, (20, 40, 230, 255))
+    red_record = _register(author, "../records/red-attempt", "red.png", "concept.png")
+    blue_record = _register(
+        author, "../records/blue-attempt", "blue.png", "concept.png"
+    )
+
+    selected = _gda(consumer).json(
+        "asset-pipeline",
+        "concept-select",
+        "--brief-record",
+        "../records/red-attempt",
+        "--handoff",
+        "../records/red-handoff",
+        "--candidates",
+        json.dumps(
+            [
+                {"record": "../records/red-attempt", "output": "concept.png"},
+                {"record": "../records/blue-attempt", "output": "concept.png"},
+            ]
+        ),
+    )["selection"]
+    assert selected["authoring_status"] == "ready"
+    assert [item["prompt_record"] for item in selected["selected"]] == [
+        str((records / "red-attempt").resolve()),
+        str((records / "blue-attempt").resolve()),
+    ]
+    assert all(item["generation_completed_by_caller"] for item in selected["selected"])
+
+    blue_selected = _gda(author).json(
+        "asset-pipeline",
+        "concept-select",
+        "--brief-record",
+        "../records/red-attempt",
+        "--handoff",
+        "../records/blue-handoff",
+        "--candidates",
+        json.dumps([{"record": "../records/blue-attempt", "output": "concept.png"}]),
+    )["selection"]
+
+    moved = records / "moved-handoff"
+    shutil.copytree(records / "red-handoff", moved)
+    shutil.rmtree(records / "red-handoff")
+    brief_path.write_text("mutated caller source")
+    _png(red_source, (5, 5, 5, 255))
+    _png(blue_source, (250, 250, 250, 255))
+    Path(red_record["outputs"][0]["file"]["path"]).write_bytes(b"mutated candidate")
+    Path(blue_record["outputs"][0]["file"]["path"]).write_bytes(b"mutated candidate")
+
+    red_authored = _author_sprite(
+        consumer, "../records/moved-handoff", "../records/red-sprites"
+    )
+    red_artifact = Path(red_authored["artifacts"][0]["path"])
+    assert red_authored["reference_loaded"] is True
+    assert red_authored["consumed"]["sha256"] == selected["selected"][0]["sha256"]
+    assert red_authored["sprite_sheet"] == {
+        "width": 4,
+        "height": 2,
+        "cell_width": 2,
+        "cell_height": 1,
+        "frames": 4,
+    }
+    assert red_artifact.read_bytes()
+    with Image.open(red_artifact) as image:
+        image.load()
+        assert image.size == (4, 2)
+        assert image.getpixel((0, 0)) == (230, 20, 30, 255)
+
+    # A new explicit selection changes the consumed bytes; the moved handoff stays pinned.
+    blue_authored = _author_sprite(
+        consumer, "../records/blue-handoff", "../records/blue-sprites"
+    )
+    blue_artifact = Path(blue_authored["artifacts"][0]["path"])
+    assert blue_authored["consumed"]["sha256"] != red_authored["consumed"]["sha256"]
+    assert blue_authored["consumed"]["sha256"] == blue_selected["selected"][0]["sha256"]
+    assert (
+        hashlib.sha256(blue_artifact.read_bytes()).hexdigest()
+        != hashlib.sha256(red_artifact.read_bytes()).hexdigest()
+    )
+    with Image.open(blue_artifact) as image:
+        image.load()
+        assert image.getpixel((0, 0)) == (20, 40, 230, 255)
+
+
+def test_invalid_or_incomplete_selection_never_creates_author_output(tmp_path):
+    cwd = tmp_path / "caller"
+    cwd.mkdir()
+    brief = cwd / "brief.json"
+    brief.write_text(
+        json.dumps(
+            {
+                "use": "sprite",
+                "subject": "marker",
+                "style": "flat",
+                "views": ["front"],
+                "poses": [],
+                "instructions": "",
+            }
+        )
+    )
+    _gda(cwd).json(
+        "asset-pipeline",
+        "concept-prepare",
+        "--brief",
+        "brief.json",
+        "--record",
+        "attempt",
+    )
+    candidate = cwd / "candidate.png"
+    _png(candidate, (200, 30, 40, 255))
+    _gda(cwd).json(
+        "asset-pipeline",
+        "prompt-register-output",
+        "--record",
+        "attempt",
+        "--output",
+        "candidate.png",
+        "--name",
+        "candidate.png",
+    )
+    _gda(cwd).error(
+        "asset-pipeline",
+        "concept-select",
+        "--brief-record",
+        "attempt",
+        "--handoff",
+        "unknown-handoff",
+        "--candidates",
+        json.dumps([{"record": "attempt", "output": "candidate.png"}]),
+        code="invalid_params",
+    )
+    assert not (cwd / "unknown-handoff").exists()
+
+    _gda(cwd).json(
+        "asset-pipeline",
+        "prompt-register-output",
+        "--record",
+        "attempt",
+        "--output",
+        "candidate.png",
+        "--name",
+        "completed.png",
+        "--caller-declarations",
+        json.dumps({"generation_completed": True}),
+    )
+    _gda(cwd).json(
+        "asset-pipeline",
+        "concept-select",
+        "--brief-record",
+        "attempt",
+        "--handoff",
+        "valid-handoff",
+        "--candidates",
+        json.dumps([{"record": "attempt", "output": "completed.png"}]),
+    )
+
+    malformed = cwd / "malformed-handoff"
+    malformed.mkdir()
+    (malformed / "handoff.json").write_text("not json")
+    absent_output = cwd / "malformed-output"
+    _gda(cwd).error(
+        "asset-pipeline",
+        "concept-author",
+        "--handoff",
+        "malformed-handoff",
+        "--consumer",
+        "sprite-sheet-reference",
+        "--output",
+        "malformed-output",
+        "--sprite-layout",
+        json.dumps(
+            {"width": 2, "height": 1, "cell_width": 2, "cell_height": 1, "frames": 1}
+        ),
+        code="invalid_params",
+    )
+    assert not absent_output.exists()
+
+    empty_handoff = cwd / "empty-handoff"
+    shutil.copytree(cwd / "valid-handoff", empty_handoff)
+    manifest = json.loads((empty_handoff / "handoff.json").read_text())
+    manifest["selected"] = []
+    (empty_handoff / "handoff.json").write_text(json.dumps(manifest))
+    no_selection_output = cwd / "no-selection-output"
+    _gda(cwd).error(
+        "asset-pipeline",
+        "concept-author",
+        "--handoff",
+        "empty-handoff",
+        "--consumer",
+        "sprite-sheet-reference",
+        "--output",
+        "no-selection-output",
+        "--sprite-layout",
+        json.dumps(
+            {"width": 2, "height": 1, "cell_width": 2, "cell_height": 1, "frames": 1}
+        ),
+        code="invalid_params",
+    )
+    assert not no_selection_output.exists()

--- a/tests/cli/test_command_descriptor_registry.py
+++ b/tests/cli/test_command_descriptor_registry.py
@@ -169,6 +169,9 @@ _RECIPE_OPERATIONS = {
     "asset-pipeline-prompt-inspect",
     "asset-pipeline-prompt-revise",
     "asset-pipeline-prompt-register-output",
+    "asset-pipeline-concept-prepare",
+    "asset-pipeline-concept-select",
+    "asset-pipeline-concept-author",
     "export-run",
     # `script run` is the third execution shape (ADR-0031): a user-script passthrough
     # run, fulfilled by a CLI-side recipe (it emits no ADR-0002 sentinel) like export


### PR DESCRIPTION
## Change

New model and sprite work needs a selected concept before authoring, and later edits must not replace that reference silently. Add three local `gda asset-pipeline` commands: `concept-prepare` preserves a project brief through the existing prompt-record path, `concept-select` copies explicitly selected registered PNGs into a movable handoff, and `concept-author` runs one of two bounded reference-use examples. Existing prompt inspection and output registration supply candidate inventory and native-tool handoff.

The Blender example decodes the selected PNG and creates an image reference before a cube blockout, deriving its material color from reference pixels. The sprite example decodes the selected image before producing and checking a declared frame layout. These examples demonstrate reference consumption; they do not infer geometry, assess art quality, or install concepts into Godot. Existing file handoff and saved-source Blender export stay independent.

Asset Domain owns brief/reference values and rules; Application composes prompt preparation, selection and the narrow file/authoring ports. Producer-specific work stays in local adapters. The gda host translates the three projectless commands and their CLI/MCP schemas. No provider SDK, registry, job system, or additional Godot seam is introduced.

Refs #913; umbrella #907 in [gda-blender milestone #14](https://github.com/aigengame/godot-agent/milestone/14).

## Validation

- 2,856 fast tests passed, 2 skipped; Ruff and full Pyright passed.
- Real Blender 5.2.1 and sprite red/blue tests passed: exact selected hashes, reference creation before geometry, two saved scene objects, different native GLB material colors, and different sprite pixels.
- Public subprocess tests preserve two prompt attempts and candidate links, relocate handoffs, mutate original inputs, and verify pinned selected bytes and explicit reselection. Missing/unknown/invalid inputs stop before authoring output creation.
- Boundary regressions refuse unknown brief fields, changed selected dimensions, escaped brief paths, and malformed or oversized Blender result documents.
- Wheel/sdist and a clean installed-wheel consumer passed outside the checkout with invalid inherited Godot/project settings. It reused the actual generated concept, relocated the handoff, ran real Blender and sprite consumers, and refused a corrupt selection.

## Actual external generation

Before calling the native `image_gen.imagegen` tool, `prepare_concept` saved the project brief and exact submitted prompt. The tool returned a local 1254×1254 concept PNG with SHA-256 `cd7d1d85376b7f01d05e80dda6c08cb77e97cfe2ff97453cf97d23d5b3158aba`. It was registered with explicit caller-declared completion and selected into the model handoff. A separate sprite brief explicitly reused that same generated candidate without another provider call. Both the source implementation and clean installed distribution reported consuming those exact selected bytes.

Blender produced a reference-loaded one-cube `.blend` and GLB; the separate sprite example produced a checked 256×256 sheet with four 128×128 cells. These are actual native-tool observations, separate from synthetic red/blue tests. Provider model, seed and request ID were not reported and are not fabricated. The prompt record continues to label provider execution details as unknown; local registration alone is not provider proof.

Independent Sol Standards, Spec and DDMA reviews and final-head rechecks passed at `1146e54c50e36c755ab3fdb86ee20aaebcd69cd3`. The brief-default contract mismatch and private helper naming findings are closed. [Final-head CI](https://github.com/aigengame/godot-agent/actions/runs/34212517398) passed. All child implementation is now integrated into shared dev; final integrated E2E/HITL remain pending. This PR targets `codex/asset-pipeline-dev`; no main merge or milestone completion is implied.
