### PR TITLE
fix(gda): game tree serializes every tree its result model accepts (#929)

### DIFF
--- a/src/gda/commands/game.py
+++ b/src/gda/commands/game.py
@@ -17,7 +17,7 @@ against the engine session it holds, reading the runtime ``SceneTree`` after
 """
 
 import json
-from typing import Any, Optional
+from typing import Any, NotRequired, Optional, TypedDict
 
 import typer
 from pydantic import (
@@ -88,17 +88,8 @@ class GameNode(BaseModel):
     # The presence rule above is a SERIALIZATION rule, so it lives on the writer
     # rather than on every caller: the field stays a plain int with a 0 default
     # (a consumer reads a number, never None), and the key is dropped from the
-    # emitted JSON when nothing was omitted. `mode="wrap"` runs pydantic's own
-    # serializer first, so nested children are serialized — and pruned — by this
-    # same rule at every depth.
-    @model_serializer(mode="wrap")
-    def _omit_absent_omission_count(
-        self, handler: SerializerFunctionWrapHandler
-    ) -> dict[str, Any]:
-        rendered = handler(self)
-        if not rendered.get("children_omitted"):
-            rendered.pop("children_omitted", None)
-        return rendered
+    # emitted JSON when nothing was omitted. The writer is ONE serializer on
+    # :class:`GameTreeResult`, not one per node — see it for why.
 
 
 class GameTreeParams(RelayedLiveParams):
@@ -139,6 +130,31 @@ class GameTreeParams(RelayedLiveParams):
     )
 
 
+# The shape ``game tree`` EMITS, as opposed to the shape it holds: identical to
+# :class:`GameNode` / :class:`GameTreeResult` except that `children_omitted` is
+# optional, which is the one difference the prune below makes. Declared because a
+# `model_serializer`'s return annotation is what pydantic builds the writer from
+# — see the method for why a bare mapping is not enough here. Not published: the
+# `--schema` document is generated from the models in validation mode, where a
+# serializer's return type does not appear.
+class EmittedGameNode(TypedDict):
+    """One node of the emitted runtime tree (#929)."""
+
+    name: str
+    type: str
+    path: str
+    children: list["EmittedGameNode"]
+    children_omitted: NotRequired[int]
+
+
+class EmittedGameTree(TypedDict):
+    """The emitted ``game tree`` result (#929)."""
+
+    root: EmittedGameNode
+    truncated: bool
+    omitted_nodes: int
+
+
 class GameTreeResult(BaseModel):
     """The result of ``gda game tree``: the running game's runtime scene tree (#849).
 
@@ -163,6 +179,38 @@ class GameTreeResult(BaseModel):
             "missing from this result."
         )
     )
+
+    # The ONE writer of :class:`GameNode`'s `children_omitted` presence rule
+    # (#929). It sits here, on the whole tree, because the obvious home — a
+    # `model_serializer` on the node itself — is a Python callback at EVERY
+    # level, and pydantic stops calling those at about 128 nested levels: a
+    # chain the model happily VALIDATED then raised an uncaught
+    # `PydanticSerializationError`, so the CLI exited 1 with a bare traceback
+    # and no `Error envelope` at all, while `scene get`'s plain nested model
+    # refused the same depth typed. One callback at the top runs pydantic's own
+    # serializer over the whole tree first and then walks the dumped
+    # dictionaries with an explicit stack — never recursion, which would only
+    # move the ceiling into Python. The emitted JSON is unchanged and every tree
+    # the model accepts now also serializes; past that the refusal stays the
+    # typed `tree_too_deep` (issue #37) that `game tree --help` states.
+    #
+    # The return type is spelled out rather than left as a bare mapping BECAUSE
+    # of the depth: pydantic serializes a callback's result through the schema
+    # the annotation gives it, and an unannotated one falls back to the inferred
+    # writer, whose own JSON guard stops at the same ~128 levels this method
+    # exists to clear. The annotation is what makes the tree schema-driven again.
+    @model_serializer(mode="wrap")
+    def _omit_absent_omission_counts(
+        self, handler: SerializerFunctionWrapHandler
+    ) -> "EmittedGameTree":
+        rendered = handler(self)
+        pending: list[Any] = [rendered["root"]]
+        while pending:
+            node = pending.pop()
+            if not node.get("children_omitted"):
+                node.pop("children_omitted", None)
+            pending.extend(node["children"])
+        return rendered
 
     @model_validator(mode="after")
     def _check_omission_counters(self) -> "GameTreeResult":
@@ -914,7 +962,9 @@ def game_tree(
     selected subtree is counted, never silently dropped: the result carries
     `truncated` and `omitted_nodes`, and each node whose children were not walked
     carries `children_omitted`. Read bounded first, then address the nodes you
-    want by their exact path (`game get`, `game rect`, `game set`).
+    want by their exact path (`game get`, `game rect`, `game set`). A tree
+    nesting deeper than about 250 levels is refused as `tree_too_deep`: bound
+    such a read with `--root` and `--max-depth`.
     """
     dispatch_domain(
         GAME_TREE_COMMAND,

--- a/src/gda/commands/game.py
+++ b/src/gda/commands/game.py
@@ -89,7 +89,8 @@ class GameNode(BaseModel):
     # rather than on every caller: the field stays a plain int with a 0 default
     # (a consumer reads a number, never None), and the key is dropped from the
     # emitted JSON when nothing was omitted. The writer is ONE serializer on
-    # :class:`GameTreeResult`, not one per node — see it for why.
+    # :class:`GameTreeResult`, not one per node — see it for why; a node dumped
+    # on its own therefore keeps the key, which no gda path does.
 
 
 class GameTreeParams(RelayedLiveParams):

--- a/src/gda/commands/game.py
+++ b/src/gda/commands/game.py
@@ -164,6 +164,22 @@ class GameTreeResult(BaseModel):
         )
     )
 
+    @model_validator(mode="after")
+    def _check_omission_counters(self) -> "GameTreeResult":
+        # The two counters ARE the partial-read contract (#929): a caller that
+        # reads `truncated` false stops looking, so a reply carrying it beside a
+        # non-zero `omitted_nodes` presents an incomplete tree as a complete one
+        # — and the reverse claims an omission the read never made. A stale or
+        # drifted harness must fail output validation and classify as
+        # contract_violation, never pass as a success. Same rule, same reason as
+        # the `input` gesture evidence (``InputTapResult``, #652).
+        if self.truncated != (self.omitted_nodes > 0):
+            raise ValueError(
+                "a tree result reports truncated true exactly when "
+                "omitted_nodes is above 0."
+            )
+        return self
+
 
 # The selectors `gda game find` ANDs together, in the order the params model
 # declares them. One authority: the model reads it to refuse a selector-less
@@ -376,6 +392,24 @@ class GameFindResult(BaseModel):
             "is the size of what was never tested against the selectors."
         )
     )
