### PR TITLE
fix(resource): explain reimport adoption failures

### DIFF
--- a/docs/command-catalog.md
+++ b/docs/command-catalog.md
@@ -1179,9 +1179,16 @@ bounded dimension check, not animation, runtime-instance, or artistic acceptance
 
 `import_result` retains the existing cache-evidence and created-file report;
 `verification` supplies the independent loaded-size observation. An import script
-can fail while old artifacts still satisfy the static import checks (#853), so that
-summary alone never establishes adoption. Failed verification or an interrupted
-import returns `error.partial_result`, including whether the sidecar changed,
+can fail while old artifacts still satisfy the static import checks, so that
+summary alone never establishes adoption. `imported` means that a pass ran and
+the subsequent cache reread passed the static checks; it does not verify the
+requested options. An unchanged cache hash alone is not failure evidence either:
+a successful cached import or no-op edit can leave those bytes unchanged.
+When loaded dimensions reject adoption, the failure explains this distinction and
+carries the last 16 KiB (UTF-8 bytes) of available project-wide import stderr in
+`diagnostics`. The message states when none was captured. These lines are context
+from the whole pass, not an inferred per-asset cause or a new import classification.
+Failed verification or an interrupted import returns `error.partial_result`, including whether the sidecar changed,
 whether an engine pass was attempted, and available import/verification results.
 There is no automatic rollback. `--timeout` bounds the import pass (default 300s);
 each sentinel query/load retains the normal headless-operation timeout.

--- a/src/gda/commands/resource.py
+++ b/src/gda/commands/resource.py
@@ -23,7 +23,7 @@ import re
 from contextlib import contextmanager
 from tempfile import TemporaryDirectory
 from pathlib import Path
-from typing import Any, Literal, Optional
+from typing import Any, Callable, Literal, Optional
 
 import typer
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -31,6 +31,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from gda.binary import resolve_godot_binary
 from gda.dispatch import dispatch_domain, dispatch_recipe, params_or_bad_parameter
 from gda.errors import (
+    captured_output_tail,
     classify_launch_or_crash,
     containment_refusal,
     Failure,
@@ -64,7 +65,7 @@ from gda.project import (
     project_anchored,
 )
 from gda.render import render_property_lines, render_set_echo
-from gda.runner import launch
+from gda.runner import RunResult, launch
 
 
 class ResourceCreateParams(BaseModel):
@@ -1133,7 +1134,9 @@ class ResourceImportSummary(BaseModel):
             "dry run; the pass does not retry these)."
         )
     )
