### PR TITLE
fix(asset-pipeline): guide file-only observation recovery

### DIFF
--- a/libs/gda-assets/docs/blender.md
+++ b/libs/gda-assets/docs/blender.md
@@ -99,6 +99,13 @@ load/inspection commands. The workflow never reruns Blender automatically. Runni
 `--production` again is an explicit new export; choose `--overwrite` deliberately.
 There is no persisted run/resume protocol.
 
+If import and load completed but optional disk observation failed because an existing
+sidecar changed, `error.partial_result` names those completed stages and retains the
+before/after byte facts. Repeat with an explicit existing-file `--files` mapping,
+`--overwrite`, `--collect-observations`, and the retained output SHA-256 as
+`--declared-output-sha256`; omit `--production`. See the
+[content observation guide](observations.md) for the concrete command and limits.
+
 ## Reproducible validation
 
 From a development checkout with Blender and Godot configured:

--- a/libs/gda-assets/docs/observations.md
+++ b/libs/gda-assets/docs/observations.md
@@ -106,3 +106,29 @@ diagnosed in the result. A collection failure returns the useful facts gathered 
 far in the command's partial result without claiming successful completion. If an
 observation output was requested and can be created, that partial observation is
 saved explicitly; an existing output file is never replaced.
+
+When `error.partial_result.failure.code` is `observation_changed`, first read
+`completed`, `outputs`, and `content_observations`. If `install`, `import`, and
+`load` completed but `observe` did not, the installed output is available even
+though collection failed. A changed configuration digest establishes only that the
+published sidecar bytes differed across the observation window. It does not identify
+the writer or establish that the two configurations are semantically equivalent.
+
+To retry collection without repeating production, submit the installed output as an
+explicit existing file. Copy its current `source_after.sha256` from the partial
+result into the declaration:
+
+```sh
+gda asset-pipeline run --project ./consumer \
+  --files '[{"source":"/absolute/path/consumer/art/model.glb","target":"res://art/model.glb"}]' \
+  --overwrite --collect-observations \
+  --declared-output-sha256 \
+  '{"res://art/model.glb":"<source_after.sha256>"}' --json
+```
+
+Do not pass `--production` on this file-only repeat. For a GLB with selected external
+references, include their file mappings and the same explicit `references` entries.
+The new invocation checks the current installed bytes before import and collects a
+new bounded observation. It can still fail if source or configuration bytes change
+again. No automatic retry, sidecar normalization, or persisted resume state is
+implied.