+
+    @model_validator(mode="after")
+    def _check_result_counters(self) -> "GameFindResult":
+        # `count` is published so a caller can branch on the number WITHOUT
+        # walking the list, which makes a count that disagrees with the list
+        # worse than no count at all. The bounding pair carries
+        # :class:`GameTreeResult`'s rule for the same reason it does there: a
+        # search that under-reports its omission reads as proven absence. Both
+        # are harness drift, so both fail output validation and classify as
+        # contract_violation (#929).
+        if self.count != len(self.matches):
+            raise ValueError("a find result's count is the length of matches.")
+        if self.truncated != (self.omitted_nodes > 0):
+            raise ValueError(
+                "a find result reports truncated true exactly when "
+                "omitted_nodes is above 0."
+            )
+        return self
 
 
 class GameGetParams(RelayedLiveParams):

--- a/src/gda/commands/game.py
+++ b/src/gda/commands/game.py
@@ -204,12 +204,16 @@ class GameTreeResult(BaseModel):
         self, handler: SerializerFunctionWrapHandler
     ) -> "EmittedGameTree":
         rendered = handler(self)
-        pending: list[Any] = [rendered["root"]]
+        # Both reads are defensive because `exclude` / `include` /
+        # `exclude_defaults` let a caller drop either key: the prune must then
+        # find nothing to do, not raise a KeyError the caller reads as a
+        # serialization failure.
+        pending: list[Any] = [rendered["root"]] if "root" in rendered else []
         while pending:
             node = pending.pop()
             if not node.get("children_omitted"):
                 node.pop("children_omitted", None)
-            pending.extend(node["children"])
+            pending.extend(node.get("children", ()))
         return rendered
 
     @model_validator(mode="after")
