### PR TITLE
refactor(gda): project_file owns every section boundary, and one key decoder (#930)

### DIFF
--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -61,7 +61,7 @@ string, and an uninstall deleted a line out of one (#930). Before that, a
 ``[autoload] ; note``: the install appended a SECOND autoload section and the
 uninstall left its entry behind (PR #898 review, round 3).
 
-Three shapes of input still come back changed, so the byte-identity guarantee of
+Five shapes of input still come back changed, so the byte-identity guarantee of
 :func:`uninstall_harness` is scoped to exclude them:
 
 - a file with MIXED terminators is normalized to its first one;
@@ -72,14 +72,21 @@ Three shapes of input still come back changed, so the byte-identity guarantee of
 - a file whose ``[autoload]`` section was ALREADY EMPTY loses that header, for the
   reason :func:`uninstall_harness` states — it is that function's guarantee, so the
   reasoning lives there and this list only names the shape (PR #898 review,
-  round 2: the list read as exhaustive and was not).
+  round 2: the list read as exhaustive and was not);
+- a file with a BYTE-ORDER MARK whose FIRST line is the ``[autoload]`` header: gda
+  joins that header, the engine reads no section there. The shared reader drops the
+  mark before it splits the text, so gda sees ``[autoload]`` where ``ConfigFile``
+  sees one marked, section-less KEY — and the install then reports a registration
+  the engine will not make. The same file declares no readable ``config_version``,
+  so the engine loads no project from it at all (#930 review, round 1).
 
 None is reachable for a ``project.godot`` the engine itself wrote: Godot's
 ``ConfigFile`` writer emits uniformly ``\\n``-terminated lines, always terminates
-the last one, and never emits an empty section. They need a hand-edited or
-tool-mangled file, so they are documented rather than coded around — the code stays
-a plain line-oriented edit instead of growing a per-line terminator model, or a
-record of pre-install state, for inputs Godot cannot produce.
+the last one, never emits an empty section, and never writes a byte-order mark.
+They need a hand-edited or tool-mangled file, so they are documented rather than
+coded around — the code stays a plain line-oriented edit instead of growing a
+per-line terminator model, a record of pre-install state, or a second reading of
+the format for inputs Godot cannot produce.
 """
 
 from dataclasses import dataclass
@@ -540,7 +547,7 @@ def install_harness(project: Path) -> HarnessInstall:
 def _drop_emptied_autoload_sections(
     config: ConfigText, sections: list[ConfigSection], removed: set[int]
 ) -> tuple[set[int], tuple[str, ...]]:
-    """Extend ``removed`` with the sections it emptied; (removed lines, dropped).
+    """Return ``removed`` widened by the sections it emptied; (lines, dropped).
 
     ``sections`` holds the ``[autoload]`` sections a harness entry was actually
     removed from — the ONLY sections this may drop. A section gda emptied would

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -466,16 +466,24 @@ def _ensure_autoload(text: str) -> _ConfigEdit:
     # Re-point an existing GdaHarness entry, or insert a fresh one — both scoped to
     # the [autoload] section, so a same-named key in another section is never
     # touched (PR #247 review; symmetric with _remove_autoload).
-    for section in sections:
-        for entry in _harness_entries(section):
-            # A no-op when the entry already declares this value, whatever spacing
-            # or trailing comment the line carries: gda writes only where the
-            # DECLARATION differs, so it never rewrites a line it did not need to.
-            if entry.value == _AUTOLOAD_VALUE:
-                return _ConfigEdit(text, False)
-            lines = list(config.lines)
-            lines[entry.index : entry.index + len(entry.lines)] = [line]
-            return _ConfigEdit(config.spelled(lines), True)
+    declared = [entry for section in sections for entry in _harness_entries(section)]
+    if declared:
+        # The LAST declaration, because that is the one the engine loads
+        # (`ConfigText.settings`, verified on 4.6.3: a bare `GdaHarness=` after a
+        # quoted `"GdaHarness"=` wins). Deciding on the first let a canonical entry
+        # hide a later one pointing elsewhere, so the install reported nothing to
+        # do and the harness never registered (#938 review, round 2). The earlier
+        # duplicates are left as the file wrote them — the engine ignores them, and
+        # `_remove_autoload` takes them all out again.
+        entry = declared[-1]
+        # A no-op when that entry already declares this value, whatever spacing or
+        # trailing comment the line carries: gda writes only where the DECLARATION
+        # differs, so it never rewrites a line it did not need to.
+        if entry.value == _AUTOLOAD_VALUE:
+            return _ConfigEdit(text, False)
+        lines = list(config.lines)
+        lines[entry.index : entry.index + len(entry.lines)] = [line]
+        return _ConfigEdit(config.spelled(lines), True)
 
     # An existing [autoload] section with no GdaHarness entry — insert right after
     # its header, preserving any sibling autoloads.
@@ -547,7 +555,7 @@ def install_harness(project: Path) -> HarnessInstall:
 def _drop_emptied_autoload_sections(
     config: ConfigText, sections: list[ConfigSection], removed: set[int]
 ) -> tuple[set[int], tuple[str, ...]]:
-    """Return ``removed`` widened by the sections it emptied; (lines, dropped).
+    """Return ``removed`` widened by the sections it emptied, and their headers.
 
     ``sections`` holds the ``[autoload]`` sections a harness entry was actually
     removed from — the ONLY sections this may drop. A section gda emptied would

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -67,8 +67,8 @@ Three shapes of input still come back changed, so the byte-identity guarantee of
 - a file with MIXED terminators is normalized to its first one;
 - a file with NO final terminator gains one (install terminates the line it
   appends after; uninstall has no way to know the file never ended in a break);
-- a CR-only (classic-Mac) file comes back CRLF — ``line_ending`` only tells
-  ``\\r\\n`` from ``\\n``, while ``str.splitlines`` also splits a bare ``\\r``;
+- a CR-only (classic-Mac) file comes back CRLF — the reader's terminator rule only
+  tells ``\\r\\n`` from ``\\n``, while ``str.splitlines`` also splits a bare ``\\r``;
 - a file whose ``[autoload]`` section was ALREADY EMPTY loses that header, for the
   reason :func:`uninstall_harness` states — it is that function's guarantee, so the
   reasoning lives there and this list only names the shape (PR #898 review,
@@ -113,7 +113,7 @@ HARNESS_VERSION = "22"
 _VERSION_HEADER_PREFIX = "# gda-harness-version:"
 _AUTOLOAD_HEADER = "[autoload]"
 # The same section by NAME. Every RECOGNITION on the edit path goes through this
-# (via the shared reader's `config_line` + `section_name`/`section_of`), because
+# (via the shared reader's `sections_named`, which reads its scan), because
 # Godot's own parser strips a header's inner whitespace and reads past a trailing
 # comment — `[ autoload ]` and `[autoload] ; note` are both the autoload section
 # (`VariantParser::_parse_tag`, `parse_tag_assign_eof`). Comparing a line to the

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -43,17 +43,23 @@ uninstall each RETURN the exact set they touched (``created_paths`` /
 agent (or a reviewer) needs to audit what gda wrote into a tracked project.
 
 **Line endings (#654).** ``project.godot`` is read and written with newline
-translation OFF and rejoined with the terminator its FIRST line uses, so a CRLF
-project file stays CRLF — Python's default text mode would otherwise silently
-rewrite the whole file to LF on any autoload edit. The line primitives this
-edit runs on (``split_config``, ``config_line``, ``section_of``,
-``is_section_header``) belong to :mod:`gda.project_file`, the one reader of
-Godot's ``ConfigFile`` text (#843); this module contributes the
-``[autoload]``-specific EDIT, not a second reading of the format. Every raw line
-this edit looks at is reduced by that reader's :func:`~gda.project_file.config_line`
-first — a ``.strip()`` of its own left the comment on, and a header written
-``[autoload] ; note`` was then missed: the install appended a SECOND autoload
-section and the uninstall left its entry behind (PR #898 review, round 3).
+translation OFF and spelled back with the terminator its FIRST line uses, so a
+CRLF project file stays CRLF — Python's default text mode would otherwise
+silently rewrite the whole file to LF on any autoload edit.
+
+**Every boundary is the reader's (#843, #930).** :mod:`gda.project_file` is the
+one reader of Godot's ``ConfigFile`` text; this module contributes the
+``[autoload]``-specific EDIT, not a second reading of the format. The edit asks
+that reader for the ``[autoload]`` sections and the entries inside them
+(:meth:`~gda.project_file.ConfigText.sections_named`) and works on the line SPANS
+its single scan recorded. Recognizing the sections here, line by line, carried
+none of that scan's state — the per-line reduction restarts it on every line — so
+a header-shaped line INSIDE a multi-line quoted value opened an ``[autoload]``
+section the file does not have: an install wrote its entry into a description
+string, and an uninstall deleted a line out of one (#930). Before that, a
+``.strip()`` of this module's own left the comment on and missed a header written
+``[autoload] ; note``: the install appended a SECOND autoload section and the
+uninstall left its entry behind (PR #898 review, round 3).
 
 Three shapes of input still come back changed, so the byte-identity guarantee of
 :func:`uninstall_harness` is scoped to exclude them:
@@ -80,14 +86,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-from gda.project_file import (
-    SECTIONLESS,
-    config_line,
-    is_section_header,
-    section_name,
-    section_of,
-    split_config,
-)
+from gda.project_file import ConfigEntry, ConfigSection, ConfigText, read_config_text
 
 # The autoload name and the res:// location the bundled harness is installed to.
 HARNESS_AUTOLOAD_NAME = "GdaHarness"
@@ -122,6 +121,11 @@ _AUTOLOAD_HEADER = "[autoload]"
 # emptied header left behind (PR #898 review). The literal above stays what the
 # install WRITES and what the #654 receipt reports.
 _AUTOLOAD_SECTION = "autoload"
+# The setting the reader names the harness entry by — `<section>/<key>`, with the
+# key DECODED. Matching the entry by that name is what makes the two spellings of
+# one key (`GdaHarness` and `"GdaHarness"`) the same entry to gda, as they are to
+# the engine, so an install can never add a duplicate beside the quoted one.
+_HARNESS_SETTING = f"{_AUTOLOAD_SECTION}/{HARNESS_AUTOLOAD_NAME}"
 _PROJECT_FILE = "project.godot"
 _BUNDLED_HARNESS = Path(__file__).parent / HARNESS_FILE
 
@@ -193,9 +197,12 @@ class _ConfigEdit:
     sections: tuple[str, ...] = ()
 
 
+# Enabled-singleton form: the res:// path prefixed with "*" (issue #119).
+_AUTOLOAD_VALUE = f'"*{HARNESS_RES_PATH}"'
+
+
 def _autoload_line() -> str:
-    # Enabled-singleton form: the res:// path prefixed with "*" (issue #119).
-    return f'{HARNESS_AUTOLOAD_NAME}="*{HARNESS_RES_PATH}"'
+    return f"{HARNESS_AUTOLOAD_NAME}={_AUTOLOAD_VALUE}"
 
 
 def _read_config(path: Path) -> str:
@@ -417,51 +424,63 @@ def _materialize(project: Path) -> bool:
     return True
 
 
+def _harness_entries(section: ConfigSection) -> list[ConfigEntry]:
+    """The GdaHarness assignments inside ``section``, in file order.
+
+    By the reader's DECODED key (:data:`_HARNESS_SETTING`), not by the spelling on
+    the line: the engine reads ``GdaHarness=`` and ``"GdaHarness"=`` as one key, so
+    gda does too.
+    """
+    return [entry for entry in section.entries if entry.name == _HARNESS_SETTING]
+
+
 def _ensure_autoload(text: str) -> _ConfigEdit:
     """Ensure the harness autoload line is present in ``[autoload]``.
 
-    The "already present" decision is scoped to the ``[autoload]`` section: only an
-    EXACT GdaHarness line *inside* ``[autoload]`` is a no-op. There is no global
-    early return on the line appearing anywhere in the file, so a same-named key in
-    another section is never consulted, re-pointed, or removed (PR #247 review).
+    The "already present" decision is scoped to the ``[autoload]`` section: only a
+    GdaHarness entry *inside* ``[autoload]`` that already declares this exact value
+    is a no-op. There is no global early return on the line appearing anywhere in
+    the file, so a same-named key in another section is never consulted,
+    re-pointed, or removed (PR #247 review).
+
+    Both the sections and the entries come from the shared reader's ONE scan
+    (:meth:`~gda.project_file.ConfigText.sections_named`), so a header-shaped line
+    inside a multi-line quoted value is not a section to join and the entry
+    spelled inside such a value is not an entry to re-point (#930).
 
     The returned :class:`_ConfigEdit` names the ``[autoload]`` section in
     ``sections`` when this call had to CREATE it — the half of the #654 receipt
     ``_remove_autoload`` mirrors when it drops the section again.
     """
     line = _autoload_line()
-    lines, eol, trailing = split_config(text)
+    config = read_config_text(text)
+    sections = config.sections_named(_AUTOLOAD_SECTION)
 
     # Re-point an existing GdaHarness entry, or insert a fresh one — both scoped to
     # the [autoload] section, so a same-named key in another section is never
     # touched (PR #247 review; symmetric with _remove_autoload).
-    section = SECTIONLESS
-    autoload_header_index: Optional[int] = None
-    for i, raw in enumerate(lines):
-        stripped = config_line(raw)
-        section = section_of(stripped, section)
-        if section != _AUTOLOAD_SECTION:
-            continue
-        if section_name(stripped) == _AUTOLOAD_SECTION:
-            if autoload_header_index is None:
-                autoload_header_index = i
-        elif stripped.startswith(f"{HARNESS_AUTOLOAD_NAME}="):
-            # A GdaHarness entry inside [autoload]: a no-op when already exact,
-            # otherwise re-point it in place.
-            if stripped == line:
+    for section in sections:
+        for entry in _harness_entries(section):
+            # A no-op when the entry already declares this value, whatever spacing
+            # or trailing comment the line carries: gda writes only where the
+            # DECLARATION differs, so it never rewrites a line it did not need to.
+            if entry.value == _AUTOLOAD_VALUE:
                 return _ConfigEdit(text, False)
-            lines[i] = line
-            return _ConfigEdit(eol.join(lines) + trailing, True)
+            lines = list(config.lines)
+            lines[entry.index : entry.index + len(entry.lines)] = [line]
+            return _ConfigEdit(config.spelled(lines), True)
 
     # An existing [autoload] section with no GdaHarness entry — insert right after
     # its header, preserving any sibling autoloads.
-    if autoload_header_index is not None:
-        lines.insert(autoload_header_index + 1, line)
-        return _ConfigEdit(eol.join(lines) + trailing, True)
+    if sections:
+        lines = list(config.lines)
+        lines.insert(sections[0].start, line)
+        return _ConfigEdit(config.spelled(lines), True)
 
     # No [autoload] section — append one at EOF (sections may appear in any order).
     # The leading blank line is the section separator ``_drop_emptied_autoload_sections``
     # takes back when uninstall empties the section again (#654).
+    eol = config.eol
     base = text if text.endswith(("\n", "\r")) else text + eol
     return _ConfigEdit(
         f"{base}{eol}{_AUTOLOAD_HEADER}{eol}{eol}{line}{eol}",
@@ -519,44 +538,52 @@ def install_harness(project: Path) -> HarnessInstall:
 
 
 def _drop_emptied_autoload_sections(
-    lines: list[str], headers: set[int]
-) -> tuple[list[str], tuple[str, ...]]:
-    """Drop the named ``[autoload]`` sections if now key-less; (lines, dropped).
+    config: ConfigText, sections: list[ConfigSection], removed: set[int]
+) -> tuple[set[int], tuple[str, ...]]:
+    """Extend ``removed`` with the sections it emptied; (removed lines, dropped).
 
-    ``headers`` holds the ``lines`` indices of the ``[autoload]`` headers a harness
-    entry was actually removed from — the ONLY sections this may drop. A section gda
-    emptied would otherwise survive as a bare header, keeping a tracked
-    ``project.godot`` modified after every live session (GDA-DF-020, #654), but an
-    unrelated ``[autoload]`` section that was ALREADY empty before this call is none
-    of gda's business and stays (PR #680 review). Scoping the removal to the touched
-    section is what makes "a pre-existing empty section is not gda's to remove" true
-    of the code and not just of the docs.
+    ``sections`` holds the ``[autoload]`` sections a harness entry was actually
+    removed from — the ONLY sections this may drop. A section gda emptied would
+    otherwise survive as a bare header, keeping a tracked ``project.godot`` modified
+    after every live session (GDA-DF-020, #654), but an unrelated ``[autoload]``
+    section that was ALREADY empty before this call is none of gda's business and
+    stays (PR #680 review). Scoping the removal to the touched section is what makes
+    "a pre-existing empty section is not gda's to remove" true of the code and not
+    just of the docs.
 
-    Deletes in DESCENDING index order so removing a later span cannot shift the
-    index of one not yet visited.
+    Every span is measured on the SCANNED text and collected as a set of line
+    indices, so no deletion can shift the bounds of a section not yet visited — the
+    order the old descending walk had to keep for the same reason.
     """
-    kept = list(lines)
+    gone = set(removed)
     dropped: list[str] = []
-    for index in sorted(headers, reverse=True):
-        span = _emptied_autoload_span(kept, index)
+    for section in sections:
+        span = _emptied_autoload_span(config, section, gone)
         if span is None:
             continue  # a sibling autoload survives -> the section stays
-        del kept[span[0] : span[1]]
+        gone.update(range(*span))
         dropped.append(_AUTOLOAD_HEADER)
-    return kept, tuple(dropped)
+    return gone, tuple(dropped)
 
 
-def _emptied_autoload_span(lines: list[str], index: int) -> Optional[tuple[int, int]]:
+def _emptied_autoload_span(
+    config: ConfigText, section: ConfigSection, removed: set[int]
+) -> Optional[tuple[int, int]]:
     """The ``[start, end)`` slice to delete for a key-less ``[autoload]``, else None.
 
-    The section spans its header at ``index`` up to the next section header (or EOF),
-    so removing it takes the blank lines inside it. When it ran to EOF the span also
-    takes the ONE blank separator line in front of it, because nothing follows to be
-    separated from — together that is the exact inverse of the
-    ``\\n[autoload]\\n\\n<entry>\\n`` ``_ensure_autoload`` appends, so the file returns
-    to its pre-install bytes. A mid-file section keeps that separator: it still
-    divides the two neighbours.
+    The section spans its header up to the next section header (or EOF) — the bounds
+    the one scan recorded — so removing it takes the blank lines inside it, and a
+    header spelling inside a quoted value ends nothing. ``removed`` are the lines
+    the entry removal already took, which is what makes the section key-less. When
+    the section ran to EOF the span also takes the ONE blank separator line in front
+    of it, because nothing follows to be separated from — together that is the exact
+    inverse of the ``\\n[autoload]\\n\\n<entry>\\n`` ``_ensure_autoload`` appends, so
+    the file returns to its pre-install bytes. A mid-file section keeps that
+    separator: it still divides the two neighbours.
     """
+    header = section.header
+    if header is None:  # only the section-less head has no header line
+        return None
     # The one comparison on this path that is deliberately LITERAL, where
     # recognition is by name (`_AUTOLOAD_SECTION`). The asymmetry is the rule
     # itself: reading the file means reading it as Godot's parser does, so a
@@ -566,15 +593,17 @@ def _emptied_autoload_span(lines: list[str], index: int) -> Optional[tuple[int, 
     # a bare `[autoload]`. Recognizing the drop by name too would have destroyed a
     # user's empty `[ autoload ]` on a round trip that created nothing, and would
     # take a user's comment with the header here (PR #898 review, rounds 2-3).
-    if index >= len(lines) or lines[index].strip() != _AUTOLOAD_HEADER:
+    if config.lines[header].strip() != _AUTOLOAD_HEADER:
         return None
-    end = index + 1
-    while end < len(lines) and not is_section_header(lines[end]):
-        end += 1
-    if any(line.strip() for line in lines[index + 1 : end]):
+    if any(
+        config.lines[index].strip()
+        for index in range(section.start, section.end)
+        if index not in removed
+    ):
         return None
-    start = index
-    if end == len(lines) and start > 0 and not lines[start - 1].strip():
+    start = header
+    end = section.end
+    if end == len(config.lines) and start > 0 and not config.lines[start - 1].strip():
         start -= 1
     return start, end
 
@@ -582,35 +611,30 @@ def _emptied_autoload_span(lines: list[str], index: int) -> Optional[tuple[int, 
 def _remove_autoload(text: str) -> _ConfigEdit:
     """Drop the harness autoload line from ``project.godot`` text.
 
-    Removes only the ``GdaHarness=...`` line **inside the ``[autoload]`` section**,
+    Removes only the ``GdaHarness=...`` entry **inside the ``[autoload]`` section**,
     leaving any sibling autoloads intact (the inverse of ``_ensure_autoload``). A
-    same-named key in another section is left untouched. When that empties the
-    section the harness entry sat in, the header goes too
-    (:func:`_drop_emptied_autoload_sections`, #654) and the returned
-    :class:`_ConfigEdit` names it in ``sections``.
+    same-named key in another section is left untouched, and so is a line spelled
+    like the entry inside a multi-line quoted value: the sections and the entries
+    are the ones the shared reader's single scan found, and an entry is taken out by
+    the SPAN it was written on (#930). When that empties the section the harness
+    entry sat in, the header goes too (:func:`_drop_emptied_autoload_sections`,
+    #654) and the returned :class:`_ConfigEdit` names it in ``sections``.
     """
-    lines, eol, trailing = split_config(text)
-    section = SECTIONLESS
-    kept: list[str] = []
-    # The `kept` index of the [autoload] header now in scope, and the headers a
-    # harness entry was actually dropped from — only those may lose their section.
-    header_index: Optional[int] = None
-    emptied: set[int] = set()
-    for raw in lines:
-        stripped = config_line(raw)
-        section = section_of(stripped, section)
-        if section == _AUTOLOAD_SECTION:
-            if section_name(stripped) == _AUTOLOAD_SECTION:
-                header_index = len(kept)
-            elif stripped.startswith(f"{HARNESS_AUTOLOAD_NAME}="):
-                if header_index is not None:
-                    emptied.add(header_index)
-                continue  # drop the autoload entry only
-        kept.append(raw)
-    if len(kept) == len(lines):
+    config = read_config_text(text)
+    removed: set[int] = set()
+    emptied: list[ConfigSection] = []
+    for section in config.sections_named(_AUTOLOAD_SECTION):
+        entries = _harness_entries(section)
+        if not entries:
+            continue
+        for entry in entries:
+            removed.update(range(entry.index, entry.index + len(entry.lines)))
+        emptied.append(section)
+    if not removed:
         return _ConfigEdit(text, False)
-    kept, dropped = _drop_emptied_autoload_sections(kept, emptied)
-    return _ConfigEdit(eol.join(kept) + trailing, True, dropped)
+    removed, dropped = _drop_emptied_autoload_sections(config, emptied, removed)
+    kept = [raw for index, raw in enumerate(config.lines) if index not in removed]
+    return _ConfigEdit(config.spelled(kept), True, dropped)
 
 
 def _remove_files(project: Path) -> tuple[str, ...]:

--- a/src/gda/project.py
+++ b/src/gda/project.py
@@ -45,7 +45,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
-from gda.project_file import read_config, unquote
+from gda.project_file import read_config
 
 GDA_PROJECT_ENV = "GDA_PROJECT"
 
@@ -659,6 +659,7 @@ def resolve_project_dir(
 MAIN_SCENE_UNDEFINED = "live_main_scene_undefined"
 MAIN_SCENE_UNRESOLVED = "live_main_scene_unresolved"
 
+_APPLICATION_SECTION = "application"
 _MAIN_SCENE_KEY = "run/main_scene"
 _HIDDEN_DATA_DIR_KEY = "config/use_hidden_project_data_directory"
 _SETTINGS_OVERRIDE_KEY = "config/project_settings_override"
@@ -703,17 +704,37 @@ class _MainSceneSetting:
     hidden_data_dir: bool | None
 
 
+def _unquoted_literal(token: str) -> str:
+    """A Godot VALUE literal with its surrounding quotes off, or as it stands.
+
+    The one thing this lookup needs that :mod:`gda.project_file` does not provide:
+    that module reads the FORMAT and leaves every value as the text the file
+    spells, because decoding a Variant is the engine's job. A main-scene path and
+    an overlay path are the two literals this verdict compares, and both are
+    plain quoted strings — so the quotes come off here, at the one caller, and
+    nothing else in gda grows a second value decoder. It is NOT a key decoder:
+    a key's spelling is the reader's (``ConfigEntry.name``).
+    """
+    token = token.strip()
+    if len(token) >= 2 and token[0] == '"' and token[-1] == '"':
+        return token[1:-1].replace('\\"', '"')
+    return token
+
+
 def _read_main_scene(project: Path) -> _MainSceneSetting | None:
     """Read the main-scene setting, or ``None`` when it cannot be determined.
 
     Reads the ``[application]`` section through the shared ``ConfigFile`` reader
     (:mod:`gda.project_file`, #843) and takes from it only the settings this
-    verdict needs and their override declarations. An ESCAPED application key is
-    left to the engine's parser — this reader gives up on the whole file rather
-    than mistake a declaration it cannot decode for an absent setting, so the
-    verdict defers instead of refusing. A file gda cannot read or decode is
-    ``None`` too: that is not a verdict about the scene, and the next step that
-    touches the file (the harness install) reports the failure as its own.
+    verdict needs and their override declarations. Each entry is addressed by the
+    NAME that reader decoded for it, which is the one decoding of a key spelling in
+    gda: ``"run/\\u006dain_scene"`` names the main scene, as it does to the
+    engine's parser. An entry that reader could not name is left to the engine:
+    this reader gives up on the whole file rather than mistake a declaration it
+    cannot decode for an absent setting, so the verdict defers instead of refusing.
+    A file gda cannot read or decode is ``None`` too — that is not a verdict about
+    the scene, and the next step that touches the file (the harness install)
+    reports the failure as its own.
     """
     config = read_config(project / PROJECT_MARKER)
     if config is None:
@@ -722,16 +743,14 @@ def _read_main_scene(project: Path) -> _MainSceneSetting | None:
     overridden = (project / _OVERRIDE_CFG).exists()
     hidden: bool | None = True
     for entry in config.entries:
-        if entry.section != "application":
+        if entry.section != _APPLICATION_SECTION:
             continue
-        if "\\" in entry.key_token:
-            # A quoted key can encode any setting name (e.g. run/\u006dain_scene).
-            # Do not mistake a declaration we cannot decode for an absent setting.
+        if entry.name is None:
             return None
-        key = unquote(entry.key_token)
+        key = entry.name.removeprefix(f"{_APPLICATION_SECTION}/")
         token = entry.value
         if key == _MAIN_SCENE_KEY:
-            value = unquote(token)
+            value = _unquoted_literal(token)
         elif key.startswith(_MAIN_SCENE_KEY + "."):
             overridden = True
         elif key == _HIDDEN_DATA_DIR_KEY:
@@ -739,7 +758,7 @@ def _read_main_scene(project: Path) -> _MainSceneSetting | None:
                 hidden = {"true": True, "false": False}.get(token.strip())
         elif key.startswith(_HIDDEN_DATA_DIR_KEY + "."):
             hidden = None
-        elif key == _SETTINGS_OVERRIDE_KEY and unquote(token):
+        elif key == _SETTINGS_OVERRIDE_KEY and _unquoted_literal(token):
             overridden = True
         elif key.startswith(_SETTINGS_OVERRIDE_KEY + "."):
             overridden = True
@@ -776,7 +795,7 @@ def main_scene_unrunnable(
     can change the effective value in ways only the engine decides (its features
     and the overlay's contents), so their presence defers to the engine. The launch
     behaves as before this check, bounded by the readiness deadline (a native alert
-    can still appear). Escaped application keys also defer to the engine. A
+    can still appear). An application key gda cannot decode defers as well. A
     feature-tagged data-directory setting defers only the UID-cache verdict.
     """
     if scene:

--- a/src/gda/project_file.py
+++ b/src/gda/project_file.py
@@ -55,6 +55,7 @@ writes a second, duplicate line for a setting that is already there.
 """
 
 import os
+from collections.abc import Sequence
 from dataclasses import dataclass, replace
 from pathlib import Path
 
@@ -92,8 +93,9 @@ SECTIONLESS = ""
 # writes that mangled key back beside the real one. gda drops it instead, so it
 # agrees with the engine about the key the file DECLARES (`config_version`, not a
 # marked spelling of it) and never "restores" a line that is already there
-# (PR #898 review). The mark is dropped from the scanned text, so a `ConfigText`
-# of a marked file does not rebuild it — see :meth:`ConfigText.text`.
+# (PR #898 review). Dropped from the SCANNED text only: the mark is kept beside it
+# (`ConfigText.bom`) and spelled back by every writer, because the bytes of a file
+# gda edits are the file's, not gda's (#930).
 _BOM = "\ufeff"
 
 
@@ -335,35 +337,65 @@ class ConfigEntry:
     ``section`` is the section that holds it (:data:`SECTIONLESS` for a key
     written before the first header) and ``name`` the full setting name gda
     reports it by — ``section/key``, or the bare key when section-less — or
-    ``None`` when :func:`config_key` could not decode the spelling.
-    ``key_token`` is that spelling, RAW, for a caller whose own rule reads it
-    (the main-scene reader defers to the engine on any escaped key).
+    ``None`` when :func:`_config_key` could not decode the spelling. It is the ONE
+    decoding of a key in gda: a caller reads ``name`` rather than the token, and
+    ``None`` is the refusal to name a spelling this module cannot decode with
+    certainty. ``key_token`` is that spelling, RAW, for a diagnostic that must
+    quote what the file says.
 
-    ``lines`` are the raw lines the entry spans, terminator-free and in file
-    order — the span the scan recorded, which is the entry as it was WRITTEN and
-    what a restore puts back. ``value`` is the value text with comments stripped
-    and the lines of a multi-line value joined, for comparing two spellings of the
-    same assignment — never a decoded Variant (this module parses no Godot
-    values). A line the value crossed while a quoted string was open keeps its
-    newline and its spaces, because both are inside the string.
+    ``index`` is the line the entry starts on and ``lines`` the raw lines it spans,
+    terminator-free and in file order — the span the scan recorded, so
+    ``lines[index : index + len(entry.lines)]`` of the scanned text IS this entry
+    as it was WRITTEN: what a restore puts back and what an edit replaces.
+    ``value`` is the value text with comments stripped and the lines of a
+    multi-line value joined, for comparing two spellings of the same assignment —
+    never a decoded Variant (this module parses no Godot values). A line the value
+    crossed while a quoted string was open keeps its newline and its spaces,
+    because both are inside the string.
     """
 
     section: str
     name: str | None
     key_token: str
+    index: int
     lines: tuple[str, ...]
     value: str
+
+
+@dataclass(frozen=True)
+class ConfigSection:
+    """One section of a scanned text, bounded by the SCAN that found it.
+
+    ``header`` is the index of the ``[name]`` line that opens it, or ``None`` for
+    the section-less head, which no header opens. ``start`` and ``end`` bound the
+    section's body as a half-open range of line indices: from the line after its
+    header (or the file's first line) up to the line the NEXT header sits on,
+    EOF-bounded. ``entries`` are the assignments inside those bounds, in file
+    order.
+
+    The bounds come from the one scan, so a ``[looks_like_a_header]`` line inside a
+    multi-line quoted value neither opens a section nor ends this one. That is why
+    a caller that EDITS a section asks for them here instead of recognizing headers
+    line by line: its own recognizer, without the scan's quote state, put the
+    harness autoload entry inside a description string (#930).
+    """
+
+    name: str
+    header: int | None
+    start: int
+    end: int
+    entries: tuple[ConfigEntry, ...]
 
 
 @dataclass(frozen=True)
 class ConfigText:
     """A ``ConfigFile`` text as gda reads it: its lines, its layout, its entries.
 
-    ``lines`` / ``eol`` / ``trailing`` rebuild the exact input
-    (``eol.join(lines) + trailing``), so an edit stays byte-faithful to the parts
-    it did not touch — with one exception, a leading byte-order mark, which
-    :data:`_BOM` explains and which no writer here can reintroduce (the only text
-    this module writes back is the engine's own, which never carries one).
+    ``bom`` / ``lines`` / ``eol`` / ``trailing`` rebuild the exact input
+    (:meth:`spelled`), so an edit stays byte-faithful to the parts it did not
+    touch. The byte-order mark is held APART from the lines, not glued to the first
+    one: the file keeps it on the way back out, while the key on that line is named
+    without it — the two answers :data:`_BOM` explains.
     ``headers`` are the section headers the scan found, with the line each sits
     on; ``sections`` names them in FILE order (the section-less head is not one of
     them), and ``entries`` holds the assignments in file order.
@@ -379,6 +411,7 @@ class ConfigText:
     trailing: str
     headers: tuple[ConfigHeader, ...]
     entries: tuple[ConfigEntry, ...]
+    bom: str = ""
     token: tuple[int, int] | None = None
 
     @property
@@ -389,6 +422,31 @@ class ConfigText:
         found them, and one list is what says where they are.
         """
         return tuple(dict.fromkeys(header.name for header in self.headers))
+
+    def sections_named(self, name: str) -> tuple[ConfigSection, ...]:
+        """Every section written under ``name``, in file order, with its bounds.
+
+        A tuple, not one section: ``ConfigFile`` lets a name be opened more than
+        once and merges the parts, so a caller that edits ``[autoload]`` must see
+        all of them. :data:`SECTIONLESS` names the file's head, which always exists
+        (it is the file's beginning) and always answers with exactly one section.
+        """
+        opens: list[tuple[ConfigHeader | None, int]] = [(None, 0)]
+        opens += [(header, header.index + 1) for header in self.headers]
+        ends = [header.index for header in self.headers] + [len(self.lines)]
+        return tuple(
+            ConfigSection(
+                name=name,
+                header=None if header is None else header.index,
+                start=start,
+                end=end,
+                entries=tuple(
+                    entry for entry in self.entries if start <= entry.index < end
+                ),
+            )
+            for (header, start), end in zip(opens, ends)
+            if (SECTIONLESS if header is None else header.name) == name
+        )
 
     def settings(self) -> dict[str, ConfigEntry]:
         """The named entries by setting name; a repeated key keeps the LAST one.
@@ -403,9 +461,19 @@ class ConfigText:
                 named[entry.name] = entry
         return named
 
+    def spelled(self, lines: Sequence[str]) -> str:
+        """``lines`` written back with THIS file's layout: its mark, breaks and end.
+
+        The one place a line list becomes a text, so every writer here — the
+        restore below and the harness installer's ``[autoload]`` edit — leaves the
+        parts it did not touch byte-identical, a CRLF file and a marked file
+        included (#654, #930).
+        """
+        return self.bom + self.eol.join(lines) + self.trailing
+
     def text(self) -> str:
         """The text these lines spell."""
-        return self.eol.join(self.lines) + self.trailing
+        return self.spelled(self.lines)
 
 
 def read_config_text(text: str) -> ConfigText:
@@ -419,6 +487,7 @@ def read_config_text(text: str) -> ConfigText:
     all), so gda has nothing truthful to say about such a text either.
     """
     lines, eol, trailing = split_config(text.removeprefix(_BOM))
+    bom = _BOM if text.startswith(_BOM) else ""
     headers: list[ConfigHeader] = []
     entries: list[ConfigEntry] = []
     section = SECTIONLESS
@@ -453,6 +522,7 @@ def read_config_text(text: str) -> ConfigText:
                 if key is None
                 else (key if section == SECTIONLESS else f"{section}/{key}"),
                 key_token=key_token.strip(),
+                index=start,
                 lines=tuple(lines[start : index + 1]),
                 value="".join(parts),
             )
@@ -464,6 +534,7 @@ def read_config_text(text: str) -> ConfigText:
         trailing=trailing,
         headers=tuple(headers),
         entries=tuple(entries),
+        bom=bom,
     )
 
 
@@ -666,7 +737,7 @@ def _restored(after: ConfigText, dropped: list[ConfigEntry]) -> str:
         # The blank separator the engine's own writer puts between two sections.
         separator = [] if not lines or not lines[-1].strip() else [""]
         lines.extend([*separator, f"[{section}]", "", *body])
-    return after.eol.join(lines) + after.trailing
+    return after.spelled(lines)
 
 
 def _section_end(config: ConfigText, section: str) -> int | None:
@@ -676,21 +747,15 @@ def _section_end(config: ConfigText, section: str) -> int | None:
     restored entry. ``None`` says the text has no such section, and the caller
     re-opens one. The section-less head always exists (it is the file's
     beginning), so only a named section can be missing.
+
+    The bounds come from :meth:`ConfigText.sections_named`, which reads the scan's
+    recordings — the FIRST part of a section that was opened more than once, which
+    is where the engine's own writer keeps that section's keys.
     """
-    headers = config.headers
-    if section == SECTIONLESS:
-        start = 0
-        end = headers[0].index if headers else len(config.lines)
-    else:
-        found = next(
-            (at for at, header in enumerate(headers) if header.name == section), None
-        )
-        if found is None:
-            return None
-        start = headers[found].index + 1
-        end = (
-            headers[found + 1].index if found + 1 < len(headers) else len(config.lines)
-        )
+    found = config.sections_named(section)
+    if not found:
+        return None
+    start, end = found[0].start, found[0].end
     while end > start and not config.lines[end - 1].strip():
         end -= 1
     return end

--- a/src/gda/project_file.py
+++ b/src/gda/project_file.py
@@ -16,17 +16,22 @@ human or a tool wrote rather than on the engine's merged view of them:
   v->initial) continue;``), adds or rewrites ``application/config/features``, and
   writes the sections in its own (alphabetical) order.
 
-Those three grew three partial readers. This module is the one they share (#843):
-the line primitives (:func:`split_config`, :func:`config_line`,
-:func:`section_name`, …) plus the entry scan (:func:`read_config_text`) that
-turns a text into its ``section``/``key``/``value`` assignments — each carrying
-the RAW lines it spans, so a caller can put an entry back exactly as it was
-written.
+Those three grew three partial readers. This module is the one they share (#843).
+Its interface is the two readers (:func:`read_config_text`, :func:`read_config`),
+the bounded write (:func:`bound_project_write`), and what they answer with: a
+:class:`ConfigText` — the :class:`ConfigHeader` and :class:`ConfigEntry` records
+its scan made, plus the :class:`ConfigSection` bounds it computes on request — a
+:class:`ProjectWriteMutation`, and the two errors. The line primitives below it
+are PRIVATE (#930): a caller that reduces lines itself keeps no state between
+them, which is how a second recognizer of the boundaries came back (see below).
 
 It is a READER of the format, not a parser of Godot values: an entry's ``value``
 is the literal text, never a decoded Variant. Decoding is the engine's job and
 gda has no business re-implementing ``VariantParser``; every consumer here either
-compares value TEXT or hands the line back verbatim.
+compares value TEXT or hands the line back verbatim. The one exception is a KEY,
+which the format itself spells (``String::property_name_encode``) and which this
+module therefore decodes — once, into :attr:`ConfigEntry.name`, so no caller has a
+second rule for it.
 
 **One lexical scan owns every boundary.** ``ConfigFile`` values may span lines: an
 ``input/<action>`` entry is a ``Dictionary`` the engine writes across several, and
@@ -36,13 +41,15 @@ bracket state from one line to the next, so a value continues while a string is
 open or a bracket is unclosed, and a ``[looks_like_a_header]`` line INSIDE a
 quoted value is not a section. :func:`read_config_text` records what that one scan
 found — every section header's line index (:class:`ConfigHeader`) and every
-entry's lines — and the restore below consumes those recordings rather than
-rescanning the raw text. A SECOND recognizer without the same state is the defect
-this replaces: a ``[debug]`` inside a description made the restore write a dropped
-line into the wrong section, and a successful ``project set`` then read back its
-OLD value (PR #898 review, round 3).
+entry's lines — and both writers built on it, the restore below and the harness
+installer's ``[autoload]`` edit, consume those recordings rather than rescanning
+the raw text. A SECOND recognizer without the same state is the defect this
+replaces, twice over: a ``[debug]`` inside a description made the restore write a
+dropped line into the wrong section, and a successful ``project set`` then read
+back its OLD value (PR #898 review, round 3); the installer kept such a recognizer
+of its own and wrote the harness autoload entry INTO a description string (#930).
 
-**Key spellings.** :func:`config_key` mirrors the engine on both forms a key can
+**Key spellings.** :func:`_config_key` mirrors the engine on both forms a key can
 take. Quoted (``String::property_name_encode``), it is decoded exactly as
 ``VariantParser``'s string tokenizer decodes it — ``\\uXXXX`` four hex digits,
 ``\\UXXXXXX`` SIX, every other escape standing for the character it precedes.
@@ -99,7 +106,7 @@ SECTIONLESS = ""
 _BOM = "\ufeff"
 
 
-def line_ending(text: str) -> str:
+def _line_ending(text: str) -> str:
     """The terminator the text's FIRST line uses (``\\r\\n`` or ``\\n``).
 
     Rejoining with it keeps a CRLF ``project.godot`` CRLF (#654). A file with
@@ -112,9 +119,9 @@ def line_ending(text: str) -> str:
     return "\n"
 
 
-def split_config(text: str) -> tuple[list[str], str, str]:
+def _split_config(text: str) -> tuple[list[str], str, str]:
     """A config text as (terminator-free lines, line ending, trailing terminator)."""
-    eol = line_ending(text)
+    eol = _line_ending(text)
     return text.splitlines(), eol, eol if text.endswith(("\n", "\r")) else ""
 
 
@@ -185,53 +192,40 @@ def _scan_line(line: str, state: _Scan) -> _Lexed:
     return _Lexed(line, _Scan(quoted, False, depth), assign)
 
 
-def strip_comment(line: str) -> str:
+def _strip_comment(line: str) -> str:
     """``line`` up to a ``;`` comment outside double quotes (Godot's comment char)."""
     return _scan_line(line, _Scan()).content
 
 
-def config_line(raw: str) -> str:
+def _config_line(raw: str) -> str:
     """A RAW config line reduced to what Godot's parser reads on it.
 
-    The comment gone and the surrounding whitespace trimmed. This is the one
-    reduction every recognizer applies — here and in the harness installer, which
-    consumes it per line — so a header written ``[autoload] ; note`` is the
-    autoload section to all of them. Two reducers, one of which skipped the
-    comment, is how an install appended a SECOND ``[autoload]`` section next to a
-    commented one (PR #898 review, round 3).
+    The comment gone and the surrounding whitespace trimmed. The one reduction
+    every recognizer in this module applies, so a header written
+    ``[autoload] ; note`` is the autoload section to all of them. Two reducers, one
+    of which skipped the comment, is how an install appended a SECOND
+    ``[autoload]`` section next to a commented one (PR #898 review, round 3) — and
+    the reduction is private now, because a caller that applies it per line has no
+    state to carry between them (#930).
     """
-    return strip_comment(raw).strip()
+    return _strip_comment(raw).strip()
 
 
-def is_section_header(line: str) -> bool:
+def _is_section_header(line: str) -> bool:
     """Whether a config line is an INI section header (``[name]``)."""
-    reduced = config_line(line)
+    reduced = _config_line(line)
     return reduced.startswith("[") and reduced.endswith("]")
 
 
-def section_name(line: str) -> str | None:
+def _section_name(line: str) -> str | None:
     """The section a ``[name]`` line opens, or ``None`` for any other line."""
-    reduced = config_line(line)
-    if is_section_header(reduced):
+    reduced = _config_line(line)
+    if _is_section_header(reduced):
         return reduced[1:-1].strip()
     return None
 
 
-def section_of(line: str, current: str) -> str:
-    """The active section after a config line, or ``current`` if unchanged."""
-    opened = section_name(line)
-    return current if opened is None else opened
-
-
-def unquote(token: str) -> str:
-    """Strip surrounding quotes; this is not a ``ConfigFile`` escape decoder."""
-    token = token.strip()
-    if len(token) >= 2 and token[0] == '"' and token[-1] == '"':
-        return token[1:-1].replace('\\"', '"')
-    return token
-
-
-def config_key(token: str) -> str | None:
+def _config_key(token: str) -> str | None:
     """The key ``token`` names, or ``None`` when gda cannot decode it.
 
     ``String::property_name_encode`` quotes and escapes a key holding ``=``,
@@ -338,10 +332,10 @@ class ConfigEntry:
     written before the first header) and ``name`` the full setting name gda
     reports it by — ``section/key``, or the bare key when section-less — or
     ``None`` when :func:`_config_key` could not decode the spelling. It is the ONE
-    decoding of a key in gda: a caller reads ``name`` rather than the token, and
-    ``None`` is the refusal to name a spelling this module cannot decode with
-    certainty. ``key_token`` is that spelling, RAW, for a diagnostic that must
-    quote what the file says.
+    decoding of a key in gda — a caller reads ``name``, never the spelling on the
+    line — and ``None`` is the refusal to name a key this module cannot decode with
+    certainty, which a caller reads as "ask the engine" (#930). The raw spelling is
+    in ``lines`` for anything that must quote what the file says.
 
     ``index`` is the line the entry starts on and ``lines`` the raw lines it spans,
     terminator-free and in file order — the span the scan recorded, so
@@ -356,7 +350,6 @@ class ConfigEntry:
 
     section: str
     name: str | None
-    key_token: str
     index: int
     lines: tuple[str, ...]
     value: str
@@ -486,7 +479,7 @@ def read_config_text(text: str) -> ConfigText:
     its entry — which is what the engine does too (it refuses to load the file at
     all), so gda has nothing truthful to say about such a text either.
     """
-    lines, eol, trailing = split_config(text.removeprefix(_BOM))
+    lines, eol, trailing = _split_config(text.removeprefix(_BOM))
     bom = _BOM if text.startswith(_BOM) else ""
     headers: list[ConfigHeader] = []
     entries: list[ConfigEntry] = []
@@ -494,7 +487,7 @@ def read_config_text(text: str) -> ConfigText:
     index = 0
     while index < len(lines):
         lexed = _scan_line(lines[index], _Scan())
-        opened = section_name(lexed.content)
+        opened = _section_name(lexed.content)
         if opened is not None:
             section = opened
             headers.append(ConfigHeader(index=index, name=opened))
@@ -514,14 +507,13 @@ def read_config_text(text: str) -> ConfigText:
             continued = _scan_line(lines[index], state)
             state = continued.state
             parts.append(_continuation(continued.content, inside, state.quoted))
-        key = config_key(key_token)
+        key = _config_key(key_token)
         entries.append(
             ConfigEntry(
                 section=section,
                 name=None
                 if key is None
                 else (key if section == SECTIONLESS else f"{section}/{key}"),
-                key_token=key_token.strip(),
                 index=start,
                 lines=tuple(lines[start : index + 1]),
                 value="".join(parts),

--- a/src/gda/project_file.py
+++ b/src/gda/project_file.py
@@ -430,7 +430,9 @@ class ConfigText:
         A tuple, not one section: ``ConfigFile`` lets a name be opened more than
         once and merges the parts, so a caller that edits ``[autoload]`` must see
         all of them. :data:`SECTIONLESS` names the file's head, which always exists
-        (it is the file's beginning) and always answers with exactly one section.
+        (it is the file's beginning); a literal ``[]`` header reopens it, so even
+        that answer can have two parts — as it has for the engine, which merges
+        them into the same section-less keys.
         """
         opens: list[tuple[ConfigHeader | None, int]] = [(None, 0)]
         opens += [(header, header.index + 1) for header in self.headers]

--- a/src/gda/project_file.py
+++ b/src/gda/project_file.py
@@ -103,6 +103,13 @@ SECTIONLESS = ""
 # (PR #898 review). Dropped from the SCANNED text only: the mark is kept beside it
 # (`ConfigText.bom`) and spelled back by every writer, because the bytes of a file
 # gda edits are the file's, not gda's (#930).
+#
+# The drop decides more than a key: on line 0 it decides a SECTION. `﻿[autoload]`
+# is a header to this scan and is NOT one to the engine, which reads the marked
+# line as a single section-less key. gda reads the file the engine's own reader
+# CANNOT (such a file declares no readable `config_version` either, so the engine
+# loads no project from it), and the harness installer scopes that shape out
+# rather than model it — see `gda.harness.install` (#930 review, round 1).
 _BOM = "\ufeff"
 
 
@@ -360,7 +367,9 @@ class ConfigSection:
     """One section of a scanned text, bounded by the SCAN that found it.
 
     ``header`` is the index of the ``[name]`` line that opens it, or ``None`` for
-    the section-less head, which no header opens. ``start`` and ``end`` bound the
+    the section-less head, which no header opens. The NAME is not repeated here:
+    a section is asked for by name (:meth:`ConfigText.sections_named`), so the
+    answer only has to say where it is. ``start`` and ``end`` bound the
     section's body as a half-open range of line indices: from the line after its
     header (or the file's first line) up to the line the NEXT header sits on,
     EOF-bounded. ``entries`` are the assignments inside those bounds, in file
@@ -373,7 +382,6 @@ class ConfigSection:
     harness autoload entry inside a description string (#930).
     """
 
-    name: str
     header: int | None
     start: int
     end: int
@@ -429,7 +437,6 @@ class ConfigText:
         ends = [header.index for header in self.headers] + [len(self.lines)]
         return tuple(
             ConfigSection(
-                name=name,
                 header=None if header is None else header.index,
                 start=start,
                 end=end,

--- a/tests/harness/test_harness_install.py
+++ b/tests/harness/test_harness_install.py
@@ -556,6 +556,123 @@ def test_harness_artifacts_names_the_script_and_its_uid_sidecar(tmp_path):
     )
 
 
+# --- One scan owns every section boundary (#930) ------------------------------
+# The edit recognized sections line by line, restarting the scan on every line, so
+# a header-shaped line INSIDE a multi-line quoted value opened a section the file
+# does not have: the install wrote its entry into the string and the uninstall
+# deleted a line out of it. The edit now runs on the spans the shared reader's one
+# scan recorded, which carry the quote state from one line to the next.
+
+
+def _documented_harness_project() -> str:
+    """A project whose ``[application]`` description QUOTES the autoload declaration.
+
+    Godot writes a multi-line string back with its newlines literal
+    (``String::c_escape_multiline`` escapes only ``\\`` and ``"``), so the middle
+    lines of this value are spelled exactly like a section header and like the entry
+    gda writes — inside a string its parser reads as three lines of text.
+    """
+    quoted = _autoload_line().replace('"', '\\"')
+    return (
+        "config_version=5\n\n[application]\n\n"
+        f'config/description="how to install:\n[autoload]\n{quoted}\n'
+        'is what gda writes"\n'
+        'config/name="t"\n'
+        '\n[autoload]\n\nOther="*res://other.gd"\n'
+    )
+
+
+def test_install_writes_into_the_real_autoload_section_not_a_quoted_one(tmp_path):
+    project_godot = tmp_path / "project.godot"
+    before = _documented_harness_project()
+    project_godot.write_text(before, encoding="utf-8")
+
+    result = install_harness(tmp_path)
+
+    assert result.changed is True
+    assert result.created_sections == ()  # the file already has an [autoload]
+    text = project_godot.read_text(encoding="utf-8")
+    # The entry goes under the file's own header, beside the sibling autoload, and
+    # the description keeps its bytes — its escaped quotes included.
+    assert text == before.replace(
+        '[autoload]\n\nOther="*res://other.gd"\n',
+        f'[autoload]\n{_autoload_line()}\n\nOther="*res://other.gd"\n',
+    )
+    assert text.count("[autoload]") == 2  # the quoted line and the real header
+
+
+def test_uninstall_takes_only_the_real_entry_out_of_a_documented_project(tmp_path):
+    project_godot = tmp_path / "project.godot"
+    before = _documented_harness_project()
+    project_godot.write_text(before, encoding="utf-8")
+    install_harness(tmp_path)
+
+    result = uninstall_harness(tmp_path)
+
+    assert result.removed is True
+    assert project_godot.read_bytes() == before.encode("utf-8")  # byte-identical
+    assert result.removed_sections == ()  # the sibling autoload holds the section
+
+
+def test_a_commented_autoload_header_is_the_autoload_section(tmp_path):
+    # Godot's parser reads past a trailing comment, so `[autoload] ; note` IS the
+    # autoload section: the install joins it instead of appending a second one, and
+    # the uninstall takes its entry out again. Pinned here, at the installer whose
+    # behaviour it is (it used to be pinned only on the reader's line reduction).
+    project_godot = tmp_path / "project.godot"
+    before = _NO_AUTOLOAD + '\n[autoload] ; the autoloads\n\nOther="*res://other.gd"\n'
+    project_godot.write_text(before, encoding="utf-8")
+
+    install_harness(tmp_path)
+
+    text = project_godot.read_text(encoding="utf-8")
+    assert text.count("[autoload]") == 1  # joined, never a second section
+    assert text == before.replace(
+        "[autoload] ; the autoloads\n",
+        f"[autoload] ; the autoloads\n{_autoload_line()}\n",
+    )
+
+    uninstall_harness(tmp_path)
+
+    assert project_godot.read_bytes() == before.encode("utf-8")
+
+
+def test_an_emptied_commented_autoload_header_is_not_gda_s_to_drop(tmp_path):
+    # The deliberate asymmetry of `_emptied_autoload_span`: the section is JOINED by
+    # name (the comment is not part of it), but only a header gda itself writes — a
+    # bare `[autoload]` — is dropped again. Removing this one would delete a line,
+    # and a comment, gda never wrote.
+    project_godot = tmp_path / "project.godot"
+    before = _NO_AUTOLOAD + f'\n[autoload] ; mine\n\nGdaHarness="*{HARNESS_RES_PATH}"\n'
+    project_godot.write_text(before, encoding="utf-8")
+
+    result = uninstall_harness(tmp_path)
+
+    text = project_godot.read_text(encoding="utf-8")
+    assert _autoload_line() not in text  # the entry went
+    assert "[autoload] ; mine" in text  # the header stayed, comment and all
+    assert result.removed_sections == ()
+
+
+def test_a_round_trip_keeps_a_leading_byte_order_mark(tmp_path):
+    # The reader drops a leading BOM from the keys it NAMES (the engine glues it to
+    # the first key), but the bytes stay the file's: an edit spells the text back
+    # with the mark it came with, so the round trip is byte-identical here too.
+    project_godot = tmp_path / "project.godot"
+    before = ("﻿" + _NO_AUTOLOAD).encode("utf-8")
+    project_godot.write_bytes(before)
+
+    install_harness(tmp_path)
+
+    installed = project_godot.read_bytes()
+    assert installed.startswith("﻿".encode("utf-8"))
+    assert _autoload_line().encode("utf-8") in installed
+
+    uninstall_harness(tmp_path)
+
+    assert project_godot.read_bytes() == before
+
+
 # --- Snapshot-exact restoration of a failed install (#680 rechecks) -----------
 # A `daemon start` installs the harness BEFORE the daemon exists, so a start that
 # never comes ready must hand the project back untouched. The restore is the

--- a/tests/harness/test_harness_install.py
+++ b/tests/harness/test_harness_install.py
@@ -654,6 +654,39 @@ def test_an_emptied_commented_autoload_header_is_not_gda_s_to_drop(tmp_path):
     assert result.removed_sections == ()
 
 
+def test_an_entry_written_across_lines_is_re_pointed_and_removed_whole(tmp_path):
+    # A `ConfigFile` value may hold a literal newline, so the entry the edit acts on
+    # is the SPAN the scan recorded, not the line it starts on. Taking one line of
+    # it leaves the continuation behind — a stray `continued"` line the engine then
+    # reads as a declaration of its own.
+    project_godot = tmp_path / "project.godot"
+    across_lines = (
+        _NO_AUTOLOAD + '\n[autoload]\n\nGdaHarness="*res://legacy/old.gd\ncontinued"\n'
+    )
+    project_godot.write_text(across_lines, encoding="utf-8")
+
+    assert install_harness(tmp_path).changed is True
+
+    # Re-pointed: the whole span becomes the one line gda writes.
+    assert (
+        project_godot.read_text(encoding="utf-8")
+        == _NO_AUTOLOAD + f"\n[autoload]\n\n{_autoload_line()}\n"
+    )
+
+    uninstall_harness(tmp_path)
+
+    assert project_godot.read_text(encoding="utf-8") == _NO_AUTOLOAD
+
+    # And an uninstall that meets the multi-line entry itself takes all of its
+    # lines — which is what leaves the section key-less, so the header goes too.
+    project_godot.write_text(across_lines, encoding="utf-8")
+
+    result = uninstall_harness(tmp_path)
+
+    assert project_godot.read_text(encoding="utf-8") == _NO_AUTOLOAD
+    assert result.removed_sections == ("[autoload]",)
+
+
 def test_a_round_trip_keeps_a_leading_byte_order_mark(tmp_path):
     # The reader drops a leading BOM from the keys it NAMES (the engine glues it to
     # the first key), but the bytes stay the file's: an edit spells the text back

--- a/tests/harness/test_harness_install.py
+++ b/tests/harness/test_harness_install.py
@@ -657,8 +657,9 @@ def test_an_emptied_commented_autoload_header_is_not_gda_s_to_drop(tmp_path):
 def test_an_entry_written_across_lines_is_re_pointed_and_removed_whole(tmp_path):
     # A `ConfigFile` value may hold a literal newline, so the entry the edit acts on
     # is the SPAN the scan recorded, not the line it starts on. Taking one line of
-    # it leaves the continuation behind — a stray `continued"` line the engine then
-    # reads as a declaration of its own.
+    # it leaves the continuation behind, and the engine then refuses the WHOLE file:
+    # `ConfigFile.load` returns ERR_PARSE_ERROR ("Unterminated string", verified on
+    # 4.6.3), so the project stops loading over a line gda left in it.
     project_godot = tmp_path / "project.godot"
     across_lines = (
         _NO_AUTOLOAD + '\n[autoload]\n\nGdaHarness="*res://legacy/old.gd\ncontinued"\n'
@@ -683,6 +684,40 @@ def test_an_entry_written_across_lines_is_re_pointed_and_removed_whole(tmp_path)
 
     result = uninstall_harness(tmp_path)
 
+    assert project_godot.read_text(encoding="utf-8") == _NO_AUTOLOAD
+    assert result.removed_sections == ("[autoload]",)
+
+
+def test_install_re_points_the_entry_the_engine_reads_last(tmp_path):
+    # `ConfigFile` lets the LAST declaration of a key win, and the two spellings
+    # here are one key to it (verified on 4.6.3: `get_section_keys` reports a single
+    # `GdaHarness` and `get_value` returns the bare line's `*res://old.gd`). Gda has
+    # to decide on that last entry: stopping at the canonical FIRST one reported
+    # nothing to do while the engine went on loading `res://old.gd`, so the harness
+    # never registered and `daemon start` waited out its readiness deadline
+    # (PR #938 review, round 2).
+    project_godot = tmp_path / "project.godot"
+    before = (
+        _NO_AUTOLOAD + f'\n[autoload]\n\n"GdaHarness"="*{HARNESS_RES_PATH}"\n'
+        'GdaHarness="*res://old.gd"\n'
+    )
+    project_godot.write_text(before, encoding="utf-8")
+
+    result = install_harness(tmp_path)
+
+    assert result.changed is True
+    text = project_godot.read_text(encoding="utf-8")
+    # The last declaration is re-pointed; the earlier spelling stays as written
+    # (the engine ignores it, and gda rewrites no line it does not have to).
+    assert text == before.replace(
+        'GdaHarness="*res://old.gd"\n', f"{_autoload_line()}\n"
+    )
+    assert install_harness(tmp_path).changed is False  # and the repeat is a no-op
+
+    result = uninstall_harness(tmp_path)
+
+    # Both spellings go: the removal takes every harness entry it finds, so the
+    # section is key-less and the header gda wrote goes with it.
     assert project_godot.read_text(encoding="utf-8") == _NO_AUTOLOAD
     assert result.removed_sections == ("[autoload]",)
 

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -865,13 +865,46 @@ def test_a_feature_data_directory_defers_only_the_uid_verdict(
     assert verdict is not None and verdict.code == MAIN_SCENE_UNDEFINED
 
 
-def test_an_escaped_application_key_is_not_an_absent_main_scene(tmp_path):
+def test_an_escaped_application_key_is_read_as_the_setting_it_spells(tmp_path):
+    # `property_name_encode` may write any setting name escaped, and the shared
+    # reader decodes it the way the engine's parser does. The lookup reads that ONE
+    # decoding (the entry's name), so an escaped spelling is not itself a reason to
+    # defer: it declares the main scene here, and declares it EMPTY below.
+    from gda.project import MAIN_SCENE_UNDEFINED, main_scene_unrunnable
+
+    declared = _project_with(
+        tmp_path, "[application]\n" + r'"run/\u006dain_scene"="res://main.tscn"' + "\n"
+    )
+    assert main_scene_unrunnable(declared, None) is None
+
+    empty = _project_with(
+        tmp_path, "[application]\n" + r'"run/\u006dain_scene"=""' + "\n"
+    )
+    verdict = main_scene_unrunnable(empty, None)
+    assert verdict is not None and verdict.code == MAIN_SCENE_UNDEFINED
+
+
+def test_an_application_key_gda_cannot_decode_defers_to_the_engine(tmp_path):
+    # A spelling the engine's own tokenizer refuses the FILE for (a truncated hex
+    # escape): gda gives up on the whole file rather than mistake a declaration it
+    # cannot decode for an absent setting, so the verdict defers instead of
+    # refusing a launch the engine may well make.
     from gda.project import main_scene_unrunnable
 
     project = _project_with(
-        tmp_path, "[application]\n" + r'"run/\u006dain_scene"="res://main.tscn"' + "\n"
+        tmp_path, "[application]\n" + r'"run/\u00"="res://main.tscn"' + "\n"
     )
     assert main_scene_unrunnable(project, None) is None
+
+
+def test_the_main_scene_value_reader_takes_only_a_quoted_literal_apart():
+    # `gda.project_file` reads the FORMAT and leaves a Godot value as the text the
+    # file spells, so the quote stripping this verdict needs lives with the verdict
+    # — the one place in gda that reads a value literal (#930).
+    from gda.project import _unquoted_literal
+
+    assert _unquoted_literal('"res://main.tscn"') == "res://main.tscn"
+    assert _unquoted_literal("false") == "false"
 
 
 def test_an_unreadable_project_file_is_no_verdict(tmp_path):

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -883,6 +883,15 @@ def test_an_escaped_application_key_is_read_as_the_setting_it_spells(tmp_path):
     verdict = main_scene_unrunnable(empty, None)
     assert verdict is not None and verdict.code == MAIN_SCENE_UNDEFINED
 
+    # A BARE key with inner whitespace is the same key to the engine, which
+    # accumulates only characters above code 32 into it (verified on 4.6.3:
+    # `get_section_keys` reports `run/main_scene` and the value loads). Reading it
+    # as a different key refused a project the engine runs perfectly well.
+    spaced = _project_with(
+        tmp_path, '[application]\nrun/main _scene="res://main.tscn"\n'
+    )
+    assert main_scene_unrunnable(spaced, None) is None
+
 
 def test_an_application_key_gda_cannot_decode_defers_to_the_engine(tmp_path):
     # A spelling the engine's own tokenizer refuses the FILE for (a truncated hex

--- a/tests/project/test_project_file.py
+++ b/tests/project/test_project_file.py
@@ -5,6 +5,10 @@ precondition, the harness installer's ``[autoload]`` edit, and the bounded proje
 write. These tests pin the format rules it owns: comments, sections, section-less
 keys, multi-line values, escaped key spellings, and the byte-faithful round trip an
 edit relies on.
+
+They exercise it through the interface its callers have — the readers, the bounded
+write and what they answer with. The line primitives are private (#930), so a rule
+they used to be asked about directly is asked of the text it applies to.
 """
 
 import pytest
@@ -16,13 +20,8 @@ from gda.project_file import (
     ProjectFileRestoreError,
     ProjectWriteMutation,
     bound_project_write,
-    config_key,
-    config_line,
     read_config,
     read_config_text,
-    section_name,
-    strip_comment,
-    unquote,
 )
 
 
@@ -49,66 +48,73 @@ file_logging/enable_file_logging=false
 """
 
 
-def test_strip_comment_cuts_at_an_unquoted_semicolon_only():
-    assert strip_comment('a="x" ; note').strip() == 'a="x"'
-    assert strip_comment('a="x ; y"') == 'a="x ; y"'
+def test_a_comment_ends_a_line_only_outside_quotes():
+    config = read_config_text('a="x" ; note\nb="x ; y"\n')
+
+    settings = config.settings()
+    assert settings["a"].value == '"x"'  # the comment is not part of the value
+    assert settings["b"].value == '"x ; y"'  # a quoted `;` is not a comment
 
 
-def test_section_name_reads_a_header_and_nothing_else():
-    assert section_name("[application]") == "application"
-    assert section_name("config/name=1") is None
+def test_a_header_line_opens_a_section_and_an_assignment_does_not():
+    config = read_config_text("[application]\nconfig/name=1\n")
+
+    assert [(header.index, header.name) for header in config.headers] == [
+        (0, "application")
+    ]
+    assert [entry.name for entry in config.entries] == ["application/config/name"]
 
 
-def test_config_key_decodes_the_engine_encoded_spelling():
+def test_an_entry_is_named_by_the_key_the_engine_reads():
     # property_name_encode() quotes and escapes a key holding '=' or non-ASCII, so
-    # the two spellings of one key have to compare equal.
-    assert config_key("config/name") == "config/name"
-    assert config_key('"run/\\u006dain_scene"') == "run/main_scene"
-    assert config_key('"a=b"') == "a=b"
-    # VariantParser::get_token reads SIX hex digits after \U and four after \u, and
-    # gives every other escape the character it precedes (`default: res = next`) —
-    # there is no \a or \v in that switch. Demanding eight digits made this exact
-    # declaration unnameable, so the save dropped it and gda reported nothing
-    # (PR #898 review, round 3).
-    assert (
-        config_key('"\\U000066ile_logging/enable_file_logging"')
-        == "file_logging/enable_file_logging"
+    # the two spellings of one key have to compare equal. VariantParser::get_token
+    # reads SIX hex digits after \U and four after \u, and gives every other escape
+    # the character it precedes (`default: res = next`) — there is no \a or \v in
+    # that switch. Demanding eight digits made a valid declaration unnameable, so
+    # the save dropped it and gda reported nothing (PR #898 review, round 3).
+    config = read_config_text(
+        "config/name=1\n"
+        '"run/\\u006dain_scene"=1\n'
+        '"a=b"=1\n'
+        '"\\U000066ile_logging/enable_file_logging"=1\n'
+        '"a\\q"=1\n'
+        '"\\a\\v"=1\n'
+        '"\\ud83d\\ude00"=1\n'  # a UTF-16 pair, combined as the tokenizer combines it
     )
-    assert config_key('"a\\q"') == "aq"
-    assert config_key('"\\a\\v"') == "av"
-    # A UTF-16 pair is combined the way the tokenizer combines it.
-    assert config_key('"\\ud83d\\ude00"') == "\U0001f600"
+
+    assert [entry.name for entry in config.entries] == [
+        "config/name",
+        "run/main_scene",
+        "a=b",
+        "file_logging/enable_file_logging",
+        "aq",
+        "av",
+        "\U0001f600",
+    ]
 
 
-def test_config_key_drops_what_a_bare_key_cannot_hold():
+def test_a_bare_key_drops_what_a_bare_key_cannot_hold():
     # parse_tag_assign_eof accumulates ONLY characters of code > 32 into a bare
     # key, so `foo bar` IS `foobar` to the engine. Keeping the space made gda read
     # one declaration as a second setting, and the restore then re-declared the
     # old value under the name a `project set` had just written (PR #898 review,
     # round 3).
-    assert config_key("foo bar") == "foobar"
-    assert config_key("debug/foo\tbar baz") == "debug/foobarbaz"
-    assert config_key("config/name") == "config/name"
+    config = read_config_text("foo bar=1\ndebug/foo\tbar baz=1\n")
+
+    assert [entry.name for entry in config.entries] == ["foobar", "debug/foobarbaz"]
 
 
-def test_config_key_refuses_a_spelling_it_cannot_decode():
-    # A key gda cannot name is excluded from every comparison rather than guessed
-    # at — a key wrongly read as two keys is how a restore writes a duplicate line.
-    # These are the spellings the engine's own tokenizer refuses the FILE for.
-    assert config_key('"\\u00"') is None  # truncated hex sequence
-    assert config_key('"\\uzzzz"') is None  # not hex at all
-    assert config_key('"\\ud800"') is None  # unpaired lead surrogate
-    assert config_key('"\\udc00"') is None  # unpaired trail surrogate
-    assert config_key("a\\b") is None  # a backslash in a bare key
+def test_a_commented_header_is_a_section_and_a_quoted_semicolon_is_not_a_comment():
+    # The reduction every boundary is decided on: the comment goes and the
+    # surrounding whitespace with it, so a header written `[autoload] ; note` IS
+    # the autoload section — a second reducer that skipped the comment made the
+    # harness installer miss one (PR #898 review, round 3).
+    config = read_config_text('  [autoload] ; note  \na="x ; y" \n')
 
-
-def test_config_line_reduces_a_raw_line_to_what_the_parser_reads():
-    # The ONE reduction every recognizer applies. A second one that skipped the
-    # comment made the harness installer miss a commented header (PR #898 review,
-    # round 3).
-    assert config_line("  [autoload] ; note  ") == "[autoload]"
-    assert section_name("[autoload] ; note") == "autoload"
-    assert config_line('a="x ; y" ') == 'a="x ; y"'
+    assert [(header.index, header.name) for header in config.headers] == [
+        (0, "autoload")
+    ]
+    assert config.settings()["autoload/a"].value == '"x ; y"'
 
 
 def test_entries_carry_section_name_and_raw_lines():
@@ -208,8 +214,56 @@ def test_an_entry_after_a_multi_line_string_is_read_in_its_real_section():
 
 
 def test_text_round_trips_the_input_byte_for_byte():
-    for text in (PROJECT, PROJECT.replace("\n", "\r\n"), "a=1", ""):
+    # The byte-order mark included: the engine glues it to the first key, so the
+    # scan keeps it out of the KEYS it names — but the bytes are the file's, and
+    # every writer built on this spells them back (#930).
+    for text in (PROJECT, PROJECT.replace("\n", "\r\n"), "﻿" + PROJECT, "a=1", ""):
         assert read_config_text(text).text() == text
+
+
+def test_an_entry_knows_the_line_it_starts_on():
+    # The span an edit replaces or removes: `lines[index : index + len(lines)]` of
+    # the scanned text IS the entry as it was written, multi-line values included.
+    config = read_config_text(MULTILINE)
+
+    for entry in config.entries:
+        span = config.lines[entry.index : entry.index + len(entry.lines)]
+        assert span == entry.lines
+    assert config.settings()["application/config/description"].index == 4
+
+
+def test_sections_named_bounds_every_part_the_scan_found():
+    # A name can be opened more than once, and a caller that edits the section has
+    # to see all of them — the harness installer's `[autoload]` edit does.
+    config = read_config_text(
+        'config_version=5\n\n[autoload]\n\nOne="*res://one.gd"\n'
+        "\n[application]\n\n"
+        'config/description="line one\n[autoload]\nline three"\n'
+        '\n[autoload]\n\nTwo="*res://two.gd"\n'
+    )
+
+    autoloads = config.sections_named("autoload")
+
+    assert [(section.header, section.start, section.end) for section in autoloads] == [
+        (2, 3, 6),
+        (12, 13, 15),
+    ]
+    # The `[autoload]` spelled inside the description opens nothing, so the
+    # section it appears to start is not one of these — and the entries are the
+    # scan's, each under the header that really holds it.
+    assert [[entry.name for entry in section.entries] for section in autoloads] == [
+        ["autoload/One"],
+        ["autoload/Two"],
+    ]
+
+
+def test_the_section_less_head_is_always_one_section():
+    # It is the file's beginning, so it exists even when nothing is written there.
+    for text, end in ((PROJECT, 3), ("[application]\n", 0), ("a=1\n", 1)):
+        head = read_config_text(text).sections_named(SECTIONLESS)
+        assert len(head) == 1
+        assert (head[0].header, head[0].start, head[0].end) == (None, 0, end)
+    assert read_config_text(PROJECT).sections_named("nowhere") == ()
 
 
 def test_settings_keeps_the_last_assignment_of_a_repeated_key():
@@ -221,15 +275,24 @@ def test_settings_keeps_the_last_assignment_of_a_repeated_key():
 
 
 def test_an_undecodable_key_is_scanned_but_never_named():
-    config = read_config_text('[application]\n\n"a\\u00"=1\nconfig/name="x"\n')
+    # A key gda cannot name is excluded from every comparison rather than guessed
+    # at — a key wrongly read as two keys is how a restore writes a duplicate line.
+    # These are the spellings the engine's own tokenizer refuses the FILE for.
+    config = read_config_text(
+        "[application]\n\n"
+        '"a\\u00"=1\n'  # truncated hex sequence
+        '"a\\uzzzz"=1\n'  # not hex at all
+        '"a\\ud800"=1\n'  # unpaired lead surrogate
+        '"a\\udc00"=1\n'  # unpaired trail surrogate
+        "a\\b=1\n"  # a backslash in a bare key
+        'config/name="x"\n'
+    )
 
-    assert [entry.name for entry in config.entries] == [None, "application/config/name"]
+    assert [entry.name for entry in config.entries] == [
+        *[None] * 5,
+        "application/config/name",
+    ]
     assert set(config.settings()) == {"application/config/name"}
-
-
-def test_unquote_strips_a_quoted_literal():
-    assert unquote('"res://main.tscn"') == "res://main.tscn"
-    assert unquote("false") == "false"
 
 
 def test_read_config_reports_a_file_it_cannot_read_as_none(tmp_path):


### PR DESCRIPTION
## Summary

`gda.project_file` now owns every `project.godot` section boundary, for the harness
installer too, and one decoder names every key.

The installer recognized `[autoload]` line by line with the reader's per-line reduction,
which restarts the scan on every line. That second recognizer carried none of the scan's
quote state, so a header-shaped line inside a multi-line quoted value opened a section the
file does not have. Reproduced on the dev head with an `[application]` description that
quotes the autoload declaration: the install re-pointed the line INSIDE the string (and
added no real entry), and the uninstall then deleted that line out of the value.

Both installer loops now run on what the reader's one scan recorded:

- `ConfigText.sections_named(name)` returns every part of a section with its bounds
  (`header`, `start`, `end`) and the entries inside them - the one section-scoped
  accessor the edit needed, which `_section_end` (the bounded write's restore) now reads
  as well;
- `ConfigEntry` carries the line it starts on, so an entry is re-pointed or removed by the
  SPAN it was written on, multi-line values included - and where a key is declared more
  than once, the install decides on the LAST declaration, which is the one `ConfigFile`
  loads;
- `ConfigText.spelled(lines)` is the one place a line list becomes this file's text - its
  terminator, its final break and its leading byte-order mark. Without it a rebuild from
  the scanned lines would have dropped the mark, so the installer's byte-identity
  guarantee is kept by construction and now pinned.

One key decoder: `gda.project`'s main-scene lookup decoded the raw key token itself and
re-implemented the refusal of a key it could not read. It now addresses each entry by
`ConfigEntry.name`, and only a key the reader could not name defers to the engine.
`ConfigEntry.key_token` existed for that second decoding and has no reader left, so it is
gone. The quote stripper moves to that lookup as `_unquoted_literal`, the one place in gda
that reads a Godot VALUE literal - `project_file` reads the format and leaves a value as
the text the file spells.

Interface trim: the line primitives become private, so the reader is used through the two
readers, the bounded write, and what they answer with.

## Public behavior

No command-surface change: no schema change, no help change, no result-model change, no
harness change. Inside the installer and the main-scene precondition, seven differences,
all of them consequences of the two rules above. Six are improvements; one shape (6) is
disclosed rather than fixed. Every engine claim below was checked with `ConfigFile.load`
on Godot 4.6.3.

1. **Fixed.** A header-shaped line inside a multi-line quoted value is no longer a section
   to the installer: the entry goes into the file's real `[autoload]`, and the string keeps
   its bytes. (The reproduced defect.)
2. **Narrowed to the engine's own reading.** A GdaHarness entry is matched by the reader's
   DECODED key, so ANY spelling the reader decodes to that key is the same entry to gda
   that it is to the engine - a quoted `"GdaHarness"`, a bare key with internal whitespace
   (`Gda Harness=`, `Gda\tHarness=`, which `parse_tag_assign_eof` reads as `GdaHarness`),
   or an escaped `\uXXXX` form. Before, the install added a duplicate beside it and the
   uninstall left it.
3. **Fewer writes.** The no-op is decided on the DECLARATION (key and value text), not on
   the raw line:
   - `GdaHarness= "*res://..."` (a space AFTER the `=`) already declares this value, so
     head leaves it alone; base rewrote it to the canonical spelling.
   - `GdaHarness = "*res://..."` (a space BEFORE the `=`) is the same entry to head; base
     did not recognize it at all (its check was `startswith("GdaHarness=")`) and appended
     a duplicate beside it.
   - A trailing comment was already a no-op on base - its own reduction stripped it - so
     nothing changes there.

   The receipt follows the write: `daemon start` on such a project now reports
   `installed_harness: false`, where base reported `true` once (it rewrote the entry, or
   added a duplicate beside it, and converged on the next start).
4. **One decoder decides, and a false refusal goes.** The main-scene lookup addresses each
   entry by the name the reader decoded, which changes two of the three spellings:
   - a plain quoted `"run/main_scene"` base already read (its quote stripper handled it) -
     unchanged;
   - an ESCAPED `"run/main_scene"` base DEFERRED on (any backslash in the token made it
     give up on the whole file); head reads it, so an escaped declaration of an EMPTY main
     scene is refused with `live_main_scene_undefined` instead of being left to the macOS
     alert;
   - a bare `run/main _scene=` base read as a DIFFERENT key, so it refused a project the
     engine runs perfectly well - `live_main_scene_undefined` on a declared main scene.
     Verified: the engine reports that key as `run/main_scene` and loads `res://main.tscn`.
     Removing that false refusal is the strongest single improvement in this PR, and it is
     now pinned.
5. **Degenerate input, one blank line.** On a hand-mangled file with TWO `[autoload]`
   sections that both hold a harness entry and are dropped together, the blank separator in
   front of the first section survives; the old walk re-measured after each drop and took
   it. Godot's own writer never emits two parts of one section, and no test pinned it.
6. **Disclosed, not fixed - the one shape where head is worse than base.** A file with a
   byte-order mark whose FIRST line is the `[autoload]` header. The reader drops the mark
   before it splits the text, so gda joins that header; the engine does not. Verified,
   `ConfigFile.load` of that file:

   ```
   load_err=0
   sections=[""]
   section= keys=["<mark>[autoload]GdaHarness"]
   ```

   The engine reads one section-less KEY and registers no autoload, while the install
   reports `installed_harness: true` with `created_sections: []` (it believes it joined a
   section). Base appended a fresh `[autoload]` at EOF, which the engine did read. The same
   file declares no readable `config_version`, so the engine loads no project from it at
   all: it belongs to the "Godot cannot write this" class the installer docstring already
   scopes out, and it is added to that list rather than coded around. The `_BOM` comment in
   the reader now states that the drop decides a SECTION on line 0, not only a key.
7. **A repeated key is decided the engine's way.** When the file declares GdaHarness more
   than once - `"GdaHarness"=<canonical>` followed by `GdaHarness="*res://old.gd"`, say -
   the install re-points the LAST declaration and leaves the earlier ones, because that is
   the one `ConfigFile` loads (verified: `get_section_keys` reports ONE `GdaHarness` and
   `get_value` returns `*res://old.gd`). Base matched only a literal `GdaHarness=` prefix,
   so it rewrote the first such line and appended a duplicate when the only entry was
   spelled otherwise. Review round 2 caught an interim state here: widening the match by
   decoded key while still stopping at the FIRST entry made the install report nothing to
   do while the engine went on loading `res://old.gd`, so the harness never registered and
   `daemon start` waited out its readiness deadline. Fixed in `f6fee77b8`, pinned by a test
   the first-entry mutant kills. The uninstall already removed every duplicate, so the two
   halves stay symmetric.

## Surface diff (byte-identity proof)

Captured from a detached checkout of the base `b7c485693` and from this branch's HEAD, with
`COLUMNS=100`: `gda schema` plus 98 `--help` outputs - the root, every group (`project` and
`daemon` included), every command in the schema manifest, and the meta commands. Re-run
after each review round against the reviewer's own base checkout:

```
$ diff -r /tmp/w3-930-surface-base2 /tmp/w3-930-surface-head4   # /private/tmp/pr938-base-b7c485693 vs HEAD f6fee77b8
(no output)
IDENTICAL: gda schema + 98 --help outputs
```

Harness bytes untouched: `git diff base..HEAD -- src/gda/harness/gda_harness.gd` is empty
and `HARNESS_VERSION` stays `"22"` (the pin in `tests/harness/test_harness_install.py` is
not touched; the new tests sit in their own block far above it).

## The reader's interface, before and after

19 public names to **11**; one is new (`ConfigSection`).

| | before | after |
| --- | --- | --- |
| readers | `read_config`, `read_config_text` | unchanged |
| bounded write | `bound_project_write` | unchanged |
| result types | `ConfigHeader`, `ConfigEntry`, `ConfigText`, `ProjectWriteMutation`, `SECTIONLESS` | unchanged, plus `ConfigSection` |
| errors | `ProjectFileRestoreError`, `ProjectFileChangedError` | unchanged |
| line primitives | `line_ending`, `split_config`, `strip_comment`, `config_line`, `is_section_header`, `section_name`, `config_key` | private (`_line_ending`, ...) |
| removed | `section_of` (no caller after the rework), `unquote` (moved to its one consumer) | - |

Consumers after the change:

- `src/gda/harness/install.py`: `ConfigEntry`, `ConfigSection`, `ConfigText`,
  `read_config_text` (was six line primitives);
- `src/gda/project.py`: `read_config` (was `read_config` + `unquote`);
- `src/gda/commands/project.py`: `read_config`, `bound_project_write` and the two errors
  (unchanged);
- tests: `tests/project/test_project_file.py` exercises the interface, with one
  pre-existing exception it keeps - it monkeypatches the private `project_file._restored`
  to land an external edit inside the restore's write window, the only seam a test can
  reach that race through; `tests/project/test_project_bounded_write.py` uses the two
  errors.

`ConfigHeader` has no importer of its own: it stays public as the element type of
`ConfigText.headers`, which callers do read.

No production caller outside the module uses a privatized name:

```
$ grep -rn --include='*.py' -E '\b(line_ending|split_config|strip_comment|config_line|is_section_header|section_name|section_of|config_key|unquote)\b' src | grep -v '^src/gda/project_file.py'
src/gda/mcp/server.py:47:from urllib.parse import unquote, urlparse
src/gda/mcp/server.py:238:    dirs = [unquote(urlparse(str(root.uri)).path) for root in result.roots]
```

Both hits are `urllib.parse.unquote` (a URL decoder), not this module's.

## Validation

Red then green. The two boundary regressions were written first and run against the
unchanged installer (commit `ccc2e150a`):

```
$ uv run --frozen pytest tests/harness/test_harness_install.py -q -k "quoted_one or documented_project or commented_autoload or byte_order_mark or emptied_commented"
FAILED ...::test_install_writes_into_the_real_autoload_section_not_a_quoted_one
FAILED ...::test_uninstall_takes_only_the_real_entry_out_of_a_documented_project
2 failed, 3 passed, 41 deselected
```

The three that passed are guards, not repairs: the commented-header pins move the
`[autoload] ; note` rule from the reader's primitive to the installer whose behavior it is,
and the byte-order-mark round trip guards a byte-identity the rework could have dropped in
silence. All five pass on HEAD.

Two rules the reviews found unpinned are now pinned by mutant. Each mutant was applied to
`install.py` and reverted, the file restored byte-identically (md5 checked):

```
# round 1 - the span edit
both span uses cut to one line:   1 failed, 46 passed  (test_an_entry_written_across_lines_...)
the remove use alone:             1 failed, 46 passed  (same test)

# round 2 - the last declaration
declared[-1] -> declared[0]:      1 failed, 47 passed  (test_install_re_points_the_entry_the_engine_reads_last)

restored:                        48 passed
```

Gates on HEAD (`f6fee77b8`):

| gate | result |
| --- | --- |
| `uv run --frozen pytest -m "not e2e" -q -p no:cacheprovider` | **2636 passed**, 684 deselected (base `b7c485693`: 2626 passed - +10 tests, none removed in net) |
| `uv run --frozen ruff check .` | All checks passed |
| `uv run --frozen ruff format --check .` | 515 files already formatted |
| `uv run --frozen pyright` | 0 errors, 0 warnings, 0 informations |
| `pytest tests/harness tests/project -m e2e` (real Godot 4.6.3, machine lock) | **122 passed** in 2:27 |

The existing harness suite (the install/uninstall guarantees, the #654 receipts, the
snapshot restores) is unchanged and green; the migrated reader tests keep every case the
privatized primitives pinned, asked of the text the rule applies to.

## Guards on PR CI vs the e2e tier

Everything this change is about runs in the **PR gate**: `_ensure_autoload` and
`_remove_autoload` are pure text edits, so the boundary regressions, the commented header,
the multi-line span, the repeated key, the byte-order mark and the whole reader suite are
unit tests. Nothing here needs an engine.

The **Godot e2e tier** is schedule/dispatch-only, so it does not run on this PR. It was run
locally instead - `tests/harness tests/project -m e2e`, 122 tests, all passing - because the
daemon's harness install writes a real `project.godot` an engine then boots, and the
main-scene precondition gates a real session launch. Every engine CLAIM in this PR was
checked the same way, by loading the file in question through `ConfigFile.load` on 4.6.3:
the repeated key, the marked header, the spaced bare key, and the orphan continuation line
(which the engine refuses outright - `ERR_PARSE_ERROR`, "Unterminated string").

## Review round 1

| finding | resolution |
| --- | --- |
| P2-1 marked `[autoload]` on line 0, disclosure only | Adopted as asked, no code change: a fifth bullet on the installer's scoped list, item 6 in Public behavior above, and the `_BOM` comment now says the drop decides a SECTION on line 0. Re-verified on Godot 4.6.3 before writing it down. |
| P3-2 span edit unpinned | Adopted: `test_an_entry_written_across_lines_is_re_pointed_and_removed_whole` covers both halves - the install re-points the whole span, and an uninstall that meets the multi-line entry takes all of its lines, which is what empties the section. Both mutants killed; evidence above. |
| P3-3 `ConfigSection.name` has no reader | Adopted: field dropped. A section is asked for by name, so the answer only has to say where it is. |
| P3-4 "Extend ``removed``" | Adopted: "Return ``removed`` widened by the sections it emptied". |
| P3-5 "Three shapes" over five bullets | Adopted: five, counting the new one. |
| P3-6 behaviors 2 and 4 under-state the rule | Adopted: both now say "any spelling the reader decodes to this key", with the whitespace and escaped forms named. |
| P3-7 PR body: test-file claim, receipt line | Adopted: the `_restored` monkeypatch is named as the one seam the reader tests still reach, and behavior 3 carries the receipt change. |

## Review round 2

| finding | resolution |
| --- | --- |
| P2-1 the install decided on the FIRST harness entry, the engine takes the LAST | Adopted, two lines: `_ensure_autoload` collects the harness entries across the `[autoload]` sections and decides on `declared[-1]` - a no-op when its value is canonical, otherwise that entry's span is re-pointed. `test_install_re_points_the_entry_the_engine_reads_last` pins install, repeat install and uninstall for the shape, and the first-entry mutant kills it. Engine behavior re-verified before the fix (`get_value` returned `*res://old.gd`). |
| P3-2 Public behavior 3 mis-stated base | Adopted: the space-AFTER-`=` spelling is the one base rewrote, the space-BEFORE-`=` one is the duplicate it appended, the trailing comment was already a no-op on base, and the receipt line now says base reported `true` once and then converged. |
| P3-3 Public behavior 4 mis-stated base, and its strongest case was unpinned | Adopted: the item separates the three spellings (quoted: already read; escaped: read instead of deferred; bare with inner whitespace: a FALSE refusal removed), and `test_an_escaped_application_key_is_read_as_the_setting_it_spells` gains the `run/main _scene=` case. The engine's reading of it was verified. |
| P3-4 three stale lines | Adopted: the `_drop_emptied_autoload_sections` summary no longer names a return shape it lost; the span test says the engine refuses the whole file (`ERR_PARSE_ERROR`, verified) instead of reading a stray declaration; `sections_named` no longer claims the section-less head is always exactly one section - a literal `[]` reopens it, and the engine merges the parts. |
| P3-5 `ConfigHeader` has no importer | Recorded, no change: it is the element type of `ConfigText.headers`, which callers read. Noted in the interface section above. |

The three open questions of round 0 were judged YES by review and are settled: the wider
no-op matches what the engine reads, the two-section blank line is unreachable by a clean
round trip, and indices (not lines) is the right shape for `ConfigSection` - only the unread
`name` field was wrong, and it is gone.

Closes #930
