### PR TITLE
test(cli): align native argv refusals with JSON contract

### DIFF
--- a/tests/project/test_e2e_project.py
+++ b/tests/project/test_e2e_project.py
@@ -16,7 +16,7 @@ import json
 import pytest
 
 from gda.commands.project import INPUT_EVENT_DEVICE_MAX
-from tests.support import Gda, panel_text
+from tests.support import Gda
 
 from tests.conftest import project_godot
 
@@ -861,7 +861,11 @@ def test_project_add_input_action_with_no_binding_is_a_usage_error(godot_project
     bad = Gda(godot_project)("project", "add-input-action", "jump", "--json")
 
     assert bad.returncode == 2, bad.stdout + bad.stderr
-    assert "at least one binding" in panel_text(bad.stderr)
+    assert bad.stderr == ""
+    error = json.loads(bad.stdout)["error"]
+    assert error["category"] == "usage"
+    assert error["code"] == "invalid_argument"
+    assert "at least one binding" in error["message"]
     assert (
         not (godot_project / "project.godot")
         .read_text(encoding="utf-8")

--- a/tests/value_projection/test_e2e_live_number_transport.py
+++ b/tests/value_projection/test_e2e_live_number_transport.py
@@ -33,7 +33,7 @@ from tests.live_number_corpus import (
     tally_outcome,
     value_bits,
 )
-from tests.support import Gda, panel_text
+from tests.support import Gda
 
 from tests.conftest import LIVE_PROJECT_GODOT
 
@@ -291,8 +291,12 @@ def test_live_call_refuses_an_argument_the_wire_would_flatten(
                 "--args",
                 f"[{literal}]",
             )
-            assert refused.returncode != 0, refused.stdout + refused.stderr
-            assert "cannot cross the live wire" in panel_text(refused.stderr), literal
+            assert refused.returncode == 2, refused.stdout + refused.stderr
+            assert refused.stderr == ""
+            error = json.loads(refused.stdout)["error"]
+            assert error["category"] == "usage"
+            assert error["code"] == "invalid_argument"
+            assert "cannot cross the live wire" in error["message"], literal
             assert "live_timeout" not in refused.stdout
 
         # The --params-json path reaches the same validator and reports the
@@ -368,8 +372,12 @@ def test_every_live_ingress_refuses_a_flattening_value_against_a_real_daemon(
             ),
         ):
             refused = run(*argv)
-            assert refused.returncode != 0, refused.stdout + refused.stderr
-            message = panel_text(refused.stderr)
+            assert refused.returncode == 2, refused.stdout + refused.stderr
+            assert refused.stderr == ""
+            error = json.loads(refused.stdout)["error"]
+            assert error["category"] == "usage"
+            assert error["code"] == "invalid_argument"
+            message = error["message"]
             assert "cannot cross the live wire" in message, argv
             # Decided before the daemon is asked: not a live-channel failure, and
             # not the windowed-display refusal a real `screen capture` would hit.


### PR DESCRIPTION
The full integrated native suite found three pre-#947 assertions that still read Rich stderr after explicitly requesting JSON. The unchanged implementation already returns the required stdout envelope. Update those assertions to require exit 2, empty stderr, `usage` / `invalid_argument`, and the original refusal message.

Keep the project input-section check, real-daemon session checks, structured-parameter refusals, and neighboring valid number round trips. This changes two test files only; it does not relax the live-number guard or add a product mechanism.

Validation:
- Base dev `61eccd74fe9156d6424801e6fdf3aa5ac64dce86`: full native RED was 746 passed, 3 failed, 1 platform-specific skip. All three failures came from those obsolete stderr expectations.
- Corrected project case plus the complete native live-number transport module: 6 passed on Godot 4.6.3. Original input-section, no-session-reset and positive round-trip assertions remain active.
- 244 focused fast cases, targeted Pyright, Ruff lint/format and diff check pass. One independent Sol reviewer passed both Standards and Spec; no implementation change was needed. All applicable CI passed (native and unrelated balancing shards skipped). Actual dev merge replay of all three failures passed (3 tests). Head `238ebf8089acc240443ca62222674d8e19160be6`.

Refs #947 and #907. Targets `codex/asset-pipeline-dev` only. #947 is complete again after squash `7dd397e7d701db2744b4de6d34970324b9286003`, tree `f79f2b196a81cb55606dbcd623c062616bf8a70e`, which matches the tested merge. The full final native suite passed at this dev head: 749 passed, 1 expected platform skip. Its 750 test IDs match the first run, and all three former failures pass.
