### PR TITLE
fix(asset-pipeline): clarify incomplete refresh and file reuse

### DIFF
--- a/libs/gda-assets/docs/runtime-refresh.md
+++ b/libs/gda-assets/docs/runtime-refresh.md
@@ -23,6 +23,60 @@ and 1,000,000 vertices.
 Refresh is independent of `--collect-observations`. Use both when you also need the
 optional disk/import observations described in [Content observations](observations.md).
 
+## Inspect the installed output before choosing to refresh
+
+For a single driver controlling the project, separate preparation from the reset:
+
+1. Finish production and processing, then install/import/load without `--refresh`.
+2. Inspect that selected installed output and review `content.complete`,
+   `content.unsupported`, and `content.omitted`. A complete sample has a digest;
+   localized reasons explain an incomplete sample. Choose whether to refresh only
+   after reviewing these facts against the current [measurement scope](../../../docs/model-content.md).
+3. Check that the selected files have not changed, then explicitly reuse the
+   installed files with `--files` and `--refresh`. Omit production and already
+   completed processing, such as `resize`.
+
+For example, first install a completed GLB and inspect its imported content:
+
+```sh
+gda asset-pipeline run --project ./consumer --source-root ./production \
+  --files '[{"source":"model.glb","target":"res://model.glb"}]' --overwrite --json
+installed_hash=$(shasum -a 256 ./consumer/model.glb)
+gda resource inspect-model-content --project ./consumer \
+  --path res://model.glb --json
+```
+
+`resource inspect-model-content` does **not** import. Inspecting a pre-existing
+cache before replacing and importing its source says nothing about support for the
+incoming output. Keep the installed source and imported cache under this driver's
+control between these steps. After reviewing the inspection and deciding to reset,
+run the following separate step:
+
+```sh
+if [ "$installed_hash" = "$(shasum -a 256 ./consumer/model.glb)" ]; then
+  gda asset-pipeline run --project ./consumer --source-root ./consumer \
+    --files '[{"source":"model.glb","target":"res://model.glb"}]' --overwrite \
+    --refresh '{"path":"res://model.glb","scene":"res://test.tscn","node":"/root/Test/Model"}' \
+    --json
+else
+  printf '%s\n' 'Output changed: import and inspect it again before refreshing.' >&2
+fi
+```
+
+The second call reuses the installed GLB; it still performs the ordinary
+installation/import/load checks. It does not call Blender, regenerate the source,
+or repeat omitted processing. For a selected set, check every output and its
+required referenced files. This procedure has no lock or atomicity guarantee;
+changes by another driver or engine invalidate the inspected state. Re-import and
+inspect again after a change. No saved receipt or mandatory inspection gate is
+introduced.
+
+LOD and embedded albedo were incomplete at the initial dogfood baseline. They are
+not permanent rejection criteria: use the scope of the delivered measurement. An
+explicitly low vertex budget (for example `--max-vertices 1` for a larger model)
+still demonstrates a localized omission. An incomplete sample does not cancel a
+later explicit reset request; it prevents verification from passing.
+
 ## What the workflow does
 
 Refresh starts only after file processing, installation, Godot import and load, and
@@ -88,3 +142,11 @@ is the final status read and is the best available last-known daemon/session sta
 it does not itself prove readiness. If that final read also fails, `issues` records
 that the final state is unavailable. The workflow does not silently retry the launch
 or rebuild the asset.
+
+For incomplete verification, the error message also summarizes the completed
+reset stages and the before/last-observed running state and session IDs. A result
+can therefore report a new running session and still be unverified. Completed
+stop/start/readiness stages are not undone when comparison is incomplete. If no
+reset stage completed or the final status is unavailable, the message says so;
+consult the retained stage facts and localized content reasons before another
+explicit refresh.

