### PR TITLE
docs(asset-pipeline): respect Panda archival boundary

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -27,8 +27,9 @@ prompt preparation and concept-reference handoff. Project recipes, prompts,
 selected concepts, art direction, and gameplay expectations are project-owned
 inputs. Panda Adventure is a one-time scaffold source for this work; it is not a
 runtime dependency or a migration target. The project owner has confirmed that
-Panda is archived and receives no further maintenance. Its historical examples
-are not maintained regression targets or acceptance gates for Asset Pipeline.
+Panda is archived and receives no further maintenance. Its unchanged historical
+examples may support one-time compatibility diagnosis; they are not maintained
+regression targets or acceptance gates for Asset Pipeline.
 
 The gda-side integration contract is owned by
 [ADR-0042](docs/adr/0042-asset-pipeline-supporting-context-integration.md);

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -5,7 +5,7 @@ domain names its own (see `docs/agents/domain.md`). Each non-root domain's layou
 override rules are declared in its own `AGENTS.md`.
 
 - [gda](CONTEXT.md) — the agent-facing Godot toolchain: `gda`, `gda-mcp`, `gda-daemon`.
-- [Panda Adventure](examples/platformer/panda-adventure/GAME-CONTEXT.md) — the 2D-platformer game demo.
+- [Panda Adventure](examples/platformer/panda-adventure/GAME-CONTEXT.md) — the archived, unmaintained 2D-platformer game demo.
 - [gda-balancing](libs/gda-balancing/BALANCING-CONTEXT.md) — the standalone numeric design & balancing toolkit.
 - [Asset Pipeline](libs/gda-assets/ASSETS-CONTEXT.md) — the internal supporting
   context, physically carried by `libs/gda-assets` and exposed through
@@ -26,8 +26,9 @@ their outbound adapters and anti-corruption layers. Its application also owns
 prompt preparation and concept-reference handoff. Project recipes, prompts,
 selected concepts, art direction, and gameplay expectations are project-owned
 inputs. Panda Adventure is a one-time scaffold source for this work; it is not a
-runtime dependency or a migration target.
-Its planned archival does not mean that it has already been archived.
+runtime dependency or a migration target. The project owner has confirmed that
+Panda is archived and receives no further maintenance. Its historical examples
+are not maintained regression targets or acceptance gates for Asset Pipeline.
 
 The gda-side integration contract is owned by
 [ADR-0042](docs/adr/0042-asset-pipeline-supporting-context-integration.md);

--- a/libs/gda-assets/docs/ARCHITECTURE.md
+++ b/libs/gda-assets/docs/ARCHITECTURE.md
@@ -315,9 +315,10 @@ boundaries, selected raster transforms, deterministic emitters, and isolation te
 ideas. Its raster-shaped orchestration and game manifest policy are redesigned in
 the new home. The equal-frame packer/SpriteFrames emitter is not complete Aseprite
 support for trimmed regions, frame timing, or richer metadata. Panda is archived
-and unmaintained; do not change its original codebase or make its tests regression
-targets or acceptance gates for the new pipeline. Maintained validation belongs
-to gda and Asset Pipeline.
+and unmaintained. Its unchanged historical scenarios may be run for one-time
+compatibility diagnosis; a failure creates no Panda maintenance or migration
+obligation. Do not make those scenarios routine acceptance gates for the new
+pipeline. Maintained validation belongs to gda and Asset Pipeline.
 
 ## Evidence limits and validation gates
 

--- a/libs/gda-assets/docs/ARCHITECTURE.md
+++ b/libs/gda-assets/docs/ARCHITECTURE.md
@@ -314,8 +314,10 @@ Panda extraction is part of the first applicable vertical slice: reuse acquisiti
 boundaries, selected raster transforms, deterministic emitters, and isolation test
 ideas. Its raster-shaped orchestration and game manifest policy are redesigned in
 the new home. The equal-frame packer/SpriteFrames emitter is not complete Aseprite
-support for trimmed regions, frame timing, or richer metadata. Do not change the
-original Panda codebase or mark it archived as part of this work.
+support for trimmed regions, frame timing, or richer metadata. Panda is archived
+and unmaintained; do not change its original codebase or make its tests regression
+targets or acceptance gates for the new pipeline. Maintained validation belongs
+to gda and Asset Pipeline.
 
 ## Evidence limits and validation gates
 


### PR DESCRIPTION
## Change

The context map still described Panda's archival as a future action. The project owner has now confirmed that Panda Adventure is archived and receives no further maintenance.

Update the current context map and Asset Pipeline architecture guide to record that status and exclude Panda from maintained regression targets and new-pipeline acceptance gates. Maintained validation belongs to gda and Asset Pipeline. This changes no Panda code/test, historical ADR, or optional-helper guidance.

Refs #907. Targets shared dev only.

## Validation

Documentation-only: checked the diff and local link targets. Independent Standards, Spec and DDMA final reviews passed at `29ca32fea01783319d279a19d798222de03718bc`, including a wording clarification that preserves one-time historical diagnosis without maintenance obligations. Applicable final-head scope-guard CI passed. The ongoing native gda E2E run started on the identical implementation and tests at `fbf0ea2bf0a9871758d6b5fada6881468463dc87`; this two-document correction does not change that code.
