### PR TITLE
fix(asset-pipeline): clarify package load recovery guidance

### DIFF
--- a/src/gda/integrations/package.py
+++ b/src/gda/integrations/package.py
@@ -81,6 +81,28 @@ class GdaGodotPackagePort:
             godot=self._godot,
         )
         if isinstance(outcome, Failure):
+            # The shared engine operation explains source-project recovery. At
+            # this package boundary the staged PCK is the whole resource view,
+            # so importing source cannot repair it. Keep `not_a_scene` uncertain:
+            # it covers several load failures, and diagnostics prose is evidence,
+            # not a stable dependency classifier.
+            if outcome.error.code == "not_a_scene":
+                outcome = Failure(
+                    error=outcome.error.model_copy(
+                        update={
+                            "message": (
+                                "package resource could not be loaded as PackedScene: "
+                                f"{path}; inspect engine diagnostics. "
+                                "This failure does not establish that a dependency is "
+                                "missing; check export inclusion and dependencies, then "
+                                "rebuild the package. Importing the source project does "
+                                "not modify this existing PCK."
+                            )
+                        }
+                    ),
+                    exit_code=outcome.exit_code,
+                    child_stderr=outcome.child_stderr,
+                )
             self._raise(outcome)
         try:
             model = project_model_report(outcome)

--- a/tests/asset_pipeline/test_e2e_package_check.py
+++ b/tests/asset_pipeline/test_e2e_package_check.py
@@ -360,3 +360,84 @@ def test_cold_exported_packages_use_only_imported_remaps_for_checks_and_exclusio
         for path in unrelated.rglob("*")
         if path.is_file()
     } == unrelated_before
+
+
+def test_missing_package_dependency_guides_rebuild_and_keeps_source_control(
+    tmp_path, monkeypatch
+):
+    project = tmp_path / "source"
+    project.mkdir()
+    (project / "accent.tres").write_text(
+        '[gd_resource type="StandardMaterial3D" format=3]\n\n'
+        "[resource]\n"
+        "albedo_color = Color(0.9, 0.2, 0.1, 1)\n"
+    )
+    (project / "wrapper.tscn").write_text(
+        "[gd_scene load_steps=3 format=3]\n\n"
+        '[ext_resource type="Material" path="res://accent.tres" id="1"]\n\n'
+        '[sub_resource type="BoxMesh" id="Box"]\n\n'
+        '[node name="Wrapper" type="Node3D"]\n'
+        '[node name="Body" type="MeshInstance3D" parent="."]\n'
+        'mesh = SubResource("Box")\n'
+        'material_override = ExtResource("1")\n'
+    )
+    (project / "main.tscn").write_text(
+        "[gd_scene load_steps=2 format=3]\n\n"
+        '[ext_resource type="PackedScene" path="res://wrapper.tscn" id="1"]\n\n'
+        '[node name="Main" type="Node3D"]\n'
+        '[node name="Wrapper" parent="." instance=ExtResource("1")]\n'
+    )
+    (project / "project.godot").write_text(
+        project_godot(name="gda-949-e2e", extra='run/main_scene="res://main.tscn"')
+    )
+    (project / "export_presets.cfg").write_text(
+        _preset("MissingDependency", 0, exclude="accent.tres")
+    )
+    expectations = project / "expectations.json"
+    expectations.write_text(
+        '{"checks":[{"id":"body","kind":"node","node":"Body","type":"MeshInstance3D"}]}'
+    )
+    monkeypatch.setenv("GDA_USER_DATA_ROOT", str(tmp_path / "user-data"))
+    run = Gda(project, json_output=True, timeout=300)
+
+    source = run.json(
+        "asset-pipeline",
+        "check",
+        "--path",
+        "res://wrapper.tscn",
+        "--expectations",
+        str(expectations),
+    )
+    assert source["verdict"] == "pass"
+
+    package = tmp_path / "missing-dependency.pck"
+    _export(run, "MissingDependency", package)
+    source_hidden = tmp_path / "source-hidden"
+    project.rename(source_hidden)
+    failure = Gda(None, json_output=True).error(
+        "asset-pipeline",
+        "check-package",
+        "--package",
+        str(package),
+        "--path",
+        "res://wrapper.tscn",
+        "--expectations",
+        str(source_hidden / "expectations.json"),
+        code="not_a_scene",
+        timeout=180,
+    )
+
+    assert "res://wrapper.tscn" in failure["message"]
+    assert "check export inclusion and dependencies" in failure["message"]
+    assert "rebuild the package" in failure["message"]
+    assert "does not establish that a dependency is missing" in failure["message"]
+    assert "resource import" not in failure["message"]
+    assert "accent.tres" in failure["diagnostics"]
+    partial = failure["partial_result"]["package_check"]
+    assert partial["failure"]["cause"]["code"] == "not_a_scene"
+    assert partial["failure"]["cause"]["message"] == failure["message"].removeprefix(
+        "package check failed during inspect: "
+    )
+    assert partial["failure"]["cause"]["diagnostics"] == failure["diagnostics"]
+    assert partial["cleanup"] == {"staging_removed": True, "issues": []}
+    assert not Path(partial["package"]["root"]).exists()