--- a/libs/gda-assets/docs/runtime-refresh.md
+++ b/libs/gda-assets/docs/runtime-refresh.md
@@ -150,3 +150,8 @@ stop/start/readiness stages are not undone when comparison is incomplete. If no
 reset stage completed or the final status is unavailable, the message says so;
 consult the retained stage facts and localized content reasons before another
 explicit refresh.
+
+A completed content match remains a match if capture or the final session check
+fails later. In that case, the message preserves the comparison and identifies the
+failed refresh stage; it does not describe the content as unverified. If comparison
+was never reached, the message says it was not completed.

--- a/src/gda/commands/asset_pipeline.py
+++ b/src/gda/commands/asset_pipeline.py
@@ -344,6 +344,32 @@ def _failure_message(stage: str, message: str, result: PipelineRunResult) -> str
         or "no installed files"
     )
     summary = f"asset pipeline failed during {stage}: {message}; affected: {affected}"
+    refresh = result.refresh
+    if refresh is not None and refresh.status == "incomplete":
+        reset_stages = (
+            ", ".join(
+                name for name in ("stop", "start", "ready") if name in refresh.completed
+            )
+            or "none"
+        )
+        details = [f"completed reset stages: {reset_stages}"]
+        for label, state in (
+            ("before", refresh.before),
+            ("last observed", refresh.after),
+        ):
+            observed = (
+                "unavailable"
+                if state is None
+                else f"running={str(state.running).lower()}, session={state.session_id or 'unavailable'}"
+            )
+            details.append(f"{label}: {observed}")
+        return (
+            f"{summary}; {'; '.join(details)}; content verification is incomplete. "
+            "Completed reset stages are not undone. Read refresh.completed, "
+            "ready_session, after, issues, and localized content reasons. "
+            "Inspect the installed output with resource inspect-model-content "
+            "before explicitly requesting another refresh."
+        )
     if (
         result.failure is None
         or result.failure.code != "observation_changed"

--- a/src/gda/commands/asset_pipeline.py
+++ b/src/gda/commands/asset_pipeline.py
@@ -363,12 +363,24 @@ def _failure_message(stage: str, message: str, result: PipelineRunResult) -> str
                 else f"running={str(state.running).lower()}, session={state.session_id or 'unavailable'}"
             )
             details.append(f"{label}: {observed}")