--- a/libs/gda-assets/tests/test_content_observations.py
+++ b/libs/gda-assets/tests/test_content_observations.py
@@ -81,7 +81,10 @@ def test_cold_handoff_collects_selected_disk_facts_and_repeat_is_stable(tmp_path
     assert content.limitations
 
 
-@pytest.mark.parametrize("changed", ["source", "configuration", "dependency"])
+@pytest.mark.parametrize(
+    "changed",
+    ["source", pytest.param("configuration", id="unrelated-sidecar"), "dependency"],
+)
 def test_changed_input_during_import_refuses_mixed_observation(tmp_path, changed):
     from gda_assets.api import (
         AssetFile,

--- a/src/gda/commands/asset_pipeline.py
+++ b/src/gda/commands/asset_pipeline.py
@@ -316,12 +316,53 @@ def _pipeline_result(result: PipelineResult) -> PipelineRunResult:
     return PipelineRunResult.model_validate(asdict(result))
 
 
+def _configuration_only_observation_change(result: PipelineRunResult) -> bool:
+    content = result.content_observations
+    if content is None or not content.changes:
+        return False
+    if any(
+        asset.source_after is None
+        or asset.source_after.state != "observed"
+        or asset.source_after.sha256 is None
+        for asset in content.assets
+    ):
+        return False
+    configurations = {
+        digest.path
+        for asset in content.assets
+        for digest in (asset.configuration_before, asset.configuration_after)
+        if digest is not None
+    }
+    return bool(configurations) and all(
+        change.before.path in configurations for change in content.changes
+    )
+
+
 def _failure_message(stage: str, message: str, result: PipelineRunResult) -> str:
     affected = (
         ", ".join(f"{item.target} ({item.state})" for item in result.outputs)
         or "no installed files"
     )
-    return f"asset pipeline failed during {stage}: {message}; affected: {affected}"
+    summary = f"asset pipeline failed during {stage}: {message}; affected: {affected}"
+    if (
+        result.failure is None
+        or result.failure.code != "observation_changed"
+        or not {"install", "import", "load"}.issubset(result.completed)
+        or "observe" in result.completed
+        or not _configuration_only_observation_change(result)
+    ):
+        return summary
+    completed = ", ".join(result.completed)
+    return (
+        f"{summary}; completed stages: {completed}; observation did not complete. "
+        "The result establishes an observed "
+        "configuration byte change, not its writer or semantic equivalence. Reuse the "
+        "installed files in a new asset-pipeline run with explicit existing-file "
+        "--files, --overwrite, --collect-observations, and "
+        "--declared-output-sha256 values from the retained source hashes; omit "
+        "--production. This does not rerun Blender or another producer. The new "
+        "invocation checks current inputs and can fail if they change again"
+    )
 
 
 def run_asset_pipeline(

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -50,7 +50,13 @@ checks caller declarations before import; `--observations-output /reports/new.js
 saves to a new file without overwriting one. Read `content_observations` and its
 coverage limitations; `stable` means no change detected in the covered disk reads,
 not runtime proof or full reproducibility. Changed or unavailable required file
-facts fail with retained partial observations. See the
+facts fail with retained partial observations. If install, import, and load completed
+but observation failed on changed configuration bytes, reuse the installed output in
+a new existing-file `--files` invocation with `--overwrite`,
+`--collect-observations`, and its retained `source_after.sha256` supplied through
+`--declared-output-sha256`; omit `--production`. The repeat checks current inputs,
+can fail again, and does not establish who changed the sidecar or whether its content
+is semantically equivalent. See the
 [observation guide](https://github.com/aigengame/godot-agent/blob/main/libs/gda-assets/docs/observations.md).
 
 Add `--refresh '{"path":"res://art/model.glb","scene":"res://test.tscn","node":"/root/Test/Model"}'`

--- a/tests/asset_pipeline/fixtures/configure_import_for_normalization.gd
+++ b/tests/asset_pipeline/fixtures/configure_import_for_normalization.gd
@@ -1,0 +1,13 @@
+extends SceneTree
+
+# Save a supported import option through Godot's ConfigFile API while leaving
+# one default absent. The test observes that line after the next real import;
+# the endpoint reads do not attribute a writer or establish equivalence.
+func _initialize() -> void:
+	var path := "res://models/model.glb.import"
+	var config := ConfigFile.new()
+	assert(config.load(path) == OK)
+	config.set_value("params", "meshes/generate_lods", false)
+	config.erase_section_key("params", "nodes/root_script")
+	assert(config.save(path) == OK)
+	quit()

--- a/tests/asset_pipeline/test_asset_pipeline_cli.py
+++ b/tests/asset_pipeline/test_asset_pipeline_cli.py
@@ -517,9 +517,9 @@ def test_observation_change_publishes_stage_facts_and_file_reuse_guidance_to_jso
         "import",
         "load",
     ]
-    assert "completed stages: validate, stage, install, import, load" in error[
-        "message"
-    ]
+    assert (
+        "completed stages: validate, stage, install, import, load" in error["message"]
+    )
     assert "observation did not complete" in error["message"]
     assert "not its writer or semantic equivalence" in error["message"]
     assert "--files" in error["message"]

--- a/tests/asset_pipeline/test_asset_pipeline_cli.py
+++ b/tests/asset_pipeline/test_asset_pipeline_cli.py
@@ -445,6 +445,91 @@ def test_failure_is_nonzero_preserves_child_error_and_carries_partial_result(
     assert error["partial_result"]["completed"] == ["validate", "stage", "install"]
 
 
+def test_observation_change_publishes_stage_facts_and_file_reuse_guidance_to_json_and_human(
+    monkeypatch, tmp_path
+):
+    from gda_assets.domain.observations import (
+        AssetDiskObservation,
+        ContentObservations,
+        FileChange,
+        FileDigest,
+    )
+
+    project = minimal_project(tmp_path / "project")
+    before = FileDigest("res://models/model.glb.import", "observed", "a" * 64, 10)
+    after = FileDigest("res://models/model.glb.import", "observed", "b" * 64, 33)
+    source = FileDigest("res://models/model.glb", "observed", "c" * 64, 100)
+
+    class Port:
+        last_failure = None
+
+    monkeypatch.setattr(
+        "gda.commands.asset_pipeline.GdaGodotAssetPort", lambda *args: Port()
+    )
+    monkeypatch.setattr(
+        "gda.commands.asset_pipeline.run_pipeline",
+        lambda *args, **kwargs: PipelineResult(
+            completed=["validate", "stage", "install", "import", "load"],
+            outputs=[InstalledFile("model.glb", "res://models/model.glb", "installed")],
+            failure=PipelineFailure(
+                "observe",
+                "observation_changed",
+                "Selected input bytes changed during collection",
+            ),
+            content_observations=ContentObservations(
+                status="changed",
+                assets=[
+                    AssetDiskObservation(
+                        "res://models/model.glb",
+                        (),
+                        source_before=source,
+                        source_after=source,
+                        configuration_before=before,
+                        configuration_after=after,
+                    )
+                ],
+                changes=[FileChange(before, after)],
+            ),
+        ),
+    )
+    invocation = [
+        "asset-pipeline",
+        "run",
+        "--files",
+        '[{"source":"model.glb","target":"res://models/model.glb"}]',
+        "--source-root",
+        str(tmp_path),
+        "--project",
+        str(project),
+    ]
+
+    runner = CliRunner()
+    structured = runner.invoke(app, [*invocation, "--json"])
+    human = runner.invoke(app, invocation)
+
+    assert structured.exit_code != 0
+    assert human.exit_code == structured.exit_code
+    error = json.loads(structured.stdout)["error"]
+    assert error["partial_result"]["completed"] == [
+        "validate",
+        "stage",
+        "install",
+        "import",
+        "load",
+    ]
+    assert "completed stages: validate, stage, install, import, load" in error[
+        "message"
+    ]
+    assert "observation did not complete" in error["message"]
+    assert "not its writer or semantic equivalence" in error["message"]
+    assert "--files" in error["message"]
+    assert "--declared-output-sha256" in error["message"]
+    assert "omit --production" in error["message"]
+    assert "does not rerun Blender" in error["message"]
+    assert "can fail if they change again" in error["message"]
+    assert error["message"] in human.stdout
+
+
 def test_nested_project_target_is_rejected_before_pipeline_install(
     monkeypatch, tmp_path
 ):

--- a/tests/asset_pipeline/test_e2e_content_observations.py
+++ b/tests/asset_pipeline/test_e2e_content_observations.py
@@ -239,9 +239,9 @@ def test_native_configuration_normalization_refuses_then_explicit_file_reuse_suc
         }
     ]
     assert b"nodes/root_script=null" in sidecar.read_bytes()
-    assert "completed stages: validate, stage, install, import, load" in first[
-        "message"
-    ]
+    assert (
+        "completed stages: validate, stage, install, import, load" in first["message"]
+    )
     assert "not its writer or semantic equivalence" in first["message"]
     assert "omit --production" in first["message"]
     assert "can fail if they change again" in first["message"]
@@ -279,9 +279,9 @@ def test_native_configuration_normalization_refuses_then_explicit_file_reuse_suc
     ]
     assert repeated_observations["status"] == "stable"
     assert repeated_asset["source_before"] == repeated_asset["source_after"]
-    assert repeated_asset["configuration_before"] == repeated_asset[
-        "configuration_after"
-    ]
+    assert (
+        repeated_asset["configuration_before"] == repeated_asset["configuration_after"]
+    )
 
 
 def test_wrong_declared_digest_refuses_before_import_and_retains_pre_facts(

--- a/tests/asset_pipeline/test_e2e_content_observations.py
+++ b/tests/asset_pipeline/test_e2e_content_observations.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import json
+import shutil
 import struct
 from pathlib import Path
 
@@ -12,6 +13,7 @@ from tests.support import Gda
 pytestmark = pytest.mark.e2e
 
 TARGET = "res://models/model.glb"
+FIXTURES = Path(__file__).with_name("fixtures")
 
 
 def _glb(path: Path, extent: float) -> None:
@@ -177,6 +179,109 @@ def test_config_only_root_scale_change_keeps_source_and_changes_config_digest(
         != after["configuration_after"]["sha256"]
     )
     assert after["configuration_before"] == after["configuration_after"]
+
+
+def test_native_configuration_normalization_refuses_then_explicit_file_reuse_succeeds(
+    godot_project,
+):
+    source_root = _source_root(godot_project)
+    source = source_root / "model.glb"
+    _glb(source, 1.0)
+    run, args = _run(godot_project, source_root, "model.glb")
+    _asset(run.json(*args))
+
+    fixture = godot_project / "configure_import_for_normalization.gd"
+    shutil.copyfile(FIXTURES / fixture.name, fixture)
+    run.json("script", "run", f"res://{fixture.name}")
+    sidecar = godot_project / "models/model.glb.import"
+    configured = sidecar.read_bytes()
+    assert b"meshes/generate_lods=false" in configured
+    assert b"nodes/root_script" not in configured
+
+    _glb(source, 2.0)
+    run, args = _run(godot_project, source_root, "model.glb", overwrite=True)
+    first = run.error(*args, code="operation_failed")
+    partial = first["partial_result"]
+    observations, asset = _asset({"pipeline": partial})
+
+    assert partial["completed"] == [
+        "validate",
+        "stage",
+        "install",
+        "import",
+        "load",
+    ]
+    assert partial["failure"] == {
+        "stage": "observe",
+        "code": "observation_changed",
+        "message": (
+            "Selected input bytes changed during collection; see "
+            "content_observations.changes"
+        ),
+        "cause": None,
+    }
+    assert partial["outputs"] == [
+        {
+            "source": "model.glb",
+            "target": TARGET,
+            "state": "installed",
+            "resize": None,
+        }
+    ]
+    assert partial["production"] is None
+    assert partial["cleanup"] is None
+    assert observations["status"] == "changed"
+    assert asset["source_before"] == asset["source_after"]
+    assert observations["changes"] == [
+        {
+            "before": asset["configuration_before"],
+            "after": asset["configuration_after"],
+        }
+    ]
+    assert b"nodes/root_script=null" in sidecar.read_bytes()
+    assert "completed stages: validate, stage, install, import, load" in first[
+        "message"
+    ]
+    assert "not its writer or semantic equivalence" in first["message"]
+    assert "omit --production" in first["message"]
+    assert "can fail if they change again" in first["message"]
+
+    reuse_files = [
+        {
+            "source": str((godot_project / "models/model.glb").resolve()),
+            "target": TARGET,
+            "references": [],
+        }
+    ]
+    recovery_run = Gda(
+        project=godot_project,
+        json_output=True,
+        extra_env={"GDA_BLENDER": str(godot_project / "must-not-run-blender")},
+    )
+    repeated = recovery_run.json(
+        "asset-pipeline",
+        "run",
+        "--files",
+        json.dumps(reuse_files),
+        "--overwrite",
+        "--collect-observations",
+        "--declared-output-sha256",
+        json.dumps({TARGET: asset["source_after"]["sha256"]}),
+    )
+    repeated_observations, repeated_asset = _asset(repeated)
+    assert repeated["pipeline"]["completed"] == [
+        "validate",
+        "stage",
+        "install",
+        "import",
+        "load",
+        "observe",
+    ]
+    assert repeated_observations["status"] == "stable"
+    assert repeated_asset["source_before"] == repeated_asset["source_after"]
+    assert repeated_asset["configuration_before"] == repeated_asset[
+        "configuration_after"
+    ]
 
 
 def test_wrong_declared_digest_refuses_before_import_and_retains_pre_facts(


### PR DESCRIPTION
An import can finish installing and loading the model while optional observation fails because existing sidecar bytes changed. Make that partial result explain the completed stages and explicit existing-file reuse, so callers can check the installed output again without repeating Blender production.

Reuse the current result and failure-message surfaces. The docs and native witness submit `--files`, `--overwrite`, `--collect-observations`, and retained output hashes explicitly, omitting `--production`. Strict `observation_changed` behavior, cold-import admission, declared-hash checks, and bounded observations stay intact. No recovery-plan model, generated command, normalization policy or automatic retry is introduced.

Validation:
- 307 Asset Pipeline fast tests passed; 36 native tests excluded by marker in that run.
- Native observation module: 5 passed. The final normalization/reuse witness also passed after rebasing.
- Parent reran the native witness plus CLI and observation controls on the final branch.
- Shipped skill checks: 7 passed; Ruff, targeted Pyright and diff checks passed.

Refs #945; implements the strict-refusal decision in completed #946. Targets `codex/asset-pipeline-dev`. Endpoint byte changes do not identify a writer or prove semantic equivalence; explicit reuse can fail again.

Independent Sol review at `c414373ebe9b78434229c2a26dd412b4dc7fcaad`: Standards PASS; Spec PASS. Parent retained the narrow existing-message design. The first published CI run found formatting in two test files; the follow-up only formats those files, with identical Python ASTs. Full Ruff lint and format checks then passed.

Integration rehearsal on dev `2b38824de4a0470d76784c4456255da51d4784bb`: 29 native-observation, CLI, observation-domain and help checks passed. Tested merge tree: `7b4056537e8273242d942eddae4ca673e9b23034`. GitHub native E2E is scheduled-only and skipped on this PR; the native witness above ran locally with Godot 4.6.3.
