### PR TITLE
fix(asset-pipeline): reject incomplete V3 PCK headers

### DIFF
--- a/libs/gda-assets/README.md
+++ b/libs/gda-assets/README.md
@@ -173,6 +173,16 @@ nonzero with `error.partial_result.package_check`; cleanup issues remain explici
 This initial path requires a desktop editor-capable Godot binary. It does not run a
 release executable or prove native input, rendering, or gameplay behavior.
 
+Treat a failed `export run` as final even if it left an output file. Before loading a
+package, gda narrowly refuses the Godot V3 `GDPC` header state whose directory
+offset is still zero and reports it as an incomplete PCK; rebuild and check only the
+output of a successful export. This is one known incomplete writer state, not
+general PCK validation: opaque, short, other-version, and other malformed packages
+remain engine-owned and can still reach the package inspection's 60-second timeout
+with limited diagnostics. The
+[architecture evidence](docs/ARCHITECTURE.md#evidence-limits-and-validation-gates)
+records the native controls and Godot source basis for this boundary.
+
 ## Preview a model
 
 Write captures to a new output directory:

--- a/libs/gda-assets/docs/ARCHITECTURE.md
+++ b/libs/gda-assets/docs/ARCHITECTURE.md
@@ -371,6 +371,28 @@ operations in `tests/test_e2e_package_operations.py` cover both inclusion and di
 resource omission. They do not claim transitive-dependency corruption coverage or
 native release execution. See [the package guide](../README.md#check-an-exported-package).
 
+[#948](https://github.com/aigengame/godot-agent/issues/948) reproduced one failed
+Godot 4.6.3 pack export: `export_failed` with `Must select at least one file to
+export` left a 112-byte V3 `GDPC` header with file base 112 and directory offset
+zero. Before the narrow admission check, the empty-cwd `--main-pack` package
+presence launch reached its 60-second bound at 60.019 seconds with empty captured
+streams; public staging cleanup still completed. During this investigation, a legal
+zero-file PCK made by `PCKPacker` had directory offset 128 and file count zero; a
+minimal export and the maintained GLB package had nonzero offsets and 4 and 7 files.
+Those controls completed package presence in 0.835, 0.409, and 0.421 seconds during
+the investigation; these observations are discriminators, not performance
+guarantees. The V3 writer initializes the offset to zero and returns before the
+directory on failed resource export, then backfills it only on success
+([header](https://github.com/godotengine/godot/blob/4.6.3-stable/editor/export/editor_export_platform.cpp#L1966-L1993),
+[write path](https://github.com/godotengine/godot/blob/4.6.3-stable/editor/export/editor_export_platform.cpp#L2068-L2157));
+the loader otherwise seeks offset zero and reads `GDPC` as the file count
+([load path](https://github.com/godotengine/godot/blob/4.6.3-stable/core/io/file_access_pack.cpp#L286-L348)).
+A legal empty pack writes a nonzero directory offset and then a zero count
+([PCKPacker flush](https://github.com/godotengine/godot/blob/4.6.3-stable/core/io/pck_packer.cpp#L204-L219)).
+The check therefore recognizes only that V3 zero-offset state in gda's package
+runner admission. Other invalid packages remain engine-owned and can still reach
+the existing 60-second bound; this is not a general PCK parser or validator.
+
 ## Research basis and retained limits
 
 - DDD bounded contexts and local anti-corruption layers support model ownership;

--- a/src/gda/package_runner.py
+++ b/src/gda/package_runner.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+import struct
 from tempfile import TemporaryDirectory
 
 from gda.errors import Failure, classify_launch_or_crash, make_failure
@@ -17,6 +18,40 @@ from gda.runner import (
 
 
 PackageRunnerFactory = Callable[[Path, Path], GodotRunner | Failure]
+
+_PCK_V3_HEADER_BYTES = 40
+_PCK_V3_FORMAT = 3
+
+
+def _incomplete_v3_package(package: Path) -> Failure | None:
+    """Refuse the V3 header state left before Godot writes a PCK directory."""
+    try:
+        with package.open("rb") as stream:
+            header = stream.read(_PCK_V3_HEADER_BYTES)
+    except OSError:
+        # Input admission already established a regular file. Preserve the prior
+        # engine-owned outcome if that file changes before this narrow read.
+        return None
+    if len(header) < _PCK_V3_HEADER_BYTES or header[:4] != b"GDPC":
+        return None
+    format_version = struct.unpack_from("<I", header, 4)[0]
+    directory_offset = struct.unpack_from("<Q", header, 32)[0]
+    if format_version != _PCK_V3_FORMAT or directory_offset != 0:
+        return None
+    return make_failure(
+        "operation_failed",
+        "package inspection refused an incomplete Godot PCK",
+        "\n".join(
+            (
+                f"package: {package}",
+                f"format version: {format_version}",
+                f"directory offset: {directory_offset}",
+                "The V3 header has no file-directory offset. This matches a partial "
+                "artifact left by a failed export; rebuild the package and inspect "
+                "only output from a successful export.",
+            )
+        ),
+    )
 
 
 @dataclass
@@ -80,4 +115,7 @@ def make_package_runner(
             "the configured binary is not an editor build",
             diagnostics,
         )
+    incomplete = _incomplete_v3_package(package)
+    if incomplete is not None:
+        return incomplete
     return PackageGodotRunner(binary, package, make_launch=make_launch)

--- a/tests/asset_pipeline/test_package_check_cli.py
+++ b/tests/asset_pipeline/test_package_check_cli.py
@@ -1,7 +1,10 @@
 """Unified package acceptance command across CLI and MCP transports."""
 
+import hashlib
 import json
 from pathlib import Path
+import struct
+import sys
 
 from typer.testing import CliRunner
 
@@ -166,6 +169,66 @@ def test_package_workflow_failure_is_nonzero_with_full_partial_result(
     assert result.error.partial_result is not None
     assert result.error.partial_result["package_check"]["completed"] == ["validate"]
     assert result.child_stderr == "native stderr"
+
+
+def test_incomplete_pck_failure_retains_snapshot_and_cleanup(monkeypatch, tmp_path):
+    marker = tmp_path / "main-pack-launched"
+    binary = tmp_path / "godot-editor-probe"
+    binary.write_text(
+        f"#!{sys.executable}\n"
+        "import pathlib, sys\n"
+        f"marker = pathlib.Path({str(marker)!r})\n"
+        "if '--main-pack' in sys.argv:\n"
+        "    marker.write_text('launched')\n"
+        "print('Options: \\n-e, --editor  Start the editor.')\n"
+    )
+    binary.chmod(0o755)
+    package = tmp_path / "failed-export.pck"
+    package.write_bytes(
+        struct.pack(
+            "<6I2Q16I",
+            0x43504447,
+            3,
+            4,
+            6,
+            3,
+            2,
+            112,
+            0,
+            *([0] * 16),
+        )
+        + b"\0" * 8
+    )
+    expectations = tmp_path / "expectations.json"
+    expectations.write_text(
+        '{"checks":[{"id":"nodes","kind":"count","metric":"node_count","min":1}]}'
+    )
+    monkeypatch.setenv("GDA_USER_DATA_ROOT", str(tmp_path / "user-data"))
+
+    result = run_asset_package_check(
+        AssetPipelinePackageCheckParams(
+            package=package,
+            path="res://main.tscn",
+            expectations=expectations,
+        ),
+        project=None,
+        godot=str(binary),
+    )
+
+    assert isinstance(result, Failure)
+    assert result.error.code == "operation_failed"
+    assert result.error.partial_result is not None
+    partial = result.error.partial_result["package_check"]
+    assert partial["failure"]["stage"] == "presence"
+    assert partial["package"]["source"] == str(package)
+    assert (
+        partial["package"]["sha256"] == hashlib.sha256(package.read_bytes()).hexdigest()
+    )
+    assert partial["package"]["size_bytes"] == 112
+    assert partial["completed"] == ["validate", "stage", "cleanup"]
+    assert partial["cleanup"] == {"staging_removed": True, "issues": []}
+    assert not Path(partial["package"]["root"]).exists()
+    assert not marker.exists()
 
 
 def test_package_load_recovery_is_consistent_in_json_and_human_output(

--- a/tests/test_e2e_package_operations.py
+++ b/tests/test_e2e_package_operations.py
@@ -16,6 +16,7 @@ from gda.commands.resource import (
     run_package_resource_presence_operation,
 )
 from gda.errors import Failure
+from gda.runner import launch
 from tests.support import Gda, GODOT
 
 
@@ -95,6 +96,30 @@ def _project(root: Path) -> None:
     _glb(root / "omitted.glb", "OmittedMesh")
 
 
+def _simple_export_project(root: Path, *, exclude: str) -> None:
+    root.mkdir()
+    (root / "project.godot").write_text(
+        'config_version=5\n[application]\nconfig/name="package-header-probe"\n'
+        'run/main_scene="res://main.tscn"\n'
+    )
+    (root / "main.tscn").write_text(
+        '[gd_scene format=3]\n\n[node name="Main" type="Node"]\n'
+    )
+    (root / "export_presets.cfg").write_text(
+        '[preset.0]\n\nname="Probe"\nplatform="Linux/X11"\n'
+        'runnable=true\ncustom_features=""\nexport_filter="all_resources"\n'
+        f'include_filter=""\nexclude_filter="{exclude}"\n'
+        'export_path="build/probe.pck"\n\n[preset.0.options]\n\n'
+        "binary_format/embed_pck=false\n"
+    )
+
+
+def _pck_directory(package: Path) -> tuple[int, int]:
+    data = package.read_bytes()
+    offset = struct.unpack_from("<Q", data, 32)[0]
+    return offset, struct.unpack_from("<I", data, offset)[0]
+
+
 def test_package_only_inspection_sees_imported_remap_and_exclusion(
     tmp_path, monkeypatch
 ):
@@ -152,6 +177,132 @@ def test_package_only_inspection_sees_imported_remap_and_exclusion(
     )
     assert isinstance(omitted, Failure)
     assert omitted.error.code == "path_not_found"
+
+
+def test_failed_export_header_is_refused_without_rejecting_valid_v3_controls(
+    tmp_path, monkeypatch
+):
+    failed_source = tmp_path / "failed-source"
+    minimal_source = tmp_path / "minimal-source"
+    normal_source = tmp_path / "normal-source"
+    failed_package = tmp_path / "failed.pck"
+    minimal_package = tmp_path / "minimal.pck"
+    normal_package = tmp_path / "normal.pck"
+    empty_package = tmp_path / "empty.pck"
+    _simple_export_project(failed_source, exclude="*")
+    _simple_export_project(minimal_source, exclude="")
+    _project(normal_source)
+    monkeypatch.setenv("GDA_USER_DATA_ROOT", str(tmp_path / "user-data"))
+
+    failed_export = Gda(failed_source, json_output=True).error(
+        "export",
+        "run",
+        "--preset",
+        "Probe",
+        "--mode",
+        "pack",
+        "--output",
+        str(failed_package),
+        code="export_failed",
+        timeout=120,
+    )
+    assert "Must select at least one file to export" in failed_export["diagnostics"]
+    failed_bytes = failed_package.read_bytes()
+    assert len(failed_bytes) == 112
+    assert failed_bytes[:4] == b"GDPC"
+    assert struct.unpack_from("<I", failed_bytes, 4)[0] == 3
+    assert struct.unpack_from("<Q", failed_bytes, 32)[0] == 0
+
+    for source, output, preset in (
+        (minimal_source, minimal_package, "Probe"),
+        (normal_source, normal_package, "Linux/X11"),
+    ):
+        exported = Gda(source, json_output=True).json(
+            "export",
+            "run",
+            "--preset",
+            preset,
+            "--mode",
+            "pack",
+            "--output",
+            str(output),
+            timeout=180,
+        )
+        assert exported["mode"] == "pack"
+
+    generator = tmp_path / "empty-pck.gd"
+    generator.write_text(
+        "extends SceneTree\n\n"
+        "func _initialize() -> void:\n"
+        "    var packer := PCKPacker.new()\n"
+        "    var started := packer.pck_start(OS.get_cmdline_user_args()[0])\n"
+        "    var flushed := packer.flush()\n"
+        '    print("EMPTY_PCK_RESULTS:", started, ":", flushed)\n'
+        "    quit(0 if started == OK and flushed == OK else 9)\n"
+    )
+    empty_cwd = tmp_path / "empty-cwd"
+    empty_cwd.mkdir()
+    generated = launch(
+        GODOT,
+        ["--script", str(generator), "--", str(empty_package)],
+        cwd=empty_cwd,
+        timeout=15,
+        timeout_label="Godot empty PCK generation",
+    )
+    assert generated.exit_code == 0, generated
+    assert "EMPTY_PCK_RESULTS:0:0" in generated.stdout
+
+    empty_offset, empty_count = _pck_directory(empty_package)
+    minimal_offset, minimal_count = _pck_directory(minimal_package)
+    normal_offset, normal_count = _pck_directory(normal_package)
+    assert empty_offset > 0 and empty_count == 0
+    assert minimal_offset > 0 and minimal_count > 0
+    assert normal_offset > 0 and normal_count > minimal_count
+
+    expectations = tmp_path / "expectations.json"
+    expectations.write_text(
+        '{"checks":[{"id":"nodes","kind":"count","metric":"node_count","min":1}]}'
+    )
+    refusal = Gda(None, json_output=True).error(
+        "asset-pipeline",
+        "check-package",
+        "--package",
+        str(failed_package),
+        "--path",
+        "res://main.tscn",
+        "--expectations",
+        str(expectations),
+        code="operation_failed",
+        timeout=30,
+    )
+    assert "incomplete Godot PCK" in refusal["message"]
+    partial = refusal["partial_result"]["package_check"]
+    assert partial["completed"] == ["validate", "stage", "cleanup"]
+    assert partial["package"]["source"] == str(failed_package)
+    assert partial["package"]["size_bytes"] == 112
+    assert partial["cleanup"] == {"staging_removed": True, "issues": []}
+    assert not Path(partial["package"]["root"]).exists()
+
+    for package, paths, expected in (
+        (empty_package, ["res://missing.tscn"], [("res://missing.tscn", False)]),
+        (minimal_package, ["res://main.tscn"], [("res://main.tscn", True)]),
+        (
+            normal_package,
+            ["res://included.glb", "res://omitted.glb", "res://main.tscn"],
+            [
+                ("res://included.glb", True),
+                ("res://omitted.glb", False),
+                ("res://main.tscn", True),
+            ],
+        ),
+    ):
+        presence = run_package_resource_presence_operation(
+            package,
+            PackageResourcePresenceParams(paths=paths),
+            godot=str(GODOT),
+        )
+        assert isinstance(presence, PackageResourcePresenceResult), presence
+        assert [(item.path, item.present) for item in presence.resources] == expected
 
 
 def test_public_package_check_refuses_an_installed_release_template_before_script(

--- a/tests/test_package_operations.py
+++ b/tests/test_package_operations.py
@@ -1,6 +1,9 @@
 """Returning package-only resource operations and isolated runner."""
 
 from pathlib import Path
+import struct
+
+import pytest
 
 from gda.commands.resource import (
     PackageResourcePresenceParams,
@@ -43,6 +46,25 @@ def _package(tmp_path: Path, suffix: str = ".pck") -> Path:
     package = tmp_path / f"game{suffix}"
     package.write_bytes(b"package")
     return package
+
+
+def _godot_v3_pck_header(
+    *, directory_offset: int, file_base: int = 112, format_version: int = 3
+) -> bytes:
+    """The fixed Godot 4.6.3 V3 header, plus its 16-byte export alignment."""
+    header = struct.pack(
+        "<6I2Q16I",
+        0x43504447,
+        format_version,
+        4,
+        6,
+        3,
+        2,
+        file_base,
+        directory_offset,
+        *([0] * 16),
+    )
+    return header + b"\0" * 8
 
 
 def test_package_runner_uses_isolated_main_pack(tmp_path):
@@ -102,6 +124,77 @@ def test_returning_operation_refuses_template_before_running_payload(tmp_path):
     assert result.error.code == "operation_failed"
     assert "requires a Godot desktop editor binary" in result.error.message
     assert "release export template" in result.error.diagnostics
+
+
+def test_returning_operation_refuses_an_incomplete_v3_pck_before_main_pack(
+    tmp_path,
+):
+    calls = []
+
+    def launch(
+        binary, args, *, cwd, timeout, timeout_label="Godot operation", **_kwargs
+    ):
+        calls.append(args)
+        if args == ["--help"]:
+            return RunResult("Options:\n-e, --editor  Start the editor.\n", "", 0)
+        return RunResult(
+            build_result(
+                {
+                    "engine_version": ENGINE,
+                    "resources": [{"path": "res://model.glb", "present": False}],
+                }
+            ),
+            "",
+            0,
+        )
+
+    package = tmp_path / "failed-export.pck"
+    package.write_bytes(_godot_v3_pck_header(directory_offset=0))
+    result = run_package_resource_presence_operation(
+        package,
+        PackageResourcePresenceParams(paths=["res://model.glb"]),
+        godot="/godot",
+        make_runner=lambda binary, selected: make_package_runner(
+            binary, selected, make_launch=launch
+        ),
+    )
+
+    assert calls == [["--help"]]
+    assert isinstance(result, Failure)
+    assert result.error.code == "operation_failed"
+    assert "incomplete Godot PCK" in result.error.message
+    assert str(package) in result.error.diagnostics
+    assert "format version: 3" in result.error.diagnostics
+    assert "directory offset: 0" in result.error.diagnostics
+
+
+@pytest.mark.parametrize(
+    "contents",
+    [
+        b"package",
+        b"NOPE" + _godot_v3_pck_header(directory_offset=0)[4:],
+        _godot_v3_pck_header(directory_offset=0, format_version=99),
+        _godot_v3_pck_header(directory_offset=128, file_base=128)
+        + b"\0" * 16
+        + struct.pack("<I", 0),
+    ],
+    ids=("short", "opaque", "unknown-format", "legal-empty-v3"),
+)
+def test_package_admission_leaves_other_artifacts_to_godot(tmp_path, contents):
+    calls = []
+
+    def launch(
+        binary, args, *, cwd, timeout, timeout_label="Godot operation", **_kwargs
+    ):
+        calls.append(args)
+        return RunResult("Options:\n-e, --editor  Start the editor.\n", "", 0)
+
+    package = tmp_path / "package.pck"
+    package.write_bytes(contents)
+    result = make_package_runner(Path("/godot"), package, make_launch=launch)
+
+    assert isinstance(result, PackageGodotRunner)
+    assert calls == [["--help"]]
 
 
 def test_package_inspection_returns_the_existing_typed_model(tmp_path):


### PR DESCRIPTION
A failed Godot pack export can leave a 112-byte V3 PCK whose directory offset is still zero. Godot then reads its header as a directory count and stalls before the package inspection script starts. Refuse that specific incomplete state after desktop-editor capability admission, returning the existing `operation_failed` with rebuild guidance. Public package checks retain the staged snapshot, original source/hash/size and cleanup result.

The fixed 40-byte read lives in gda's existing package runner. It identifies only `GDPC` V3 with a zero directory offset; short/opaque/other-version and other malformed packages remain engine-owned and can still reach the existing 60-second bound. The supporting context's file-copy/ownership boundary and public error vocabulary are unchanged.

Validation:
- Review head: `11e25a9683f38295926e314a900ad3fef73f706c`; base `c6e20e439c1b1ee06ba03b741a1bf78bc33ac4ce`.
- Pre-fix public reproduction: failed export, native package launch 60.019 seconds with empty captured streams, successful staging cleanup. Exact Godot 4.6.3 writer/loader source links and investigation limits are in the architecture evidence section.
- RED/GREEN returning-operation regression; 50 package/CLI/domain checks passed.
- Maintained native regression passed: real failed export, legal empty PCK, valid minimal pack and maintained GLB pack; public refusal/cleanup and valid presence controls. Legal empty PCK has a nonzero directory offset and is accepted.
- Ruff, Pyright and diff checks passed. Independent Sol Standards and Spec reviews PASS; all applicable CI checks passed. Scheduled Godot CI was skipped; the native evidence above is the separately executed local regression.

Refs #948. Targets `codex/asset-pipeline-dev` only.

Parent integration validation: 53 package/CLI/domain/adapter checks passed on the actual merge with dev `becdc99c817324da5d45be585d734af9437793ee`; tested tree `4135f084aa0f303731565f9793de20642066e558`.