@@ -963,8 +967,9 @@ def game_tree(
     `truncated` and `omitted_nodes`, and each node whose children were not walked
     carries `children_omitted`. Read bounded first, then address the nodes you
     want by their exact path (`game get`, `game rect`, `game set`). A tree
-    nesting deeper than about 250 levels is refused as `tree_too_deep`: bound
-    such a read with `--root` and `--max-depth`.
+    nesting deeper than about 250 levels is refused (`tree_too_deep`; past about
+    500 the engine's own JSON writer cuts the reply short and the refusal is
+    `contract_violation`): bound such a read with `--root` and `--max-depth`.
     """
     dispatch_domain(
         GAME_TREE_COMMAND,

--- a/tests/live/test_e2e_game.py
+++ b/tests/live/test_e2e_game.py
@@ -14,7 +14,7 @@ import time
 
 import pytest
 
-from gda.exit_codes import EXIT_LIVE
+from gda.exit_codes import EXIT_LIVE, EXIT_PARSE
 from tests.support import PNG_1X1_B64, Gda
 
 from tests.conftest import LIVE_PROJECT_GODOT, project_godot
@@ -804,16 +804,27 @@ def test_game_tree_bounds_the_read_and_counts_what_it_left_out(
 # total, and the op published that as a successful read — the exact-count promise
 # of #849 broken on a finite, valid tree.
 DEEP_CHAIN_DEPTH = 2200
-DEEP_CHAIN_MAIN_GD = (
-    "extends Node2D\n"
-    "func _ready() -> void:\n"
-    "\tvar current: Node = self\n"
-    f"\tfor index in range({DEEP_CHAIN_DEPTH}):\n"
-    "\t\tvar child := Node.new()\n"
-    "\t\tchild.name = str(index)\n"
-    "\t\tcurrent.add_child(child)\n"
-    "\t\tcurrent = child\n"
-)
+
+
+def chain_main_gd(depth: int) -> str:
+    """The main-scene script building ONE chain `depth` nodes deep below Main.
+
+    The chain length is the only thing the depth cases vary, and each of them
+    reads a different ceiling, so the script is built rather than copied.
+    """
+    return (
+        "extends Node2D\n"
+        "func _ready() -> void:\n"
+        "\tvar current: Node = self\n"
+        f"\tfor index in range({depth}):\n"
+        "\t\tvar child := Node.new()\n"
+        "\t\tchild.name = str(index)\n"
+        "\t\tcurrent.add_child(child)\n"
+        "\t\tcurrent = child\n"
+    )
+
+
+DEEP_CHAIN_MAIN_GD = chain_main_gd(DEEP_CHAIN_DEPTH)
 DEEP_CHAIN_MAIN_TSCN = (
     "[gd_scene load_steps=2 format=3]\n\n"
     '[ext_resource type="Script" path="res://main.gd" id="1"]\n\n'
@@ -864,6 +875,96 @@ def test_game_tree_counts_an_omitted_subtree_deeper_than_the_call_stack(
         errors = run("diag", "errors")
         assert errors.returncode == 0, errors.stdout + errors.stderr
         assert json.loads(errors.stdout)["errors"] == []
+    finally:
+        run("daemon", "stop")
+
+
+# The two depths that bracket the ONE ceiling `game tree` promises anything
+# about (#929): the result model validates a tree of about 254 nesting levels,
+# and everything it accepts must also reach the caller. Below the ceiling the
+# read is whole; above it the refusal is the typed `tree_too_deep` that
+# `game tree --help` names, with `--max-depth` as the remedy. The ceilings above
+# THAT one — the engine's own JSON writer and its call stack — are disclosed,
+# not promised: the 2200-node cases above stay bounded reads.
+SERIALIZED_CHAIN_DEPTH = 200
+REFUSED_CHAIN_DEPTH = 300
+
+
+def _chain_project(tmp_path, depth):
+    (tmp_path / "project.godot").write_text(LIVE_PROJECT_GODOT, encoding="utf-8")
+    (tmp_path / "main.tscn").write_text(DEEP_CHAIN_MAIN_TSCN, encoding="utf-8")
+    (tmp_path / "main.gd").write_text(chain_main_gd(depth), encoding="utf-8")
+    return Gda(tmp_path, json_output=True)
+
+
+@pytest.mark.e2e
+def test_game_tree_serializes_a_chain_the_result_model_accepts(
+    tmp_path, daemon_runtime_dir
+):
+    # 201 nesting levels is well inside the result model's own recursion limit,
+    # and this read used to exit 1 with a bare traceback and NO error envelope:
+    # the per-node `children_omitted` prune was a Python callback at every level,
+    # and pydantic stops calling those at about 128 levels — far below the depth
+    # it validates. A tree the model accepts must reach the caller whole.
+    run = _chain_project(tmp_path, SERIALIZED_CHAIN_DEPTH)
+
+    try:
+        assert run("daemon", "start").returncode == 0
+
+        whole = run("game", "tree")
+        assert whole.returncode == 0, whole.stdout + whole.stderr
+        data = json.loads(whole.stdout)
+        assert data["root"]["path"] == "/root/Main"
+        assert data["truncated"] is False
+        assert data["omitted_nodes"] == 0
+
+        node, levels = data["root"], 1
+        while node["children"]:
+            assert len(node["children"]) == 1, levels
+            node = node["children"][0]
+            levels += 1
+        assert levels == SERIALIZED_CHAIN_DEPTH + 1
+        assert node["name"] == str(SERIALIZED_CHAIN_DEPTH - 1)
+        # The prune still reaches every depth: an unbounded read pays no
+        # per-node key for a bound it never had.
+        assert "children_omitted" not in whole.stdout
+
+        # And nothing in the engine had to fail for that: the depth is gda's
+        # own arithmetic, not something the session survived.
+        errors = run("diag", "errors")
+        assert errors.returncode == 0, errors.stdout + errors.stderr
+        assert json.loads(errors.stdout)["errors"] == []
+    finally:
+        run("daemon", "stop")
+
+
+@pytest.mark.e2e
+def test_game_tree_refuses_a_chain_past_the_result_model_limit(
+    tmp_path, daemon_runtime_dir
+):
+    # Past the model's limit the read is REFUSED, typed, and the refusal names
+    # gda's own ceiling rather than blaming the engine's payload (issue #37).
+    # The remedy `game tree --help` states is the same call bounded, and it
+    # still counts the unread remainder exactly.
+    run = _chain_project(tmp_path, REFUSED_CHAIN_DEPTH)
+
+    try:
+        assert run("daemon", "start").returncode == 0
+
+        whole = run("game", "tree")
+        assert whole.returncode == EXIT_PARSE, whole.stdout + whole.stderr
+        error = json.loads(whole.stdout)["error"]
+        assert error["code"] == "tree_too_deep"
+        assert error["category"] == "parse"
+
+        bounded = run("game", "tree", "--max-depth", "1")
+        assert bounded.returncode == 0, bounded.stdout + bounded.stderr
+        data = json.loads(bounded.stdout)
+        assert [child["name"] for child in data["root"]["children"]] == ["0"]
+        assert data["root"]["children"][0]["children_omitted"] == 1
+        assert "children_omitted" not in data["root"]
+        assert data["truncated"] is True
+        assert data["omitted_nodes"] == REFUSED_CHAIN_DEPTH - 1
     finally:
         run("daemon", "stop")
 

--- a/tests/live/test_game_commands.py
+++ b/tests/live/test_game_commands.py
@@ -232,6 +232,25 @@ def test_game_tree_emits_a_deep_tree_the_model_accepts(monkeypatch, tmp_path):
     assert "children_omitted" not in result.stdout
 
 
+def test_game_tree_refuses_a_reply_past_the_result_model_limit(monkeypatch, tmp_path):
+    # The mirror of the case above, and the guard for the ceiling `game tree
+    # --help` states: the deep-emit case catches the limit FALLING, this one
+    # catches it RISING. A dependency that lifted the recursion limit past 300
+    # would turn this documented refusal into a success and make the help
+    # sentence wrong, with only the nightly engine tier to say so.
+    inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(_chain_reply(300)), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app, ["game", "tree", "--project", str(minimal_project(tmp_path)), "--json"]
+    )
+
+    assert result.exit_code == EXIT_PARSE, result.stdout + result.stderr
+    assert json.loads(result.stdout)["error"]["code"] == "tree_too_deep"
+
+
 def test_game_tree_renders_the_omission_for_a_human(monkeypatch, tmp_path):
     # Without --json the outline must not read as a complete tree: the total
     # rides one trailing line, so a truncated read is visible on both channels.

--- a/tests/live/test_game_commands.py
+++ b/tests/live/test_game_commands.py
@@ -15,7 +15,7 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.commands.game import GameFindParams, GameTreeParams
-from gda.exit_codes import EXIT_LIVE
+from gda.exit_codes import EXIT_LIVE, EXIT_PARSE
 from gda.runner import RunResult
 from tests.support import (
     GAME_CALL_RESULT,
@@ -152,6 +152,40 @@ def test_game_tree_renders_the_omission_for_a_human(monkeypatch, tmp_path):
     assert result.exit_code == 0, result.stdout + result.stderr
     assert "HUD (Control)" in result.stdout
     assert "truncated: 2 nodes omitted" in result.stdout
+
+
+# The two counters a `game tree` reply carries are an invariant, not a pair of
+# independent numbers (#929): `truncated` is true exactly when `omitted_nodes` is
+# above 0. A reply that breaks it in either direction is a stale or drifted
+# harness, and must fail output validation rather than publish an incomplete tree
+# as a complete one. Built from the shared fixture so the ONLY difference is the
+# contradiction under test.
+_CONTRADICTORY_TREE_REPLIES = [
+    # An omission the read reports nowhere: `truncated` says complete.
+    {**GAME_TREE_TRUNCATED_RESULT, "truncated": False},
+    # And the reverse: a truncation claimed with nothing left out.
+    {**GAME_TREE_RESULT, "truncated": True},
+]
+
+
+def test_a_tree_reply_whose_counters_disagree_is_a_contract_violation(
+    monkeypatch, tmp_path
+):
+    for payload in _CONTRADICTORY_TREE_REPLIES:
+        inject_live_runner(
+            monkeypatch,
+            RunResult(stdout=sentinel(payload), stderr="", exit_code=0),
+        )
+
+        result = CliRunner().invoke(
+            app,
+            ["game", "tree", "--project", str(minimal_project(tmp_path)), "--json"],
+        )
+
+        assert result.exit_code == EXIT_PARSE, (payload, result.stdout)
+        assert json.loads(result.stdout)["error"]["code"] == "contract_violation", (
+            payload
+        )
 
 
 def test_game_tree_refuses_a_negative_max_depth(monkeypatch, tmp_path):
@@ -359,6 +393,33 @@ def test_game_find_counts_what_a_bound_kept_it_from_searching(monkeypatch, tmp_p
     assert data["truncated"] is True
     assert data["omitted_nodes"] == 4
     assert data["count"] == 1
+
+
+# A `game find` reply carries `game tree`'s counter invariant AND one of its own
+# (#929): `count` is the length of `matches`. It is published so a caller can
+# branch on the number without walking the list, which is exactly why a count
+# that disagrees with the list must not reach that caller.
+_CONTRADICTORY_FIND_REPLIES = [
+    # A count that overstates the list a caller would walk.
+    {**GAME_FIND_RESULT, "count": 5},
+    # An unsearched remainder the reply calls a complete search: an empty list
+    # would then read as proven absence.
+    {**GAME_FIND_TRUNCATED_RESULT, "truncated": False},
+    # And the reverse: a truncation claimed with nothing left unsearched.
+    {**GAME_FIND_RESULT, "truncated": True},
+]
+
+
+def test_a_find_reply_whose_counters_disagree_is_a_contract_violation(
+    monkeypatch, tmp_path
+):
+    for payload in _CONTRADICTORY_FIND_REPLIES:
+        _, result = _find(monkeypatch, tmp_path, payload, "--type", "Control")
+
+        assert result.exit_code == EXIT_PARSE, (payload, result.stdout)
+        assert json.loads(result.stdout)["error"]["code"] == "contract_violation", (
+            payload
+        )
 
 
 def test_game_find_renders_the_matches_and_the_bound_for_a_human(monkeypatch, tmp_path):

--- a/tests/live/test_game_commands.py
+++ b/tests/live/test_game_commands.py
@@ -14,7 +14,7 @@ from pydantic import ValidationError
 from typer.testing import CliRunner
 
 from gda.cli import app
-from gda.commands.game import GameFindParams, GameTreeParams
+from gda.commands.game import GameFindParams, GameTreeParams, GameTreeResult
 from gda.exit_codes import EXIT_LIVE, EXIT_PARSE
 from gda.runner import RunResult
 from tests.support import (
@@ -127,6 +127,78 @@ def test_game_tree_reports_the_omitted_counts_of_a_bounded_read(monkeypatch, tmp
     # A node whose children were ALL serialized keeps the key absent.
     assert "children_omitted" not in children[1]
     assert "children_omitted" not in children[2]
+
+
+# The zero-`children_omitted` prune is a SERIALIZATION rule, and #929 moved the
+# serializer that carries it from every node to the result. These cases pin what
+# the rule EMITS, so the move is provable without them naming the mechanism: the
+# key is absent wherever the count is 0, present where it is not, and a tree the
+# model accepts reaches the caller whole.
+def _chain_reply(levels: int) -> dict:
+    """A `game tree` reply whose root is a single chain `levels` nodes deep."""
+    node = {"name": "leaf", "type": "Node", "path": "/root/Main", "children": []}
+    for index in range(levels - 1):
+        node = {
+            "name": str(index),
+            "type": "Node",
+            "path": "/root/Main",
+            "children": [node],
+        }
+    return {"root": node, "truncated": False, "omitted_nodes": 0}
+
+
+def test_game_tree_json_keeps_only_the_omission_counts_above_zero(
+    monkeypatch, tmp_path
+):
+    # The bounded fixture carries both cases on one tree, so the emitted JSON
+    # must equal it exactly: `children_omitted` on the one node whose children
+    # the read left out, and nowhere else.
+    inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(GAME_TREE_TRUNCATED_RESULT), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app, ["game", "tree", "--project", str(minimal_project(tmp_path)), "--json"]
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert json.loads(result.stdout) == GAME_TREE_TRUNCATED_RESULT
+
+
+def test_both_dump_paths_prune_the_zero_omission_counts():
+    # The CLI emits through `model_dump_json`, but the object model is a public
+    # surface too, so the rule must hold on both paths rather than on the one
+    # the CLI happens to take.
+    model = GameTreeResult.model_validate(GAME_TREE_TRUNCATED_RESULT)
+
+    assert model.model_dump() == GAME_TREE_TRUNCATED_RESULT
+    assert json.loads(model.model_dump_json()) == GAME_TREE_TRUNCATED_RESULT
+
+
+def test_game_tree_emits_a_deep_tree_the_model_accepts(monkeypatch, tmp_path):
+    # #929: a 200-level chain is well inside the model's own recursion limit,
+    # yet the read used to exit 1 with a bare traceback and NO error envelope —
+    # a per-node prune serializer is a Python callback at every level, and
+    # pydantic stops calling those far below the depth it validates. The tree
+    # the model accepts must reach the caller instead.
+    inject_live_runner(
+        monkeypatch,
+        RunResult(stdout=sentinel(_chain_reply(200)), stderr="", exit_code=0),
+    )
+
+    result = CliRunner().invoke(
+        app, ["game", "tree", "--project", str(minimal_project(tmp_path)), "--json"]
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    node, levels = json.loads(result.stdout)["root"], 1
+    while node["children"]:
+        node = node["children"][0]
+        levels += 1
+    assert levels == 200
+    # And the prune still reaches every depth of it.
+    assert "children_omitted" not in result.stdout
 
 
 def test_game_tree_renders_the_omission_for_a_human(monkeypatch, tmp_path):

--- a/tests/live/test_game_commands.py
+++ b/tests/live/test_game_commands.py
@@ -14,7 +14,14 @@ from pydantic import ValidationError
 from typer.testing import CliRunner
 
 from gda.cli import app
-from gda.commands.game import GameFindParams, GameTreeParams, GameTreeResult
+from gda.commands.game import (
+    EmittedGameNode,
+    EmittedGameTree,
+    GameFindParams,
+    GameNode,
+    GameTreeParams,
+    GameTreeResult,
+)
 from gda.exit_codes import EXIT_LIVE, EXIT_PARSE
 from gda.runner import RunResult
 from tests.support import (
@@ -174,6 +181,30 @@ def test_both_dump_paths_prune_the_zero_omission_counts():
 
     assert model.model_dump() == GAME_TREE_TRUNCATED_RESULT
     assert json.loads(model.model_dump_json()) == GAME_TREE_TRUNCATED_RESULT
+
+
+def test_the_emitted_shape_names_every_field_the_models_hold():
+    # The emitted TypedDicts are what pydantic builds the tree writer from, so
+    # they decide what reaches the caller — a field added to a model but not to
+    # them is dropped from the JSON silently, while `--schema` keeps publishing
+    # it. The models stay the single authority for WHICH fields exist; these
+    # declarations only restate `children_omitted`'s optionality, so the field
+    # NAMES must agree.
+    assert set(EmittedGameNode.__annotations__) == set(GameNode.model_fields)
+    assert set(EmittedGameTree.__annotations__) == set(GameTreeResult.model_fields)
+
+
+def test_the_prune_leaves_an_excluded_tree_alone():
+    # `exclude` / `include` / `exclude_defaults` let a caller drop `root` or
+    # `children` from the dump. The prune must find nothing to do then, rather
+    # than raise a KeyError the caller reads as a serialization failure.
+    model = GameTreeResult.model_validate(GAME_TREE_TRUNCATED_RESULT)
+
+    assert model.model_dump(exclude={"root"}) == {"truncated": True, "omitted_nodes": 2}
+    assert json.loads(model.model_dump_json(exclude={"root"})) == {
+        "truncated": True,
+        "omitted_nodes": 2,
+    }
 
 
 def test_game_tree_emits_a_deep_tree_the_model_accepts(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

`gda game tree` crashed on a runtime tree its own result model accepts. `GameNode`
carried a `model_serializer` that dropped a zero `children_omitted` from the emitted
JSON; a model serializer is a Python callback, and pydantic stops calling those at
about 128 nested levels — far below the 254 levels the model validates. A tree
between those two depths validated and then raised an uncaught
`PydanticSerializationError` on the way out: a `--json` read exited 1 with a bare
traceback and no `Error envelope` at all, while `scene get`'s plain nested model
refused the same depth as the typed `tree_too_deep`. The human channel was
unaffected — it renders from the model and never calls `model_dump_json` — so the
failure hit exactly the channel an agent reads. Regression from #849.

The prune moves to ONE `model_serializer` on `GameTreeResult`, which runs pydantic's
own serializer over the whole tree once and then walks the dumped dictionaries with
an explicit stack. `GameTreeResult` and `GameFindResult` also gain the `after`
validators that enforce the invariants their field descriptions already promised.

The wire shape is unchanged, and the three ceilings above the result model's are
disclosed rather than fixed, per the 2026-09-09 re-scope.

## Public behavior

- A `game tree --json` read of 128 to 254 nesting levels now returns the tree instead
  of crashing. The JSON is what it always was: `children_omitted` present exactly
  where the count is above zero. The human channel already worked at those depths;
  only `--json` failed.
- Past 254 levels the refusal is unchanged: the typed `tree_too_deep`.
- Past about 512 levels the reply is still `contract_violation` — Godot's own
  `JSON.stringify` bails at `Variant::MAX_RECURSION_DEPTH` and cuts the reply short.
  Not addressed here.
- `game tree --help` now discloses BOTH ceilings and the remedy in one sentence:
  "A tree nesting deeper than about 250 levels is refused (`tree_too_deep`; past
  about 500 the engine's own JSON writer cuts the reply short and the refusal is
  `contract_violation`): bound such a read with `--root` and `--max-depth`."
- A caller's `exclude=` / `include=` / `exclude_defaults=True` on the result model
  keeps working; the prune finds nothing to do rather than raising.
- A `game tree` or `game find` reply whose counters contradict each other
  (`truncated` disagreeing with `omitted_nodes > 0`, or `count != len(matches)`) is
  now `contract_violation` instead of a successful, complete-looking read.
- No harness change: `src/gda/harness` and `HARNESS_VERSION` are untouched.

## Surface diff

Compared against a detached checkout of the base `b7c485693`:

| surface | result |
| --- | --- |
| `gda schema` | ONE structural difference in the whole document: `commands[15].description` (`game tree`) gains the ceiling sentence quoted under Public behavior. No property, `$defs`, type or required-list change anywhere. |
| `gda game tree --schema` | byte-identical (the per-command document carries no command description) |
| `gda game tree --help` | the same one sentence added, nothing else |
| `gda game find --help` | byte-identical |
| emitted JSON for `GAME_TREE_RESULT` and `GAME_TREE_TRUNCATED_RESULT` | byte-identical on `model_dump()`, `model_dump(mode="json")` and `model_dump_json()`, key order included |

The `TypedDict` return annotation on the new serializer is not published: `--schema`
is generated in validation mode, where a serializer's return type does not appear.
The zero-difference `game tree --schema` diff is the evidence.

Re-measured after review round 1 against the reviewer's base checkout
`/private/tmp/pr939-base-b7c485693`: the same four rows hold, with the reworded
sentence in place of the first one.

## Validation

Measured ladder, `GameTreeResult` with a single chain of N nesting levels
(pydantic 2.13.4 / pydantic-core 2.46.4, CPython 3.13.13):

| levels | base `b7c485693` | this PR |
| --- | --- | --- |
| 127 | validate OK, dump OK, dump_json OK | same |
| 128 | validate OK, dump OK, **dump_json raises `PydanticSerializationError` (uncaught: a `--json` read exits 1 with no envelope; the human channel still prints the tree)** | validate OK, dump OK, dump_json OK |
| 200 | same crash | OK |
| 253 | same crash | OK |
| 254 | same crash | OK |
| 255 | `ValidationError` (`recursion_loop`) -> `tree_too_deep` | unchanged |
| 300 | `tree_too_deep` | unchanged |

Bisected ceilings: base `model_dump_json` 127 levels, this PR 254 levels — exactly the
model's validation limit, which is the condition the re-scope set. `model_dump` was
254 on both.

Red then green, real engine (Godot 4.6.3, macOS), `tests/live/test_e2e_game.py`:

- `test_game_tree_serializes_a_chain_the_result_model_accepts` (201 levels unbounded)
  with the per-node serializer restored: `1 failed`, the child process exiting 1 with
  `PydanticSerializationError: Error calling function _omit_absent_omission_count`.
  With the fix: passes — exit 0, 201 levels walked, `truncated` false, `omitted_nodes`
  0, no `children_omitted` anywhere, `diag errors` empty.
- `test_game_tree_refuses_a_chain_past_the_result_model_limit` (301 levels): unbounded
  gives `tree_too_deep` / category `parse`; the same chain with `--max-depth 1` reads
  exactly (`children_omitted` 1 on the one node, `omitted_nodes` 299).

Fast tier, red first: `test_game_tree_emits_a_deep_tree_the_model_accepts` failed on
the base with the same uncaught error, while the two byte-identity cases passed on the
base — so they pin the rule, not the new mechanism.

Mutant checks (each reverted, run, restored):

| mutant | result |
| --- | --- |
| per-node `children_omitted` serializer restored | the 201-level e2e fails (exit 1, uncaught `PydanticSerializationError`) |
| serializer return annotation back to `dict[str, Any]` | `test_game_tree_emits_a_deep_tree_the_model_accepts` fails |
| `children_omitted` removed from `EmittedGameNode` | `test_the_emitted_shape_names_every_field_the_models_hold` fails |
| `omitted_nodes` removed from `EmittedGameTree` | the same drift test fails |
| the prune's defensive reads removed | `test_the_prune_leaves_an_excluded_tree_alone` fails (`PydanticSerializationError`) |
| the refusal case's reply made shallow (stands for the model limit rising) | `test_game_tree_refuses_a_reply_past_the_result_model_limit` fails |
| `GameTreeResult._check_omission_counters` body removed | `test_a_tree_reply_whose_counters_disagree_is_a_contract_violation` fails |
| `GameFindResult._check_result_counters` body removed | `test_a_find_reply_whose_counters_disagree_is_a_contract_violation` fails |

Gates:

| gate | result |
| --- | --- |
| `uv run --frozen pytest -m "not e2e" -q` | 2634 passed |
| `uv run --frozen ruff check .` | All checks passed |
| `uv run --frozen ruff format --check .` | 515 files already formatted |
| `uv run --frozen pyright` | 0 errors, 0 warnings, 0 informations |
| `pytest tests/live/test_e2e_game.py tests/harness -m e2e` (real engine, serialized by the machine-wide lock) | 20 passed |
| `scripts/harness_version_guard.py origin/feat/gda-dogfooding-dev HEAD` | valid (harness unchanged) |
| `git diff <base> -- src/gda/harness tests/harness/test_harness_install.py` | empty |

## Guards on PR CI vs the e2e tier

PR CI runs NO Godot e2e (that tier is schedule/dispatch-only), so the two tiers guard
different halves of this change:

- **On PR CI**: the fast tier, which carries the whole serializer contract — the
  byte-identity cases against both shared fixtures, the 200-level deep-emit case, the
  300-level refusal case that pins the documented ceiling from the other side, the
  emitted-shape drift test, and the five contradictory-reply cases; plus `ruff`,
  `pyright`, and
  `harness_version_guard.py`, which proves the harness bytes and `HARNESS_VERSION` did
  not move. The 200-level case reaches the same code path as the e2e one through the
  fake live runner, so the regression itself cannot come back unnoticed on PR CI.
- **Needs the real engine** (run locally for this PR, and on the nightly `godot-e2e`
  job): that a real `Engine session` actually builds a 201-node chain and that the
  daemon relays a reply of that size; that `diag errors` is empty afterwards, which
  only a live session can report; and that the 301-level chain refuses as
  `tree_too_deep` rather than failing earlier inside the engine.

## Review round 1

| finding | resolution |
| --- | --- |
| P2-1 — the emitted `TypedDict`s are a hand-written parallel of the models' fields; a forgotten field is dropped from the JSON silently while `--schema` keeps publishing it | Adopted. `test_the_emitted_shape_names_every_field_the_models_hold` requires `set(EmittedGameNode.__annotations__) == set(GameNode.model_fields)` and the same for the result pair, so the models stay the one authority for WHICH fields exist and the declarations only restate `children_omitted`'s optionality. Two drift mutants kill it. Fixed at `312c3593d`. |
| P2-2 — the help sentence names only gda's ceiling; the re-scope requires it to disclose the engine's too | Adopted verbatim. The sentence now reads "...is refused (`tree_too_deep`; past about 500 the engine's own JSON writer cuts the reply short and the refusal is `contract_violation`)...". Schema and help re-diffed against `/private/tmp/pr939-base-b7c485693`: still exactly one structural difference in `gda schema`, `game tree --schema` and `game find --help` byte-identical. Fixed at `312c3593d`. |
| P3-1 — the prune indexes `root` and `children`, so `exclude=` / `include=` / `exclude_defaults=True` raise a `KeyError` where the base returned a value | Adopted. Both reads are defensive; `test_the_prune_leaves_an_excluded_tree_alone` covers `exclude={"root"}` on both dump paths. Measured after the change: `exclude`, `include` and `exclude_defaults` all succeed, no serialization warnings under `warnings="error"`, and the ceiling is still 254. Fixed at `312c3593d`. |
| P3-2 — fold the pre-existing 2200-node test's three writes into `_chain_project` | Not adopted, by the orchestrator's decision: no rule is at stake and the existing test is left untouched. |

## Review round 2

| finding | resolution |
| --- | --- |
| P3-1 — the documented refusal ceiling is guarded only by the nightly engine tier; the fast tier catches the limit falling but not rising | Adopted. `test_game_tree_refuses_a_reply_past_the_result_model_limit` sends a 300-level reply through the fake live runner and asserts `EXIT_PARSE` + `tree_too_deep`, so a dependency that lifted the limit past 300 goes red on PR CI instead of only on the nightly tier. Its own mutant (a shallow reply) kills it. Fixed at `6c2811b8d`. |
| P3-2 — the body said "a read of 128 to 254 nesting levels … exit 1"; only the `--json` channel crashed, the human channel printed the tree | Adopted. Summary, Public behavior and the ladder row now say `--json` and name the human channel explicitly. No code change. |
| P3-3 — a bare `GameNode` dumped alone now keeps `children_omitted: 0` | Adopted. The comment on the field says so in half a sentence, with the note that no gda path dumps a node alone. Comment only. Fixed at `6c2811b8d`. |
| Splitting the help sentence into two | Not adopted, by the orchestrator's decision: the re-scope asked for one sentence and round 1 adopted this wording verbatim. |
| `ge=0` on the counters | Not adopted, by the orchestrator's decision: it would add `minimum: 0` to the published schema, and the harness cannot emit a negative count. Recorded as a non-issue. |

## Open questions

- The ceiling sentence says "about 250 levels" rather than the exact 254. The exact
  number is a pydantic-core internal and could move with a dependency bump, so the
  help states the order of magnitude and the remedy. Say if you would rather pin the
  measured number.
- The two ceilings above this one stay unaddressed by decision: the engine's
  `JSON.stringify` guard (about 512 tree levels, `contract_violation`) and the GDScript
  call stack (about 1024). Making `game tree` exact at any depth needs a flat wire
  shape and is an ADR-level decision outside this milestone.

## History note

The first attempt on this branch also carried an explicit-stack rewrite of the
harness `_serialize` (`73ebcd292`). It was dropped at the 2026-09-09 re-scope: the
measurement showed that ceiling is the highest of four and that removing it changes no
CLI outcome. This branch was reset to the base and only the validator commit was
cherry-picked forward.

Closes #929