### PR TITLE
feat(resource): verify embedded albedo model content

### DIFF
--- a/docs/model-content.md
+++ b/docs/model-content.md
@@ -16,7 +16,7 @@ shared `content` object:
 
 ```json
 {
-  "measurement": "godot-static-model-content-v2",
+  "measurement": "godot-static-model-content-v3",
   "engine_version": {"major": 4, "minor": 6},
   "complete": true,
   "digest": "<64 lowercase hexadecimal characters>",
@@ -60,15 +60,15 @@ instance. Its wrapper adds:
 locates the observation in that session; it does not make the traversal an
 atomic frame snapshot.
 
-## Version 2 sampling rules
+## Version 3 sampling rules
 
-The headless and live implementations use the same sampling block. Version 2
+The headless and live implementations use the same sampling block. Version 3
 walks the selected root and its bounded child prefix in stable child order. It
 hashes each node's root-relative locator and engine class. It excludes the
 selected root's name and local placement because those belong to its consumer;
 it includes each descendant `Node3D` local transform.
 
-For each `MeshInstance3D`, version 2 supports `ArrayMesh` surfaces, including
+For each `MeshInstance3D`, version 3 supports `ArrayMesh` surfaces, including
 static LODs, without blend shapes, skins, or material overlays. Other
 `VisualInstance3D` nodes and `Camera3D` are unsupported because their visible
 content is outside this static mesh measurement. The sampler hashes the surface index,
@@ -79,14 +79,14 @@ of total public surface buffer data, 8 MiB of LOD index bytes, 1,024 LOD
 entries, and 64 MiB of serialized hash input in addition to the caller's node
 and vertex limits.
 
-Version 2 reads each surface through public
+Version 3 reads each surface through public
 [`RenderingServer.mesh_get_surface()`](https://docs.godotengine.org/en/4.6/classes/class_renderingserver.html#class-renderingserver-method-mesh-get-surface).
 On the validated Godot 4.6 representation, a LOD is a Dictionary containing a
 positive `edge_length` float and a nonempty `index_data` byte array. Entries are
 strictly ordered by increasing threshold. The sampler hashes every threshold
 and every index byte in that order. Godot stores two-byte indices when the
 surface has at most 65,536 vertices and four-byte indices above that boundary;
-version 2 validates the corresponding byte width without decoding or dropping
+version 3 validates the corresponding byte width without decoding or dropping
 indices. Godot omits the `lods` key for a valid surface with no LODs. The sampler
 accepts that omission only after validating the rest of the public surface
 shape; an empty or malformed surface Dictionary is incomplete rather than
@@ -109,13 +109,55 @@ systems, or other engine minor versions.
 The effective surface material comes from
 `MeshInstance3D.get_active_material()`, so normal material and surface override
 precedence is observed. A material is supported when it is an unscripted
-`StandardMaterial3D`. Version 2 hashes its storage properties in property-name
+`StandardMaterial3D`. Version 3 hashes its storage properties in property-name
 order for these Variant types: null, bool, int, float, String, StringName,
-Vector2, Vector3, Vector4, and Color. A null Object property is included. A
-non-null Resource property, including a referenced texture, makes the sample
-unsupported because version 2 does not recursively identify Resource content.
+Vector2, Vector3, Vector4, and Color. A null Object property is included. The non-null
+`albedo_texture` property has the narrow image-content rule below. Other non-null
+Resource properties remain unsupported; the sampler does not recursively identify
+arbitrary Resource content.
 Resource bookkeeping fields such as `resource_name`, `resource_path`,
 `resource_local_to_scene`, and `script` are excluded.
+
+For albedo, version 3 admits unscripted `ImageTexture` and `CompressedTexture2D`
+whose public [`Texture2D.get_image()`](https://docs.godotengine.org/en/4.6/classes/class_texture2d.html#class-texture2d-method-get-image)
+returns a nonempty, uncompressed RGB8 or RGBA8 `Image` with matching dimensions.
+It hashes width, height, format, mipmap presence/count, and every returned image
+byte, including mipmaps. This distinguishes an image-only change even when the
+resource path, node names, geometry counts, and bounds stay the same. It also
+observes global and surface material overrides through `get_active_material()`.
+An absent image, inconsistent dimensions, another image format, a scripted or
+procedural texture, and render-target textures remain unsupported. Non-albedo
+texture slots remain unsupported even when their image data is readable.
+
+The maintained GLB fixture contains an embedded base-color PNG. Godot's default
+embedded-image option extracts it to a project PNG and imports a
+`CompressedTexture2D`; sampling its decoded Image still measures the received
+image content. This implementation does not infer production provenance from a
+texture path or require the engine to retain the original embedding. See the
+[Godot 4.6.3 extraction and texture loading path](https://github.com/godotengine/godot/blob/4.6.3-stable/modules/gltf/gltf_document.cpp#L2186-L2263).
+
+Before each image read, the sampler charges the texture's reported base-level
+width × height against a fixed aggregate limit of 16,777,216 pixels. Repeated
+references and attempted reads that later fail consume that budget too. It checks
+`Image.get_data_size()` against the remaining 64 MiB total serialized hash budget
+before requesting the byte array; all mip levels count toward that byte budget.
+The image shares this existing budget with geometry, LODs, and material values.
+An omitted or unsupported image makes the complete sample's digest null.
+
+The pixel check precedes `get_image()`. The byte check happens after that method
+has returned: Godot may already have allocated or copied an image or read from the
+GPU. Neither limit bounds that initial native allocation or latency. In the
+validated 4.6.3 arm64/macOS GL Compatibility experiment, a default-imported 1024²
+RGBA8 image had 10 mip levels and 5,592,404 data bytes. Headless and windowed
+readback returned identical image metadata and raw SHA-256. Three windowed
+`get_image()` reads took 2,629, 617, and 306 microseconds; headless reads took
+1–3 microseconds. The coarse static-memory delta while retaining the windowed
+image was about 11.2 MB, while the headless delta was zero. These snapshots reflect
+allocator reuse and object lifetimes, not transient/native peak memory or an SLA.
+A 2048² headless image had 11 mip levels and 22,369,620 bytes. Runtime-created
+1024² RGB8 and RGBA8 `ImageTexture` controls also returned identical raw bytes
+between headless and windowed GL Compatibility. Other formats and renderers are
+not established by these measurements.
 
 Scripted nodes, `Skeleton3D`, `AnimationPlayer`, skins, non-`ArrayMesh` meshes,
 blend shapes, and other material or property types remain visible through
@@ -152,14 +194,18 @@ resource and one selected live instance within a compatible engine context.
 `complete` is true only when both `unsupported` and `omitted` are empty and the
 sample contains at least one surface and one vertex. Only a complete result
 carries `digest`; otherwise `digest` is null. `unsupported`
-means encountered content is outside version 2's admitted semantics. `omitted`
-means a node, vertex, surface, index, stored-buffer, or serialized-byte limit
+means encountered content is outside version 3's admitted semantics. `omitted`
+means a node, vertex, surface, index, stored-buffer, albedo-pixel, or serialized-byte limit
 prevented complete sampling. The lists are sorted and deduplicated so the
 incomplete result remains useful for diagnosis.
 
-The digest identifies the admitted static content for measurement version 2.
+The digest identifies the admitted static content for measurement version 3.
 It does not identify a full resource, rendered appearance, animated pose,
 runtime behavior, or visual equivalence. Godot's Variant byte encoding and
 imported representation participate in the measurement, so cross-version
 digest identity is not promised. Compare the measurement identifier and actual
 engine versions before interpreting two digests.
+
+Version 3 supersedes version 2 when albedo image bytes become part of the
+measurement. Digests with different measurement identifiers are not comparable,
+even for a model without a texture.

--- a/libs/gda-assets/docs/runtime-refresh.md
+++ b/libs/gda-assets/docs/runtime-refresh.md
@@ -125,7 +125,7 @@ as verified. A complete digest mismatch reports `mismatch`. The digest remains a
 bounded content comparison, not a general resource identity or proof of all visual
 behavior.
 
-Measurement version 2 includes the complete admitted static LOD thresholds and
+Measurement version 3 includes the complete admitted static LOD thresholds and
 index bytes returned by Godot 4.6's public RenderingServer surface readback. This
 lets refresh reject an old running instance after generated LOD content changes
 and accept the replacement after the controlled session reset. The LOD data is a
@@ -133,6 +133,14 @@ Godot import/runtime representation; a standard GLB does not itself carry that
 Godot representation. The sampler's script-side limits apply after the engine has
 materialized the public surface Dictionary, as detailed in the static-content
 guide.
+
+Version 3 also compares the admitted albedo Image metadata and bytes, including
+mipmaps. An image-only replacement can therefore reject an old instance even
+when paths, counts, and bounds do not change. The texture pixel and shared byte
+limits can make a sample incomplete; they do not bound the engine's initial GPU
+readback or allocation. Other texture slots and unreadable texture forms remain
+outside the measurement. Different measurement versions cannot be compared; no
+new workflow identity or recovery mechanism is required.
 
 ## Capture and failure evidence
 

--- a/libs/gda-assets/tests/test_refresh_composition.py
+++ b/libs/gda-assets/tests/test_refresh_composition.py
@@ -28,7 +28,7 @@ from gda_assets.api import (
 
 
 CONTENT = ModelContent(
-    "godot-static-model-content-v2", "4.6.3.stable.official", True, "a" * 64
+    "godot-static-model-content-v3", "4.6.3.stable.official", True, "a" * 64
 )
 
 

--- a/libs/gda-assets/tests/test_runtime_refresh.py
+++ b/libs/gda-assets/tests/test_runtime_refresh.py
@@ -22,7 +22,7 @@ from gda_assets.domain.refresh import (
 from gda_assets.application.ports import PortFailure
 
 
-CONTENT = ModelContent("godot-static-model-content-v2", "4.6.3", True, "b" * 64)
+CONTENT = ModelContent("godot-static-model-content-v3", "4.6.3", True, "b" * 64)
 
 
 class Runtime:

--- a/src/gda/harness/gda_harness.gd
+++ b/src/gda/harness/gda_harness.gd
@@ -459,12 +459,13 @@ func _handle_game_tree(params: Dictionary) -> String:
 # This block is duplicated byte-for-byte in the live harness: imported and live
 # facts must be produced by one algorithm even though neither script can preload
 # the other. Keep the surface deliberately narrow; this is not Resource identity.
-const MODEL_CONTENT_MEASUREMENT := "godot-static-model-content-v2"
+const MODEL_CONTENT_MEASUREMENT := "godot-static-model-content-v3"
 const MODEL_CONTENT_MAX_BYTES := 67108864
 const MODEL_CONTENT_MAX_STORED_BYTES := 33554432
 const MODEL_CONTENT_MAX_LOD_BYTES := 8388608
 const MODEL_CONTENT_MAX_LODS := 1024
 const MODEL_CONTENT_MAX_SURFACES := 4096
+const MODEL_CONTENT_MAX_ALBEDO_PIXELS := 16777216
 
 
 func _model_content_note(items: Array, note: String) -> void:
@@ -480,6 +481,51 @@ func _model_content_hash(state: Dictionary, value: Variant, location: String) ->
 	state["bytes"] = int(state["bytes"]) + bytes.size()
 	(state["hash"] as HashingContext).update(bytes)
 	return true
+
+
+func _model_content_albedo(value: Variant, state: Dictionary, location: String) -> void:
+	if not value is Texture2D or value.get_script() != null \
+			or not value.get_class() in ["ImageTexture", "CompressedTexture2D"]:
+		_model_content_note(state["unsupported"], location + ": albedo texture type is unsupported")
+		return
+	var texture: Texture2D = value
+	var width := texture.get_width()
+	var height := texture.get_height()
+	if width <= 0 or height <= 0:
+		_model_content_note(state["unsupported"], location + ": albedo dimensions are unavailable")
+		return
+	var pixels := width * height
+	if pixels > MODEL_CONTENT_MAX_ALBEDO_PIXELS - int(state["albedo_pixels"]):
+		_model_content_note(state["omitted"], "albedo pixel limit exceeded at " + location)
+		return
+	# Charge every attempted read, including repeated references and failed reads.
+	state["albedo_pixels"] = int(state["albedo_pixels"]) + pixels
+	# Native readback may allocate/copy before the returned-size checks below.
+	var image: Image = texture.get_image()
+	if image == null or image.is_empty():
+		_model_content_note(state["unsupported"], location + ": albedo image data is unavailable")
+		return
+	if image.get_width() != width or image.get_height() != height:
+		_model_content_note(state["unsupported"], location + ": albedo image dimensions are inconsistent")
+		return
+	var format := image.get_format()
+	if image.is_compressed() or not format in [Image.FORMAT_RGB8, Image.FORMAT_RGBA8]:
+		_model_content_note(state["unsupported"], location + ": albedo image format is unsupported")
+		return
+	var size := image.get_data_size()
+	if size <= 0:
+		_model_content_note(state["unsupported"], location + ": albedo image data is unavailable")
+		return
+	if size > MODEL_CONTENT_MAX_BYTES - int(state["bytes"]):
+		_model_content_note(state["omitted"], "albedo byte limit exceeded at " + location)
+		return
+	var data := image.get_data()
+	if data.size() != size:
+		_model_content_note(state["unsupported"], location + ": albedo image data is incomplete")
+		return
+	_model_content_hash(state, "albedo_image", location)
+	_model_content_hash(state, [width, height, format, image.has_mipmaps(), image.get_mipmap_count()], location)
+	_model_content_hash(state, data, location)
 
 
 func _model_content_material(instance: MeshInstance3D, surface: int,
@@ -518,6 +564,10 @@ func _model_content_material(instance: MeshInstance3D, surface: int,
 				return
 			if not _model_content_hash(state, null, location):
 				return
+		elif type == TYPE_OBJECT and name == "albedo_texture":
+			if not _model_content_hash(state, name, location):
+				return
+			_model_content_albedo(value, state, location + ":albedo_texture")
 		elif type == TYPE_OBJECT:
 			_model_content_note(state["unsupported"], location + ": material resource property "
 					+ name + " is unsupported")
@@ -684,7 +734,7 @@ func _model_static_content(root: Node, max_nodes: int, max_vertices: int) -> Dic
 	var hashing := HashingContext.new()
 	hashing.start(HashingContext.HASH_SHA256)
 	var state := {"hash": hashing, "bytes": 0, "stored_bytes": 0,
-			"lod_bytes": 0, "lods": 0,
+			"lod_bytes": 0, "lods": 0, "albedo_pixels": 0,
 			"unsupported": [], "omitted": []}
 	var engine := Engine.get_version_info()
 	if int(engine.get("major", 0)) != 4 or int(engine.get("minor", 0)) != 6:

--- a/src/gda/harness/install.py
+++ b/src/gda/harness/install.py
@@ -87,7 +87,7 @@ HARNESS_ADDONS_RES_PATH = f"res://{HARNESS_ADDONS_DIR}"
 # copy to it (#225). The installed copy declares its version in a leading header
 # (`# gda-harness-version: <N>`); a mismatch re-materializes via the content
 # compare. NOT the package version — the harness changes far less often.