--- a/tests/asset_pipeline/test_package_adapter.py
+++ b/tests/asset_pipeline/test_package_adapter.py
@@ -89,3 +89,43 @@ def test_package_adapter_retains_native_failure(monkeypatch, tmp_path):
     assert raised.value.code == "path_not_found"
     assert port.last_failure is failure
     assert failure.child_stderr == "native stderr"
+
+
+def test_package_adapter_projects_load_recovery_without_source_import_advice(
+    monkeypatch, tmp_path
+):
+    failure = make_failure(
+        "not_a_scene",
+        "resource could not be loaded as PackedScene: res://wrapper.tscn; "
+        "inspect engine diagnostics; imported sources may need resource import",
+        "ERROR: Cannot open file 'res://accent.tres'.",
+    )
+    monkeypatch.setattr(
+        "gda.integrations.package.run_package_inspect_model_operation",
+        lambda *args, **kwargs: failure,
+    )
+    port = GdaGodotPackagePort()
+
+    with pytest.raises(PortFailure) as raised:
+        port.inspect_model(
+            tmp_path / "game.pck",
+            "res://wrapper.tscn",
+            subtree=".",
+            max_nodes=12,
+            max_items=34,
+        )
+
+    assert raised.value.code == "not_a_scene"
+    assert "res://wrapper.tscn" in str(raised.value)
+    assert "check export inclusion and dependencies" in str(raised.value)
+    assert "rebuild the package" in str(raised.value)
+    assert "does not establish that a dependency is missing" in str(raised.value)
+    assert "resource import" not in str(raised.value)
+    assert raised.value.cause is not None
+    assert raised.value.cause["code"] == "not_a_scene"
+    assert raised.value.cause["message"] == str(raised.value)
+    assert raised.value.cause["diagnostics"] == failure.error.diagnostics
+    assert port.last_failure is not None
+    assert port.last_failure.error.message == str(raised.value)
+    assert port.last_failure.error.diagnostics == failure.error.diagnostics
+    assert port.last_failure.child_stderr == failure.error.diagnostics

--- a/tests/asset_pipeline/test_package_check_cli.py
+++ b/tests/asset_pipeline/test_package_check_cli.py
@@ -1,6 +1,7 @@
 """Unified package acceptance command across CLI and MCP transports."""
 
 import json
+from pathlib import Path
 
 from typer.testing import CliRunner
 
@@ -9,8 +10,10 @@ from gda.commands.asset_pipeline import (
     AssetPipelinePackageCheckParams,
     run_asset_package_check,
 )
+from gda.commands.resource import PackageResourcePresenceResult
 from gda.errors import Failure, make_failure
 from gda.mcp.server import build_server