-        return (
-            f"{summary}; {'; '.join(details)}; content verification is incomplete. "
-            "Completed reset stages are not undone. Read refresh.completed, "
-            "ready_session, after, issues, and localized content reasons. "
+        comparison = refresh.comparison
+        if comparison is None:
+            content_outcome = "content comparison was not completed"
+        elif comparison.status == "match":
+            content_outcome = "content comparison matched; refresh did not complete"
+        else:
+            content_outcome = "content verification is incomplete"
+        recovery = (
             "Inspect the installed output with resource inspect-model-content "
             "before explicitly requesting another refresh."
+            if comparison is not None and comparison.status == "incomplete"
+            else "Resolve the reported failing stage before another explicit refresh."
+        )
+        return (
+            f"{summary}; {'; '.join(details)}; {content_outcome}. "
+            "Completed reset stages are not undone. Read refresh.completed, "
+            "ready_session, after, issues, and localized content reasons. "
+            f"{recovery}"
         )
     if (
         result.failure is None

--- a/tests/asset_pipeline/test_e2e_refresh_guidance.py
+++ b/tests/asset_pipeline/test_e2e_refresh_guidance.py
@@ -1,0 +1,99 @@
+"""Public installed-output inspection and explicit file-only refresh."""
+
+import hashlib
+import os
+
+import pytest
+
+from tests.asset_pipeline.test_e2e_runtime_refresh import (
+    MODEL,
+    NODE,
+    SCENE,
+    _fixture,
+    _handoff_args,
+)
+from tests.support import Gda
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"),
+    pytest.mark.xdist_group("windowed"),
+]
+
+
+@pytest.mark.usefixtures("daemon_runtime_dir")
+def test_inspect_installed_output_then_refresh_only_those_files(tmp_path, monkeypatch):
+    project, source = tmp_path / "project", tmp_path / "source"
+    _fixture(project, source)
+    monkeypatch.setenv("GDA_USER_DATA_ROOT", str(tmp_path / "user-data"))
+    monkeypatch.setenv("GDA_BLENDER", str(tmp_path / "missing-blender"))
+    run = Gda(project, json_output=True, timeout=180)
+    installed = project / "model.glb"
+    request = {"path": MODEL, "scene": SCENE, "node": NODE}
+    try:
+        run.json(*_handoff_args(source, "a.glb"))
+        run.json("daemon", "start")
+        run.json("daemon", "wait-ready", "--timeout", "25")
+        old = run.json("game", "inspect-model-content", "--node", NODE)
+        assert old["content"]["complete"] is True
+
+        # Install/import/load B without resetting the still-running A session.
+        run.json(*_handoff_args(source, "b.glb"))
+        installed_hash = hashlib.sha256(installed.read_bytes()).hexdigest()
+        inspected = run.json("resource", "inspect-model-content", "--path", MODEL)
+        assert inspected["content"]["complete"] is True
+        assert inspected["content"]["digest"] != old["content"]["digest"]
+        stale = run.json("game", "inspect-model-content", "--node", NODE)
+        assert stale["session_id"] == old["session_id"]
+        assert stale["content"]["digest"] == old["content"]["digest"]
+
+        # The producer's original output is gone; the installed file is sufficient.
+        (source / "b.glb").unlink()
+        assert hashlib.sha256(installed.read_bytes()).hexdigest() == installed_hash
+        result = run.json(*_handoff_args(project, str(installed), refresh=request))
+        refresh = result["pipeline"]["refresh"]
+        assert result["pipeline"]["production"] is None
+        assert refresh["status"] == "verified"
+        assert refresh["before"]["session_id"] == old["session_id"]
+        assert refresh["after"]["session_id"] != old["session_id"]
+        assert (
+            refresh["instance"]["content"]["digest"] == inspected["content"]["digest"]
+        )
+        assert hashlib.sha256(installed.read_bytes()).hexdigest() == installed_hash
+
+        # A diagnosed omission remains a negative when LOD/texture support expands.
+        bounded = run.json(
+            "resource",
+            "inspect-model-content",
+            "--path",
+            MODEL,
+            "--max-vertices",
+            "1",
+        )
+        assert bounded["content"]["complete"] is False
+        assert bounded["content"]["digest"] is None
+        assert bounded["content"]["omitted"]
+        assert hashlib.sha256(installed.read_bytes()).hexdigest() == installed_hash
+        error = run.error(
+            *_handoff_args(
+                project, str(installed), refresh=request | {"max_vertices": 1}
+            ),
+            code="operation_failed",
+        )
+        partial = error["partial_result"]["refresh"]
+        assert partial["status"] == "incomplete"
+        assert partial["before"]["running"] is True
+        assert partial["before"]["session_id"] == refresh["after"]["session_id"]
+        assert partial["after"]["running"] is True
+        assert partial["after"]["session_id"] != partial["before"]["session_id"]
+        assert partial["imported"]["content"]["omitted"]
+        assert partial["runtime_state_preserved"] is False
+        assert "completed reset stages: stop, start, ready" in error["message"]
+        assert (
+            f"last observed: running=true, session={partial['after']['session_id']}"
+            in error["message"]
+        )
+        assert "content verification is incomplete" in error["message"]
+    finally:
+        stopped = run("daemon", "stop")
+        assert stopped.returncode == 0, stopped.stdout + stopped.stderr

--- a/tests/asset_pipeline/test_runtime_refresh_cli.py
+++ b/tests/asset_pipeline/test_runtime_refresh_cli.py
@@ -141,3 +141,75 @@ def test_mcp_relays_concrete_lifecycle_facts_in_refresh_result():
         result.structured_content["pipeline"]["refresh"] | lifecycle
         == result.structured_content["pipeline"]["refresh"]
     )
