### PR TITLE
fix(cli): select control modes from parsed options

### DIFF
--- a/docs/adr/0004-schema-flag-self-description.md
+++ b/docs/adr/0004-schema-flag-self-description.md
@@ -352,6 +352,13 @@ semantics here, and deliberately scope out an overloaded interpretation.
 
 ## Decision
 
+Control modes follow the command parser's option bindings (#971). A value or
+positional argument equal to `--schema` does not request self-description.
+Required operational arguments are relaxed only for an actual schema request or
+the structured-input mode in ADR-0015; ordinary calls retain normal validation.
+Token binding precedes that choice, while parameter callbacks and value validation
+run once through the existing command parser.
+
 - **`gda <command> --schema` emits the command's own machine-readable contract**: a
   JSON object with three keys — an `input` JSON Schema (the command's
   arguments/params), an `output` JSON Schema (the shape of its **success** `--json`

--- a/docs/adr/0015-structured-params-input-abi.md
+++ b/docs/adr/0015-structured-params-input-abi.md
@@ -42,6 +42,9 @@ through verbatim rather than reconstruct argv.
   **stdin**. gda deserializes it into the command's existing Pydantic input model
   (`model_validate_json`). Command selection stays in argv (Typer routing is
   unchanged); only the params *source* changes.
+  The equivalent `--params-json=<json>` form uses the same path. Mode selection
+  follows the parser-bound options described in [ADR-0004](0004-schema-flag-self-description.md#decision),
+  so control-looking data does not relax an ordinary call's required arguments.
 
 - **The params (input) model is the single source of truth for the input side** —
   both the emitted `input` schema (`--schema` / the `gda schema` dump, via

--- a/src/gda/headless.py
+++ b/src/gda/headless.py
@@ -556,7 +556,13 @@ def schema_command_class(
                     param.required = required
 
         def parse_args(self, ctx: typer.Context, args: list[str]) -> list[str]:
-            if "--schema" in args:
+            # Bind tokens with the command's own parser before deciding whether
+            # required arguments can be relaxed. This phase runs no callbacks or
+            # value validation; the normal/relaxed parse below owns those once.
+            # Raw membership mistakes consumed values for flags and misses the
+            # --params-json=<value> spelling (#971).
+            options, _, _ = self.make_parser(ctx).parse_args(list(args))
+            if options.get("schema"):
                 self._parse_relaxed(ctx, args)
                 # Carry the command's static execution channel (ADR-0017) from
                 # the one source of truth — the backing ``HeadlessCommand.kind``
@@ -587,7 +593,7 @@ def schema_command_class(
                     ).model_dump_json()
                 )
                 raise typer.Exit()
-            if command is not None and "--params-json" in args:
+            if command is not None and options.get("params_json") is not None:
                 # The individual operation args are absent — supplied by the JSON
                 # object instead; ``invoke`` builds the model and dispatches.
                 return self._parse_relaxed(ctx, args)

--- a/tests/cli/test_control_options.py
+++ b/tests/cli/test_control_options.py
@@ -1,0 +1,157 @@
+"""Control-looking values must not change the command's input mode (#971)."""
+
+import json
+import subprocess
+
+import pytest
+from pydantic import BaseModel
+import typer
+from typer.testing import CliRunner
+
+from gda.headless import schema_command_class, schema_option
+from tests.support import GDA_CMD, panel_text
+
+
+@pytest.mark.parametrize("equal_form", [False, True], ids=["space", "equals"])
+@pytest.mark.parametrize("json_output", [False, True], ids=["human", "json"])
+def test_schema_token_as_option_value_is_an_argv_refusal(
+    equal_form, json_output, tmp_path
+):
+    project = tmp_path / "project"
+    project.mkdir()
+    config = project / "project.godot"
+    config.write_text("config_version=5\n", encoding="utf-8")
+    updates = (
+        ["--updates-json=--schema"] if equal_form else ["--updates-json", "--schema"]
+    )
+    done = subprocess.run(
+        [
+            *GDA_CMD,
+            "resource",
+            "reimport",
+            "res://model.glb",
+            *updates,
+            "--project",
+            str(project),
+            "--godot",
+            str(tmp_path / "must-not-launch"),
+            *(["--json"] if json_output else []),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert done.returncode == 2, done.stdout + done.stderr
+    if json_output:
+        assert done.stderr == ""
+        error = json.loads(done.stdout)["error"]
+        assert error["category"] == "usage"
+        assert error["code"] == "invalid_argument"
+        message = error["message"]
+    else:
+        assert done.stdout == ""
+        message = panel_text(done.stderr)
+    assert "updates-json must be a JSON object" in message
+    assert list(project.iterdir()) == [config]
+    assert config.read_text(encoding="utf-8") == "config_version=5\n"
+
+
+@pytest.mark.parametrize("token", ["--schema", "--params-json"])
+def test_control_looking_values_do_not_relax_required_arguments(token):
+    done = subprocess.run(
+        [*GDA_CMD, "resource", "reimport", "--updates-json", token, "--json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert done.returncode == 2, done.stdout + done.stderr
+    assert done.stderr == ""
+    error = json.loads(done.stdout)["error"]
+    assert error["code"] == "invalid_argument"
+    assert error["message"].lower().startswith("path:")
+
+
+@pytest.mark.parametrize("token", ["--schema", "--params-json"])
+def test_control_looking_positionals_do_not_select_an_input_mode(token):
+    done = subprocess.run(
+        [*GDA_CMD, "resource", "reimport", "--json", "--", token],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert done.returncode == 2, done.stdout + done.stderr
+    assert done.stderr == ""
+    error = json.loads(done.stdout)["error"]
+    assert error["code"] == "invalid_argument"
+    assert error["message"].startswith("--updates-json:")
+
+
+@pytest.mark.parametrize("equal_form", [False, True], ids=["space", "equals"])
+@pytest.mark.parametrize("conflict", [False, True], ids=["invalid", "conflict"])
+def test_schema_token_in_structured_input_retains_its_failure_contract(
+    equal_form, conflict
+):
+    params = ["--params-json=--schema"] if equal_form else ["--params-json", "--schema"]
+    done = subprocess.run(
+        [
+            *GDA_CMD,
+            "resource",
+            "reimport",
+            *(["res://model.glb"] if conflict else []),
+            *params,
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert done.returncode == 4, done.stdout + done.stderr
+    assert done.stderr == ""
+    error = json.loads(done.stdout)["error"]
+    assert error["category"] == "operation"
+    assert error["code"] == ("usage_error" if conflict else "invalid_params")
+
+
+def test_mode_selection_keeps_parameter_callbacks_single_and_restores_required():
+    class Input(BaseModel):
+        value: str
+
+    callbacks = []
+    invoked = []
+
+    def record(value: str) -> str:
+        callbacks.append(value)
+        return value
+
+    probe = typer.Typer()
+
+    @probe.command(cls=schema_command_class(Input, Input))
+    def run(
+        value: str = typer.Option(..., callback=record),
+        schema: bool = schema_option(),
+    ) -> None:
+        invoked.append(value)
+        typer.echo(value)
+
+    runner = CliRunner()
+    ordinary = runner.invoke(probe, ["--value", "--schema"])
+    assert ordinary.exit_code == 0, ordinary.stdout + ordinary.stderr
+    assert ordinary.stdout.strip() == "--schema"
+    assert invoked == ["--schema"]
+    assert callbacks == ["--schema"]
+
+    callbacks.clear()
+    schema = runner.invoke(probe, ["--value", "data", "--schema"])
+    assert schema.exit_code == 0, schema.stdout + schema.stderr
+    assert "input" in json.loads(schema.stdout)
+    assert callbacks == ["data"]
+    assert invoked == ["--schema"]
+
+    missing = runner.invoke(probe, [])
+    assert missing.exit_code == 2
+    assert "Missing option" in panel_text(missing.stderr)
+    assert invoked == ["--schema"]

--- a/tests/cli/test_e2e_params_json.py
+++ b/tests/cli/test_e2e_params_json.py
@@ -17,11 +17,13 @@ gda = Gda()
 
 
 @pytest.mark.e2e
-def test_scene_create_via_params_json_creates_the_scene(godot_project):
+@pytest.mark.parametrize("equal_form", [False, True], ids=["space", "equals"])
+def test_scene_create_via_params_json_creates_the_scene(godot_project, equal_form):
     scene_path = godot_project / "main.tscn"
     params = json.dumps({"path": str(scene_path), "root_type": "Node2D"})
 
-    created = gda("scene", "create", "--params-json", params, "--json")
+    args = [f"--params-json={params}"] if equal_form else ["--params-json", params]
+    created = gda("scene", "create", *args, "--json")
 
     assert created.returncode == 0, created.stdout + created.stderr
     data = json.loads(created.stdout)


### PR DESCRIPTION
A control-looking option value could bypass validation: `resource reimport ... --updates-json --schema --json` returned a schema with exit 0. Raw token checks also relaxed required arguments for consumed `--params-json` values and missed `--params-json=<json>` requests.

Bind tokens with the command's existing parser before selecting schema or structured-input mode. Ordinary calls retain required-argument validation; genuine probes retain relaxed arguments and existing help/schema precedence. Parameter callbacks and value validation still run once through the existing command path. This removes the two raw-membership mode decisions without adding a token scanner, public state or output protocol.

Validation at `a8c7ffe99a63941d3f38a7163632cae84919c426`:
- RED: 10 of the original 12 new refusal cases failed on dev; the callback/ordinary-value control also failed. Equal-form native scene creation failed before engine dispatch.
- GREEN: 311 schema/structured-input/argv/human/unknown-invocation checks passed. Controls cover consumed values, positional data, equal-form values, required arguments and callback execution once.
- Full fast suite: 2,928 passed, 2 skipped.
- Native Godot: 9 passed, including actual scene creation/readback for space/equal structured input, stdin input, live-number refusal/valid-roundtrip controls, and the original project argv refusal.
- Full Ruff lint/format, full Pyright and diff checks passed.

Refs #971. Targets `codex/asset-pipeline-dev`; independent Sol Standards/Spec reviews passed at the listed head, with 0 findings on each axis (16 and 247 independently checked cases). All applicable CI checks passed; the scheduled-only Godot job was skipped, separate from the 9 local native tests above. The issue records the earlier #947 patch cycle, causal analysis, pre-existing-defect classification and bounded repair decision. Parent issues and the gda-assets boundary are unchanged.

The complete public command schema is byte-identical to dev before the change. The parent independently checked the two review reports and retained the bounded parser-binding implementation without further patches. Dev remained at `7dd397e7d701db2744b4de6d34970324b9286003`, so the reviewed feature tree is the integration tree.