-    imported: int = Field(description="Assets the pass imported.")
+    imported: int = Field(
+        description="Assets with cached artifact evidence after the pass; not proof that requested options were adopted."
+    )
     not_importable: int = Field(description="Assets the pass decided need no import.")
     failed: int = Field(description="Assets still without an intact cache.")
     created_cache_owned: int = Field(
@@ -1838,6 +1841,7 @@ def run_resource_import_operation(
     *,
     godot: Optional[str] = None,
     options_changed: bool = False,
+    _observe_pass: Callable[[RunResult], None] | None = None,
 ) -> "ResourceImportResult | Failure":
     """Decide per asset, run the engine pass only when needed, account for it all.
 
@@ -1849,6 +1853,8 @@ def run_resource_import_operation(
     change: cached artifact evidence then also requests a pass, since it does
     not check importer options. This does not bypass invalid evidence or add
     a per-file engine primitive; ordinary resource import leaves it false.
+    The internal pass observer lets reimport retain diagnostics for a later
+    adoption failure without adding fields to the public import result.
     """
     assert project is not None  # a project-using recipe; dispatch resolved it
     res_paths: list[str] = []
@@ -1911,6 +1917,8 @@ def run_resource_import_operation(
             timeout=params.timeout,
             timeout_label="Godot import",
         )
+        if _observe_pass is not None:
+            _observe_pass(raw)
         prefix = classify_launch_or_crash(raw, binary)
         if prefix is not None:
             return prefix
@@ -2182,6 +2190,12 @@ def run_resource_reimport_operation(
             "requested size change is below verification tolerance; unchanged geometry could pass",
             "",
         )
+    import_stderr = ""
+
+    def retain_import_stderr(raw: RunResult) -> None:
+        nonlocal import_stderr
+        import_stderr = captured_output_tail(raw.stderr)
+
     with _import_config_project() as scratch:
         reference = scratch / "original.import"
         reference.write_bytes(original)
@@ -2201,6 +2215,7 @@ def run_resource_reimport_operation(
             ResourceImportParams(assets=[options.path], timeout=params.timeout),
             godot=godot,
             options_changed=True,
+            _observe_pass=retain_import_stderr,
         )
         if isinstance(imported, Failure):
             return _reimport_failure(imported, result)
@@ -2244,11 +2259,25 @@ def run_resource_reimport_operation(
             hashlib.file_digest(stream, "sha256").digest() == source_digest
         )
     if not source_unchanged or not result.verification.matched:
+        import_explanation = (
+            " The project-wide import pass completed and its cache reread reported "
+            f"{imported.summary.imported} imported asset(s); that count does not prove adoption. "
+            "Existing cache artifacts can remain loadable after a rejected import. "
+        )
+        diagnostic_explanation = (
+            "Diagnostics contain the last 16 KiB of project-wide import stderr; "
+            "these lines alone do not establish this asset's cause."
+            if import_stderr
+            else "No stderr was captured from the import pass; a native cause was not established."
+        )
         return _reimport_failure(
             make_failure(
                 "operation_failed",
-                "loaded dimensions do not verify the requested scale on unchanged source bytes; no rollback was attempted",
-                "",
+                "loaded dimensions do not verify the requested scale on unchanged source bytes; "
+                "updated options remain on disk and no rollback was attempted."
+                + import_explanation
+                + diagnostic_explanation,
+                import_stderr,
             ),
             result,
         )

--- a/src/gda/errors.py
+++ b/src/gda/errors.py
@@ -341,7 +341,7 @@ def _labelled_script_output(stdout: str, stderr: str) -> str:
 CAPTURED_OUTPUT_TAIL_CAP_BYTES = 16 * 1024
 
 
-def _tail(stream: str) -> str:
+def captured_output_tail(stream: str) -> str:
     """The last :data:`CAPTURED_OUTPUT_TAIL_CAP_BYTES` UTF-8 bytes of a stream.
 
     Slicing bytes can land inside a multi-byte sequence, so the decode uses
@@ -480,8 +480,8 @@ def launch_timeout_failure(raw: RunResult) -> Failure:
         f"stream, and any engine error in it is advisory: the verdict here is the "
         f"timeout.",
         _labelled_output(
-            _tail(raw.stdout),
-            _tail(raw.stderr),
+            captured_output_tail(raw.stdout),
+            captured_output_tail(raw.stderr),
             stdout_header=CAPTURED_STDOUT_HEADER,
             stderr_header=CAPTURED_STDERR_HEADER,
         ),
@@ -1056,7 +1056,9 @@ def _ended_run_diagnostics(
         if rendered
         else f"gda: no recognized script errors appeared before {what}\n"
     )
-    return header + _labelled_script_output(_tail(stdout), _tail(stderr))
+    return header + _labelled_script_output(
+        captured_output_tail(stdout), captured_output_tail(stderr)
+    )
 
 
 def script_run_timeout_failure(

--- a/src/gda/skill/SKILL.md
+++ b/src/gda/skill/SKILL.md
@@ -303,7 +303,11 @@ Omit `--dry-run` to update root scale, run project-wide import and verify change
 static dimensions on unchanged GLB bytes. Start from an imported baseline; no-op
 does not verify adoption. Read `verification` as well as `import_result`, because
 old cache artifacts can survive an import failure. On failure, `error.partial_result`
-reports completed effects; configuration is not automatically rolled back. See the
+reports completed effects; configuration is not automatically rolled back. An
+`imported` count describes the pass and cache reread, not adoption of the requested
+options. A dimension-verification failure carries bounded project-wide import
+stderr when available and states when none was captured; it does not infer a
+per-asset cause from those lines. See the
 command schema and catalog for measurement bounds and unavailable metadata.
 
 Every headless reply carries its floats at full binary64 precision, so a value read back through `node get`, `scene get-exports`, `project get`/`project list`, `resource get`, or the echo of a `set` is the exact number the project holds — `1e-300` reads back as `1e-300`, not `0.0`; the one residual belongs to the ENGINE's writer — a negative zero reads back as `0.0` (#771). The `--value` string you send IN is coerced by the engine's own parser, and gda refuses what that parser would destroy: a literal it reads as `0.0` when you did not write zero, or as `NaN` at all, fails with `uncoercible_value` (exit 4, target untouched) instead of writing a number you never sent — `2.2250738585072014e-308` and `5e-324`, and also `0.000000000000000001`, whose 18 leading zeros fill the parser's whole mantissa window (`1e-18` is exact). The rule follows the LITERAL, not the property type, so a number inside a Dictionary or Array `--value` is refused the same way and names the offending literal: `--value '{"a": 1e-320}'` fails, `--value '{"a": 1e-18}'` stores exactly. Only real JSON numbers are read — a numeric-looking STRING value (`{"a": "1e-320"}`) and a numeric-looking KEY (`{"1e-320": 1.0}`) are stored unchanged (#805). So spell a small or many-digit value in SCIENTIFIC notation carrying only the digits it needs: that also avoids the low-digit loss the parser inflicts on a full-precision literal between `1e-4` and `1e-2`, which is disclosed rather than refused (#772). Read the `set` echo when the exact bits matter.

--- a/tests/resource/test_e2e_resource_import_options.py
+++ b/tests/resource/test_e2e_resource_import_options.py
@@ -1,9 +1,14 @@
 """Supported import-option changes are proved against real Godot results."""
 
+import hashlib
 import json
 from pathlib import Path
 
 import pytest
+from typer.testing import CliRunner
+
+from gda.cli import app
+from gda.commands import resource
 
 from tests.support import Gda
 
@@ -146,11 +151,19 @@ def test_option_only_edit_reimports_and_proves_scaled_geometry(
     assert (project / "authored.tscn").read_text() == wrapper
 
 
-def test_failed_native_reimport_reports_retained_configuration(imported_options_model):
+@pytest.mark.parametrize("diagnostic_mode", ["silent", "short", "long"])
+def test_failed_native_reimport_reports_retained_configuration(
+    imported_options_model, monkeypatch, diagnostic_mode
+):
     project = imported_options_model
+    diagnostic = "res://model.glb: deliberate post-import rejection"
+    prefix = '"界".repeat(6000) + ' if diagnostic_mode == "long" else ""
+    hook_log = (
+        f'\tpush_error({prefix}"{diagnostic}")\n' if diagnostic_mode != "silent" else ""
+    )
     (project / "reject.gd").write_text(
         "@tool\nextends EditorScenePostImport\n"
-        "func _post_import(scene):\n\tscene.free()\n\treturn null\n"
+        "func _post_import(scene):\n" + hook_log + "\tscene.free()\n\treturn null\n"
     )
     sidecar = project / "model.glb.import"
     sidecar.write_text(
@@ -158,22 +171,73 @@ def test_failed_native_reimport_reports_retained_configuration(imported_options_
             'import_script/path=""', 'import_script/path="res://reject.gd"'
         )
     )
-    error = Gda(project, json_output=True).error(
-        "resource",
-        "reimport",
-        "res://model.glb",
-        "--updates-json",
-        '{"nodes/root_scale":2}',
-        code="operation_failed",
+    cache = project / ".godot" / "imported"
+    before = {
+        p.name: hashlib.sha256(p.read_bytes()).hexdigest()
+        for p in cache.iterdir()
+        if p.is_file()
+    }
+    source = (project / "model.glb").read_bytes()
+    passes = []
+    original_launch = resource.launch
+
+    def observe_pass(*args, **kwargs):
+        raw = original_launch(*args, **kwargs)
+        passes.append(raw)
+        return raw
+
+    monkeypatch.setattr(resource, "launch", observe_pass)
+    response = CliRunner().invoke(
+        app,
+        [
+            "resource",
+            "reimport",
+            "res://model.glb",
+            "--updates-json",
+            '{"nodes/root_scale":2}',
+            "--project",
+            str(project),
+            "--json",
+        ],
     )
+    assert response.exit_code == 4, response.stdout + response.stderr
+    error = json.loads(response.stdout)["error"]
+    assert error["code"] == "operation_failed"
+    assert len(passes) == 1
+    assert passes[0].exit_code == 0
+    assert "Godot Engine" in passes[0].stdout
+    if diagnostic_mode != "silent":
+        assert diagnostic in passes[0].stderr
+        assert diagnostic in error["diagnostics"]
+        assert "project-wide import stderr" in error["message"]
+        if diagnostic_mode == "long":
+            assert len(passes[0].stderr.encode("utf-8")) > 16384
+            assert len(error["diagnostics"].encode("utf-8")) <= 16384
+            assert passes[0].stderr.endswith(error["diagnostics"])
+        else:
+            assert error["diagnostics"] == passes[0].stderr
+    else:
+        assert passes[0].stderr == error["diagnostics"] == ""
+        assert "No stderr was captured" in error["message"]
+    assert "1 imported asset(s)" in error["message"]
+    assert "does not prove adoption" in error["message"]
+    assert "no rollback was attempted" in error["message"]
+    assert {
+        p.name: hashlib.sha256(p.read_bytes()).hexdigest()
+        for p in cache.iterdir()
+        if p.is_file()
+    } == before
+    assert (project / "model.glb").read_bytes() == source
     partial = error["partial_result"]
     assert partial["status"] == "failed"
     assert partial["sidecar_changed"] is True
     assert partial["engine_pass_attempted"] is True
     # Godot retains the old cache after this failure. Existing import evidence
-    # can still classify it as imported (#853); dimensions must reject that
+    # can still classify it as imported (#952); dimensions must reject that
     # stale result instead of treating the import summary as adoption proof.
     assert partial["import_result"]["assets"][0]["status"] == "imported"
+    assert partial["import_result"]["summary"]["failed"] == 0
+    assert partial["import_result"]["engine_pass"] is True
     assert partial["verification"]["matched"] is False
     assert partial["verification"]["after"]["size"][:2] == pytest.approx([100, 5])
     assert "nodes/root_scale=2.0" in sidecar.read_text()
@@ -188,6 +252,9 @@ def test_noop_and_invalid_updates_do_not_touch_the_target(imported_options_model
         if p.is_file()
     }
     run = Gda(project, json_output=True)
+    imported = run.json("resource", "import", "res://model.glb")
+    assert imported["engine_pass"] is False
+    assert imported["assets"][0]["status"] == "cached"
     result = run.json(
         "resource",
         "reimport",


### PR DESCRIPTION
A scene import hook can reject its scene while Godot exits 0 and leaves the old cache loadable. `resource reimport` already rejects adoption through independent loaded dimensions, but the nested imported count and empty diagnostics do not explain that partial result.

Explain the distinction in the failure message, schema description and nearby guidance. Retain the current imported classification, dimension verification, unchanged-source check and no-rollback behavior. A small internal pass callback lets reimport retain the existing 16 KiB UTF-8 stderr tail for a later adoption failure, using the shared output-tail function. The diagnostics belong to the project-wide pass; the message does not infer a per-asset cause. No public result field or state is added.

Native investigation on Godot 4.6.3 reproduced exit 0, empty stderr, unchanged cache hashes, one imported asset, zero failed assets and failed loaded-dimension verification for a hook that frees its scene and returns null. A controlled hook that emits its reason proves that available stderr now reaches the failure envelope. An oversized Unicode cause proves the byte bound. Ordinary cached import and no-op reimport controls succeed with unchanged cache bytes.

Validation:
- Both native refusal controls failed before the implementation (missing explanation / dropped stderr), then passed.
- Native import-option module: 8 passed; added long-diagnostic control: 1 passed.
- Resource, CLI and failure projection checks: 150 passed, 64 native tests deselected.
- Shared timeout/script diagnostic checks: 140 passed.
- Full Ruff lint/format and full Pyright passed; targeted type check also passed after exposing the unchanged shared tail helper under its descriptive name.

Refs #952. Related #853 retains ownership of reasons for already-failed/invalid assets; this slice explains retained-cache imported results and does not move that issue's work into Asset Pipeline. Targets `codex/asset-pipeline-dev`; independent Sol Standards and Spec reviews PASS at `b6628d294ebba61e1c954ce3ab9a2471f04da9b0`. The Spec reviewer independently reran the two silent/short native controls (2 passed); Standards checked the shared Unicode tail and ownership. All applicable CI checks passed; the scheduled-only Godot job is skipped on PRs. The current dev tip still equals this PR's tested base, so the reviewed feature tree is the integration tree.