+
+
+def test_incomplete_refresh_message_reports_reset_stages_and_last_session_facts(
+    monkeypatch, tmp_path
+):
+    from gda_assets.api import PipelineFailure, RefreshRequest, SessionState
+
+    project = minimal_project(tmp_path / "project")
+    request = RefreshRequest("res://model.glb", "res://test.tscn", "/root/Test/Model")
+    refresh = RefreshResult(
+        request,
+        completed=["inspect_imported", "stop", "start", "ready", "observe_instance"],
+        before=SessionState(True, 10, False, "old"),
+        after=SessionState(True, 11, False, "new"),
+    )
+    pipeline = PipelineResult(
+        refresh=refresh,
+        failure=PipelineFailure(
+            "refresh.compare", "refresh_incomplete", "vertex limit exceeded"
+        ),
+    )
+    monkeypatch.setattr(
+        "gda.commands.asset_pipeline.run_pipeline", lambda *_args, **_kwargs: pipeline
+    )
+    outcome = CliRunner().invoke(
+        app,
+        [
+            "asset-pipeline",
+            "run",
+            "--project",
+            str(project),
+            "--files",
+            json.dumps(
+                [{"source": str(tmp_path / "model.glb"), "target": "res://model.glb"}]
+            ),
+            "--refresh",
+            json.dumps(
+                {"path": request.path, "scene": request.scene, "node": request.node}
+            ),
+            "--json",
+        ],
+    )
+    assert outcome.exit_code == 4
+    error = json.loads(outcome.stdout)["error"]
+    assert error["code"] == "operation_failed"
+    assert "completed reset stages: stop, start, ready" in error["message"]
+    assert "before: running=true, session=old" in error["message"]
+    assert "last observed: running=true, session=new" in error["message"]
+    assert "content verification is incomplete" in error["message"]
+    assert error["partial_result"]["refresh"]["after"]["session_id"] == "new"
+
+
+def test_refresh_failure_before_reset_does_not_imply_a_restart_or_final_state():
+    from gda.commands.asset_pipeline import _failure_message, _pipeline_result
+    from gda_assets.api import PipelineFailure, RefreshRequest
+
+    refresh = RefreshResult(
+        RefreshRequest("res://model.glb", "res://test.tscn", "/root/Test/Model")
+    )
+    result = _pipeline_result(
+        PipelineResult(
+            refresh=refresh,
+            failure=PipelineFailure(
+                "refresh.inspect_imported", "read_failed", "unavailable"
+            ),
+        )
+    )
+    message = _failure_message("refresh.inspect_imported", "unavailable", result)
+    assert "completed reset stages: none" in message
+    assert "before: unavailable" in message
+    assert "last observed: unavailable" in message
+    assert "restarted" not in message

--- a/tests/asset_pipeline/test_runtime_refresh_cli.py
+++ b/tests/asset_pipeline/test_runtime_refresh_cli.py
@@ -3,6 +3,8 @@
 import json
 from pathlib import Path
 
+import pytest
+from pydantic import TypeAdapter
 from typer.testing import CliRunner
 
 from gda.cli import app