+from gda.models import EngineVersion
 from gda_assets.api import PackageCheckResult, PipelineFailure
 from gda_assets.domain.model import CheckResult, ModelCheckResult
 from gda_assets.domain.package import (
@@ -163,6 +166,71 @@ def test_package_workflow_failure_is_nonzero_with_full_partial_result(
     assert result.error.partial_result is not None
     assert result.error.partial_result["package_check"]["completed"] == ["validate"]
     assert result.child_stderr == "native stderr"
+
+
+def test_package_load_recovery_is_consistent_in_json_and_human_output(
+    monkeypatch, tmp_path
+):
+    package = tmp_path / "game.pck"
+    package.write_bytes(b"fixture")
+    expectations = tmp_path / "expectations.json"
+    expectations.write_text('{"checks":[{"id":"root","kind":"node","node":"."}]}')
+    engine = EngineVersion(
+        major=4,
+        minor=6,
+        patch=3,
+        hex=0x40603,
+        status="stable",
+        build="official",
+        hash="abc",
+        string="4.6.3.stable.official",
+        timestamp=0,
+    )
+    monkeypatch.setattr(
+        "gda.integrations.package.run_package_resource_presence_operation",
+        lambda *args, **kwargs: PackageResourcePresenceResult.model_validate(
+            {
+                "engine_version": engine.model_dump(),
+                "resources": [{"path": "res://wrapper.tscn", "present": True}],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "gda.integrations.package.run_package_inspect_model_operation",
+        lambda *args, **kwargs: make_failure(
+            "not_a_scene",
+            "imported sources may need resource import",
+            "ERROR: Cannot open file 'res://accent.tres'.",
+        ),
+    )
+    args = [
+        "asset-pipeline",
+        "check-package",
+        "--package",
+        str(package),
+        "--path",
+        "res://wrapper.tscn",
+        "--expectations",
+        str(expectations),
+    ]
+    runner = CliRunner()
+
+    structured = runner.invoke(app, [*args, "--json"])
+    human = runner.invoke(app, args)
+
+    assert structured.exit_code == human.exit_code == 4
+    error = json.loads(structured.stdout)["error"]
+    assert error["message"] in human.stdout
+    assert error["diagnostics"] in human.stdout
+    assert "check export inclusion and dependencies" in error["message"]
+    assert "does not establish that a dependency is missing" in error["message"]
+    assert "resource import" not in error["message"]
+    partial = error["partial_result"]["package_check"]
+    assert partial["failure"]["cause"]["message"] == error["message"].removeprefix(
+        "package check failed during inspect: "
+    )
+    assert partial["cleanup"] == {"staging_removed": True, "issues": []}
+    assert not Path(partial["package"]["root"]).exists()
 
 
 def test_human_result_names_editor_evidence_verdict_and_cleanup(monkeypatch, tmp_path):


### PR DESCRIPTION
A package load failure carried source-project import advice even though importing source cannot repair an existing PCK. Project `not_a_scene` failures at the existing package adapter boundary with advice to inspect export inclusion/dependencies and rebuild the package.

Keep the error code, requested resource location, native diagnostics, partial cause and cleanup. The message retains uncertainty about the cause; it does not classify dependencies by matching diagnostic text. Source inspection is unchanged.

Validation:
- Real Godot: source check passed; exported PCK excluded a material, source tree was hidden, and package check retained the missing-material diagnostics and removed staging.
- Parent independently reran the native case and adapter/CLI checks: 9 passed.
- After rebasing on current dev, focused adapter/CLI/library package tests: 41 passed.
- Ruff, targeted Pyright, and diff checks passed.

Refs #949. Targets `codex/asset-pipeline-dev`. This remains editor package inspection, separate from exported native application behavior.

Independent Sol Standards and Spec reviews passed at `ab6f5e5b3021529d13eab83144db7b0eab8c20e0`. Parent found no additional required changes. A local merge rehearsal against current dev `b41139d6c9ecbaa32e4477a1874274ea836705d4` passed 11 native package/CLI/help checks; tested tree: `fc6f77d132bbe99b445dc050bcf8ab0d189519c6`. Applicable PR CI passed; scheduled-only native CI was skipped, separate from the recorded local native test.