-HARNESS_VERSION = "23"
+HARNESS_VERSION = "24"
 
 _VERSION_HEADER_PREFIX = "# gda-harness-version:"
 _AUTOLOAD_HEADER = "[autoload]"

--- a/src/gda/model_content.py
+++ b/src/gda/model_content.py
@@ -10,7 +10,7 @@ from gda.models import EngineVersion
 class ModelContent(BaseModel):
     """Bounded, deterministic content facts returned by the native sampler."""
 
-    measurement: Literal["godot-static-model-content-v2"]
+    measurement: Literal["godot-static-model-content-v3"]
     engine_version: EngineVersion
     complete: bool
     digest: str | None = Field(default=None, pattern=r"^[0-9a-f]{64}$")

--- a/src/gda/ops/operations.gd
+++ b/src/gda/ops/operations.gd
@@ -3623,12 +3623,13 @@ func _op_package_resource_presence(params: Dictionary) -> void:
 # This block is duplicated byte-for-byte in the live harness: imported and live
 # facts must be produced by one algorithm even though neither script can preload
 # the other. Keep the surface deliberately narrow; this is not Resource identity.
-const MODEL_CONTENT_MEASUREMENT := "godot-static-model-content-v2"
+const MODEL_CONTENT_MEASUREMENT := "godot-static-model-content-v3"
 const MODEL_CONTENT_MAX_BYTES := 67108864
 const MODEL_CONTENT_MAX_STORED_BYTES := 33554432
 const MODEL_CONTENT_MAX_LOD_BYTES := 8388608
 const MODEL_CONTENT_MAX_LODS := 1024
 const MODEL_CONTENT_MAX_SURFACES := 4096