@@ -150,11 +152,23 @@ def test_incomplete_refresh_message_reports_reset_stages_and_last_session_facts(
 
     project = minimal_project(tmp_path / "project")
     request = RefreshRequest("res://model.glb", "res://test.tscn", "/root/Test/Model")
-    refresh = RefreshResult(
-        request,
-        completed=["inspect_imported", "stop", "start", "ready", "observe_instance"],
-        before=SessionState(True, 10, False, "old"),
-        after=SessionState(True, 11, False, "new"),
+    refresh = TypeAdapter(RefreshResult).validate_python(
+        {
+            "request": request,
+            "completed": [
+                "inspect_imported",
+                "stop",
+                "start",
+                "ready",
+                "observe_instance",
+            ],
+            "before": SessionState(True, 10, False, "old"),
+            "after": SessionState(True, 11, False, "new"),
+            "comparison": {
+                "status": "incomplete",
+                "reasons": ["vertex limit exceeded"],
+            },
+        }
     )
     pipeline = PipelineResult(
         refresh=refresh,
@@ -212,4 +226,52 @@ def test_refresh_failure_before_reset_does_not_imply_a_restart_or_final_state():
     assert "completed reset stages: none" in message
     assert "before: unavailable" in message
     assert "last observed: unavailable" in message
+    assert "content comparison was not completed" in message
     assert "restarted" not in message
+
+
+@pytest.mark.parametrize(
+    "stage,code",
+    [
+        ("refresh.capture", "capture_failed"),
+        ("refresh.status", "refresh_session_changed"),
+        ("refresh.status", "daemon_not_running"),
+    ],
+)
+def test_later_refresh_failure_preserves_completed_content_match(stage, code):
+    from gda.commands.asset_pipeline import PipelineRunResult, _failure_message
+
+    result = PipelineRunResult.model_validate(
+        {
+            "completed": [],
+            "outputs": [],
+            "observations": [],
+            "refresh": {
+                "request": {
+                    "path": "res://model.glb",
+                    "scene": "res://test.tscn",
+                    "node": "/root/Test/Model",
+                },
+                "completed": [
+                    "inspect_imported",
+                    "stop",
+                    "start",
+                    "ready",
+                    "observe_instance",
+                    "compare",
+                ],
+                "comparison": {"status": "match", "reasons": []},
+            },
+            "failure": {
+                "stage": stage,
+                "code": code,
+                "message": "later operation failed",
+            },
+        }
+    )
+    message = _failure_message(stage, "later operation failed", result)
+    assert stage in message
+    assert "completed reset stages: stop, start, ready" in message
+    assert "content comparison matched; refresh did not complete" in message
+    assert "content verification is incomplete" not in message
+    assert "Inspect the installed output" not in message


### PR DESCRIPTION
A refresh can replace a running session yet remain unable to verify selected content. Explain that outcome in the existing failure message using completed reset stages and before/last-observed session facts. Preserve the full structured partial result and the explicit reset contract.

The guide now demonstrates installation/import/load without refresh, inspection of the selected installed GLB, and a separate file-only refresh after checking its bytes are unchanged. It states that inspection does not import, that old cache inspection cannot establish support for incoming content, and that producer/processing steps must be omitted from reuse. No mandatory gate, receipt, lock, or automatic retry is added.

Validation:
- Final head `28c6a16f374a82bd5c882eccdda79c44a844279d` from dev baseline `becdc99c817324da5d45be585d734af9437793ee`.
- Initial failure-message cases RED before the change; 49 related CLI/domain checks pass after the review correction. Missing reset/final state is not represented as a successful restart.
- Maintained public native Godot 4.6.3 headless flow: 1 passed in 14.09 seconds. B is installed while A remains running; selected B is inspected; deleting the producer source still permits installed-file reuse and verifies the replacement session. A vertex-budget omission then remains incomplete while the actual completed reset and new running session are reported. Cleanup passes.
- The native test follows the delivered measurement instead of pinning historical LOD/albedo exclusions; archived Panda is not used.
- Full Pyright, changed-file Ruff/format and diff checks pass. Independent Sol Standards/Spec reviews passed at the final head. Both identified the same overbroad incomplete-content message: a successful comparison can precede capture or final-session failure. The correction preserves match, incomplete and not-completed separately; capture and two final-session regressions failed before correction and passed after it. All applicable CI passed; scheduled Godot E2E was skipped. The native validation above was run locally.
- Parent final integration rehearsal on dev `10646635543258b599974438be4dabfc1c9d78a1`: 49 checks passed, tested tree `55871f394d93e9ba823563583f6955c581aa2295`.

Refs #942. Targets `codex/asset-pipeline-dev` only.
