### PR TITLE
fix(cli): render literal Vector3 help examples

### DIFF
--- a/src/gda/commands/game.py
+++ b/src/gda/commands/game.py
@@ -786,7 +786,7 @@ def game_get(
     script is addressable explicitly after storage properties are checked; unfiltered
     reads keep the storage-property listing and do not dump script variables.
     Node3D position, rotation and scale are explicitly addressable local components;
-    rotation is in radians and Vector3 values read as [x, y, z].
+    rotation is in radians and Vector3 values read as \\[x, y, z].
     A path-less Texture2D value projects as a TextureProjection ({type, width,
     height, object_string, digest}, ADR-0035 amendment #666); `--texture-digest`
     opts into its content digest.

--- a/src/gda/commands/node.py
+++ b/src/gda/commands/node.py
@@ -771,7 +771,7 @@ def get(
 ) -> None:
     """Read storage properties and Node3D local position, rotation and scale.
 
-    Vector3 values are [x, y, z]. Local components use parent space; rotation
+    Vector3 values are \\[x, y, z]. Local components use parent space; rotation
     uses Euler radians under the node's rotation_order. This read does not save.
     """
     dispatch_domain(

--- a/tests/cli/test_vector3_help.py
+++ b/tests/cli/test_vector3_help.py
@@ -1,0 +1,23 @@
+"""Vector3 examples remain visible in the rendered help (#951)."""
+
+import pytest
+from typer.testing import CliRunner
+
+from gda.cli import app
+from tests.support import panel_text
+
+
+@pytest.mark.parametrize("group", ["node", "game"])
+def test_get_help_renders_literal_vector3_without_project_or_engine(group, tmp_path):
+    result = CliRunner().invoke(
+        app,
+        [group, "get", "--godot", str(tmp_path / "absent-godot"), "--help"],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    text = panel_text(result.stdout)
+    assert "[x, y, z]" in text
+    assert "rotation" in text and "radians" in text
+    if group == "game":
+        assert "--property" in text
+        assert "position, rotation and scale are explicitly addressable" in text


### PR DESCRIPTION
Rich markup swallowed the literal `[x, y, z]` example in both `node get --help` and `game get --help`. Escape the opening bracket so the example stays visible while preserving local-transform and explicit-property guidance.

Validation:
- Rendered-help regression: both cases failed before the fix and passed afterward.
- Both commands also passed through real subprocesses without a project or an available Godot executable.
- Focused tests: 2 passed; Ruff lint/format and diff checks passed.

Refs #951. Targets `codex/asset-pipeline-dev`; property discovery and transform behavior are unchanged.

Independent Sol Standards and Spec reviews passed at `d7ec5047ef2744d21de211deb2dc82e602ad7cb0`. The Spec review also confirmed that executable ASTs are unchanged after excluding docstrings, and independently reproduced the help failure on the base and success on the head.

After integrating #941, both reviewers confirmed the final head `713841330d3eae4c909682d838d908bbc6178fe6` against dev `cb2a935e0ab73f8aedeafedcb30b3435a04e2d90`: the PR patch is unchanged. Six help/CI-wiring tests and final-head applicable CI passed.