+const MODEL_CONTENT_MAX_ALBEDO_PIXELS := 16777216
 
 
 func _model_content_note(items: Array, note: String) -> void:
@@ -3644,6 +3645,51 @@ func _model_content_hash(state: Dictionary, value: Variant, location: String) ->
 	state["bytes"] = int(state["bytes"]) + bytes.size()
 	(state["hash"] as HashingContext).update(bytes)
 	return true
+
+
+func _model_content_albedo(value: Variant, state: Dictionary, location: String) -> void:
+	if not value is Texture2D or value.get_script() != null \
+			or not value.get_class() in ["ImageTexture", "CompressedTexture2D"]:
+		_model_content_note(state["unsupported"], location + ": albedo texture type is unsupported")
+		return
+	var texture: Texture2D = value
+	var width := texture.get_width()
+	var height := texture.get_height()
+	if width <= 0 or height <= 0:
+		_model_content_note(state["unsupported"], location + ": albedo dimensions are unavailable")
+		return
+	var pixels := width * height
+	if pixels > MODEL_CONTENT_MAX_ALBEDO_PIXELS - int(state["albedo_pixels"]):
+		_model_content_note(state["omitted"], "albedo pixel limit exceeded at " + location)
+		return
+	# Charge every attempted read, including repeated references and failed reads.
+	state["albedo_pixels"] = int(state["albedo_pixels"]) + pixels
+	# Native readback may allocate/copy before the returned-size checks below.
+	var image: Image = texture.get_image()
+	if image == null or image.is_empty():
+		_model_content_note(state["unsupported"], location + ": albedo image data is unavailable")
+		return
+	if image.get_width() != width or image.get_height() != height:
+		_model_content_note(state["unsupported"], location + ": albedo image dimensions are inconsistent")
+		return
+	var format := image.get_format()
+	if image.is_compressed() or not format in [Image.FORMAT_RGB8, Image.FORMAT_RGBA8]:
+		_model_content_note(state["unsupported"], location + ": albedo image format is unsupported")
+		return
+	var size := image.get_data_size()
+	if size <= 0:
+		_model_content_note(state["unsupported"], location + ": albedo image data is unavailable")
+		return
+	if size > MODEL_CONTENT_MAX_BYTES - int(state["bytes"]):
+		_model_content_note(state["omitted"], "albedo byte limit exceeded at " + location)
+		return
+	var data := image.get_data()
+	if data.size() != size:
+		_model_content_note(state["unsupported"], location + ": albedo image data is incomplete")
+		return
+	_model_content_hash(state, "albedo_image", location)
+	_model_content_hash(state, [width, height, format, image.has_mipmaps(), image.get_mipmap_count()], location)
+	_model_content_hash(state, data, location)
 
 
 func _model_content_material(instance: MeshInstance3D, surface: int,
@@ -3682,6 +3728,10 @@ func _model_content_material(instance: MeshInstance3D, surface: int,
 				return
 			if not _model_content_hash(state, null, location):
 				return
+		elif type == TYPE_OBJECT and name == "albedo_texture":
+			if not _model_content_hash(state, name, location):
+				return
+			_model_content_albedo(value, state, location + ":albedo_texture")
 		elif type == TYPE_OBJECT:
 			_model_content_note(state["unsupported"], location + ": material resource property "
 					+ name + " is unsupported")
@@ -3848,7 +3898,7 @@ func _model_static_content(root: Node, max_nodes: int, max_vertices: int) -> Dic
 	var hashing := HashingContext.new()
 	hashing.start(HashingContext.HASH_SHA256)
 	var state := {"hash": hashing, "bytes": 0, "stored_bytes": 0,
-			"lod_bytes": 0, "lods": 0,
+			"lod_bytes": 0, "lods": 0, "albedo_pixels": 0,
 			"unsupported": [], "omitted": []}
 	var engine := Engine.get_version_info()
 	if int(engine.get("major", 0)) != 4 or int(engine.get("minor", 0)) != 6:

--- a/tests/albedo_support.py
+++ b/tests/albedo_support.py
@@ -1,0 +1,176 @@
+"""Deterministic embedded-albedo GLB fixtures shared by native tests."""
+
+import json
+from pathlib import Path
+import struct
+import zlib
+
+
+def _png_chunk(kind: bytes, data: bytes) -> bytes:
+    return (
+        struct.pack(">I", len(data))
+        + kind
+        + data
+        + struct.pack(">I", zlib.crc32(kind + data) & 0xFFFFFFFF)
+    )
+
+
+def _rgba_png(*, color: tuple[int, int, int, int], size: int) -> bytes:
+    compressor = zlib.compressobj(level=9)
+    pixel = bytes(color)
+    row = b"\0" + pixel * size
+    compressed = [compressor.compress(row) for _ in range(size)]
+    compressed.append(compressor.flush())
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + _png_chunk(b"IHDR", struct.pack(">IIBBBBB", size, size, 8, 6, 0, 0, 0))
+        + _png_chunk(b"IDAT", b"".join(compressed))
+        + _png_chunk(b"IEND", b"")
+    )
+
+
+def write_albedo_glb(
+    path: Path,
+    *,
+    color: tuple[int, int, int, int],
+    size: int = 2,
+) -> None:
+    """Write one fixed quad whose only variable content is an embedded RGBA PNG."""
+    if size < 1:
+        raise ValueError("size must be at least 1")
+    if len(color) != 4 or any(
+        type(channel) is not int or not 0 <= channel <= 255 for channel in color
+    ):
+        raise ValueError("color must contain four integer channels in 0..255")
+
+    positions = struct.pack(
+        "<12f",
+        -1.0,
+        -1.0,
+        0.0,
+        1.0,
+        -1.0,
+        0.0,
+        1.0,
+        1.0,
+        0.0,
+        -1.0,
+        1.0,
+        0.0,
+    )
+    normals = struct.pack("<12f", *(0.0, 0.0, 1.0) * 4)
+    texcoords = struct.pack("<8f", 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0)
+    indices = struct.pack("<6H", 0, 1, 2, 0, 2, 3)
+    geometry = positions + normals + texcoords + indices
+    geometry += b"\0" * (-len(geometry) % 4)
+    image = _rgba_png(color=color, size=size)
+    binary = geometry + image
+    binary += b"\0" * (-len(binary) % 4)
+
+    document = {
+        "asset": {"version": "2.0", "generator": "gda embedded albedo fixture"},
+        "scene": 0,
+        "scenes": [{"nodes": [0]}],
+        "nodes": [
+            {"name": "AssetRoot", "children": [1]},
+            {"name": "Body", "mesh": 0},
+        ],
+        "materials": [
+            {
+                "name": "BodyMaterial",
+                "pbrMetallicRoughness": {
+                    "baseColorFactor": [1.0, 1.0, 1.0, 1.0],
+                    "baseColorTexture": {"index": 0},
+                    "metallicFactor": 0.0,
+                    "roughnessFactor": 0.5,
+                },
+            }
+        ],
+        "meshes": [
+            {
+                "name": "BodyMesh",
+                "primitives": [
+                    {
+                        "attributes": {
+                            "POSITION": 0,
+                            "NORMAL": 1,
+                            "TEXCOORD_0": 2,
+                        },
+                        "indices": 3,
+                        "material": 0,
+                    }
+                ],
+            }
+        ],
+        "textures": [{"source": 0}],
+        "images": [{"bufferView": 4, "mimeType": "image/png"}],
+        "buffers": [{"byteLength": len(binary)}],
+        "bufferViews": [
+            {
+                "buffer": 0,
+                "byteOffset": 0,
+                "byteLength": len(positions),
+                "target": 34962,
+            },
+            {
+                "buffer": 0,
+                "byteOffset": len(positions),
+                "byteLength": len(normals),
+                "target": 34962,
+            },
+            {
+                "buffer": 0,
+                "byteOffset": len(positions) + len(normals),
+                "byteLength": len(texcoords),
+                "target": 34962,
+            },
+            {
+                "buffer": 0,
+                "byteOffset": len(positions) + len(normals) + len(texcoords),
+                "byteLength": len(indices),
+                "target": 34963,
+            },
+            {
+                "buffer": 0,
+                "byteOffset": len(geometry),
+                "byteLength": len(image),
+            },
+        ],
+        "accessors": [
+            {
+                "bufferView": 0,
+                "componentType": 5126,
+                "count": 4,
+                "type": "VEC3",
+                "min": [-1.0, -1.0, 0.0],
+                "max": [1.0, 1.0, 0.0],
+            },
+            {
+                "bufferView": 1,
+                "componentType": 5126,
+                "count": 4,
+                "type": "VEC3",
+            },
+            {
+                "bufferView": 2,
+                "componentType": 5126,
+                "count": 4,
+                "type": "VEC2",
+            },
+            {
+                "bufferView": 3,
+                "componentType": 5123,
+                "count": 6,
+                "type": "SCALAR",
+            },
+        ],
+    }
+    payload = json.dumps(document, separators=(",", ":"), sort_keys=True).encode()
+    payload += b" " * (-len(payload) % 4)
+    chunks = (
+        struct.pack("<I4s", len(payload), b"JSON")
+        + payload
+        + struct.pack("<I4s", len(binary), b"BIN\0")
+        + binary
+    )
+    path.write_bytes(struct.pack("<4sII", b"glTF", 2, len(chunks) + 12) + chunks)

--- a/tests/asset_pipeline/test_e2e_runtime_refresh.py
+++ b/tests/asset_pipeline/test_e2e_runtime_refresh.py
@@ -202,7 +202,7 @@ def _run_handoff(run: Gda, source_root: Path, source: str, *, refresh=None) -> d
 
 def _assert_complete(sample: dict) -> str:
     content = sample["content"]
-    assert content["measurement"] == "godot-static-model-content-v2"
+    assert content["measurement"] == "godot-static-model-content-v3"
     assert content.get("engine") or content.get("engine_version")
     assert content["complete"] is True
     assert content["unsupported"] == []
@@ -310,16 +310,14 @@ def test_refresh_digest_detects_each_admitted_material_or_geometry_change(
         run("daemon", "stop")
 
 
-def test_native_sampler_marks_unsupported_and_bounded_samples_incomplete(tmp_path):
+def test_native_sampler_admits_embedded_albedo_but_keeps_vertex_omissions(tmp_path):
     project, source = tmp_path / "project", tmp_path / "source"
     _fixture(project, source)
     run = Gda(project, json_output=True, timeout=180)
 
     _run_handoff(run, source, "textured.glb")
-    unsupported = run.json("resource", "inspect-model-content", "--path", MODEL)
-    assert unsupported["content"]["complete"] is False
-    assert unsupported["content"]["digest"] is None
-    assert unsupported["content"]["unsupported"]
+    textured = run.json("resource", "inspect-model-content", "--path", MODEL)
+    assert _assert_complete(textured)
 
     _run_handoff(run, source, "a.glb")
     bounded = run.json(

--- a/tests/asset_pipeline/test_e2e_runtime_refresh_albedo.py
+++ b/tests/asset_pipeline/test_e2e_runtime_refresh_albedo.py
@@ -1,0 +1,116 @@
+"""Imported embedded-image changes remain visible across selected live instances."""
+
+import json
+import os
+
+import pytest
+
+from tests.albedo_support import write_albedo_glb
+from tests.conftest import project_godot
+from tests.support import Gda, assert_windowed_ok
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"),
+    pytest.mark.xdist_group("windowed"),
+]
+
+MODEL = "res://model.glb"
+NODE = "/root/Test/Model"
+
+
+def _digest(sample):
+    content = sample["content"]
+    assert content["complete"] is True, content
+    assert content["measurement"] == "godot-static-model-content-v3"
+    assert content["unsupported"] == []
+    assert content["omitted"] == []
+    assert len(content["digest"]) == 64
+    return content["digest"]
+
+
+@pytest.mark.usefixtures("windowed_host", "daemon_runtime_dir")
+def test_embedded_image_change_preserves_summaries_but_rejects_stale_content(
+    tmp_path, monkeypatch
+):
+    project, source = tmp_path / "project", tmp_path / "source"
+    project.mkdir()
+    source.mkdir()
+    (project / "project.godot").write_text(
+        project_godot(
+            name="gda-albedo-refresh-e2e",
+            extra=(
+                'run/main_scene="res://test.tscn"\n\n'
+                '[rendering]\n\nrenderer/rendering_method="gl_compatibility"'
+            ),
+        )
+    )
+    (project / "test.tscn").write_text(
+        "[gd_scene load_steps=2 format=3]\n"
+        '[ext_resource type="Script" path="res://startup.gd" id="1"]\n'
+        '[node name="Test" type="Node3D"]\nscript = ExtResource("1")\n'
+        '[node name="Camera3D" type="Camera3D" parent="."]\nposition = Vector3(0,0,4)\n'
+    )
+    (project / "startup.gd").write_text(
+        "extends Node3D\nfunc _ready():\n"
+        '\tvar model = (load("res://model.glb") as PackedScene).instantiate()\n'
+        '\tmodel.name = "Model"\n\tadd_child(model)\n'
+    )
+    write_albedo_glb(source / "a.glb", color=(255, 32, 16, 255))
+    write_albedo_glb(source / "b.glb", color=(16, 32, 255, 255))
+    monkeypatch.setenv("GDA_USER_DATA_ROOT", str(tmp_path / "user-data"))
+    run = Gda(project, json_output=True, timeout=180)
+
+    def handoff(filename, *, refresh=False):
+        args = [
+            "asset-pipeline",
+            "run",
+            "--source-root",
+            str(source),
+            "--files",
+            json.dumps([{"source": filename, "target": MODEL}]),
+            "--overwrite",
+        ]
+        if refresh:
+            args += [
+                "--refresh",
+                json.dumps(
+                    {
+                        "path": MODEL,
+                        "scene": "res://test.tscn",
+                        "node": NODE,
+                        "windowed": True,
+                    }
+                ),
+            ]
+        return run.json(*args)
+
+    try:
+        handoff("a.glb")
+        imported_a = run.json("resource", "inspect-model-content", "--path", MODEL)
+        report_a = run.json("resource", "inspect-model", MODEL)
+        assert_windowed_ok(run("daemon", "start", "--windowed"))
+        run.json("daemon", "wait-ready", "--timeout", "25")
+        live_a = run.json("game", "inspect-model-content", "--node", NODE)
+        assert _digest(live_a) == _digest(imported_a)
+
+        handoff("b.glb")
+        imported_b = run.json("resource", "inspect-model-content", "--path", MODEL)
+        report_b = run.json("resource", "inspect-model", MODEL)
+        stale = run.json("game", "inspect-model-content", "--node", NODE)
+        for field in ("path", "summary", "bounds", "nodes"):
+            assert report_a[field] == report_b[field]
+        assert _digest(imported_a) != _digest(imported_b)
+        assert _digest(stale) == _digest(imported_a)
+        assert stale["session_id"] == live_a["session_id"]
+
+        result = handoff("b.glb", refresh=True)
+        refresh = result["pipeline"]["refresh"]
+        assert refresh["status"] == "verified"
+        assert refresh["comparison"] == {"status": "match", "reasons": []}
+        assert refresh["ready_session"]["session_id"] != live_a["session_id"]
+        assert _digest(refresh["imported"]) == _digest(imported_b)
+        assert _digest(refresh["instance"]) == _digest(imported_b)
+    finally:
+        stopped = run("daemon", "stop")
+        assert stopped.returncode == 0, stopped.stdout + stopped.stderr

--- a/tests/asset_pipeline/test_e2e_runtime_refresh_combined.py
+++ b/tests/asset_pipeline/test_e2e_runtime_refresh_combined.py
@@ -1,0 +1,254 @@
+"""Final combined LOD and embedded-albedo runtime-refresh witness (#907)."""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import project_godot
+from tests.support import Gda, assert_windowed_ok
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"),
+    pytest.mark.xdist_group("windowed"),
+]
+
+MODEL = "res://model.glb"
+NODE = "/root/Test/Model"
+
+GENERATOR = """extends SceneTree
+
+func _initialize() -> void:
+    DirAccess.make_dir_absolute("res://generated")
+    _write_model("res://generated/a.glb", Color8(255, 32, 16, 255))
+    _write_model("res://generated/b.glb", Color8(16, 32, 255, 255))
+    quit()
+
+func _write_model(path: String, color: Color) -> void:
+    var root := Node3D.new()
+    root.name = "AssetRoot"
+    var instance := MeshInstance3D.new()
+    instance.name = "Body"
+    var mesh := SphereMesh.new()
+    mesh.radial_segments = 32
+    mesh.rings = 16
+    var image := Image.create(2, 2, false, Image.FORMAT_RGBA8)
+    image.fill(color)
+    var material := StandardMaterial3D.new()
+    material.resource_name = "BodyMaterial"
+    material.albedo_texture = ImageTexture.create_from_image(image)
+    mesh.material = material
+    instance.mesh = mesh
+    root.add_child(instance)
+    instance.owner = root
+    var document := GLTFDocument.new()
+    var state := GLTFState.new()
+    assert(document.append_from_scene(root, state) == OK)
+    assert(document.write_to_filesystem(state, path) == OK)
+    root.free()
+"""
+
+PROBE = """extends SceneTree
+
+func _initialize() -> void:
+    var packed := load("res://model.glb") as PackedScene
+    assert(packed != null)
+    var root := packed.instantiate()
+    var instance := _mesh_instance(root)
+    assert(instance != null and instance.mesh is ArrayMesh)
+    var mesh := instance.mesh as ArrayMesh
+    var lods := 0
+    for surface_index in mesh.get_surface_count():
+        var surface := RenderingServer.mesh_get_surface(mesh.get_rid(), surface_index)
+        var levels: Variant = surface.get("lods", [])
+        assert(levels is Array)
+        lods += levels.size()
+    var material := instance.get_active_material(0) as StandardMaterial3D
+    assert(material != null and material.albedo_texture != null)
+    var image := material.albedo_texture.get_image()
+    assert(image != null and not image.is_empty())
+    var hashing := HashingContext.new()
+    assert(hashing.start(HashingContext.HASH_SHA256) == OK)
+    assert(hashing.update(image.get_data()) == OK)
+    print("COMBINED_FACTS=" + JSON.stringify({
+        "lods": lods,
+        "image_width": image.get_width(),
+        "image_height": image.get_height(),
+        "image_bytes": image.get_data_size(),
+        "image_sha256": hashing.finish().hex_encode(),
+    }))
+    root.free()
+    quit()
+
+func _mesh_instance(node: Node) -> MeshInstance3D:
+    if node is MeshInstance3D:
+        return node
+    for child in node.get_children():
+        var found := _mesh_instance(child)
+        if found != null:
+            return found
+    return null
+"""
+
+STARTUP = """extends Node3D
+func _ready() -> void:
+    var model := (load("res://model.glb") as PackedScene).instantiate()
+    model.name = "Model"
+    add_child(model)
+"""
+
+SCENE = """[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://startup.gd" id="1"]
+
+[node name="Test" type="Node3D"]
+script = ExtResource("1")
+"""
+
+
+def _handoff(run: Gda, source_root: Path, source: str, *, refresh=None) -> dict:
+    args = [
+        "asset-pipeline",
+        "run",
+        "--source-root",
+        str(source_root),
+        "--files",
+        json.dumps([{"source": source, "target": MODEL}]),
+        "--overwrite",
+    ]
+    if refresh is not None:
+        args += ["--refresh", json.dumps(refresh)]
+    return run.json(*args)
+
+
+def _digest(sample: dict) -> str:
+    content = sample["content"]
+    assert content["measurement"] == "godot-static-model-content-v3"
+    assert content["complete"] is True, content
+    assert content["unsupported"] == []
+    assert content["omitted"] == []
+    assert len(content["digest"]) == 64
+    return content["digest"]
+
+
+def _geometry(report: dict) -> dict:
+    surfaces = []
+    for node in report["nodes"]:
+        mesh = node.get("mesh")
+        if mesh is None:
+            continue
+        surfaces.extend(
+            {
+                "node": node["path"],
+                "primitive": surface["primitive"],
+                "vertex_count": surface["vertex_count"],
+                "index_count": surface["index_count"],
+                "triangle_count": surface["triangle_count"],
+            }
+            for surface in mesh["surfaces"]
+        )
+    return {
+        "path": report["path"],
+        "node_paths": [node["path"] for node in report["nodes"]],
+        "summary": report["summary"],
+        "bounds": report["bounds"],
+        "surfaces": surfaces,
+    }
+
+
+def _native_facts(run: Gda) -> dict:
+    result = run.json("script", "run", "res://combined_probe.gd", "--strict")
+    line = next(
+        line
+        for line in result["stdout"].splitlines()
+        if line.startswith("COMBINED_FACTS=")
+    )
+    return json.loads(line.removeprefix("COMBINED_FACTS="))
+
+
+@pytest.mark.usefixtures("windowed_host", "daemon_runtime_dir")
+def test_normal_import_refreshes_combined_lod_and_embedded_albedo_model(
+    tmp_path, monkeypatch
+):
+    project, source = tmp_path / "project", tmp_path / "source"
+    project.mkdir()
+    source.mkdir()
+    (project / "project.godot").write_text(
+        project_godot(
+            name="gda-combined-refresh-e2e",
+            extra=(
+                'run/main_scene="res://test.tscn"\n\n'
+                '[rendering]\n\nrenderer/rendering_method="gl_compatibility"'
+            ),
+        ),
+        encoding="utf-8",
+    )
+    (project / "test.tscn").write_text(SCENE, encoding="utf-8")
+    (project / "startup.gd").write_text(STARTUP, encoding="utf-8")
+    (project / "generate.gd").write_text(GENERATOR, encoding="utf-8")
+    (project / "combined_probe.gd").write_text(PROBE, encoding="utf-8")
+    monkeypatch.setenv("GDA_USER_DATA_ROOT", str(tmp_path / "user-data"))
+    run = Gda(project, json_output=True, timeout=180)
+
+    generated = project / "generated"
+    assert (
+        run.json("script", "run", "res://generate.gd", "--strict")["exit_status"] == 0
+    )
+    for name in ("a.glb", "b.glb"):
+        (source / name).write_bytes((generated / name).read_bytes())
+        (generated / name).unlink()
+    generated.rmdir()
+
+    try:
+        _handoff(run, source, "a.glb")
+        imported_a = run.json("resource", "inspect-model-content", "--path", MODEL)
+        report_a = run.json("resource", "inspect-model", MODEL)
+        facts_a = _native_facts(run)
+        assert facts_a["lods"] > 0
+        assert facts_a["image_width"] == facts_a["image_height"] == 2
+        assert facts_a["image_bytes"] > 0
+        assert len(facts_a["image_sha256"]) == 64
+
+        assert_windowed_ok(run("daemon", "start", "--windowed"))
+        run.json("daemon", "wait-ready", "--timeout", "25")
+        live_a = run.json("game", "inspect-model-content", "--node", NODE)
+        assert _digest(live_a) == _digest(imported_a)
+
+        _handoff(run, source, "b.glb")
+        imported_b = run.json("resource", "inspect-model-content", "--path", MODEL)
+        report_b = run.json("resource", "inspect-model", MODEL)
+        facts_b = _native_facts(run)
+        stale_a = run.json("game", "inspect-model-content", "--node", NODE)
+
+        assert _geometry(report_b) == _geometry(report_a)
+        assert facts_b["lods"] == facts_a["lods"]
+        assert facts_b["image_width"] == facts_a["image_width"]
+        assert facts_b["image_height"] == facts_a["image_height"]
+        assert facts_b["image_bytes"] == facts_a["image_bytes"]
+        assert facts_b["image_sha256"] != facts_a["image_sha256"]
+        assert _digest(imported_b) != _digest(imported_a)
+        assert _digest(stale_a) == _digest(imported_a)
+        assert stale_a["session_id"] == live_a["session_id"]
+
+        result = _handoff(
+            run,
+            source,
+            "b.glb",
+            refresh={
+                "path": MODEL,
+                "scene": "res://test.tscn",
+                "node": NODE,
+                "windowed": True,
+            },
+        )
+        refresh = result["pipeline"]["refresh"]
+        assert refresh["status"] == "verified"
+        assert refresh["comparison"] == {"status": "match", "reasons": []}
+        assert refresh["ready_session"]["session_id"] != live_a["session_id"]
+        assert _digest(refresh["imported"]) == _digest(imported_b)
+        assert _digest(refresh["instance"]) == _digest(imported_b)
+    finally:
+        stopped = run("daemon", "stop")
+        assert stopped.returncode == 0, stopped.stdout + stopped.stderr

--- a/tests/asset_pipeline/test_e2e_runtime_refresh_lods.py
+++ b/tests/asset_pipeline/test_e2e_runtime_refresh_lods.py
@@ -75,7 +75,7 @@ def _handoff(run: Gda, source_root: Path, source: str, *, refresh=None) -> dict:
 
 def _digest(sample: dict) -> str:
     content = sample["content"]
-    assert content["measurement"] == "godot-static-model-content-v2"
+    assert content["measurement"] == "godot-static-model-content-v3"
     assert content["complete"] is True
     assert content["unsupported"] == []
     assert content["omitted"] == []

--- a/tests/asset_pipeline/test_runtime_refresh_adapter.py
+++ b/tests/asset_pipeline/test_runtime_refresh_adapter.py
@@ -38,7 +38,7 @@ ENGINE = EngineVersion(
 
 def _content(digest: str = "a" * 64) -> NativeModelContent:
     return NativeModelContent(
-        measurement="godot-static-model-content-v2",
+        measurement="godot-static-model-content-v3",
         engine_version=ENGINE,
         complete=True,
         digest=digest,

--- a/tests/harness/test_harness_install.py
+++ b/tests/harness/test_harness_install.py
@@ -805,9 +805,9 @@ def test_ready_gates_on_template_feature_as_its_first_statement():
 #   1. edit gda_harness.gd;
 #   2. bump HARNESS_VERSION in src/gda/harness/install.py;
 #   3. update the current pins below (the failure carries the new hash).
-PINNED_HARNESS_VERSION = "23"
+PINNED_HARNESS_VERSION = "24"
 PINNED_HARNESS_SHA256 = (
-    "7926bd4d72c4cebdee5d1c842e0739c1574d113e9b335482c73e0b6124575380"
+    "66248beb356b14b27ef44d4dae6a493726f60f1c9739bfc4c7f1a96d1ef4a7dc"
 )
 
 

--- a/tests/resource/test_albedo_fixture.py
+++ b/tests/resource/test_albedo_fixture.py
@@ -1,0 +1,65 @@
+"""Contract tests for the shared embedded-albedo GLB fixture."""
+
+import json
+from pathlib import Path
+import struct
+
+import pytest
+
+from tests.albedo_support import write_albedo_glb
+
+
+def _glb(path: Path) -> tuple[dict, bytes]:
+    data = path.read_bytes()
+    magic, version, total = struct.unpack_from("<4sII", data)
+    assert (magic, version, total) == (b"glTF", 2, len(data))
+    json_size, json_kind = struct.unpack_from("<I4s", data, 12)
+    assert json_kind == b"JSON"
+    document = json.loads(data[20 : 20 + json_size])
+    binary_header = 20 + json_size
+    binary_size, binary_kind = struct.unpack_from("<I4s", data, binary_header)
+    assert binary_kind == b"BIN\0"
+    binary = data[binary_header + 8 :]
+    assert len(binary) == binary_size
+    return document, binary
+
+
+@pytest.mark.parametrize("size", [1, 2, 1024, 2048])
+def test_albedo_variants_change_only_embedded_image_bytes(tmp_path, size):
+    first = tmp_path / "first.glb"
+    second = tmp_path / "second.glb"
+    write_albedo_glb(first, color=(240, 40, 80, 255), size=size)
+    write_albedo_glb(second, color=(20, 170, 230, 255), size=size)
+
+    first_document, first_binary = _glb(first)
+    second_document, second_binary = _glb(second)
+    image_view = first_document["bufferViews"][4]
+    image_offset = image_view["byteOffset"]
+    image_end = image_offset + image_view["byteLength"]
+
+    assert first_document == second_document
+    assert [node["name"] for node in first_document["nodes"]] == [
+        "AssetRoot",
+        "Body",
+    ]
+    assert [mesh["name"] for mesh in first_document["meshes"]] == ["BodyMesh"]
+    assert [material["name"] for material in first_document["materials"]] == [
+        "BodyMaterial"
+    ]
+    assert len(first_document["textures"]) == len(first_document["images"]) == 1
+    assert "uri" not in first_document["images"][0]
+    assert first_binary[:image_offset] == second_binary[:image_offset]
+    assert first_binary[image_offset:image_end].startswith(b"\x89PNG\r\n\x1a\n")
+    assert second_binary[image_offset:image_end].startswith(b"\x89PNG\r\n\x1a\n")
+    assert first_binary[image_offset:image_end] != second_binary[image_offset:image_end]
+    assert first_binary[image_end:] == second_binary[image_end:]
+    assert first_document["accessors"][0] == {
+        "bufferView": 0,
+        "componentType": 5126,
+        "count": 4,
+        "type": "VEC3",
+        "min": [-1.0, -1.0, 0.0],
+        "max": [1.0, 1.0, 0.0],
+    }
+    assert first_document["accessors"][3]["count"] == 6
+    assert "extensionsUsed" not in first_document

--- a/tests/resource/test_e2e_model_content_albedo.py
+++ b/tests/resource/test_e2e_model_content_albedo.py
@@ -1,0 +1,47 @@
+"""Imported embedded-albedo coverage for static model content (#954)."""
+
+import pytest
+
+from tests.albedo_support import write_albedo_glb
+from tests.conftest import project_godot
+from tests.support import Gda
+
+
+pytestmark = pytest.mark.e2e
+
+
+def test_embedded_albedo_only_change_changes_complete_content_digest(
+    tmp_path, monkeypatch
+):
+    model = tmp_path / "model.glb"
+    (tmp_path / "project.godot").write_text(
+        project_godot(
+            name="gda-embedded-albedo-content",
+            extra='[rendering]\nrenderer/rendering_method="gl_compatibility"',
+        )
+    )
+    monkeypatch.setenv("GDA_USER_DATA_ROOT", str(tmp_path / "user-data"))
+    run = Gda(tmp_path, json_output=True, timeout=120)
+
+    write_albedo_glb(model, color=(240, 40, 80, 255))
+    run.json("resource", "import", "res://model.glb")
+    first = run.json("resource", "inspect-model-content", "--path", "res://model.glb")[
+        "content"
+    ]
+
+    write_albedo_glb(model, color=(20, 170, 230, 255))
+    run.json("resource", "import", "res://model.glb")
+    second = run.json("resource", "inspect-model-content", "--path", "res://model.glb")[
+        "content"
+    ]
+
+    assert first["complete"] is True
+    assert second["complete"] is True
+    assert first["unsupported"] == second["unsupported"] == []
+    assert first["omitted"] == second["omitted"] == []
+    assert (first["nodes"], first["surfaces"], first["vertices"]) == (
+        second["nodes"],
+        second["surfaces"],
+        second["vertices"],
+    )
+    assert first["digest"] != second["digest"]

--- a/tests/resource/test_e2e_model_content_albedo_bounds.py
+++ b/tests/resource/test_e2e_model_content_albedo_bounds.py
@@ -1,0 +1,153 @@
+"""Native effective-material precedence and bounded albedo content controls."""
+
+import os
+
+import pytest
+
+from tests.conftest import project_godot
+from tests.support import Gda
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(os.name != "posix", reason="daemon uses AF_UNIX"),
+]
+
+SCRIPT = """extends Node3D
+func _ready():
+    var red := _texture(Color.RED)
+    var blue := _texture(Color.BLUE)
+    _model(self, "Plain", null)
+    _model(self, "Red", red)
+    _model(self, "Blue", blue)
+    _model(self, "Rgb", _texture(Color.RED, Image.FORMAT_RGB8))
+    _model(self, "Mipped", _texture(Color.RED, Image.FORMAT_RGBA8, true))
+    var overridden := _model(self, "SurfaceOverride", red)
+    overridden.set_surface_override_material(0, _material(blue))
+    var global := _model(self, "GlobalOverride", blue)
+    global.set_surface_override_material(0, _material(blue))
+    global.material_override = _material(red)
+    var normal := _model(self, "NormalResource", null)
+    (normal.mesh.surface_get_material(0) as StandardMaterial3D).normal_texture = red
+    _model(self, "Empty", ImageTexture.new())
+    _model(self, "Procedural", GradientTexture2D.new())
+    var viewport := SubViewport.new()
+    viewport.size = Vector2i(2, 2)
+    add_child(viewport)
+    _model(self, "RenderTarget", viewport.get_texture())
+    _model(self, "FloatFormat", _texture(Color.RED, Image.FORMAT_RGBAF))
+    var script := GDScript.new()
+    script.source_code = "extends ImageTexture\\n"
+    assert(script.reload() == OK)
+    var scripted := _texture(Color.RED)
+    scripted.set_script(script)
+    _model(self, "Scripted", scripted)
+    var oversized := _texture(Color.RED)
+    oversized.set_size_override(Vector2i(4097, 4097))
+    _model(self, "PixelLimit", oversized)
+    # One texture reused across surfaces must still consume per-read budgets.
+    var shared := _texture(Color.RED, Image.FORMAT_RGBA8, true, 1024)
+    var budget := Node3D.new()
+    budget.name = "Repeated"
+    add_child(budget)
+    for i in range(17):
+        _model(budget, "Part" + str(i), shared)
+
+func _texture(color: Color, format := Image.FORMAT_RGBA8, mipmaps := false, size := 2) -> ImageTexture:
+    var image := Image.create(size, size, false, format)
+    image.fill(color)
+    if mipmaps:
+        image.generate_mipmaps()
+    return ImageTexture.create_from_image(image)
+
+func _material(texture: Texture2D) -> StandardMaterial3D:
+    var material := StandardMaterial3D.new()
+    material.albedo_texture = texture
+    return material
+
+func _model(parent: Node, model_name: String, texture: Texture2D) -> MeshInstance3D:
+    var arrays := []
+    arrays.resize(Mesh.ARRAY_MAX)
+    arrays[Mesh.ARRAY_VERTEX] = PackedVector3Array([Vector3.ZERO, Vector3.RIGHT, Vector3.UP])
+    arrays[Mesh.ARRAY_INDEX] = PackedInt32Array([0, 1, 2])
+    var mesh := ArrayMesh.new()
+    mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, arrays)
+    mesh.surface_set_material(0, _material(texture))
+    var instance := MeshInstance3D.new()
+    instance.name = model_name
+    instance.mesh = mesh
+    parent.add_child(instance)
+    return instance
+"""
+
+
+def test_albedo_precedence_formats_and_repeated_read_budgets(
+    tmp_path, daemon_runtime_dir, monkeypatch
+):
+    (tmp_path / "project.godot").write_text(
+        project_godot(
+            name="gda-albedo-boundary-e2e",
+            extra=(
+                'run/main_scene="res://main.tscn"\n\n'
+                '[rendering]\n\nrenderer/rendering_method="gl_compatibility"'
+            ),
+        )
+    )
+    (tmp_path / "main.tscn").write_text(
+        "[gd_scene load_steps=2 format=3]\n"
+        '[ext_resource type="Script" path="res://main.gd" id="1"]\n'
+        '[node name="Main" type="Node3D"]\nscript = ExtResource("1")\n'
+    )
+    (tmp_path / "main.gd").write_text(SCRIPT)
+    monkeypatch.setenv("GDA_USER_DATA_ROOT", str(tmp_path / "user-data"))
+    run = Gda(tmp_path, json_output=True, timeout=120)
+
+    def inspect(name):
+        return run.json(
+            "game", "inspect-model-content", "--node", f"/root/Main/{name}"
+        )["content"]
+
+    try:
+        assert run("daemon", "start").returncode == 0
+        run.json("daemon", "wait-ready")
+        complete = {
+            name: inspect(name)
+            for name in (
+                "Plain",
+                "Red",
+                "Blue",
+                "Rgb",
+                "Mipped",
+                "SurfaceOverride",
+                "GlobalOverride",
+            )
+        }
+        for content in complete.values():
+            assert content["complete"] is True, content
+            assert len(content["digest"]) == 64
+        assert complete["Red"]["digest"] != complete["Blue"]["digest"]
+        assert complete["SurfaceOverride"]["digest"] == complete["Blue"]["digest"]
+        assert complete["GlobalOverride"]["digest"] == complete["Red"]["digest"]
+        assert complete["Rgb"]["digest"] != complete["Red"]["digest"]
+        assert complete["Mipped"]["digest"] != complete["Red"]["digest"]
+        for name in (
+            "NormalResource",
+            "Empty",
+            "Procedural",
+            "RenderTarget",
+            "FloatFormat",
+            "Scripted",
+        ):
+            unsupported = inspect(name)
+            assert unsupported["complete"] is False
+            assert unsupported["digest"] is None
+            assert unsupported["unsupported"], (name, unsupported)
+        pixel = inspect("PixelLimit")
+        assert pixel["complete"] is False and pixel["digest"] is None
+        assert any("albedo pixel limit" in reason for reason in pixel["omitted"])
+        repeated = inspect("Repeated")
+        assert repeated["complete"] is False and repeated["digest"] is None
+        assert any("albedo pixel limit" in reason for reason in repeated["omitted"])
+        assert any("albedo byte limit" in reason for reason in repeated["omitted"])
+    finally:
+        stopped = run("daemon", "stop")
+        assert stopped.returncode == 0, stopped.stdout + stopped.stderr

--- a/tests/resource/test_e2e_model_content_lods.py
+++ b/tests/resource/test_e2e_model_content_lods.py
@@ -181,7 +181,7 @@ def test_live_static_content_hashes_lods_and_bounds_their_count(
         run("daemon", "stop")
 
     for result in (first, changed, index_changed):
-        assert result["content"]["measurement"] == "godot-static-model-content-v2"
+        assert result["content"]["measurement"] == "godot-static-model-content-v3"
         assert result["content"]["complete"] is True
         assert result["content"]["unsupported"] == []
         assert result["content"]["omitted"] == []
@@ -236,7 +236,7 @@ def test_normally_imported_lod_sphere_matches_its_live_instance(
     finally:
         run("daemon", "stop")
 
-    assert resource["content"]["measurement"] == "godot-static-model-content-v2"
+    assert resource["content"]["measurement"] == "godot-static-model-content-v3"
     assert resource["content"]["complete"] is True
     assert resource["content"]["unsupported"] == []
     assert resource["content"]["omitted"] == []

--- a/tests/resource/test_model_content_discovery.py
+++ b/tests/resource/test_model_content_discovery.py
@@ -27,7 +27,7 @@ from tests.support import (
 
 
 CONTENT = {
-    "measurement": "godot-static-model-content-v2",
+    "measurement": "godot-static-model-content-v3",
     "engine_version": {
         "major": 4,
         "minor": 6,
@@ -67,7 +67,7 @@ def test_resource_and_game_commands_publish_the_same_bounded_content_shape():
         assert props["max_vertices"]["maximum"] == 1000000
         content = schema["output"]["$defs"]["ModelContent"]
         assert content["properties"]["measurement"]["const"] == (
-            "godot-static-model-content-v2"
+            "godot-static-model-content-v3"
         )
         assert content["properties"]["nodes"]["minimum"] == 0
         assert content["properties"]["surfaces"]["minimum"] == 0


### PR DESCRIPTION
Embedded albedo made imported/live static-model samples incomplete. Measurement `godot-static-model-content-v3` now reads effective albedo through public Texture2D/Image APIs and hashes dimensions, RGB8/RGBA8 format, mipmap metadata, and all returned bytes. Only unscripted ImageTexture and CompressedTexture2D are admitted; other texture slots, scripted/procedural/render-target forms and unavailable data retain localized incomplete results with a null digest.

A 16,777,216 aggregate base-pixel budget applies before every image read, including repeated references and failed reads. Image bytes share the existing 64 MiB serialized hash budget with geometry, LODs and material values. The byte check occurs after get_image(): it does not cap initial engine allocation or GPU readback. No image cache, resource registry, new port or gda-assets production dependency is introduced. Imported/live sampling remains byte-identical; the installed harness advances to v24.

Validation:
- Base: dev `6379b65844ee94f1d3c55ad0e2acdaef3eb3bf31` after #953. Native v2 RED: a maintained no-LOD GLB with embedded base-color PNG remained incomplete (1 failing acceptance test).
- Native #954 acceptance: 3 passed, including image-only A/B, unchanged complete model reports, headless imported/windowed live equality, stale-session retention, controlled refresh, material override precedence, RGB8/RGBA8 and mipmap controls, unsupported forms and repeated-reference/pixel/byte omissions.
- Adjacent native regression: 14 passed, including render-target refusal, previous refresh paths, LOD threshold/index changes and refresh, and installed-file recovery guidance.
- Full non-E2E: 2,914 passed, 2 skipped; the single wheel build check initially failed because the sandbox denied the default uv cache. Rerunning that check with a task-local cache passed, giving 2,915 passing cases in total. No product change was needed for that environmental failure.
- Ruff lint/format, full Pyright and shared sampler/harness tests pass. The maintained combined normal-import LOD+albedo witness also passes (1 native windowed test): independently observed nonzero LODs and image bytes, fixed geometry/path/counts/bounds, stale A, and a refreshed B session. Independent Sol Standards, Spec and DDMA all pass at `5ec50c06fcd37cc966bbcb143a35d07a7a5f44c9`; no further fixes were required. All applicable final-head CI checks pass (native CI is skipped). Squash `61eccd74fe9156d6424801e6fdf3aa5ac64dce86` on dev has the tested merge tree. Actual dev merge rehearsal passed 106 fast checks (4 native cases deselected), tree `a06b821b5b5b3174c9b273f0a3fc0cb7f8410990`. Clean wheel and sdist installations outside the checkout expose the identical complete schema, v3 and harness v24; the maintained installed-wheel native workflow smoke passed.

Native scope and costs:
- Godot 4.6.3 official, arm64 macOS, GL Compatibility headless/windowed. Default GLB import extracts its embedded PNG and returns a CompressedTexture2D with uncompressed RGBA8 Image data; runtime-created ImageTexture RGB8/RGBA8 controls also passed. A resource path is not evidence of original embedding.
- 1024² imported RGBA8: 10 mip levels, 5,592,404 bytes, identical raw SHA-256 in headless/windowed. Windowed get_image reads: 2,629/617/306 microseconds; headless 1–3 microseconds. Held-image static-memory delta about 11.2 MB windowed, zero headless; coarse snapshots do not measure transient/native peak. A 2048² headless image returned 22,369,620 bytes with 11 mip levels. Detailed limits and compatibility are in the model-content guide; no other renderer/format or visual-equivalence claim.

Refs #954 and #907. Targets `codex/asset-pipeline-dev` only. The final umbrella remains open for integrated validation and HITL; Panda Adventure is outside maintained acceptance.
