### PR TITLE
fix(cli): structure JSON argv validation errors

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -280,14 +280,14 @@ successful result. It is what `--json` emits; without that flag the same failure
 is RENDERED for a human instead — the code and its category on a head line, the
 message, each optional typed key as a labelled line, then `diagnostics` verbatim
 as real lines. Two renderings of ONE outcome, at one exit code, from one renderer
-that keys on no `Gda error code` — the `usage` refusals included. An invalid supplied
-argv value keeps the parser's readable stderr panel for a human, while explicit
-`--json` reports `invalid_argument` through this channel before an operation runs
-(#947). Click syntax errors outside that validation boundary, such as an option with
-no value, retain Click's text on `stderr`. One other case falls outside it, by that
-channel's own rule: where gda has no correction to add AND no JSON was asked for, it
-says nothing and the parser's message stands — silence rather than a second gda
-layout.
+that keys on no `Gda error code` — the `usage` refusals included. A missing required
+parameter or invalid supplied argv value keeps the parser's readable stderr panel for
+a human, while explicit `--json` reports `invalid_argument` through this channel
+before an operation runs (#947). Other Click syntax errors, such as an option token
+with no following value, may retain Click's text on `stderr`. One other case falls
+outside it, by that channel's own rule: where gda has no correction to add AND no
+JSON was asked for, it says nothing and the parser's message stands — silence rather
+than a second gda layout.
 _Avoid_: error blob, failure JSON
 
 **Failure evidence**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -270,8 +270,8 @@ _Avoid_: script error code, raw engine error
 **Classifier error code**:
 A `Gda error code` assigned by `gda` itself rather than reported by an operation —
 after classifying a runner, parser, version, crash, or fallback operation failure,
-or before any operation is identified at all, when the invocation names no command
-or option gda has (#670).
+or before any operation runs, when the invocation names no command or option gda has
+or its argv fails the identified command's contract (#670, #947).
 _Avoid_: wrapper error code, Python error code
 
 **Error envelope**:
@@ -280,11 +280,12 @@ successful result. It is what `--json` emits; without that flag the same failure
 is RENDERED for a human instead — the code and its category on a head line, the
 message, each optional typed key as a labelled line, then `diagnostics` verbatim
 as real lines. Two renderings of ONE outcome, at one exit code, from one renderer
-that keys on no `Gda error code` — the `usage` refusals included, since they answer
-through this channel rather than through the parser's own error (#685). One case falls
-outside it, by that channel's own rule: where gda has no correction to add AND no JSON
-was asked for, it says nothing and the parser's message stands — silence rather than a
-second gda layout.
+that keys on no `Gda error code` — the `usage` refusals included. An invalid argv
+value keeps the parser's readable stderr panel for a human, while explicit `--json`
+reports `invalid_argument` through this channel before an operation runs (#947). One
+case falls outside it, by that channel's own rule: where gda has no correction to add
+AND no JSON was asked for, it says nothing and the parser's message stands — silence
+rather than a second gda layout.
 _Avoid_: error blob, failure JSON
 
 **Failure evidence**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -280,12 +280,14 @@ successful result. It is what `--json` emits; without that flag the same failure
 is RENDERED for a human instead — the code and its category on a head line, the
 message, each optional typed key as a labelled line, then `diagnostics` verbatim
 as real lines. Two renderings of ONE outcome, at one exit code, from one renderer
-that keys on no `Gda error code` — the `usage` refusals included. An invalid argv
-value keeps the parser's readable stderr panel for a human, while explicit `--json`
-reports `invalid_argument` through this channel before an operation runs (#947). One
-case falls outside it, by that channel's own rule: where gda has no correction to add
-AND no JSON was asked for, it says nothing and the parser's message stands — silence
-rather than a second gda layout.
+that keys on no `Gda error code` — the `usage` refusals included. An invalid supplied
+argv value keeps the parser's readable stderr panel for a human, while explicit
+`--json` reports `invalid_argument` through this channel before an operation runs
+(#947). Click syntax errors outside that validation boundary, such as an option with
+no value, retain Click's text on `stderr`. One other case falls outside it, by that
+channel's own rule: where gda has no correction to add AND no JSON was asked for, it
+says nothing and the parser's message stands — silence rather than a second gda
+layout.
 _Avoid_: error blob, failure JSON
 
 **Failure evidence**:

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -228,12 +228,12 @@ the standard build), and they never determine the outcome or a stable code.
 >   them through the renderer makes the one-renderer statement exact and makes the
 >   `hint:` line reachable: it is set nowhere else, so before #798 a human could not
 >   read it.
-> - An invalid supplied value keeps Click's parser panel on `stderr` for a human. Under
->   explicit `--json`, validation that reaches `BadParameter` is classified as
->   `invalid_argument` and emitted on `stdout` before any operation runs (#947). Model
->   validators contribute their already-sanitized sentence. Click type conversion
->   names only the argument contract and does not echo the raw token. Click syntax
->   errors outside that validation boundary, such as an option with no value, retain
+> - A missing required parameter or invalid supplied value keeps Click's parser panel
+>   on `stderr` for a human. Under explicit `--json`, command parameter validation is
+>   classified as `invalid_argument` and emitted on `stdout` before any operation runs
+>   (#947). Model validators contribute their already-sanitized sentence. Click type
+>   conversion names only the argument contract and does not echo the raw token. Other
+>   Click syntax errors, such as an option token with no following value, may retain
 >   Click's text on `stderr` even under `--json`. The same human fall-through holds
 >   where gda recognizes a mistake but has no correction to add and no `--json` was
 >   asked for: gda declines to answer and the parser's message stands.
@@ -290,7 +290,7 @@ operation, and parse codes the CLI assigns).
 | `user_data_unwritable` | `environment` | `runner` | `127` | The log or user-data placement for the launch could not be made usable, so the launch was refused. |
 | `unknown_command` | `usage` | `classifier` | `2` | gda has no such command; discover the surface with `gda schema` or `gda --help`. A recognized near miss also carries the supported invocation in the envelope's `hint`. |
 | `unknown_option` | `usage` | `classifier` | `2` | The command exists but has no such option; read its options with `--help` or its input contract with `--schema`. A recognized near miss also carries the supported invocation in the envelope's `hint`. |
-| `invalid_argument` | `usage` | `classifier` | `2` | A supplied command-line argument or option value does not match the command's argv contract; with `--json`, gda reports that validation as a structured envelope before any operation runs. |
+| `invalid_argument` | `usage` | `classifier` | `2` | A required command-line parameter is missing or a supplied argument or option value does not match the command's argv contract; with `--json`, gda reports that validation as a structured envelope before any operation runs. |
 | `unsupported_version` | `version` | `version_gate` | `3` | The detected Godot version is below the supported minimum. |
 | `engine_crashed` | `operation` | `classifier` | `4` | Godot terminated abnormally, such as by signal death. |
 | `operation_failed` | `operation` | `classifier` | `4` | The engine or operation failed without a valid registered operation error envelope. |

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -196,10 +196,9 @@ the standard build), and they never determine the outcome or a stable code.
 > It now reports through this same envelope, with three consequences recorded here:
 >
 > - **A sixth category, `usage`**, rather than folding into `operation`: no engine was
->   launched and no operation was named, so `operation`'s meaning ("a launched engine
->   failed to deliver a result") would have been false. It is the one category whose
->   codes cannot be reported by any operation — both are classifier-source and neither
->   is GDScript-mirrored.
+>   launched, so `operation`'s meaning ("a launched engine failed to deliver a result")
+>   would have been false. It is the one category whose codes cannot be reported by
+>   any operation — all are classifier-source and none is GDScript-mirrored.
 > - **Exit `2`, which gda did not choose.** It is the exit every CLI parser already
 >   uses for a usage error, and it is what these invocations already exited with, so
 >   registering it changes no observable exit code — it only makes the envelope's
@@ -229,11 +228,14 @@ the standard build), and they never determine the outcome or a stable code.
 >   them through the renderer makes the one-renderer statement exact and makes the
 >   `hint:` line reachable: it is set nowhere else, so before #798 a human could not
 >   read it.
-> - The recorded exception is click's own parse errors (a missing argument, an invalid
->   value), which stay click-formatted on `stderr`: gda did not classify them, so it has
->   no envelope to render. The same holds where gda recognizes a mistake but has no
->   correction to add and no `--json` was asked for: gda declines to answer and the
->   parser's message stands.
+> - Click's own parse errors (a missing argument or invalid value) keep that panel on
+>   `stderr` for a human. Under explicit `--json`, gda classifies the same exit-2
+>   refusal as `invalid_argument` and emits the envelope on `stdout` before any
+>   operation runs (#947). Model validators contribute their already-sanitized
+>   sentence. Click type conversion names only the argument contract and does not echo
+>   the raw token. The same human fall-through holds where gda recognizes a mistake
+>   but has no correction to add and no `--json` was asked for: gda declines to answer
+>   and the parser's message stands.
 > - `--json` is unchanged. The envelope goes to `stdout`, byte for byte; the flag
 >   chooses the rendering, never the stream.
 > - Two reversals were considered and declined. Sending the `usage` refusals back to
@@ -287,6 +289,7 @@ operation, and parse codes the CLI assigns).
 | `user_data_unwritable` | `environment` | `runner` | `127` | The log or user-data placement for the launch could not be made usable, so the launch was refused. |
 | `unknown_command` | `usage` | `classifier` | `2` | gda has no such command; discover the surface with `gda schema` or `gda --help`. A recognized near miss also carries the supported invocation in the envelope's `hint`. |
 | `unknown_option` | `usage` | `classifier` | `2` | The command exists but has no such option; read its options with `--help` or its input contract with `--schema`. A recognized near miss also carries the supported invocation in the envelope's `hint`. |
+| `invalid_argument` | `usage` | `classifier` | `2` | A command-line argument or option value does not match the command's argv contract; with `--json`, gda reports the parser refusal as a structured envelope before any operation runs. |
 | `unsupported_version` | `version` | `version_gate` | `3` | The detected Godot version is below the supported minimum. |
 | `engine_crashed` | `operation` | `classifier` | `4` | Godot terminated abnormally, such as by signal death. |
 | `operation_failed` | `operation` | `classifier` | `4` | The engine or operation failed without a valid registered operation error envelope. |

--- a/docs/adr/0002-headless-structured-output-contract.md
+++ b/docs/adr/0002-headless-structured-output-contract.md
@@ -228,14 +228,15 @@ the standard build), and they never determine the outcome or a stable code.
 >   them through the renderer makes the one-renderer statement exact and makes the
 >   `hint:` line reachable: it is set nowhere else, so before #798 a human could not
 >   read it.
-> - Click's own parse errors (a missing argument or invalid value) keep that panel on
->   `stderr` for a human. Under explicit `--json`, gda classifies the same exit-2
->   refusal as `invalid_argument` and emits the envelope on `stdout` before any
->   operation runs (#947). Model validators contribute their already-sanitized
->   sentence. Click type conversion names only the argument contract and does not echo
->   the raw token. The same human fall-through holds where gda recognizes a mistake
->   but has no correction to add and no `--json` was asked for: gda declines to answer
->   and the parser's message stands.
+> - An invalid supplied value keeps Click's parser panel on `stderr` for a human. Under
+>   explicit `--json`, validation that reaches `BadParameter` is classified as
+>   `invalid_argument` and emitted on `stdout` before any operation runs (#947). Model
+>   validators contribute their already-sanitized sentence. Click type conversion
+>   names only the argument contract and does not echo the raw token. Click syntax
+>   errors outside that validation boundary, such as an option with no value, retain
+>   Click's text on `stderr` even under `--json`. The same human fall-through holds
+>   where gda recognizes a mistake but has no correction to add and no `--json` was
+>   asked for: gda declines to answer and the parser's message stands.
 > - `--json` is unchanged. The envelope goes to `stdout`, byte for byte; the flag
 >   chooses the rendering, never the stream.
 > - Two reversals were considered and declined. Sending the `usage` refusals back to
@@ -289,7 +290,7 @@ operation, and parse codes the CLI assigns).
 | `user_data_unwritable` | `environment` | `runner` | `127` | The log or user-data placement for the launch could not be made usable, so the launch was refused. |
 | `unknown_command` | `usage` | `classifier` | `2` | gda has no such command; discover the surface with `gda schema` or `gda --help`. A recognized near miss also carries the supported invocation in the envelope's `hint`. |
 | `unknown_option` | `usage` | `classifier` | `2` | The command exists but has no such option; read its options with `--help` or its input contract with `--schema`. A recognized near miss also carries the supported invocation in the envelope's `hint`. |
-| `invalid_argument` | `usage` | `classifier` | `2` | A command-line argument or option value does not match the command's argv contract; with `--json`, gda reports the parser refusal as a structured envelope before any operation runs. |
+| `invalid_argument` | `usage` | `classifier` | `2` | A supplied command-line argument or option value does not match the command's argv contract; with `--json`, gda reports that validation as a structured envelope before any operation runs. |
 | `unsupported_version` | `version` | `version_gate` | `3` | The detected Godot version is below the supported minimum. |
 | `engine_crashed` | `operation` | `classifier` | `4` | Godot terminated abnormally, such as by signal death. |
 | `operation_failed` | `operation` | `classifier` | `4` | The engine or operation failed without a valid registered operation error envelope. |

--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -785,8 +785,9 @@ script as **raw text** — it never compiles or loads the script, so editing one
 project code (the read trust boundary of #30). It edits only a script that exists; a missing
 target is `path_not_found`, never a silent create. Exactly one of three mutually-exclusive
 modes must be selected — derived once by the params model, identically on argv and
-`--params-json` (ADR-0015, #713); a missing or mixed mode is a usage error, exit 2, on argv,
-and structured `invalid_params` on `--params-json`:
+`--params-json` (ADR-0015, #713); a missing or mixed mode is a usage error, exit 2,
+on argv (`invalid_argument` when `--json` selects the envelope), and structured
+`invalid_params` on `--params-json`:
 
 - **search-replace** — `--search <old> --replace <new>`: replace **every** literal (not regex)
   occurrence of `<old>` with `<new>`. A search string the source does not contain is refused
@@ -1155,7 +1156,10 @@ gda resource reimport --params-json '{"path":"res://model.glb","updates":{"nodes
 Dry-run validates the patch and recorded configuration without target mutation,
 target loading, or an import pass. It does not predict geometry or prove engine
 adoption. Unknown keys, nonnumeric values (including booleans), out-of-range values
-and unavailable scene scale configuration are refused. A no-op returns `unchanged`
+and unavailable scene scale configuration are refused. On argv, malformed
+`--updates-json` and model refusals are `invalid_argument`/exit 2 under `--json`;
+the equivalent structured object remains `invalid_params`/exit 4 under
+`--params-json`. Both are decided before any engine operation or file change. A no-op returns `unchanged`
 with no configuration write, import pass or dimension verification; this does not
 prove that a previously edited sidecar was adopted. Invalid cache evidence needs
 explicit repair; this command does not delete sidecars or caches to repair it.
@@ -1639,8 +1643,9 @@ re-derives every verdict from a running engine.
   sequence's selected-clock window (`max(frame)+1` or `max(physics_frame)+1` ≤ the
   per-window ceiling, the same bound `perf monitor` enforces, #223) are bounded
   **model-side** (ADR-0015), so an
-  out-of-contract request is a structured `invalid_params` (or argv usage error)
-  before it reaches the harness. The two failures that need the live engine
+  out-of-contract request is structured `invalid_params` on `--params-json`, or
+  `invalid_argument`/exit 2 on argv under `--json`, before it reaches the harness.
+  The two failures that need the live engine
   to decide are deferred to the harness: a key name the engine cannot resolve to a
   keycode is `live_invalid_key`, an action absent from the running `InputMap` is
   `live_unknown_action`; a sequence event whose type the harness does not recognize

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -140,8 +140,8 @@ def main(
         # way: this callback body runs before click parses one.)
         is_eager=True,
         help="Emit the invoked command's structured result or gda error envelope "
-        "as JSON — the same as passing --json after the command. Click syntax "
-        "errors stay text. With --version it emits structured install provenance "
+        "as JSON — the same as passing --json after the command. Some syntax "
+        "errors remain text. With --version it emits structured install provenance "
         "(`--help` stays text).",
     ),
     user_data_root: Optional[str] = typer.Option(

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -139,9 +139,10 @@ def main(
         # `--version`, whose callback reads it. (A SUBCOMMAND is unaffected either
         # way: this callback body runs before click parses one.)
         is_eager=True,
-        help="Emit the invoked command's result as JSON — the same as passing "
-        "--json after the command; with --version it emits structured install "
-        "provenance (`--help` stays text).",
+        help="Emit the invoked command's outcome as JSON — the result on success "
+        "or an error envelope on failure; the same as passing --json after the "
+        "command. With --version it emits structured install provenance "
+        "(`--help` stays text).",
     ),
     user_data_root: Optional[str] = typer.Option(
         None,

--- a/src/gda/cli.py
+++ b/src/gda/cli.py
@@ -139,9 +139,9 @@ def main(
         # `--version`, whose callback reads it. (A SUBCOMMAND is unaffected either
         # way: this callback body runs before click parses one.)
         is_eager=True,
-        help="Emit the invoked command's outcome as JSON — the result on success "
-        "or an error envelope on failure; the same as passing --json after the "
-        "command. With --version it emits structured install provenance "
+        help="Emit the invoked command's structured result or gda error envelope "
+        "as JSON — the same as passing --json after the command. Click syntax "
+        "errors stay text. With --version it emits structured install provenance "
         "(`--help` stays text).",
     ),
     user_data_root: Optional[str] = typer.Option(

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -146,9 +146,9 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.USAGE,
         EXIT_USAGE,
         ErrorCodeSource.CLASSIFIER,
-        "A supplied command-line argument or option value does not match the "
-        "command's argv contract; with --json, gda reports that validation as a "
-        "structured envelope before any operation runs.",
+        "A required command-line parameter is missing or a supplied argument or "
+        "option value does not match the command's argv contract; with --json, gda "
+        "reports that validation as a structured envelope before any operation runs.",
     ),
     ErrorCodeSpec(
         "unsupported_version",

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -146,8 +146,8 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         ErrorCategory.USAGE,
         EXIT_USAGE,
         ErrorCodeSource.CLASSIFIER,
-        "A command-line argument or option value does not match the command's "
-        "argv contract; with --json, gda reports the parser refusal as a "
+        "A supplied command-line argument or option value does not match the "
+        "command's argv contract; with --json, gda reports that validation as a "
         "structured envelope before any operation runs.",
     ),
     ErrorCodeSpec(

--- a/src/gda/error_codes.py
+++ b/src/gda/error_codes.py
@@ -114,14 +114,15 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "so the launch was refused.",
     ),
     # The USAGE category (#670): gda could not resolve WHAT was asked for, so no
-    # operation was ever identified — the stage before every other code here. Both
-    # rows are classifier-source (the CLI decides them; no GDScript operation can
-    # report one, so neither is mirrored) and both exit 2, the code every CLI parser
+    # operation was ever run — the stage before every other code here. All rows are
+    # classifier-source (the CLI decides them; no GDScript operation can report one,
+    # so none is mirrored) and all exit 2, the code every CLI parser
     # already uses for a usage error: gda's structured refusal is that same failure
     # reported better, not a different one, so the exit an agent already keys on is
     # unchanged. They are kept apart from each other because the remedy differs — an
     # unknown COMMAND sends the caller to `gda schema` / `gda --help`, an unknown
-    # OPTION to that command's own `--help` / `--schema`.
+    # OPTION to that command's own `--help` / `--schema`; an invalid argument
+    # keeps the parser's safe validation sentence.
     ErrorCodeSpec(
         "unknown_command",
         ErrorCategory.USAGE,
@@ -139,6 +140,15 @@ ERROR_CODES: tuple[ErrorCodeSpec, ...] = (
         "The command exists but has no such option; read its options with "
         "`--help` or its input contract with `--schema`. A recognized near miss "
         "also carries the supported invocation in the envelope's `hint`.",
+    ),
+    ErrorCodeSpec(
+        "invalid_argument",
+        ErrorCategory.USAGE,
+        EXIT_USAGE,
+        ErrorCodeSource.CLASSIFIER,
+        "A command-line argument or option value does not match the command's "
+        "argv contract; with --json, gda reports the parser refusal as a "
+        "structured envelope before any operation runs.",
     ),
     ErrorCodeSpec(
         "unsupported_version",

--- a/src/gda/exit_codes.py
+++ b/src/gda/exit_codes.py
@@ -24,7 +24,8 @@ glance and new codes cannot silently collide.
   ``parse`` it spans several ``GdaError.code``s that the ``code`` field tells
   apart.
 - ``EXIT_USAGE`` (exit ``2``) is the ``usage`` category: gda could not resolve
-  what was asked for — an unrecognized command or option (#670). It is the ONE
+  what was asked for, or argv did not satisfy the command's declared contract
+  (#670, #947). It is the ONE
   value here gda did not choose: ``2`` is the exit every CLI parser (click's
   included) already uses for a usage error, and gda's structured refusal is the
   same failure reported better, not a different one. Registering it therefore

--- a/src/gda/exit_codes.py
+++ b/src/gda/exit_codes.py
@@ -24,8 +24,8 @@ glance and new codes cannot silently collide.
   ``parse`` it spans several ``GdaError.code``s that the ``code`` field tells
   apart.
 - ``EXIT_USAGE`` (exit ``2``) is the ``usage`` category: gda could not resolve
-  what was asked for, or argv did not satisfy the command's declared contract
-  (#670, #947). It is the ONE
+  what was asked for, or a supplied argv value did not satisfy the command's
+  declared contract (#670, #947). It is the ONE
   value here gda did not choose: ``2`` is the exit every CLI parser (click's
   included) already uses for a usage error, and gda's structured refusal is the
   same failure reported better, not a different one. Registering it therefore

--- a/src/gda/exit_codes.py
+++ b/src/gda/exit_codes.py
@@ -24,8 +24,8 @@ glance and new codes cannot silently collide.
   ``parse`` it spans several ``GdaError.code``s that the ``code`` field tells
   apart.
 - ``EXIT_USAGE`` (exit ``2``) is the ``usage`` category: gda could not resolve
-  what was asked for, or a supplied argv value did not satisfy the command's
-  declared contract (#670, #947). It is the ONE
+  what was asked for, or an argv parameter did not satisfy the command's declared
+  contract (#670, #947). It is the ONE
   value here gda did not choose: ``2`` is the exit every CLI parser (click's
   included) already uses for a usage error, and gda's structured refusal is the
   same failure reported better, not a different one. Registering it therefore

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -203,8 +203,8 @@ def json_option() -> bool:
         False,
         "--json",
         callback=_inherit_ancestor_json,
-        help="Emit the outcome as one JSON object: the result on success or an "
-        "error envelope on failure.",
+        help="Emit the command's structured result or gda error envelope as one "
+        "JSON object. Click syntax errors stay text.",
     )
 
 
@@ -232,9 +232,9 @@ def _group_json(
         False,
         "--json",
         callback=_record_group_json,
-        help="Emit the invoked command's outcome as JSON — the result on success "
-        "or an error envelope on failure; the same as passing --json after the "
-        "command.",
+        help="Emit the invoked command's structured result or gda error envelope "
+        "as JSON — the same as passing --json after the command. Click syntax "
+        "errors stay text.",
     ),
 ) -> None:
     """The callback every command group is given, so ``--json`` parses there too.

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -153,11 +153,12 @@ def json_in_effect(ctx: ClickContext) -> bool:
     2. The ancestor ``--json``, recorded when the root callback (#671) or a group's
        (#683) bound it — the reading available at parse time, before any command's
        params exist.
-    3. The literal token in the recorded argv. A ``--json`` written AFTER an
-       offending token never parses, because the command or option it would have
-       belonged to does not exist, so the token itself is the only evidence of the
-       intent — and it is read as exactly that. The Skill teaches the trailing
-       spelling, so leaving this reading out would answer most agents in prose.
+    3. The literal token in the recorded argv, before an end-of-options ``--``. A
+       ``--json`` written AFTER an offending token never parses, because the command
+       or option it would have belonged to does not exist, so the token itself is the
+       only evidence of the intent. The Skill teaches the trailing spelling, so
+       leaving this reading out would answer most agents in prose. A token after
+       ``--`` is positional data, not a flag, and therefore supplies no such evidence.
 
     It lives HERE, beside :func:`ancestor_json` and the option that inherits it,
     rather than with the near-miss refusal that introduced it (``gda.hints``, #670).
@@ -172,7 +173,12 @@ def json_in_effect(ctx: ClickContext) -> bool:
         return True
     if ancestor_json(ctx):
         return True
-    return "--json" in ctx.meta.get(RAW_ARGV_META_KEY, ())
+    for token in ctx.meta.get(RAW_ARGV_META_KEY, ()):
+        if token == "--":
+            break
+        if token == "--json":
+            return True
+    return False
 
 
 def _inherit_ancestor_json(
@@ -204,7 +210,7 @@ def json_option() -> bool:
         "--json",
         callback=_inherit_ancestor_json,
         help="Emit the command's structured result or gda error envelope as one "
-        "JSON object. Click syntax errors stay text.",
+        "JSON object. Some syntax errors remain text.",
     )
 
 
@@ -233,8 +239,8 @@ def _group_json(
         "--json",
         callback=_record_group_json,
         help="Emit the invoked command's structured result or gda error envelope "
-        "as JSON — the same as passing --json after the command. Click syntax "
-        "errors stay text.",
+        "as JSON — the same as passing --json after the command. Some syntax "
+        "errors remain text.",
     ),
 ) -> None:
     """The callback every command group is given, so ``--json`` parses there too.

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -166,11 +166,11 @@ def json_in_effect(ctx: ClickContext) -> bool:
     It lives HERE, beside :func:`ancestor_json` and the option that inherits it,
     rather than with the near-miss refusal that introduced it (``gda.hints``, #670).
     :func:`emit_failure` does NOT ask it — it takes ``json_output`` as a required
-    keyword and never reads a context; the askers in this module are the two
-    ``--params-json`` refusals in ``_SchemaCommand.invoke``, which hold a click
-    context and no flag. What settles the direction is the import: ``gda.hints``
-    already depends on this module for the failure channel, so a channel question
-    owned by ``hints`` would need that import to run backwards (#685).
+    keyword and never reads a context. The raw fallback's only callers are the
+    unknown-command and unknown-option refusals in ``gda.hints``. What settles the
+    direction is the import: ``gda.hints`` already depends on this module for the
+    failure channel, so a channel question owned by ``hints`` would need that import
+    to run backwards (#685).
     """
     if parsed_json_in_effect(ctx):
         return True
@@ -604,7 +604,7 @@ def schema_command_class(
                 ):
                     emit_failure(
                         conflicting_params_input_failure(),
-                        json_output=json_in_effect(ctx),
+                        json_output=parsed_json_in_effect(ctx),
                     )
                 raw = ctx.params["params_json"]
                 # ``-`` reads the object from stdin so large payloads avoid OS
@@ -623,7 +623,7 @@ def schema_command_class(
                     # into the structured envelope's message.
                     emit_failure(
                         invalid_params_json_failure(validation_error_message(exc)),
-                        json_output=json_in_effect(ctx),
+                        json_output=parsed_json_in_effect(ctx),
                     )
                 if _params_json_dispatch is None:  # pragma: no cover - misconfig
                     raise RuntimeError(

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -143,22 +143,25 @@ def remember_argv(ctx: ClickContext, args: list[str]) -> None:
     ctx.meta.setdefault(RAW_ARGV_META_KEY, list(args))
 
 
-def json_in_effect(ctx: ClickContext) -> bool:
-    """Whether this invocation asked for JSON, in three ordered readings.
+def parsed_json_in_effect(ctx: ClickContext) -> bool:
+    """Whether this command or an already-parsed ancestor selected JSON.
 
-    1. The command's OWN resolved flag, when the question is asked after its parse —
-       the case for a dispatched command and for ``gda help <unknown>``. It already
-       carries an inherited ancestor ``--json`` (:func:`_inherit_ancestor_json`), so
-       it answers for every spelling wherever it exists.
-    2. The ancestor ``--json``, recorded when the root callback (#671) or a group's
-       (#683) bound it — the reading available at parse time, before any command's
-       params exist.
-    3. The literal token in the recorded argv, before an end-of-options ``--``. A
-       ``--json`` written AFTER an offending token never parses, because the command
-       or option it would have belonged to does not exist, so the token itself is the
-       only evidence of the intent. The Skill teaches the trailing spelling, so
-       leaving this reading out would answer most agents in prose. A token after
-       ``--`` is positional data, not a flag, and therefore supplies no such evidence.
+    Known-command parameter validation asks this narrower question: eager JSON
+    options have already been processed before ordinary values, so parsed state can
+    distinguish a real flag from the same token used as positional data or an option
+    value. Raw argv cannot make that distinction.
+    """
+    return bool(ctx.params.get("json_output")) or ancestor_json(ctx)
+
+
+def json_in_effect(ctx: ClickContext) -> bool:
+    """Whether this invocation asked for JSON, in parsed state or raw fallback.
+
+    First use :func:`parsed_json_in_effect`. For an unresolved command or option, a
+    trailing ``--json`` may never parse because the earlier unknown token stops that
+    parser. The literal token in the recorded argv is then the only evidence of intent,
+    so those pre-parse callers retain the original raw fallback. Known-command
+    parameter validation must use the parsed-only helper instead.
 
     It lives HERE, beside :func:`ancestor_json` and the option that inherits it,
     rather than with the near-miss refusal that introduced it (``gda.hints``, #670).
@@ -169,16 +172,9 @@ def json_in_effect(ctx: ClickContext) -> bool:
     already depends on this module for the failure channel, so a channel question
     owned by ``hints`` would need that import to run backwards (#685).
     """
-    if bool(ctx.params.get("json_output")):
+    if parsed_json_in_effect(ctx):
         return True
-    if ancestor_json(ctx):
-        return True
-    for token in ctx.meta.get(RAW_ARGV_META_KEY, ()):
-        if token == "--":
-            break
-        if token == "--json":
-            return True
-    return False
+    return "--json" in ctx.meta.get(RAW_ARGV_META_KEY, ())
 
 
 def _inherit_ancestor_json(
@@ -209,6 +205,7 @@ def json_option() -> bool:
         False,
         "--json",
         callback=_inherit_ancestor_json,
+        is_eager=True,
         help="Emit the command's structured result or gda error envelope as one "
         "JSON object. Some syntax errors remain text.",
     )
@@ -238,6 +235,7 @@ def _group_json(
         False,
         "--json",
         callback=_record_group_json,
+        is_eager=True,
         help="Emit the invoked command's structured result or gda error envelope "
         "as JSON — the same as passing --json after the command. Some syntax "
         "errors remain text.",

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -203,7 +203,8 @@ def json_option() -> bool:
         False,
         "--json",
         callback=_inherit_ancestor_json,
-        help="Emit the result as a single JSON object.",
+        help="Emit the outcome as one JSON object: the result on success or an "
+        "error envelope on failure.",
     )
 
 
@@ -231,8 +232,9 @@ def _group_json(
         False,
         "--json",
         callback=_record_group_json,
-        help="Emit the invoked command's result as JSON — the same as passing "
-        "--json after the command.",
+        help="Emit the invoked command's outcome as JSON — the result on success "
+        "or an error envelope on failure; the same as passing --json after the "
+        "command.",
     ),
 ) -> None:
     """The callback every command group is given, so ``--json`` parses there too.

--- a/src/gda/hints.py
+++ b/src/gda/hints.py
@@ -11,7 +11,7 @@ opposite — operation. So the mapping here is CURATED: one row per spelling the
 record actually showed — plus, where a row says so, the sibling spelling of one, when
 the same slip reaches a second command — each naming the supported invocation.
 
-This module owns two things, which are the two halves of one job:
+This module owns the usage boundary, in two parts:
 
 - :data:`NEAR_MISSES`, the single authority for what gda recommends. One table, not
   per-group fragments: three of its rows belong to no group at all (a root option, a
@@ -21,16 +21,18 @@ This module owns two things, which are the two halves of one job:
   cannot outlive a rename.
 - :class:`GdaGroup`, the click group the composition root mounts everywhere, which
   turns an unrecognized command or option into gda's ordinary ``{"error": {...}}``
-  envelope.
+  envelope and gives explicit-JSON argv validation failures that same public
+  channel. Human argv validation keeps Click's readable stderr panel.
 
-**Where the interception sits.** A Typer parser reports these two failures at three
-places, and this class covers all of them because ``gda.cli`` gives every group the
-class: an unknown COMMAND is decided in :meth:`GdaGroup.resolve_command` (the group
-it was typed under); an unknown OPTION on the root or on a group surfaces from that
+**Where the interception sits.** Unknown names can surface at three points, and
+this class covers all of them because ``gda.cli`` gives every group the class: an
+unknown COMMAND is decided in :meth:`GdaGroup.resolve_command` (the group it was
+typed under); an unknown OPTION on the root or on a group surfaces from that
 parser's own :meth:`GdaGroup.parse_args`; and an unknown option on a LEAF command
 surfaces from the leaf's parser, which runs inside its parent group's
-:meth:`GdaGroup.invoke`. So no command module — and no leaf command class — carries
-a line of this.
+:meth:`GdaGroup.invoke`. Type and model validation failures also reach that final
+``invoke`` boundary. So no command module — and no leaf command class — carries a
+line of this.
 
 **Which channel answers.** Whichever the invocation asked for, through the ONE
 public failure channel (``gda.headless.emit_failure``): the structured envelope
@@ -66,9 +68,10 @@ from gda.headless import (
     walk_mounted_groups,
 )
 
-# The two registered codes this module reports (ADR-0002, the `usage` category).
+# The registered codes this module reports (ADR-0002, the `usage` category).
 UNKNOWN_COMMAND = "unknown_command"
 UNKNOWN_OPTION = "unknown_option"
+INVALID_ARGUMENT = "invalid_argument"
 
 # Where the whole surface is enumerated — named in every hintless refusal, so a
 # caller that gda cannot advise is still pointed somewhere useful.
@@ -340,6 +343,23 @@ def _is_option(token: str) -> bool:
     return token.startswith("-") and token != "-"
 
 
+def _bad_parameter_message(exc: typer.BadParameter) -> str:
+    """Return an argv-refusal sentence without echoing a parser input value.
+
+    Command bodies raise ``BadParameter`` with an already-sanitized sentence after
+    the shared params model rejects the request. Click's own type conversion instead
+    attaches the parameter and commonly puts the raw token in ``message``. Name that
+    parameter and its contract, but never copy the token into the public envelope.
+    """
+    if exc.param is None:
+        return exc.message
+    options = getattr(exc.param, "opts", ())
+    label = next((option for option in options if option.startswith("--")), None)
+    if label is None:
+        label = getattr(exc.param, "human_readable_name", "argument")
+    return f"{label}: does not satisfy its declared argv contract"
+
+
 class GdaGroup(TyperGroup):
     """The click group gda mounts at every level, so a wrong invocation is reported.
 
@@ -372,6 +392,17 @@ class GdaGroup(TyperGroup):
             return super().invoke(ctx)
         except NoSuchOption as exc:
             _refuse_option(ctx, exc, on_group=False)
+            raise
+        except typer.BadParameter as exc:
+            # Human callers retain Click's readable stderr panel. An explicit JSON
+            # caller instead receives the same exit-2 usage failure through gda's
+            # public envelope, before a command can dispatch an operation.
+            target = exc.ctx or ctx
+            if json_in_effect(target):
+                emit_failure(
+                    make_failure(INVALID_ARGUMENT, _bad_parameter_message(exc), ""),
+                    json_output=True,
+                )
             raise
 
     def resolve_command(self, ctx: ClickContext, args: list[str]):

--- a/src/gda/hints.py
+++ b/src/gda/hints.py
@@ -64,6 +64,7 @@ from gda.errors import Failure, make_failure
 from gda.headless import (
     emit_failure,
     json_in_effect,
+    parsed_json_in_effect,
     remember_argv,
     walk_mounted_groups,
 )
@@ -398,7 +399,7 @@ class GdaGroup(TyperGroup):
             # caller instead receives the same exit-2 usage failure through gda's
             # public envelope, before a command can dispatch an operation.
             target = exc.ctx or ctx
-            if json_in_effect(target):
+            if parsed_json_in_effect(target):
                 emit_failure(
                     make_failure(INVALID_ARGUMENT, _bad_parameter_message(exc), ""),
                     json_output=True,

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -42,8 +42,8 @@ class ErrorCategory(str, Enum):
     LIVE is a Phase-2 live operation failing against ``gda-daemon`` / the engine
     session — no running daemon, a lost session, or a live timeout (ADR-0017,
     ADR-0021). USAGE is the one bucket that precedes all of them: gda could not
-    resolve WHAT was asked for, or argv did not satisfy the identified command's
-    contract, so no operation was run (#670, #947).
+    resolve WHAT was asked for, or a supplied argv value did not satisfy the
+    identified command's contract, so no operation was run (#670, #947).
     """
 
     ENVIRONMENT = "environment"

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -42,8 +42,8 @@ class ErrorCategory(str, Enum):
     LIVE is a Phase-2 live operation failing against ``gda-daemon`` / the engine
     session — no running daemon, a lost session, or a live timeout (ADR-0017,
     ADR-0021). USAGE is the one bucket that precedes all of them: gda could not
-    resolve WHAT was asked for, or a supplied argv value did not satisfy the
-    identified command's contract, so no operation was run (#670, #947).
+    resolve WHAT was asked for, or an argv parameter did not satisfy the identified
+    command's contract, so no operation was run (#670, #947).
     """
 
     ENVIRONMENT = "environment"

--- a/src/gda/models.py
+++ b/src/gda/models.py
@@ -42,8 +42,8 @@ class ErrorCategory(str, Enum):
     LIVE is a Phase-2 live operation failing against ``gda-daemon`` / the engine
     session — no running daemon, a lost session, or a live timeout (ADR-0017,
     ADR-0021). USAGE is the one bucket that precedes all of them: gda could not
-    resolve WHAT was asked for — an unrecognized command or option — so no
-    operation was ever identified, let alone run (#670).
+    resolve WHAT was asked for, or argv did not satisfy the identified command's
+    contract, so no operation was run (#670, #947).
     """
 
     ENVIRONMENT = "environment"

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -191,11 +191,11 @@ the mistake the envelope carries a `hint` naming the invocation to run instead
 `hint`; when there is none, `gda schema` lists every command and
 `gda help <command>` describes one.
 
-An argument that does not match the command's argv contract is
-`invalid_argument` at exit `2`. With `--json`, malformed option JSON, wrong types,
-unknown object keys, and shared command-model refusals use the same error envelope
-before any engine operation runs. Click syntax errors outside that validation
-boundary, such as an option with no value, retain Click's text on `stderr` even under
+A missing required parameter or argument that does not match the command's argv
+contract is `invalid_argument` at exit `2`. With `--json`, malformed option JSON,
+wrong types, unknown object keys, and shared command-model refusals use the same error
+envelope before any engine operation runs. Other Click syntax errors, such as an
+option token with no following value, may retain Click's text on `stderr` even under
 `--json`. The equivalent invalid `--params-json` object remains `invalid_params` at
 exit `4` because it is the structured parameter contract.
 

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -193,9 +193,11 @@ the mistake the envelope carries a `hint` naming the invocation to run instead
 
 An argument that does not match the command's argv contract is
 `invalid_argument` at exit `2`. With `--json`, malformed option JSON, wrong types,
-unknown object keys, and other parser refusals use the same error envelope before any
-engine operation runs. The equivalent invalid `--params-json` object remains
-`invalid_params` at exit `4` because it is the structured parameter contract.
+unknown object keys, and shared command-model refusals use the same error envelope
+before any engine operation runs. Click syntax errors outside that validation
+boundary, such as an option with no value, retain Click's text on `stderr` even under
+`--json`. The equivalent invalid `--params-json` object remains `invalid_params` at
+exit `4` because it is the structured parameter contract.
 
 A failure that computed evidence also carries it as DATA, under the envelope's
 optional `evidence` key — omitted, never null, on the failures that computed none.

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -169,7 +169,7 @@ Branch on the stable `category`/`code` and the **exit code**, never on prose:
 | Exit | Meaning |
 | ---- | ------- |
 | `0`   | success |
-| `2`   | gda could not resolve what you asked for: `unknown_command`, `unknown_option` |
+| `2`   | argv usage failure: `unknown_command`, `unknown_option`, `invalid_argument` |
 | `127` | environment unusable: `binary_not_found`, `user_data_unwritable`, `live_unsupported_platform`, `live_windowed_unavailable`, `live_windowed_permission_denied`, `harness_install_permission_denied` |
 | `124` | engine timed out: `launch_timeout` — gda ended a run that had not returned (read it as below) |
 | `3`   | engine version too old |
@@ -190,6 +190,12 @@ the mistake the envelope carries a `hint` naming the invocation to run instead
 (`{"error": {"code": "unknown_command", "hint": "gda scene get", …}}`). Re-issue the
 `hint`; when there is none, `gda schema` lists every command and
 `gda help <command>` describes one.
+
+An argument that does not match the command's argv contract is
+`invalid_argument` at exit `2`. With `--json`, malformed option JSON, wrong types,
+unknown object keys, and other parser refusals use the same error envelope before any
+engine operation runs. The equivalent invalid `--params-json` object remains
+`invalid_params` at exit `4` because it is the structured parameter contract.
 
 A failure that computed evidence also carries it as DATA, under the envelope's
 optional `evidence` key — omitted, never null, on the failures that computed none.

--- a/tests/asset_pipeline/test_asset_pipeline_cli.py
+++ b/tests/asset_pipeline/test_asset_pipeline_cli.py
@@ -17,7 +17,7 @@ from gda_assets.api import (
     PipelineResult,
 )
 from gda.errors import make_failure
-from tests.support import minimal_project
+from tests.support import minimal_project, structured_argv_error_message
 
 
 def test_asset_pipeline_run_is_discoverable_with_typed_file_input():
@@ -203,7 +203,7 @@ def test_relative_sources_need_an_explicit_base_independent_of_cwd(
 
     assert argv_refusal.exit_code == 2
     assert params_refusal.exit_code == 4
-    assert "source_root is required" in argv_refusal.stderr
+    assert "source_root is required" in structured_argv_error_message(argv_refusal)
     assert "source_root is required" in params_refusal.stdout
     assert calls == []
 

--- a/tests/cli/test_argv_validation.py
+++ b/tests/cli/test_argv_validation.py
@@ -14,7 +14,7 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.commands.resource import ResourceReimportResult
-from gda.exit_codes import EXIT_USAGE
+from gda.exit_codes import EXIT_OPERATION, EXIT_USAGE
 from tests.support import GDA_CMD, minimal_project, panel_text
 
 
@@ -293,6 +293,53 @@ def test_real_cli_known_parameter_failures_use_only_parsed_json_flags(
     else:
         assert done.stdout == ""
         assert panel_text(done.stderr)
+
+
+@pytest.mark.parametrize(
+    ("individual_argv", "expected_code"),
+    [
+        pytest.param([], "invalid_params", id="invalid-params-object"),
+        pytest.param(
+            ["res://individual-model.glb"],
+            "usage_error",
+            id="conflicting-individual-argv",
+        ),
+    ],
+)
+def test_real_cli_params_json_failures_use_only_parsed_json_flags(
+    individual_argv, expected_code
+):
+    common = [
+        "resource",
+        "reimport",
+        *individual_argv,
+        "--params-json",
+        "--json",
+    ]
+    human = subprocess.run(
+        [*GDA_CMD, *common],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    structured = subprocess.run(
+        [*GDA_CMD, *common, "--json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert human.returncode == EXIT_OPERATION, human.stdout + human.stderr
+    assert human.stderr == ""
+    assert not human.stdout.lstrip().startswith("{")
+    assert expected_code in panel_text(human.stdout)
+    assert structured.returncode == EXIT_OPERATION, (
+        structured.stdout + structured.stderr
+    )
+    assert structured.stderr == ""
+    error = json.loads(structured.stdout)["error"]
+    assert error["category"] == "operation"
+    assert error["code"] == expected_code
 
 
 def _snapshot_files(root: Path) -> dict[str, bytes]:

--- a/tests/cli/test_argv_validation.py
+++ b/tests/cli/test_argv_validation.py
@@ -210,6 +210,61 @@ def test_click_syntax_error_outside_validation_stays_text_under_json():
     assert "requires an argument" in panel_text(done.stderr)
 
 
+def test_real_cli_raw_json_fallback_stops_at_end_of_options():
+    human = subprocess.run(
+        [
+            *GDA_CMD,
+            "game",
+            "tree",
+            "--max-depth",
+            "wrong",
+            "--",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    inherited = subprocess.run(
+        [
+            *GDA_CMD,
+            "--json",
+            "game",
+            "tree",
+            "--max-depth",
+            "wrong",
+            "--",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert human.returncode == EXIT_USAGE, human.stdout + human.stderr
+    assert human.stdout == ""
+    assert "--max-depth" in panel_text(human.stderr)
+    assert inherited.returncode == EXIT_USAGE, inherited.stdout + inherited.stderr
+    assert inherited.stderr == ""
+    assert json.loads(inherited.stdout)["error"]["code"] == "invalid_argument"
+
+
+def test_real_cli_missing_required_parameter_is_structured_under_json():
+    done = subprocess.run(
+        [*GDA_CMD, "resource", "reimport", "--json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert done.returncode == EXIT_USAGE, done.stdout + done.stderr
+    assert done.stderr == ""
+    error = json.loads(done.stdout)["error"]
+    assert error["category"] == "usage"
+    assert error["code"] == "invalid_argument"
+    assert "path" in error["message"].lower()
+
+
 def _snapshot_files(root: Path) -> dict[str, bytes]:
     return {
         path.relative_to(root).as_posix(): path.read_bytes()

--- a/tests/cli/test_argv_validation.py
+++ b/tests/cli/test_argv_validation.py
@@ -9,6 +9,7 @@ import json
 import subprocess
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from gda.cli import app
@@ -210,59 +211,88 @@ def test_click_syntax_error_outside_validation_stays_text_under_json():
     assert "requires an argument" in panel_text(done.stderr)
 
 
-def test_real_cli_raw_json_fallback_stops_at_end_of_options():
-    human = subprocess.run(
-        [
-            *GDA_CMD,
-            "game",
-            "tree",
-            "--max-depth",
-            "wrong",
-            "--",
-            "--json",
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    inherited = subprocess.run(
-        [
-            *GDA_CMD,
-            "--json",
-            "game",
-            "tree",
-            "--max-depth",
-            "wrong",
-            "--",
-            "--json",
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-
-    assert human.returncode == EXIT_USAGE, human.stdout + human.stderr
-    assert human.stdout == ""
-    assert "--max-depth" in panel_text(human.stderr)
-    assert inherited.returncode == EXIT_USAGE, inherited.stdout + inherited.stderr
-    assert inherited.stderr == ""
-    assert json.loads(inherited.stdout)["error"]["code"] == "invalid_argument"
-
-
-def test_real_cli_missing_required_parameter_is_structured_under_json():
+@pytest.mark.parametrize(
+    ("argv", "json_expected"),
+    [
+        pytest.param(
+            ["game", "tree", "--max-depth", "wrong", "--json"],
+            True,
+            id="leaf-json",
+        ),
+        pytest.param(
+            ["--", "game", "tree", "--max-depth", "wrong", "--json"],
+            True,
+            id="root-terminator-before-leaf-json",
+        ),
+        pytest.param(
+            ["game", "--", "tree", "--max-depth", "wrong", "--json"],
+            True,
+            id="group-terminator-before-leaf-json",
+        ),
+        pytest.param(
+            ["game", "tree", "--max-depth", "wrong", "--", "--json"],
+            False,
+            id="leaf-terminator-before-positional-json",
+        ),
+        pytest.param(
+            ["--json", "game", "tree", "--max-depth", "wrong", "--", "--json"],
+            True,
+            id="root-json-before-leaf-terminator",
+        ),
+        pytest.param(
+            ["game", "--json", "tree", "--max-depth", "wrong", "--", "--json"],
+            True,
+            id="group-json-before-leaf-terminator",
+        ),
+        pytest.param(
+            ["resource", "reimport", "--json"],
+            True,
+            id="missing-required-parameter-with-json",
+        ),
+        pytest.param(
+            [
+                "resource",
+                "reimport",
+                "res://model.glb",
+                "--updates-json",
+                "--json",
+            ],
+            False,
+            id="json-token-consumed-as-option-value",
+        ),
+        pytest.param(
+            [
+                "resource",
+                "reimport",
+                "res://model.glb",
+                "--updates-json",
+                "--json",
+                "--json",
+            ],
+            True,
+            id="option-value-followed-by-json-flag",
+        ),
+    ],
+)
+def test_real_cli_known_parameter_failures_use_only_parsed_json_flags(
+    argv, json_expected
+):
     done = subprocess.run(
-        [*GDA_CMD, "resource", "reimport", "--json"],
+        [*GDA_CMD, *argv],
         capture_output=True,
         text=True,
         check=False,
     )
 
     assert done.returncode == EXIT_USAGE, done.stdout + done.stderr
-    assert done.stderr == ""
-    error = json.loads(done.stdout)["error"]
-    assert error["category"] == "usage"
-    assert error["code"] == "invalid_argument"
-    assert "path" in error["message"].lower()
+    if json_expected:
+        assert done.stderr == ""
+        error = json.loads(done.stdout)["error"]
+        assert error["category"] == "usage"
+        assert error["code"] == "invalid_argument"
+    else:
+        assert done.stdout == ""
+        assert panel_text(done.stderr)
 
 
 def _snapshot_files(root: Path) -> dict[str, bytes]:

--- a/tests/cli/test_argv_validation.py
+++ b/tests/cli/test_argv_validation.py
@@ -1,0 +1,311 @@
+"""Structured argv validation failures (issue #947).
+
+These tests exercise the public Typer application.  The command bodies still use
+their shared Pydantic input models; only the rendering of a rejected argv request
+changes when the caller explicitly asks for JSON.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.commands.resource import ResourceReimportResult
+from gda.exit_codes import EXIT_USAGE
+from tests.support import GDA_CMD, minimal_project, panel_text
+
+
+def test_reimport_wrong_update_type_is_a_structured_usage_failure(monkeypatch):
+    """A model refusal is answered before the reimport recipe can run."""
+
+    def no_reimport(*args, **kwargs):
+        raise AssertionError("invalid argv must not reach the reimport recipe")
+
+    monkeypatch.setattr(
+        "gda.commands.resource.run_resource_reimport_operation", no_reimport
+    )
+
+    secret = "SECRET_ARGV_VALUE_947"
+    result = CliRunner().invoke(
+        app,
+        [
+            "resource",
+            "reimport",
+            "res://model.glb",
+            "--updates-json",
+            json.dumps({"nodes/root_scale": secret}),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == EXIT_USAGE, result.stdout + result.stderr
+    assert result.stderr == ""
+    error = json.loads(result.stdout)["error"]
+    assert error == {
+        "category": "usage",
+        "code": "invalid_argument",
+        "message": "updates.nodes/root_scale: Input should be a valid number",
+        "diagnostics": "",
+    }
+    assert secret not in result.stdout
+
+
+def test_reimport_malformed_updates_json_is_a_structured_usage_failure(monkeypatch):
+    def no_reimport(*args, **kwargs):
+        raise AssertionError("malformed argv must not reach the reimport recipe")
+
+    monkeypatch.setattr(
+        "gda.commands.resource.run_resource_reimport_operation", no_reimport
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "resource",
+            "reimport",
+            "res://model.glb",
+            "--updates-json",
+            '{"nodes/root_scale":',
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == EXIT_USAGE, result.stdout + result.stderr
+    assert result.stderr == ""
+    error = json.loads(result.stdout)["error"]
+    assert error == {
+        "category": "usage",
+        "code": "invalid_argument",
+        "message": "updates-json must be a JSON object",
+        "diagnostics": "",
+    }
+
+
+def test_click_type_error_is_structured_without_echoing_the_raw_value():
+    secret = "SECRET_MAX_DEPTH_947"
+
+    result = CliRunner().invoke(
+        app,
+        ["game", "tree", "--max-depth", secret, "--json"],
+    )
+
+    assert result.exit_code == EXIT_USAGE, result.stdout + result.stderr
+    assert result.stderr == ""
+    error = json.loads(result.stdout)["error"]
+    assert error == {
+        "category": "usage",
+        "code": "invalid_argument",
+        "message": "--max-depth: does not satisfy its declared argv contract",
+        "diagnostics": "",
+    }
+    assert secret not in result.stdout
+
+
+def test_reimport_unknown_update_key_is_a_structured_usage_failure(monkeypatch):
+    def no_reimport(*args, **kwargs):
+        raise AssertionError("unknown argv key must not reach the reimport recipe")
+
+    monkeypatch.setattr(
+        "gda.commands.resource.run_resource_reimport_operation", no_reimport
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "resource",
+            "reimport",
+            "res://model.glb",
+            "--updates-json",
+            json.dumps({"meshes/generate_lods": False}),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == EXIT_USAGE, result.stdout + result.stderr
+    error = json.loads(result.stdout)["error"]
+    assert error["category"] == "usage"
+    assert error["code"] == "invalid_argument"
+    assert (
+        "updates.meshes/generate_lods: Extra inputs are not permitted"
+        in error["message"]
+    )
+
+
+def test_equivalent_params_json_failure_retains_invalid_params_exit_four(monkeypatch):
+    def no_reimport(*args, **kwargs):
+        raise AssertionError("invalid params must not reach the reimport recipe")
+
+    monkeypatch.setattr(
+        "gda.commands.resource.run_resource_reimport_operation", no_reimport
+    )
+
+    secret = "SECRET_PARAMS_VALUE_947"
+    result = CliRunner().invoke(
+        app,
+        [
+            "resource",
+            "reimport",
+            "--params-json",
+            json.dumps(
+                {
+                    "path": "res://model.glb",
+                    "updates": {"nodes/root_scale": secret},
+                }
+            ),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 4, result.stdout + result.stderr
+    error = json.loads(result.stdout)["error"]
+    assert error["category"] == "operation"
+    assert error["code"] == "invalid_params"
+    assert error["message"].startswith("--params-json is not a valid params object: ")
+    assert secret not in result.stdout
+
+
+def test_human_argv_failure_keeps_clicks_readable_stderr():
+    result = CliRunner().invoke(
+        app,
+        [
+            "resource",
+            "reimport",
+            "res://model.glb",
+            "--updates-json",
+            "{broken",
+        ],
+    )
+
+    assert result.exit_code == EXIT_USAGE
+    assert result.stdout == ""
+    assert "updates-json must be a JSON object" in panel_text(result.stderr)
+
+
+def _snapshot_files(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+def test_real_cli_argv_failure_does_not_launch_godot_or_mutate_project(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    (project / "model.glb").write_bytes(b"unchanged model bytes")
+    absent_godot = tmp_path / "godot-must-not-be-resolved-or-launched"
+    assert not absent_godot.exists()
+    before = _snapshot_files(project)
+
+    done = subprocess.run(
+        [
+            *GDA_CMD,
+            "resource",
+            "reimport",
+            "res://model.glb",
+            "--updates-json",
+            json.dumps({"nodes/root_scale": "wrong"}),
+            "--project",
+            str(project),
+            "--godot",
+            str(absent_godot),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert done.returncode == EXIT_USAGE, done.stdout + done.stderr
+    assert json.loads(done.stdout)["error"]["code"] == "invalid_argument"
+    assert done.stderr == ""
+    # Reaching binary resolution would change this to binary_not_found/exit 127.
+    assert not absent_godot.exists()
+    assert _snapshot_files(project) == before
+
+
+def test_invalid_argv_honors_each_json_flag_position():
+    core = ["game", "tree", "--max-depth", "wrong"]
+    spellings = (
+        ["--json", *core],
+        ["game", "--json", "tree", "--max-depth", "wrong"],
+        [*core, "--json"],
+    )
+
+    outcomes = [CliRunner().invoke(app, argv) for argv in spellings]
+
+    assert all(result.exit_code == EXIT_USAGE for result in outcomes)
+    assert all(result.stderr == "" for result in outcomes)
+    assert len({result.stdout for result in outcomes}) == 1
+    assert json.loads(outcomes[0].stdout)["error"]["code"] == "invalid_argument"
+
+
+def test_valid_reimport_argv_still_reaches_the_shared_model_and_recipe(
+    monkeypatch, tmp_path
+):
+    project = minimal_project(tmp_path)
+    received = []
+
+    def checked(params_project, params, *, godot=None):
+        received.append((params_project, params, godot))
+        return ResourceReimportResult(
+            path=params.path,
+            dry_run=True,
+            status="checked",
+            changes=[],
+        )
+
+    monkeypatch.setattr(
+        "gda.commands.resource.run_resource_reimport_operation", checked
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "resource",
+            "reimport",
+            "res://model.glb",
+            "--updates-json",
+            json.dumps({"nodes/root_scale": 2.0}),
+            "--dry-run",
+            "--project",
+            str(project),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert json.loads(result.stdout)["status"] == "checked"
+    assert len(received) == 1
+    called_project, params, called_godot = received[0]
+    assert called_project == project
+    assert params.updates.root_scale == 2.0
+    assert params.dry_run is True
+    assert called_godot is None
+
+
+def test_real_cli_other_command_accepts_valid_and_structures_invalid_argv():
+    valid = subprocess.run(
+        [*GDA_CMD, "skill", "--json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    invalid = subprocess.run(
+        [*GDA_CMD, "skill", "--install", "--json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert valid.returncode == 0, valid.stdout + valid.stderr
+    assert json.loads(valid.stdout)["name"] == "gda"
+    assert invalid.returncode == EXIT_USAGE, invalid.stdout + invalid.stderr
+    error = json.loads(invalid.stdout)["error"]
+    assert error["category"] == "usage"
+    assert error["code"] == "invalid_argument"
+    assert "--install" in error["message"]
+    assert invalid.stderr == ""

--- a/tests/cli/test_argv_validation.py
+++ b/tests/cli/test_argv_validation.py
@@ -118,7 +118,12 @@ def test_reimport_unknown_update_key_is_a_structured_usage_failure(monkeypatch):
             "reimport",
             "res://model.glb",
             "--updates-json",
-            json.dumps({"meshes/generate_lods": False}),
+            json.dumps(
+                {
+                    "nodes/root_scale": 1.0,
+                    "meshes/unsupported_947": False,
+                }
+            ),
             "--json",
         ],
     )
@@ -128,7 +133,7 @@ def test_reimport_unknown_update_key_is_a_structured_usage_failure(monkeypatch):
     assert error["category"] == "usage"
     assert error["code"] == "invalid_argument"
     assert (
-        "updates.meshes/generate_lods: Extra inputs are not permitted"
+        "updates.meshes/unsupported_947: Extra inputs are not permitted"
         in error["message"]
     )
 
@@ -181,6 +186,28 @@ def test_human_argv_failure_keeps_clicks_readable_stderr():
     assert result.exit_code == EXIT_USAGE
     assert result.stdout == ""
     assert "updates-json must be a JSON object" in panel_text(result.stderr)
+
+
+def test_click_syntax_error_outside_validation_stays_text_under_json():
+    """A missing option value remains Click syntax output, outside #947's boundary."""
+
+    done = subprocess.run(
+        [
+            *GDA_CMD,
+            "--json",
+            "resource",
+            "reimport",
+            "res://model.glb",
+            "--updates-json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert done.returncode == EXIT_USAGE, done.stdout + done.stderr
+    assert done.stdout == ""
+    assert "requires an argument" in panel_text(done.stderr)
 
 
 def _snapshot_files(root: Path) -> dict[str, bytes]:

--- a/tests/cli/test_dispatch.py
+++ b/tests/cli/test_dispatch.py
@@ -31,20 +31,11 @@ from typer.testing import CliRunner
 
 from gda.cli import app
 from gda.dispatch import params_or_bad_parameter
-from tests.support import assert_no_pydantic_dump, usage_error_text
+from tests.support import assert_no_pydantic_dump, structured_argv_error_message
 
 
 def _argv_usage_error_message(result) -> str:
-    # The Rich-panel normalization is shared (tests/support.py,
-    # `usage_error_text`) — the SAME one tests/live/test_screen_commands.py uses —
-    # so only the "Invalid value: " extraction is specific to this module.
-    plain = usage_error_text(result)
-    # The panel is preceded by the "Usage: ..." / "Try '... --help'" preamble
-    # and an "Error" heading, so find the marker rather than assume it leads.
-    prefix = "Invalid value: "
-    marker = plain.rfind(prefix)
-    assert marker != -1, plain
-    return plain[marker + len(prefix) :]
+    return structured_argv_error_message(result)
 
 
 def _params_json_invalid_params_message(result) -> str:

--- a/tests/cli/test_unknown_invocation.py
+++ b/tests/cli/test_unknown_invocation.py
@@ -293,8 +293,10 @@ def test_the_adoption_reaches_a_nested_sub_group():
     assert isinstance(built.commands["middle"].commands["inner"], GdaGroup)
 
 
-def test_both_refusal_codes_are_registered_at_the_usage_exit():
-    for code in (UNKNOWN_COMMAND, UNKNOWN_OPTION):
+def test_cli_refusal_codes_are_registered_at_the_usage_exit():
+    from gda.hints import INVALID_ARGUMENT
+
+    for code in (UNKNOWN_COMMAND, UNKNOWN_OPTION, INVALID_ARGUMENT):
         spec = ERROR_CODE_BY_CODE[code]
         assert spec.exit_code == EXIT_USAGE
         assert spec.category.value == "usage"

--- a/tests/live/test_game_commands.py
+++ b/tests/live/test_game_commands.py
@@ -26,7 +26,7 @@ from tests.support import (
     inject_live_runner,
     panel_text,
     sentinel,
-    usage_error_text,
+    structured_argv_error_message,
     minimal_project,
 )
 
@@ -168,7 +168,7 @@ def test_game_tree_refuses_a_negative_max_depth(monkeypatch, tmp_path):
     )
 
     assert result.exit_code == 2, result.stdout + result.stderr
-    assert "--max-depth" in usage_error_text(result)
+    assert "--max-depth" in structured_argv_error_message(result)
 
 
 def test_game_tree_help_states_the_bounding_options():

--- a/tests/live/test_input_commands.py
+++ b/tests/live/test_input_commands.py
@@ -32,6 +32,7 @@ from tests.support import (
     error_sentinel,
     inject_live_runner,
     sentinel,
+    structured_argv_error_message,
     minimal_project,
 )
 
@@ -555,7 +556,10 @@ def test_input_tap_requires_exactly_one_target(monkeypatch, tmp_path):
 
     assert neither.exit_code == 2, neither.stdout + neither.stderr
     assert both.exit_code == 2, both.stdout + both.stderr
-    assert "exactly one of 'key' or 'action'" in neither.stderr + both.stderr
+    messages = structured_argv_error_message(neither) + structured_argv_error_message(
+        both
+    )
+    assert "exactly one of 'key' or 'action'" in messages
     assert fake.calls == []
 
 
@@ -597,9 +601,9 @@ def test_input_tap_rejects_the_other_targets_fields(monkeypatch, tmp_path):
     )
 
     assert modifiers_on_action.exit_code == 2
-    assert "rides a key tap only" in modifiers_on_action.stderr
+    assert "rides a key tap only" in structured_argv_error_message(modifiers_on_action)
     assert strength_on_key.exit_code == 2
-    assert "rides an action tap only" in strength_on_key.stderr
+    assert "rides an action tap only" in structured_argv_error_message(strength_on_key)
     assert fake.calls == []
 
 
@@ -629,7 +633,7 @@ def test_input_tap_window_is_bounded_to_the_shared_ceiling(monkeypatch, tmp_path
     )
 
     assert result.exit_code == 2, result.stdout + result.stderr
-    assert str(MAX_WINDOW_FRAMES) in result.stderr
+    assert str(MAX_WINDOW_FRAMES) in structured_argv_error_message(result)
     assert fake.calls == []
 
 
@@ -657,8 +661,8 @@ def test_input_tap_hold_frames_zero_is_a_usage_error(monkeypatch, tmp_path):
     )
 
     assert result.exit_code == 2, result.stdout + result.stderr
-    stripped = re.sub(r"\x1b\[[0-9;]*m", "", result.stderr)
-    assert "--hold-frames" in stripped, stripped
+    message = structured_argv_error_message(result)
+    assert "--hold-frames" in message, message
     assert fake.calls == []
 
 

--- a/tests/live/test_perf_commands.py
+++ b/tests/live/test_perf_commands.py
@@ -27,6 +27,7 @@ from tests.support import (
     perf_sample_reply_all_monitors,
     plain_text,
     sentinel,
+    structured_argv_error_message,
     minimal_project,
 )
 
@@ -611,7 +612,7 @@ def test_perf_monitors_selection_and_budget_require_frames(monkeypatch, tmp_path
     )
 
     assert monitor_only.exit_code == 2, monitor_only.stdout + monitor_only.stderr
-    assert "frames" in plain_text(monitor_only.stderr)
+    assert "frames" in structured_argv_error_message(monitor_only)
     assert budget_only.exit_code == 2, budget_only.stdout + budget_only.stderr
     assert json.loads(params_json.stdout)["error"]["code"] == "invalid_params"
     assert fake.calls == []
@@ -863,7 +864,7 @@ def test_perf_monitors_window_frames_over_ceiling_is_a_usage_error(
     result = _window(tmp_path, "--frames", str(MAX_WINDOW_FRAMES + 1))
 
     assert result.exit_code == 2, result.stdout + result.stderr
-    assert "--frames" in plain_text(result.stderr)
+    assert "--frames" in structured_argv_error_message(result)
     assert fake.calls == []
 
 

--- a/tests/live/test_screen_commands.py
+++ b/tests/live/test_screen_commands.py
@@ -39,7 +39,7 @@ from tests.support import (
     sentinel,
     screen_capture_reply,
     screen_frames_reply,
-    usage_error_text,
+    structured_argv_error_message,
     minimal_project,
 )
 
@@ -680,12 +680,9 @@ def test_await_unmet_predicate_is_the_typed_live_error(monkeypatch, tmp_path):
 
 
 def _usage_error_message(result):
-    # The argv path's contract (gda.dispatch.params_or_bad_parameter): a model
-    # refusal is a Click usage error — exit 2, message on stderr — while the
-    # --params-json path surfaces the SAME rule as structured invalid_params.
-    # The Rich-panel normalization itself is shared (tests/support.py,
-    # `usage_error_text`, #713 review) rather than redefined here.
-    return usage_error_text(result)
+    # The argv path retains exit 2 while an explicit JSON caller receives the
+    # shared usage envelope. The params-json twin remains invalid_params/exit 4.
+    return structured_argv_error_message(result)
 
 
 def _invalid_params_message(result):

--- a/tests/resource/test_model_content_discovery.py
+++ b/tests/resource/test_model_content_discovery.py
@@ -18,7 +18,12 @@ from gda.commands.resource import (
 )
 from gda.errors import Failure
 from gda.runner import RunResult
-from tests.support import FakeRunner, minimal_project, sentinel
+from tests.support import (
+    FakeRunner,
+    minimal_project,
+    sentinel,
+    structured_argv_error_message,
+)
 
 
 CONTENT = {
@@ -180,4 +185,4 @@ def test_live_node_must_be_absolute_before_dispatch(tmp_path):
     )
 
     assert result.exit_code == 2
-    assert "absolute" in result.stderr
+    assert "absolute" in structured_argv_error_message(result)

--- a/tests/resource/test_resource_import_commands.py
+++ b/tests/resource/test_resource_import_commands.py
@@ -963,9 +963,9 @@ def test_no_assets_is_a_usage_error(tmp_path):
     result = _run(project)
 
     assert result.exit_code == 2, result.stdout + result.stderr
-    from tests.support import plain_text
+    from tests.support import structured_argv_error_message
 
-    assert "ASSETS" in plain_text(result.stderr)
+    assert "ASSETS" in structured_argv_error_message(result)
 
 
 def test_schema_is_self_describing():

--- a/tests/support.py
+++ b/tests/support.py
@@ -79,6 +79,16 @@ def usage_error_text(result) -> str:
     return panel_text(result.stderr)
 
 
+def structured_argv_error_message(result) -> str:
+    """Return the safe message from an explicit-JSON argv usage refusal (#947)."""
+    assert result.exit_code == 2, result.stdout + result.stderr
+    assert result.stderr == "", result.stderr
+    error = json.loads(result.stdout)["error"]
+    assert error["category"] == "usage", error
+    assert error["code"] == "invalid_argument", error
+    return error["message"]
+
+
 # The exact fragments a pydantic ``ValidationError`` rendered with its own
 # ``str()`` adds around the checks' real sentences: the ``[type=...,
 # input_value=..., input_type=...]`` tag per error — whose ``input_value``


### PR DESCRIPTION
Missing or invalid argv parameters currently leave JSON callers with empty stdout and text-only parser errors. Route shared `BadParameter` validation through the existing failure envelope when an actual JSON flag is selected: `invalid_argument`, usage category, exit 2. Structured `--params-json` validation retains its codes and exit 4; human errors retain readable parser output. Other syntax errors, such as a missing option value, remain outside this normalization boundary.

Known-command errors now use parsed output state. Pure group and leaf JSON flags are eager, so parameter validation can use the selected flag without guessing whether a raw `--json` token is an option value, positional value, or flag at another command level. Both post-parse params-json refusal paths use the same parsed state. The existing raw fallback remains only for unresolved invocations. Shared input models and sanitized validation messages are retained; there is no command-specific validation schema.

Validation:
- Final head: `60643aae0db8d186c2b4f17347b74cf8cf7be9b1`.
- Real subprocess RED/GREEN controls cover root/group/leaf end markers, consumed `--json` values, actual second flags, missing required parameters, and both params-json refusal paths. Final matrix: 11 passed.
- Full non-E2E at the parsed-state recovery: 2879 passed, 2 skipped, 730 deselected. Final two-caller migration: 338 relevant checks passed; Ruff lint/format and Pyright passed.
- Parent actual merge rehearsal on dev `c6e20e439c1b1ee06ba03b741a1bf78bc33ac4ce`: 196 argv, params-json, dispatch, human failure and Asset Pipeline CLI checks passed. Tested merge tree: `535022b7b149356e620852f79f90258a3f58c624`.
- Independent Sol Standards and Spec final rechecks: PASS (56 and 30 focused checks respectively). No native Godot run is needed for this parser change. All applicable CI checks passed; scheduled Godot CI was skipped.

Review handling: adopted the documented parser-boundary correction and end-of-options counterexamples. Backtrace review identified raw token inference as the common cause and replaced the initial global end-marker scan with actual parsed state; that scan is superseded. The complete caller audit also migrated the two post-parse params-json paths. Unknown-key negatives deliberately use an unsupported key so future LOD support cannot reverse them.

Refs #947. Targets `codex/asset-pipeline-dev` only.
